### PR TITLE
🌟 Nova: Replay Mode Simulator

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -49,6 +49,33 @@ pub struct HelloWorldCmd {
     pub output: PathBuf,
 }
 
+#[derive(Debug, Args)]
+pub struct ReplayCmd {
+    /// Path to the original trajectory JSON file.
+    #[arg(long)]
+    pub trajectory_path: PathBuf,
+
+    /// Optional path to a YAML config (overlays defaults).
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+
+    /// Environment: `local` or `docker`.
+    #[arg(long)]
+    pub env: Option<String>,
+
+    /// Docker image, if `--env docker`.
+    #[arg(long)]
+    pub docker_image: Option<String>,
+
+    /// Output directory for trajectories.
+    #[arg(long, default_value = "./runs")]
+    pub output: PathBuf,
+
+    /// Override trajectory filename (default: derived from task).
+    #[arg(long)]
+    pub trajectory_name: Option<String>,
+}
+
 #[derive(Debug, Subcommand)]
 pub enum BenchCmd {
     /// Run a SWE-bench sweep over a local JSONL dataset.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -28,6 +28,8 @@ pub enum Command {
     Mini(args::MiniCmd),
     /// Smoke-test: scripted model + local env writes a trajectory.
     HelloWorld(args::HelloWorldCmd),
+    /// Replay an existing trajectory using a deterministic model.
+    Replay(args::ReplayCmd),
     /// SWE-bench parallel sweep.
     Bench {
         #[command(subcommand)]
@@ -44,6 +46,7 @@ pub async fn run() -> Result<(), Error> {
     match cli.command {
         Command::Mini(m) => mini_cmd(m).await,
         Command::HelloWorld(h) => crate::run::hello_world::main(h.output).await,
+        Command::Replay(r) => replay_cmd(r).await,
         Command::Bench {
             cmd: args::BenchCmd::Swebench(s),
         } => bench_swebench(s).await,
@@ -96,6 +99,35 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         deterministic_responses: None,
     };
     crate::run::mini::run(args).await
+}
+
+async fn replay_cmd(r: args::ReplayCmd) -> Result<(), Error> {
+    let mut cfg = match &r.config {
+        Some(p) => Config::load(p)?,
+        None => Config::defaults()?,
+    };
+    if let Some(kind) = &r.env {
+        cfg.root.environment.kind = match kind.as_str() {
+            "local" => crate::config::EnvKind::Local,
+            "docker" => crate::config::EnvKind::Docker,
+            other => {
+                return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "unknown --env `{other}` (expected `local` or `docker`)"
+                ))));
+            }
+        };
+    }
+    if let Some(img) = r.docker_image.clone() {
+        cfg.root.environment.docker_image = Some(img);
+    }
+
+    let args = crate::run::replay::ReplayArgs {
+        trajectory_path: r.trajectory_path,
+        config: cfg,
+        output_dir: r.output,
+        trajectory_name: r.trajectory_name,
+    };
+    crate::run::replay::run(args).await
 }
 
 async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -3,4 +3,5 @@
 
 pub mod hello_world;
 pub mod mini;
+pub mod replay;
 pub mod swebench;

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -1,0 +1,181 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::agent::{Agent, DefaultAgent, default::DefaultAgentBuilder};
+use crate::config::{Config, EnvKind};
+#[cfg(feature = "docker")]
+use crate::env::DockerEnvironment;
+use crate::env::{Environment, LocalEnvironment};
+use crate::error::Error;
+use crate::model::{DeterministicModel, Model};
+use crate::trajectory::Trajectory;
+
+pub struct ReplayArgs {
+    pub trajectory_path: PathBuf,
+    pub config: Config,
+    pub output_dir: PathBuf,
+    pub trajectory_name: Option<String>,
+}
+
+pub async fn run(args: ReplayArgs) -> Result<(), Error> {
+    std::fs::create_dir_all(&args.output_dir)?;
+
+    // 1. Load the original trajectory
+    let file_content = std::fs::read_to_string(&args.trajectory_path)?;
+    let orig_trajectory: Trajectory = serde_json::from_str(&file_content).map_err(|e| {
+        Error::Config(crate::error::ConfigError::Invalid(format!(
+            "Invalid trajectory JSON: {e}"
+        )))
+    })?;
+
+    // 2. Extract assistant messages (the agent's actions)
+    let responses: Vec<String> = orig_trajectory
+        .messages
+        .into_iter()
+        .filter(|m| m.role == "assistant")
+        .map(|m| m.content)
+        .collect();
+
+    if responses.is_empty() {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(
+            "No assistant messages found in trajectory to replay".into(),
+        )));
+    }
+
+    // 3. Setup the replay environment and model
+    let model: Arc<dyn Model> = Arc::new(DeterministicModel::new(responses));
+    let env = build_env(&args.config).await?;
+
+    let task = orig_trajectory
+        .info
+        .task
+        .unwrap_or_else(|| "Replayed Task".into());
+    let traj_name = args
+        .trajectory_name
+        .unwrap_or_else(|| crate::run::mini::slugify(&task));
+
+    let mut agent: DefaultAgent = DefaultAgentBuilder {
+        config: args.config.clone(),
+        model,
+        env,
+        task,
+        extra_context: None,
+        renderer: None,
+    }
+    .build()?;
+
+    // 4. Run the replay
+    tracing::info!(?args.trajectory_path, "starting replay mode");
+    let exit = agent.run().await?;
+
+    // 5. Save the new trajectory
+    let traj_path = args.output_dir.join(format!("{traj_name}.traj.json"));
+    agent.trajectory.save_pretty(&traj_path)?;
+
+    if let crate::agent::ExitReason::Submitted { final_output } = &exit {
+        let out_path = args.output_dir.join(format!("{traj_name}.output.txt"));
+        std::fs::write(&out_path, final_output)?;
+    }
+
+    tracing::info!(?traj_path, "replay trajectory written");
+    Ok(())
+}
+
+async fn build_env(cfg: &Config) -> Result<Box<dyn Environment>, Error> {
+    match cfg.root.environment.kind {
+        EnvKind::Local => Ok(Box::new(LocalEnvironment::new())),
+        EnvKind::Docker => build_docker_env(cfg).await,
+    }
+}
+
+#[cfg(feature = "docker")]
+async fn build_docker_env(cfg: &Config) -> Result<Box<dyn Environment>, Error> {
+    let image = cfg.root.environment.docker_image.clone().ok_or_else(|| {
+        Error::Config(crate::error::ConfigError::Invalid(
+            "environment.kind=docker requires environment.docker_image".into(),
+        ))
+    })?;
+    let wd = PathBuf::from(cfg.root.environment.workdir.clone());
+    let env = DockerEnvironment::start(image, wd).await?;
+    Ok(Box::new(env))
+}
+
+#[cfg(not(feature = "docker"))]
+#[allow(clippy::unused_async)] // Mirrors the docker-feature signature.
+async fn build_docker_env(_cfg: &Config) -> Result<Box<dyn Environment>, Error> {
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "docker support not compiled in — rebuild with --features docker".into(),
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use crate::model::MessageExtra;
+    use crate::trajectory::MessageRecord;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_replay_mode() {
+        let dir = tempdir().unwrap();
+
+        // Setup a dummy trajectory file
+        let traj = Trajectory {
+            trajectory_format: "mini-swe-agent-1.1".into(),
+            info: crate::trajectory::TrajectoryInfo {
+                task: Some("dummy task".into()),
+                ..Default::default()
+            },
+            messages: vec![
+                MessageRecord {
+                    role: "user".into(),
+                    content: "dummy task".into(),
+                    extra: MessageExtra::default(),
+                },
+                MessageRecord {
+                    role: "assistant".into(),
+                    content: "```bash\necho hi\n```".into(),
+                    extra: MessageExtra::default(),
+                },
+                MessageRecord {
+                    role: "user".into(),
+                    content: "hi".into(),
+                    extra: MessageExtra::default(),
+                },
+                MessageRecord {
+                    role: "assistant".into(),
+                    content: "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nhi\n```".into(),
+                    extra: MessageExtra::default(),
+                },
+            ],
+        };
+        let dummy_path = dir.path().join("input.traj.json");
+        traj.save_pretty(&dummy_path).unwrap();
+
+        let cfg = Config::defaults().unwrap();
+        let args = ReplayArgs {
+            trajectory_path: dummy_path,
+            config: cfg,
+            output_dir: dir.path().to_path_buf(),
+            trajectory_name: Some("replayed-run".into()),
+        };
+
+        run(args).await.unwrap();
+
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+
+        let traj_written = entries
+            .iter()
+            .any(|e| e.file_name().to_string_lossy() == "replayed-run.traj.json");
+        assert!(traj_written);
+
+        let output_written = entries
+            .iter()
+            .any(|e| e.file_name().to_string_lossy() == "replayed-run.output.txt");
+        assert!(output_written);
+    }
+}


### PR DESCRIPTION
🌟 **Nova: Replay Mode Simulator**

### 💡 The Spark
I noticed we already record agent sessions via the `Trajectory` feature, and we already mock agent behavior via `DeterministicModel`. By bridging these two components, we can achieve free, perfect local simulation of previous agent runs!

### 🚀 The Feature
Implemented the "Replay Mode" Simulator (`ReplayCmd`). 
It takes an existing trajectory JSON, extracts all the `assistant` blocks from it, initializes a `DeterministicModel` with them, and replays the scenario with a standard `DefaultAgent` using the local or docker environment specified.

### 🔮 The Potential
This acts as a "Debug Mode" that automatically plays back runs, allowing users to:
1. Verify if an environment changes breaks a known good solution.
2. Debug prompt generation without spending real USD.
3. Test framework changes via free regressions tests using historical trajectories.

### ⚠️ Risk
Low. Isolated in `src/run/replay.rs` and the CLI. Contains basic tests to prove the mashup actually compiles and functions correctly.

---
*PR created automatically by Jules for task [17005107854281866943](https://jules.google.com/task/17005107854281866943) started by @madmax983*