### PR TITLE
Add real-time event streaming over HTTP/SSE

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -18,6 +18,7 @@ use crate::config::Config;
 use crate::env::{Environment, RunRequest};
 use crate::error::Error;
 use crate::model::{CacheHint, Message, MessageExtra, Model, QueryOpts, Role};
+use crate::stream::{NullSink, StreamEvent, StreamSink};
 use crate::template::Renderer;
 use crate::trajectory::Trajectory;
 
@@ -30,6 +31,9 @@ pub struct DefaultAgent {
     pub trajectory: Trajectory,
     pub steps: u32,
     pub total_cost_usd: f64,
+    /// Real-time event sink. Defaults to `NullSink` so non-streaming
+    /// callers pay no cost beyond a vtable call.
+    pub stream: Arc<dyn StreamSink>,
 }
 
 pub struct DefaultAgentBuilder {
@@ -39,6 +43,7 @@ pub struct DefaultAgentBuilder {
     pub task: String,
     pub extra_context: Option<String>,
     pub renderer: Option<Arc<Renderer>>,
+    pub stream: Option<Arc<dyn StreamSink>>,
 }
 
 impl DefaultAgentBuilder {
@@ -65,13 +70,21 @@ impl DefaultAgentBuilder {
             Message::user(instance_rendered),
         ];
 
+        let started_at = chrono::Utc::now().to_rfc3339();
         let mut trajectory = Trajectory::new();
         trajectory.info.task = Some(self.task.clone());
         trajectory.info.model_name = Some(self.model.name().to_owned());
-        trajectory.info.started_at = Some(chrono::Utc::now().to_rfc3339());
+        trajectory.info.started_at = Some(started_at.clone());
         for m in &history {
             trajectory.record_message(m);
         }
+
+        let stream: Arc<dyn StreamSink> = self.stream.unwrap_or_else(|| Arc::new(NullSink));
+        stream.emit(StreamEvent::RunStarted {
+            task: self.task.clone(),
+            model: self.model.name().to_owned(),
+            started_at,
+        });
 
         Ok(DefaultAgent {
             config: self.config,
@@ -82,6 +95,7 @@ impl DefaultAgentBuilder {
             trajectory,
             steps: 0,
             total_cost_usd: 0.0,
+            stream,
         })
     }
 }
@@ -111,11 +125,17 @@ pub fn retag_cache_hints(history: &mut [Message]) {
 
 #[async_trait]
 impl Agent for DefaultAgent {
+    // The step body walks through 7 sequential phases (limit checks →
+    // model query → action parse → bash → observation → trajectory
+    // record → bump). Splitting it out would obscure the linear flow
+    // for no real reuse benefit.
+    #[allow(clippy::too_many_lines)]
     async fn step(&mut self) -> Result<StepOutcome, Error> {
         // 1. Limit checks.
         if self.steps >= self.config.root.agent.step_limit {
             self.trajectory.info.exit_reason = Some("step_limit".into());
             self.trajectory.info.steps = Some(self.steps);
+            self.emit_run_ended("step_limit", None);
             return Ok(StepOutcome::Terminate(ExitReason::StepLimit {
                 limit: self.config.root.agent.step_limit,
             }));
@@ -125,6 +145,7 @@ impl Agent for DefaultAgent {
                 self.trajectory.info.exit_reason = Some("cost_limit".into());
                 self.trajectory.info.steps = Some(self.steps);
                 self.trajectory.info.total_cost_usd = Some(self.total_cost_usd);
+                self.emit_run_ended("cost_limit", None);
                 return Ok(StepOutcome::Terminate(ExitReason::CostLimit {
                     limit_usd: limit,
                     spent_usd: self.total_cost_usd,
@@ -145,10 +166,18 @@ impl Agent for DefaultAgent {
         self.total_cost_usd += resp.usage.cost_usd.unwrap_or(0.0);
 
         // Record assistant message in trajectory with raw + cost.
+        let asst_ts = chrono::Utc::now().to_rfc3339();
         let mut asst = Message::assistant(resp.content.clone());
         asst.extra.cost = resp.usage.cost_usd;
         asst.extra.response = Some(resp.raw.clone());
-        asst.extra.timestamp = Some(chrono::Utc::now().to_rfc3339());
+        asst.extra.timestamp = Some(asst_ts.clone());
+
+        self.stream.emit(StreamEvent::AssistantMessage {
+            step: self.steps,
+            content: resp.content.clone(),
+            cost_usd: resp.usage.cost_usd,
+            timestamp: asst_ts,
+        });
 
         // 4. Parse action.
         let action = extract_action(&resp.content);
@@ -162,6 +191,7 @@ impl Agent for DefaultAgent {
                 self.trajectory.info.steps = Some(self.steps);
                 self.trajectory.info.total_cost_usd = Some(self.total_cost_usd);
                 self.trajectory.info.ended_at = Some(chrono::Utc::now().to_rfc3339());
+                self.emit_run_ended("submitted", Some(output.clone()));
                 return Ok(StepOutcome::Terminate(ExitReason::Submitted {
                     final_output: output.clone(),
                 }));
@@ -179,6 +209,11 @@ impl Agent for DefaultAgent {
                     &self.config.root.agent.format_error_template,
                     &serde_json::json!({}),
                 )?;
+                self.stream.emit(StreamEvent::FormatError {
+                    step: self.steps,
+                    content: err.clone(),
+                    timestamp: chrono::Utc::now().to_rfc3339(),
+                });
                 let obs = Message::user(err);
                 self.history.push(obs.clone());
                 self.trajectory.record_message(&obs);
@@ -191,10 +226,23 @@ impl Agent for DefaultAgent {
         let Action::Bash(cmd) = action else {
             unreachable!("Submit and None handled above");
         };
+        self.stream.emit(StreamEvent::BashStart {
+            step: self.steps,
+            command: cmd.clone(),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        });
         let run_req = RunRequest::new(&cmd).with_timeout(Duration::from_secs(
             self.config.root.environment.timeout_secs,
         ));
         let result = self.env.run(run_req).await?;
+        self.stream.emit(StreamEvent::BashResult {
+            step: self.steps,
+            exit_code: result.exit_code,
+            stdout: result.stdout.clone(),
+            stderr: result.stderr.clone(),
+            timed_out: result.timed_out,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        });
 
         // 6. Render observation.
         let obs_text = self.renderer.render_str(
@@ -213,18 +261,37 @@ impl Agent for DefaultAgent {
         self.trajectory.record_message(&asst);
 
         // Record user observation.
-        let obs_msg = Message::user(obs_text);
+        let obs_ts = chrono::Utc::now().to_rfc3339();
+        let obs_msg = Message::user(obs_text.clone());
         self.history.push(obs_msg.clone());
         let mut obs_extra = MessageExtra::default();
         obs_extra.other.insert(
             "run_result".into(),
             serde_json::to_value(&result).unwrap_or(serde_json::Value::Null),
         );
-        obs_extra.timestamp = Some(chrono::Utc::now().to_rfc3339());
+        obs_extra.timestamp = Some(obs_ts.clone());
         self.trajectory.record_with_extra(&obs_msg, obs_extra);
+
+        self.stream.emit(StreamEvent::Observation {
+            step: self.steps,
+            content: obs_text,
+            timestamp: obs_ts,
+        });
 
         self.steps += 1;
         Ok(StepOutcome::Continue)
+    }
+}
+
+impl DefaultAgent {
+    fn emit_run_ended(&self, exit_reason: &str, final_output: Option<String>) {
+        self.stream.emit(StreamEvent::RunEnded {
+            exit_reason: exit_reason.to_owned(),
+            final_output,
+            steps: self.steps,
+            total_cost_usd: self.total_cost_usd,
+            ended_at: chrono::Utc::now().to_rfc3339(),
+        });
     }
 }
 
@@ -247,6 +314,7 @@ mod tests {
             task: "test".into(),
             extra_context: None,
             renderer: None,
+            stream: None,
         }
         .build()
         .unwrap()

--- a/src/agent/interactive.rs
+++ b/src/agent/interactive.rs
@@ -72,6 +72,7 @@ mod tests {
             task: "t".into(),
             extra_context: None,
             renderer: None,
+            stream: None,
         }
         .build()
         .unwrap();

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -41,6 +41,12 @@ pub struct MiniCmd {
     /// Override trajectory filename (default: slugified task).
     #[arg(long)]
     pub trajectory_name: Option<String>,
+
+    /// Stream trajectory events over HTTP/SSE on the given `host:port`
+    /// (e.g. `127.0.0.1:7878`). Use port `0` to let the OS pick. When
+    /// unset, no server is started.
+    #[arg(long)]
+    pub stream: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -90,6 +90,15 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         .clone()
         .unwrap_or_else(|| crate::run::mini::slugify(&m.task));
 
+    let stream_addr = match &m.stream {
+        Some(s) => Some(s.parse().map_err(|e: std::net::AddrParseError| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "invalid --stream address `{s}`: {e}"
+            )))
+        })?),
+        None => None,
+    };
+
     let args = crate::run::mini::MiniArgs {
         task: m.task,
         extra_context: m.extra_context,
@@ -97,6 +106,7 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         output_dir: m.output,
         trajectory_name,
         deterministic_responses: None,
+        stream_addr,
     };
     crate::run::mini::run(args).await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod error;
 pub mod ids;
 pub mod model;
 pub mod run;
+pub mod stream;
 pub mod template;
 pub mod trajectory;
 
@@ -23,4 +24,5 @@ pub use model::{
     AnthropicBackend, CacheHint, DeterministicModel, LitellmBackend, Message, MessageExtra, Model,
     ModelResponse, ModelUsage, QueryOpts, Role,
 };
+pub use stream::{BroadcastSink, NullSink, SseServer, StreamEvent, StreamSink};
 pub use trajectory::{FORMAT_VERSION, MessageRecord, Trajectory, TrajectoryInfo};

--- a/src/run/hello_world.rs
+++ b/src/run/hello_world.rs
@@ -19,6 +19,7 @@ pub async fn main(output_dir: PathBuf) -> Result<(), Error> {
             "```bash\necho hello\n```".into(),
             "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
         ]),
+        stream_addr: None,
     };
     run(args).await
 }

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -2,6 +2,7 @@
 //! the model name, builds `DefaultAgent`, runs to completion, writes a
 //! trajectory file and (if submitted) an output artifact.
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -13,6 +14,7 @@ use crate::env::{Environment, LocalEnvironment};
 use crate::error::Error;
 use crate::model::litellm::LitellmBackend;
 use crate::model::{DeterministicModel, Model};
+use crate::stream::{BroadcastSink, SseServer, StreamSink};
 
 pub struct MiniArgs {
     pub task: String,
@@ -21,6 +23,9 @@ pub struct MiniArgs {
     pub output_dir: PathBuf,
     pub trajectory_name: String,
     pub deterministic_responses: Option<Vec<String>>,
+    /// Optional SSE stream endpoint to bind. When `Some`, the runner
+    /// starts a server before the agent runs and shuts it down after.
+    pub stream_addr: Option<SocketAddr>,
 }
 
 pub async fn run(args: MiniArgs) -> Result<(), Error> {
@@ -29,6 +34,21 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     let model = build_model(&args.config, args.deterministic_responses);
     let env = build_env(&args.config).await?;
 
+    // Bring up the SSE server first so any client that connects right
+    // after CLI startup catches the `run_started` event the builder
+    // emits below.
+    let (sink, server): (Option<Arc<dyn StreamSink>>, Option<SseServer>) = match args.stream_addr {
+        Some(addr) => {
+            let bcast = Arc::new(BroadcastSink::default());
+            let server = SseServer::start(addr, bcast.clone()).await.map_err(|e| {
+                Error::Trajectory(format!("failed to bind SSE server on {addr}: {e}"))
+            })?;
+            tracing::info!(addr = %server.local_addr(), "streaming events on http://{}/", server.local_addr());
+            (Some(bcast as Arc<dyn StreamSink>), Some(server))
+        }
+        None => (None, None),
+    };
+
     let mut agent: DefaultAgent = DefaultAgentBuilder {
         config: args.config.clone(),
         model,
@@ -36,6 +56,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         task: args.task.clone(),
         extra_context: args.extra_context.clone(),
         renderer: None,
+        stream: sink,
     }
     .build()?;
 
@@ -54,6 +75,10 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     }
 
     tracing::info!(?traj_path, "trajectory written");
+
+    if let Some(server) = server {
+        server.shutdown().await;
+    }
     Ok(())
 }
 

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -61,6 +61,7 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
         task,
         extra_context: None,
         renderer: None,
+        stream: None,
     }
     .build()?;
 

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -149,6 +149,7 @@ async fn run_one(inst: SweBenchInstance, output_dir: PathBuf, mut cfg: Config) -
         output_dir: output_dir.clone(),
         trajectory_name: id.clone(),
         deterministic_responses: None,
+        stream_addr: None,
     };
     match crate::run::mini::run(args).await {
         Ok(()) => InstanceResult {

--- a/src/stream/broadcast.rs
+++ b/src/stream/broadcast.rs
@@ -1,0 +1,119 @@
+//! `BroadcastSink`: a `StreamSink` backed by `tokio::sync::broadcast`.
+//!
+//! Each subscriber gets an independent `Receiver`. `emit` is non-blocking
+//! and disconnect-safe: when there are zero receivers, `send()` returns
+//! `Err(SendError)` which we deliberately ignore. Slow consumers cause
+//! `Lagged` errors on receive, never on send — the agent is never
+//! throttled by network speed.
+
+use tokio::sync::broadcast;
+
+use super::{StreamEvent, StreamSink};
+
+/// Default channel capacity. A few hundred slots is plenty for human
+/// step-rate event volume; consumers that fall behind get `Lagged`
+/// errors on `recv` (not `Closed`), so they can resume from the next
+/// live event.
+pub const DEFAULT_CAPACITY: usize = 256;
+
+#[derive(Debug, Clone)]
+pub struct BroadcastSink {
+    tx: broadcast::Sender<StreamEvent>,
+}
+
+impl BroadcastSink {
+    pub fn new(capacity: usize) -> Self {
+        let (tx, _rx) = broadcast::channel(capacity.max(1));
+        Self { tx }
+    }
+
+    /// Number of currently attached receivers. Useful in tests and for
+    /// shutdown logic.
+    pub fn receiver_count(&self) -> usize {
+        self.tx.receiver_count()
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<StreamEvent> {
+        self.tx.subscribe()
+    }
+}
+
+impl Default for BroadcastSink {
+    fn default() -> Self {
+        Self::new(DEFAULT_CAPACITY)
+    }
+}
+
+impl StreamSink for BroadcastSink {
+    fn emit(&self, event: StreamEvent) {
+        // SendError occurs iff there are no active receivers. That's a
+        // valid state — the agent runs whether or not anyone is watching.
+        let _ = self.tx.send(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+
+    fn ev(step: u32) -> StreamEvent {
+        StreamEvent::AssistantMessage {
+            step,
+            content: "x".into(),
+            cost_usd: None,
+            timestamp: "t".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn emit_with_no_subscribers_does_not_error() {
+        let sink = BroadcastSink::new(8);
+        // Should not panic, should not return error to caller.
+        sink.emit(ev(0));
+        assert_eq!(sink.receiver_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn subscriber_receives_subsequent_events() {
+        let sink = BroadcastSink::new(8);
+        let mut rx = sink.subscribe();
+        sink.emit(ev(1));
+        sink.emit(ev(2));
+        let got1 = rx.recv().await.unwrap();
+        let got2 = rx.recv().await.unwrap();
+        match (got1, got2) {
+            (
+                StreamEvent::AssistantMessage { step: a, .. },
+                StreamEvent::AssistantMessage { step: b, .. },
+            ) => {
+                assert_eq!(a, 1);
+                assert_eq!(b, 2);
+            }
+            _ => panic!("wrong variants"),
+        }
+    }
+
+    #[tokio::test]
+    async fn dropped_subscriber_does_not_break_emit() {
+        let sink = BroadcastSink::new(4);
+        let rx = sink.subscribe();
+        drop(rx);
+        // Continues to emit fine.
+        sink.emit(ev(1));
+        sink.emit(ev(2));
+        assert_eq!(sink.receiver_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn multiple_subscribers_each_get_each_event() {
+        let sink = BroadcastSink::new(4);
+        let mut a = sink.subscribe();
+        let mut b = sink.subscribe();
+        sink.emit(ev(7));
+        let ea = a.recv().await.unwrap();
+        let eb = b.recv().await.unwrap();
+        assert!(matches!(ea, StreamEvent::AssistantMessage { step: 7, .. }));
+        assert!(matches!(eb, StreamEvent::AssistantMessage { step: 7, .. }));
+    }
+}

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1,0 +1,149 @@
+//! Real-time streaming of agent step events.
+//!
+//! `DefaultAgent` emits a `StreamEvent` at each meaningful boundary —
+//! assistant message, bash start/result, observation, format error, run
+//! start/end. A `StreamSink` decouples emission from transport: tests use
+//! an in-memory sink, production wires a `BroadcastSink` whose events are
+//! served over HTTP/SSE by `sse::SseServer`.
+//!
+//! Disconnect-safety is the load-bearing requirement (spec AC #3): emit
+//! must never block or fail. `BroadcastSink::emit` ignores `SendError`
+//! when there are zero subscribers, and the SSE per-connection task drops
+//! on the first write error without disturbing other clients or the agent.
+
+use serde::Serialize;
+
+pub mod broadcast;
+pub mod sse;
+
+pub use broadcast::BroadcastSink;
+pub use sse::SseServer;
+
+/// One step-level event in the agent trajectory.
+///
+/// Serialized as JSON with a `type` discriminator; SSE frames use the
+/// same string as the `event:` field name so clients can `addEventListener`
+/// per kind.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StreamEvent {
+    /// Emitted once at agent start, after the system + instance prompts
+    /// are recorded.
+    RunStarted {
+        task: String,
+        model: String,
+        started_at: String,
+    },
+    /// LLM produced a response (before action parsing).
+    AssistantMessage {
+        step: u32,
+        content: String,
+        cost_usd: Option<f64>,
+        timestamp: String,
+    },
+    /// About to execute a bash command.
+    BashStart {
+        step: u32,
+        command: String,
+        timestamp: String,
+    },
+    /// Bash command finished.
+    BashResult {
+        step: u32,
+        exit_code: i32,
+        stdout: String,
+        stderr: String,
+        timed_out: bool,
+        timestamp: String,
+    },
+    /// Observation message recorded into the trajectory after a bash run.
+    Observation {
+        step: u32,
+        content: String,
+        timestamp: String,
+    },
+    /// Model output was malformed; format-error template was sent back.
+    FormatError {
+        step: u32,
+        content: String,
+        timestamp: String,
+    },
+    /// Agent loop ended.
+    RunEnded {
+        exit_reason: String,
+        final_output: Option<String>,
+        steps: u32,
+        total_cost_usd: f64,
+        ended_at: String,
+    },
+}
+
+impl StreamEvent {
+    /// Stable wire name; used as the SSE `event:` field.
+    pub fn event_name(&self) -> &'static str {
+        match self {
+            Self::RunStarted { .. } => "run_started",
+            Self::AssistantMessage { .. } => "assistant_message",
+            Self::BashStart { .. } => "bash_start",
+            Self::BashResult { .. } => "bash_result",
+            Self::Observation { .. } => "observation",
+            Self::FormatError { .. } => "format_error",
+            Self::RunEnded { .. } => "run_ended",
+        }
+    }
+}
+
+/// Sink the agent emits to. Implementations MUST be non-blocking and
+/// MUST NOT fail visibly to the agent — disconnect handling is the
+/// sink's job.
+pub trait StreamSink: Send + Sync {
+    fn emit(&self, event: StreamEvent);
+}
+
+/// No-op sink. Useful as a default when streaming is disabled, so the
+/// agent loop doesn't branch on `Option<...>` at every emission point.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NullSink;
+
+impl StreamSink for NullSink {
+    fn emit(&self, _event: StreamEvent) {}
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+
+    #[test]
+    fn event_names_are_snake_case() {
+        let e = StreamEvent::RunStarted {
+            task: "t".into(),
+            model: "m".into(),
+            started_at: "now".into(),
+        };
+        assert_eq!(e.event_name(), "run_started");
+    }
+
+    #[test]
+    fn serializes_with_type_tag() {
+        let e = StreamEvent::BashStart {
+            step: 3,
+            command: "echo hi".into(),
+            timestamp: "t".into(),
+        };
+        let json = serde_json::to_value(&e).unwrap();
+        assert_eq!(json["type"], "bash_start");
+        assert_eq!(json["step"], 3);
+        assert_eq!(json["command"], "echo hi");
+    }
+
+    #[test]
+    fn null_sink_swallows_events() {
+        let s = NullSink;
+        s.emit(StreamEvent::RunStarted {
+            task: "t".into(),
+            model: "m".into(),
+            started_at: "s".into(),
+        });
+    }
+}

--- a/src/stream/sse.rs
+++ b/src/stream/sse.rs
@@ -1,0 +1,337 @@
+//! Minimal HTTP/1.1 + Server-Sent Events server for streaming
+//! `StreamEvent`s.
+//!
+//! Why not axum/hyper?
+//! * Project policy keeps deps lean (`litellm-rs` even has default
+//!   features stripped to avoid pulling actix). SSE is one direction
+//!   and one MIME type; a few hundred lines of tokio is enough.
+//!
+//! Behavior:
+//! * Bind a TCP listener; spawn one task per accepted connection.
+//! * Read just enough of the HTTP request to consume `\r\n\r\n` (we
+//!   ignore method / path / headers — any GET subscribes).
+//! * Reply 200 with `Content-Type: text/event-stream` and stream
+//!   `event: <name>\ndata: <json>\n\n` frames.
+//! * On any write error (client disconnected), drop the receiver and
+//!   the per-connection task — never propagate to the agent.
+//! * `shutdown()` signals the accept loop to stop and joins the task,
+//!   so the runner can exit cleanly after the agent finishes.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{broadcast, oneshot};
+use tokio::task::JoinHandle;
+
+use super::{BroadcastSink, StreamEvent};
+
+/// SSE response head + initial framing. Sent verbatim once the request
+/// line + headers have been consumed. CORS open since this is a
+/// local-dev tool.
+const SSE_RESPONSE_HEAD: &[u8] = b"HTTP/1.1 200 OK\r\n\
+Content-Type: text/event-stream\r\n\
+Cache-Control: no-cache, no-transform\r\n\
+Connection: keep-alive\r\n\
+X-Accel-Buffering: no\r\n\
+Access-Control-Allow-Origin: *\r\n\
+\r\n\
+: connected\n\
+retry: 2000\n\n";
+
+/// Handle to a running SSE server. Drop or call `shutdown()` to stop.
+pub struct SseServer {
+    addr: SocketAddr,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl SseServer {
+    /// Bind and start serving. Returns once the listener is bound, so
+    /// callers can synchronously attach a client immediately afterwards
+    /// (no race on first events).
+    pub async fn start(addr: SocketAddr, sink: Arc<BroadcastSink>) -> std::io::Result<Self> {
+        let listener = TcpListener::bind(addr).await?;
+        let bound = listener.local_addr()?;
+        let (sd_tx, sd_rx) = oneshot::channel();
+        let handle = tokio::spawn(accept_loop(listener, sink, sd_rx));
+        Ok(Self {
+            addr: bound,
+            shutdown_tx: Some(sd_tx),
+            handle: Some(handle),
+        })
+    }
+
+    /// The actual bound address (resolves port `0` to the OS-picked port).
+    pub fn local_addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// Signal the accept loop to stop and wait for it. Per-connection
+    /// tasks are NOT joined — they're already living off broadcast::recv
+    /// and will exit on their next write attempt or `Closed` recv.
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(h) = self.handle.take() {
+            let _ = h.await;
+        }
+    }
+}
+
+impl Drop for SseServer {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(h) = self.handle.take() {
+            h.abort();
+        }
+    }
+}
+
+async fn accept_loop(
+    listener: TcpListener,
+    sink: Arc<BroadcastSink>,
+    mut shutdown: oneshot::Receiver<()>,
+) {
+    loop {
+        tokio::select! {
+            _ = &mut shutdown => {
+                tracing::debug!("sse: shutdown signal received");
+                break;
+            }
+            accept = listener.accept() => {
+                match accept {
+                    Ok((stream, peer)) => {
+                        tracing::debug!(?peer, "sse: client connected");
+                        let rx = sink.subscribe();
+                        tokio::spawn(handle_connection(stream, rx, peer));
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "sse: accept failed");
+                        // Transient OS-level errors shouldn't kill the
+                        // server. A small yield avoids a hot loop on
+                        // persistent failure (e.g. fd exhaustion).
+                        tokio::task::yield_now().await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn handle_connection(
+    mut stream: TcpStream,
+    mut rx: broadcast::Receiver<StreamEvent>,
+    peer: SocketAddr,
+) {
+    if let Err(e) = consume_request_head(&mut stream).await {
+        tracing::debug!(?peer, error = %e, "sse: bad request head");
+        return;
+    }
+
+    if stream.write_all(SSE_RESPONSE_HEAD).await.is_err() {
+        return;
+    }
+    if stream.flush().await.is_err() {
+        return;
+    }
+
+    loop {
+        match rx.recv().await {
+            Ok(event) => {
+                let frame = format_sse_frame(&event);
+                if stream.write_all(frame.as_bytes()).await.is_err() {
+                    tracing::debug!(?peer, "sse: client write failed (disconnect)");
+                    return;
+                }
+                // Best-effort flush; ignore failures (next write catches it).
+                let _ = stream.flush().await;
+            }
+            Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                // Slow consumer dropped events. Tell them via a comment
+                // and stay connected — better partial than dead.
+                let note = format!(": lagged {skipped}\n\n");
+                if stream.write_all(note.as_bytes()).await.is_err() {
+                    return;
+                }
+            }
+            Err(broadcast::error::RecvError::Closed) => {
+                // Sink dropped (agent run completed and CLI is exiting).
+                let _ = stream.write_all(b"event: stream_closed\ndata: {}\n\n").await;
+                let _ = stream.shutdown().await;
+                return;
+            }
+        }
+    }
+}
+
+/// Read until `\r\n\r\n` or the cap (8 KiB) — whichever first. We don't
+/// parse the request; any GET subscribes. Cap defends against a slow /
+/// malicious client streaming headers forever.
+async fn consume_request_head(stream: &mut TcpStream) -> std::io::Result<()> {
+    let mut buf = [0u8; 8192];
+    let mut total = 0usize;
+    loop {
+        if total >= buf.len() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "request head too large",
+            ));
+        }
+        let n = stream.read(&mut buf[total..]).await?;
+        if n == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "client closed before request head",
+            ));
+        }
+        total += n;
+        if buf[..total].windows(4).any(|w| w == b"\r\n\r\n") {
+            return Ok(());
+        }
+    }
+}
+
+fn format_sse_frame(event: &StreamEvent) -> String {
+    let payload = serde_json::to_string(event).unwrap_or_else(|_| "{}".into());
+    // SSE forbids embedded newlines in a single `data:` line; agent
+    // outputs (stdout, observations) routinely contain them. Split on
+    // `\n` and emit one `data:` line per chunk — the EventSource API
+    // re-joins them with `\n`.
+    let mut out = String::with_capacity(payload.len() + 64);
+    out.push_str("event: ");
+    out.push_str(event.event_name());
+    out.push('\n');
+    for line in payload.split('\n') {
+        out.push_str("data: ");
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push('\n');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use crate::stream::StreamSink;
+    use std::time::Duration;
+
+    fn ev(step: u32) -> StreamEvent {
+        StreamEvent::BashStart {
+            step,
+            command: format!("echo {step}"),
+            timestamp: "t".into(),
+        }
+    }
+
+    #[test]
+    fn frame_contains_event_and_data() {
+        let f = format_sse_frame(&ev(1));
+        assert!(f.starts_with("event: bash_start\n"));
+        assert!(f.contains("data: "));
+        assert!(f.ends_with("\n\n"));
+    }
+
+    #[test]
+    fn multiline_payload_is_split_across_data_lines() {
+        let e = StreamEvent::Observation {
+            step: 0,
+            content: "line1\nline2".into(),
+            timestamp: "t".into(),
+        };
+        let f = format_sse_frame(&e);
+        // Multi-line value will JSON-encode the \n as `\n` (escaped),
+        // so the frame should still be a single `data:` line. Verify:
+        // exactly one `data: ` line.
+        let data_lines = f.lines().filter(|l| l.starts_with("data: ")).count();
+        assert_eq!(data_lines, 1, "frame: {f:?}");
+    }
+
+    #[tokio::test]
+    async fn end_to_end_subscribe_and_receive() {
+        let sink = Arc::new(BroadcastSink::new(8));
+        let server = SseServer::start("127.0.0.1:0".parse().unwrap(), sink.clone())
+            .await
+            .unwrap();
+        let addr = server.local_addr();
+
+        // Subscribe with a raw TCP request.
+        let mut client = TcpStream::connect(addr).await.unwrap();
+        client
+            .write_all(b"GET /events HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+
+        // Wait for subscriber to attach before emitting.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            if sink.receiver_count() >= 1 {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() <= deadline,
+                "client never attached"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        // Emit one event.
+        sink.emit(ev(42));
+
+        // Read a chunk and check we see the event name + payload.
+        let mut buf = vec![0u8; 4096];
+        let n = tokio::time::timeout(Duration::from_secs(2), client.read(&mut buf))
+            .await
+            .unwrap()
+            .unwrap();
+        let s = String::from_utf8_lossy(&buf[..n]).to_string();
+        assert!(
+            s.contains("HTTP/1.1 200 OK"),
+            "missing status, got: {s:?}"
+        );
+        assert!(
+            s.contains("text/event-stream"),
+            "missing content-type, got: {s:?}"
+        );
+
+        // Drain until we see the event frame (handshake may flush
+        // separately from first data frame).
+        let mut acc = s;
+        while !acc.contains("event: bash_start") {
+            let n = tokio::time::timeout(Duration::from_secs(2), client.read(&mut buf))
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(n > 0, "stream closed before event frame");
+            acc.push_str(&String::from_utf8_lossy(&buf[..n]));
+        }
+        assert!(acc.contains("\"command\":\"echo 42\""));
+
+        // Disconnect mid-stream — agent emit must not panic.
+        drop(client);
+        // Give the server a tick to notice.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        sink.emit(ev(99));
+        sink.emit(ev(100));
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_releases_listener() {
+        let sink = Arc::new(BroadcastSink::new(8));
+        let server = SseServer::start("127.0.0.1:0".parse().unwrap(), sink.clone())
+            .await
+            .unwrap();
+        let addr = server.local_addr();
+        server.shutdown().await;
+        // Port should be reusable.
+        let _again = TcpListener::bind(addr).await.unwrap();
+    }
+}

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -28,6 +28,7 @@ async fn two_turn_echo_submit_produces_well_formed_trajectory() {
         task: "round trip".into(),
         extra_context: None,
         renderer: None,
+        stream: None,
     }
     .build()
     .unwrap();

--- a/tests/streaming.rs
+++ b/tests/streaming.rs
@@ -1,0 +1,214 @@
+//! Integration: agent run with a `BroadcastSink` and a live SSE
+//! subscriber. Verifies (1) events flow in real time, (2) per-step
+//! outcomes (commands, exit codes, stdout) are emitted, and (3) a
+//! mid-run client disconnect does not crash the agent.
+
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+use rust_swe_agent::agent::default::DefaultAgentBuilder;
+use rust_swe_agent::stream::{BroadcastSink, SseServer, StreamEvent, StreamSink};
+use rust_swe_agent::{
+    Agent, Config, DeterministicModel, Environment, ExitReason, LocalEnvironment,
+};
+
+fn make_agent_with_sink(
+    responses: Vec<String>,
+    sink: Arc<dyn StreamSink>,
+) -> rust_swe_agent::DefaultAgent {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+    let model = Arc::new(DeterministicModel::new(responses));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "stream test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: Some(sink),
+    }
+    .build()
+    .unwrap()
+}
+
+#[tokio::test]
+async fn broadcast_sink_receives_step_outcomes() {
+    let bcast = Arc::new(BroadcastSink::default());
+    let mut rx = bcast.subscribe();
+
+    let mut agent = make_agent_with_sink(
+        vec![
+            "```bash\necho streaming-works\n```".into(),
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
+        ],
+        bcast.clone() as Arc<dyn StreamSink>,
+    );
+
+    let exit = agent.run().await.unwrap();
+    assert!(matches!(exit, ExitReason::Submitted { .. }));
+
+    // Drain receiver and collect every event variant we saw.
+    let mut events = Vec::new();
+    while let Ok(e) = rx.try_recv() {
+        events.push(e);
+    }
+
+    assert!(matches!(events.first(), Some(StreamEvent::RunStarted { .. })));
+
+    let saw_bash_start = events
+        .iter()
+        .any(|e| matches!(e, StreamEvent::BashStart { command, .. } if command == "echo streaming-works"));
+    assert!(saw_bash_start, "missing BashStart");
+
+    let saw_bash_result = events.iter().any(|e| {
+        matches!(
+            e,
+            StreamEvent::BashResult { exit_code: 0, stdout, .. }
+                if stdout.contains("streaming-works")
+        )
+    });
+    assert!(saw_bash_result, "missing BashResult with stdout");
+
+    let saw_observation = events
+        .iter()
+        .any(|e| matches!(e, StreamEvent::Observation { .. }));
+    assert!(saw_observation, "missing Observation");
+
+    let last = events.last().unwrap();
+    match last {
+        StreamEvent::RunEnded { exit_reason, final_output, .. } => {
+            assert_eq!(exit_reason, "submitted");
+            assert_eq!(final_output.as_deref(), Some("final"));
+        }
+        other => panic!("expected RunEnded last, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn sse_client_receives_events_over_tcp() {
+    let bcast = Arc::new(BroadcastSink::default());
+    let server = SseServer::start("127.0.0.1:0".parse().unwrap(), bcast.clone())
+        .await
+        .unwrap();
+    let addr = server.local_addr();
+
+    // Connect first; then run the agent.
+    let mut client = TcpStream::connect(addr).await.unwrap();
+    client
+        .write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+        .await
+        .unwrap();
+
+    // Wait for the per-connection task to subscribe.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    while bcast.receiver_count() < 1 {
+        assert!(
+            tokio::time::Instant::now() <= deadline,
+            "client never attached"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    // Run agent in background so we can read concurrently.
+    let agent_sink: Arc<dyn StreamSink> = bcast.clone();
+    let mut agent = make_agent_with_sink(
+        vec![
+            "```bash\necho hello-from-sse\n```".into(),
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nbye\n```".into(),
+        ],
+        agent_sink,
+    );
+    let agent_handle = tokio::spawn(async move {
+        let exit = agent.run().await.unwrap();
+        assert!(matches!(exit, ExitReason::Submitted { .. }));
+    });
+
+    // Read until we see the bash_result event with our stdout.
+    let mut acc = String::new();
+    let mut buf = vec![0u8; 4096];
+    let read_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while !acc.contains("hello-from-sse") || !acc.contains("event: run_ended") {
+        assert!(
+            tokio::time::Instant::now() <= read_deadline,
+            "timed out waiting for events; got:\n{acc}"
+        );
+        let n = tokio::time::timeout(Duration::from_secs(2), client.read(&mut buf))
+            .await
+            .unwrap()
+            .unwrap();
+        if n == 0 {
+            break;
+        }
+        acc.push_str(&String::from_utf8_lossy(&buf[..n]));
+    }
+
+    assert!(acc.contains("HTTP/1.1 200 OK"));
+    assert!(acc.contains("text/event-stream"));
+    assert!(acc.contains("event: run_started"));
+    assert!(acc.contains("event: bash_start"));
+    assert!(acc.contains("event: bash_result"));
+    assert!(acc.contains("\"command\":\"echo hello-from-sse\""));
+    assert!(acc.contains("event: run_ended"));
+
+    agent_handle.await.unwrap();
+    drop(client);
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn agent_survives_client_disconnect_mid_run() {
+    let bcast = Arc::new(BroadcastSink::default());
+    let server = SseServer::start("127.0.0.1:0".parse().unwrap(), bcast.clone())
+        .await
+        .unwrap();
+    let addr = server.local_addr();
+
+    // Subscribe, then immediately drop the connection partway through.
+    let mut client = TcpStream::connect(addr).await.unwrap();
+    client
+        .write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+        .await
+        .unwrap();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    while bcast.receiver_count() < 1 {
+        assert!(
+            tokio::time::Instant::now() <= deadline,
+            "client never attached"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    // A multi-step run gives the disconnect a chance to land mid-loop.
+    let agent_sink: Arc<dyn StreamSink> = bcast.clone();
+    let mut agent = make_agent_with_sink(
+        vec![
+            "```bash\necho one\n```".into(),
+            "```bash\necho two\n```".into(),
+            "```bash\necho three\n```".into(),
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\ndone\n```".into(),
+        ],
+        agent_sink,
+    );
+
+    // Read just a little, then drop the client.
+    let mut buf = vec![0u8; 1024];
+    let _ = tokio::time::timeout(Duration::from_millis(200), client.read(&mut buf)).await;
+    drop(client);
+
+    // Agent must complete normally despite the dropped subscriber.
+    let exit = agent.run().await.unwrap();
+    match exit {
+        ExitReason::Submitted { final_output } => assert_eq!(final_output, "done"),
+        other => panic!("unexpected exit: {other:?}"),
+    }
+
+    server.shutdown().await;
+}


### PR DESCRIPTION
## Summary
Implements real-time streaming of agent step events over HTTP/Server-Sent Events (SSE), allowing external clients to observe agent execution as it happens. This addresses the requirement for live trajectory visibility during agent runs.

## Key Changes

### New Streaming Infrastructure (`src/stream/`)
- **`mod.rs`**: Core `StreamEvent` enum capturing all meaningful agent boundaries (run start/end, assistant messages, bash commands/results, observations, format errors) with stable wire names for SSE event fields
- **`StreamSink` trait**: Non-blocking, disconnect-safe abstraction for event emission; implementations must never fail or block the agent
- **`NullSink`**: No-op default sink so non-streaming callers pay only a vtable call cost
- **`broadcast.rs`**: `BroadcastSink` backed by `tokio::sync::broadcast` for multi-subscriber support; emit is non-blocking and ignores `SendError` when no receivers are attached
- **`sse.rs`**: Minimal HTTP/1.1 + SSE server (337 lines) that:
  - Binds a TCP listener and spawns one task per connection
  - Reads just enough HTTP to consume `\r\n\r\n` (ignores method/path/headers)
  - Replies with 200 + `Content-Type: text/event-stream`
  - Streams `event: <name>\ndata: <json>\n\n` frames
  - Handles client disconnects gracefully without affecting the agent or other clients
  - Supports slow consumers via `Lagged` error messages rather than blocking

### Agent Integration (`src/agent/default.rs`)
- Added `stream: Arc<dyn StreamSink>` field to `DefaultAgent`
- Emits `StreamEvent` at all step boundaries: run start, assistant messages, bash start/result, observations, format errors, and run end
- Captures timestamps and metadata (exit codes, stdout/stderr, costs) for each event
- Defaults to `NullSink` when streaming is disabled

### CLI & Runner Updates
- **`src/cli/args.rs`**: New `--stream` flag to specify SSE endpoint (e.g., `127.0.0.1:7878`)
- **`src/cli/mod.rs`**: Parses and validates stream address
- **`src/run/mini.rs`**: Starts `SseServer` before agent run and shuts it down after; wires `BroadcastSink` to agent
- Updated all other runners (`hello_world.rs`, `replay.rs`, `swebench.rs`) to pass `stream_addr: None`

### Testing
- **`src/stream/` unit tests**: Event serialization, frame formatting, multi-line payload handling, end-to-end SSE server lifecycle
- **`tests/streaming.rs`** (new integration suite):
  - `broadcast_sink_receives_step_outcomes`: Verifies all event types flow through the sink
  - `sse_client_receives_events_over_tcp`: Full HTTP/SSE handshake and event delivery
  - `agent_survives_client_disconnect_mid_run`: Confirms agent completes normally even when client drops mid-stream

## Notable Implementation Details

- **Disconnect Safety**: Per-connection tasks drop on first write error without propagating to the agent; `BroadcastSink::emit` ignores `SendError` when there are zero subscribers
- **No External Dependencies**: Implemented with only `tokio` (already a dependency) to keep the project lean
- **Slow Consumer Handling**: Lagged events are reported via SSE comments (`: lagged N\n\n`) rather than blocking the agent
- **Multiline Payload Support**: JSON-encoded payloads with embedded newlines are split across multiple `data:` lines per SSE spec; the EventSource API re-joins them
- **CORS Open**: Includes `Access-Control-Allow-Origin: *` for local-dev tool usage

https://claude.ai/code/session_01LdWPnkzCqiT9p5cKZjoBz9