### PR TITLE
Add token usage tracking and cost estimation to sweep results

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -11,7 +11,7 @@
 
 use async_trait::async_trait;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use super::{Action, Agent, ExitReason, StepOutcome, extract_action};
 use crate::config::Config;
@@ -20,7 +20,7 @@ use crate::error::Error;
 use crate::model::{CacheHint, Message, MessageExtra, Model, QueryOpts, Role};
 use crate::stream::{NullSink, StreamEvent, StreamSink};
 use crate::template::Renderer;
-use crate::trajectory::Trajectory;
+use crate::trajectory::{TokenUsage, Trajectory, outcome};
 
 pub struct DefaultAgent {
     pub config: Config,
@@ -31,6 +31,13 @@ pub struct DefaultAgent {
     pub trajectory: Trajectory,
     pub steps: u32,
     pub total_cost_usd: f64,
+    /// Wall-clock start, used to compute `duration_secs` on terminate.
+    pub started_at_instant: Instant,
+    /// Accumulated prompt tokens across every model call in this run.
+    /// Sum of `input_tokens + cache_read_tokens + cache_creation_tokens`.
+    pub prompt_tokens: u64,
+    /// Accumulated completion tokens across every model call in this run.
+    pub completion_tokens: u64,
     /// Real-time event sink. Defaults to `NullSink` so non-streaming
     /// callers pay no cost beyond a vtable call.
     pub stream: Arc<dyn StreamSink>,
@@ -95,6 +102,9 @@ impl DefaultAgentBuilder {
             trajectory,
             steps: 0,
             total_cost_usd: 0.0,
+            started_at_instant: Instant::now(),
+            prompt_tokens: 0,
+            completion_tokens: 0,
             stream,
         })
     }
@@ -135,6 +145,7 @@ impl Agent for DefaultAgent {
         if self.steps >= self.config.root.agent.step_limit {
             self.trajectory.info.exit_reason = Some("step_limit".into());
             self.trajectory.info.steps = Some(self.steps);
+            self.finalize_run_metadata(outcome::STEP_LIMIT_REACHED);
             self.emit_run_ended("step_limit", None);
             return Ok(StepOutcome::Terminate(ExitReason::StepLimit {
                 limit: self.config.root.agent.step_limit,
@@ -145,6 +156,9 @@ impl Agent for DefaultAgent {
                 self.trajectory.info.exit_reason = Some("cost_limit".into());
                 self.trajectory.info.steps = Some(self.steps);
                 self.trajectory.info.total_cost_usd = Some(self.total_cost_usd);
+                // Cost limit is also a resource limit; map to the same
+                // coarse outcome as step limit per the three-value spec.
+                self.finalize_run_metadata(outcome::STEP_LIMIT_REACHED);
                 self.emit_run_ended("cost_limit", None);
                 return Ok(StepOutcome::Terminate(ExitReason::CostLimit {
                     limit_usd: limit,
@@ -164,6 +178,14 @@ impl Agent for DefaultAgent {
         };
         let resp = self.model.query(&self.history, &opts).await?;
         self.total_cost_usd += resp.usage.cost_usd.unwrap_or(0.0);
+        self.prompt_tokens = self.prompt_tokens.saturating_add(
+            resp.usage.input_tokens
+                + resp.usage.cache_read_tokens
+                + resp.usage.cache_creation_tokens,
+        );
+        self.completion_tokens = self
+            .completion_tokens
+            .saturating_add(resp.usage.output_tokens);
 
         // Record assistant message in trajectory with raw + cost.
         let asst_ts = chrono::Utc::now().to_rfc3339();
@@ -191,6 +213,7 @@ impl Agent for DefaultAgent {
                 self.trajectory.info.steps = Some(self.steps);
                 self.trajectory.info.total_cost_usd = Some(self.total_cost_usd);
                 self.trajectory.info.ended_at = Some(chrono::Utc::now().to_rfc3339());
+                self.finalize_run_metadata(outcome::SUBMITTED);
                 self.emit_run_ended("submitted", Some(output.clone()));
                 return Ok(StepOutcome::Terminate(ExitReason::Submitted {
                     final_output: output.clone(),
@@ -293,6 +316,20 @@ impl DefaultAgent {
             ended_at: chrono::Utc::now().to_rfc3339(),
         });
     }
+
+    /// Stamp the trajectory with the coarse `outcome`, accumulated
+    /// `token_usage`, and wall-clock `duration_secs`. Call from every
+    /// terminal path so every `.traj.json` carries these first-class
+    /// fields without callers needing to remember.
+    pub fn finalize_run_metadata(&mut self, outcome_label: &str) {
+        self.trajectory.info.outcome = Some(outcome_label.to_owned());
+        self.trajectory.info.token_usage = Some(TokenUsage {
+            prompt_tokens: self.prompt_tokens,
+            completion_tokens: self.completion_tokens,
+        });
+        self.trajectory.info.duration_secs =
+            Some(self.started_at_instant.elapsed().as_secs_f64());
+    }
 }
 
 #[cfg(test)]
@@ -342,6 +379,42 @@ mod tests {
         assert!(matches!(exit, ExitReason::Submitted { .. }));
         // History: [system, instance, asst(bash), user(obs), asst(submit)]
         assert!(a.history.iter().any(|m| m.content.contains("xyz")));
+    }
+
+    #[tokio::test]
+    async fn submit_records_outcome_and_token_usage() {
+        let mut a = make_agent(vec![
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
+        ]);
+        let _ = a.run().await.unwrap();
+        assert_eq!(
+            a.trajectory.info.outcome.as_deref(),
+            Some(crate::trajectory::outcome::SUBMITTED)
+        );
+        // DeterministicModel zeroes its usage, so the totals are exactly 0/0.
+        let usage = a.trajectory.info.token_usage.clone().unwrap();
+        assert_eq!(usage.prompt_tokens, 0);
+        assert_eq!(usage.completion_tokens, 0);
+        assert!(a.trajectory.info.duration_secs.unwrap() >= 0.0);
+    }
+
+    #[tokio::test]
+    async fn step_limit_records_outcome() {
+        let mut a = make_agent(vec![
+            "```bash\necho 1\n```".into(),
+            "```bash\necho 2\n```".into(),
+            "```bash\necho 3\n```".into(),
+            "```bash\necho 4\n```".into(),
+            "```bash\necho 5\n```".into(),
+            "```bash\necho 6\n```".into(),
+        ]);
+        let _ = a.run().await.unwrap();
+        assert_eq!(
+            a.trajectory.info.outcome.as_deref(),
+            Some(crate::trajectory::outcome::STEP_LIMIT_REACHED)
+        );
+        assert!(a.trajectory.info.token_usage.is_some());
+        assert!(a.trajectory.info.duration_secs.is_some());
     }
 
     #[tokio::test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -160,8 +160,12 @@ async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
         total = results.total,
         submitted = results.submitted,
         errored = results.errored,
+        prompt_tokens = results.total_prompt_tokens,
+        completion_tokens = results.total_completion_tokens,
+        estimated_cost_usd = results.estimated_cost_usd,
         "sweep complete"
     );
+    print!("{}", results.summary_table());
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,4 +25,4 @@ pub use model::{
     ModelResponse, ModelUsage, QueryOpts, Role,
 };
 pub use stream::{BroadcastSink, NullSink, SseServer, StreamEvent, StreamSink};
-pub use trajectory::{FORMAT_VERSION, MessageRecord, Trajectory, TrajectoryInfo};
+pub use trajectory::{FORMAT_VERSION, MessageRecord, TokenUsage, Trajectory, TrajectoryInfo};

--- a/src/model/deterministic.rs
+++ b/src/model/deterministic.rs
@@ -75,13 +75,16 @@ impl Model for DeterministicModel {
             })?
         };
 
+        // Zero token counts: replay runs and CI tests must produce valid
+        // trajectories without implying any real API spend.
         Ok(ModelResponse {
             content,
             usage: ModelUsage {
-                input_tokens: 1,
-                output_tokens: 1,
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
                 cost_usd: Some(0.0),
-                ..ModelUsage::default()
             },
             raw: serde_json::json!({"deterministic": true}),
         })

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -60,12 +60,32 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     }
     .build()?;
 
-    let exit = agent.run().await?;
-
     let traj_path = args
         .output_dir
         .join(format!("{}.traj.json", args.trajectory_name));
+
+    // Run the agent. On error, finalize the trajectory with
+    // `outcome="error"` so the partial run is still a self-contained
+    // record of what happened — then propagate.
+    let run_result = agent.run().await;
+    if let Err(e) = &run_result {
+        agent
+            .trajectory
+            .info
+            .exit_reason
+            .get_or_insert_with(|| "error".into());
+        agent
+            .trajectory
+            .info
+            .other
+            .entry("error_message".into())
+            .or_insert_with(|| serde_json::Value::String(e.to_string()));
+        agent.finalize_run_metadata(crate::trajectory::outcome::ERROR);
+    }
+
     agent.trajectory.save_pretty(&traj_path)?;
+
+    let exit = run_result?;
 
     if let crate::agent::ExitReason::Submitted { final_output } = &exit {
         let out_path = args

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -2,6 +2,7 @@
 //! across workers with a `JoinSet` + `Semaphore`, emit per-instance
 //! trajectory + patch files, summarize in `results.json`.
 
+use std::fmt::Write as _;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -10,6 +11,25 @@ use tokio::sync::Semaphore;
 
 use crate::config::Config;
 use crate::error::Error;
+use crate::trajectory::{Trajectory, outcome};
+
+/// Standard `claude-3-5-sonnet` USD pricing per 1M tokens. Used for the
+/// summary's cost estimate; per-instance trajectories carry only token
+/// counts so downstream tooling can re-price as needed.
+pub const SONNET_INPUT_USD_PER_MTOK: f64 = 3.0;
+pub const SONNET_OUTPUT_USD_PER_MTOK: f64 = 15.0;
+
+#[must_use]
+pub fn estimate_cost_usd(prompt_tokens: u64, completion_tokens: u64) -> f64 {
+    #[allow(clippy::cast_precision_loss)]
+    let p = prompt_tokens as f64;
+    #[allow(clippy::cast_precision_loss)]
+    let c = completion_tokens as f64;
+    (c / 1_000_000.0).mul_add(
+        SONNET_OUTPUT_USD_PER_MTOK,
+        p / 1_000_000.0 * SONNET_INPUT_USD_PER_MTOK,
+    )
+}
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SweBenchInstance {
@@ -30,8 +50,14 @@ pub struct SweBenchInstance {
 pub struct InstanceResult {
     pub instance_id: String,
     pub exit_reason: String,
+    /// Coarse outcome from the trajectory: `submitted` | `step_limit_reached`
+    /// | `error`. `None` when the trajectory file could not be read.
+    pub outcome: Option<String>,
     pub steps: Option<u32>,
     pub cost_usd: Option<f64>,
+    pub prompt_tokens: Option<u64>,
+    pub completion_tokens: Option<u64>,
+    pub duration_secs: Option<f64>,
     pub error: Option<String>,
 }
 
@@ -40,7 +66,45 @@ pub struct SweepResults {
     pub total: usize,
     pub submitted: usize,
     pub errored: usize,
+    pub total_prompt_tokens: u64,
+    pub total_completion_tokens: u64,
+    pub estimated_cost_usd: f64,
     pub instances: Vec<InstanceResult>,
+}
+
+impl SweepResults {
+    /// Render the post-sweep summary table. A flat plain-text block so it
+    /// reads cleanly in CI logs and from a tail of stdout.
+    #[must_use]
+    pub fn summary_table(&self) -> String {
+        #[allow(clippy::cast_precision_loss)]
+        let submit_rate_pct = if self.total == 0 {
+            0.0
+        } else {
+            (self.submitted as f64 / self.total as f64) * 100.0
+        };
+        let total_tokens = self
+            .total_prompt_tokens
+            .saturating_add(self.total_completion_tokens);
+        let mut s = String::new();
+        s.push_str("\n=== SWE-bench sweep summary ===\n");
+        let _ = writeln!(s, "Total tasks:        {}", self.total);
+        let _ = writeln!(s, "Submitted:          {}", self.submitted);
+        let _ = writeln!(s, "Submit rate:        {submit_rate_pct:.2}%");
+        let _ = writeln!(s, "Prompt tokens:      {}", self.total_prompt_tokens);
+        let _ = writeln!(
+            s,
+            "Completion tokens:  {}",
+            self.total_completion_tokens
+        );
+        let _ = writeln!(s, "Total tokens:       {total_tokens}");
+        let _ = writeln!(
+            s,
+            "Estimated cost:     ${:.4} (claude-3-5-sonnet @ ${SONNET_INPUT_USD_PER_MTOK}/MTok in, ${SONNET_OUTPUT_USD_PER_MTOK}/MTok out)",
+            self.estimated_cost_usd
+        );
+        s
+    }
 }
 
 pub struct SwebenchArgs {
@@ -87,8 +151,12 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
                     return InstanceResult {
                         instance_id: inst.instance_id.clone(),
                         exit_reason: "error".into(),
+                        outcome: Some(outcome::ERROR.into()),
                         steps: None,
                         cost_usd: None,
+                        prompt_tokens: None,
+                        completion_tokens: None,
+                        duration_secs: None,
                         error: Some(e.to_string()),
                     };
                 }
@@ -100,13 +168,21 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     let mut results = Vec::new();
     let mut submitted = 0;
     let mut errored = 0;
+    let mut total_prompt = 0u64;
+    let mut total_completion = 0u64;
     while let Some(j) = set.join_next().await {
         match j {
             Ok(r) => {
-                if r.exit_reason == "submitted" {
-                    submitted += 1;
-                } else if r.exit_reason == "error" {
-                    errored += 1;
+                match r.outcome.as_deref() {
+                    Some(outcome::SUBMITTED) => submitted += 1,
+                    Some(outcome::ERROR) => errored += 1,
+                    _ => {}
+                }
+                if let Some(p) = r.prompt_tokens {
+                    total_prompt = total_prompt.saturating_add(p);
+                }
+                if let Some(c) = r.completion_tokens {
+                    total_completion = total_completion.saturating_add(c);
                 }
                 results.push(r);
             }
@@ -115,8 +191,12 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
                 results.push(InstanceResult {
                     instance_id: "<join_error>".into(),
                     exit_reason: "error".into(),
+                    outcome: Some(outcome::ERROR.into()),
                     steps: None,
                     cost_usd: None,
+                    prompt_tokens: None,
+                    completion_tokens: None,
+                    duration_secs: None,
                     error: Some(e.to_string()),
                 });
             }
@@ -127,6 +207,9 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
         total,
         submitted,
         errored,
+        total_prompt_tokens: total_prompt,
+        total_completion_tokens: total_completion,
+        estimated_cost_usd: estimate_cost_usd(total_prompt, total_completion),
         instances: results,
     };
     let summary_path = args.output_dir.join("results.json");
@@ -151,28 +234,82 @@ async fn run_one(inst: SweBenchInstance, output_dir: PathBuf, mut cfg: Config) -
         deterministic_responses: None,
         stream_addr: None,
     };
-    match crate::run::mini::run(args).await {
-        Ok(()) => InstanceResult {
-            instance_id: id,
-            exit_reason: "submitted".into(),
-            steps: None,
-            cost_usd: None,
-            error: None,
-        },
-        Err(e) => InstanceResult {
-            instance_id: id,
-            exit_reason: "error".into(),
-            steps: None,
-            cost_usd: None,
-            error: Some(e.to_string()),
-        },
+    let run_err = crate::run::mini::run(args).await.err();
+
+    // Trajectory is the source of truth — `mini::run` writes it on both
+    // success and error paths, so reading it covers every outcome.
+    let traj_path = output_dir.join(format!("{id}.traj.json"));
+    let info = read_trajectory_info(&traj_path);
+
+    let outcome_str = info
+        .as_ref()
+        .and_then(|i| i.outcome.clone())
+        .or_else(|| run_err.as_ref().map(|_| outcome::ERROR.to_owned()))
+        .unwrap_or_else(|| outcome::ERROR.to_owned());
+
+    let exit_reason = info
+        .as_ref()
+        .and_then(|i| i.exit_reason.clone())
+        .unwrap_or_else(|| outcome_str.clone());
+
+    let (prompt_tokens, completion_tokens) = info
+        .as_ref()
+        .and_then(|i| i.token_usage.as_ref())
+        .map_or((None, None), |t| {
+            (Some(t.prompt_tokens), Some(t.completion_tokens))
+        });
+
+    InstanceResult {
+        instance_id: id,
+        exit_reason,
+        outcome: Some(outcome_str),
+        steps: info.as_ref().and_then(|i| i.steps),
+        cost_usd: info.as_ref().and_then(|i| i.total_cost_usd),
+        prompt_tokens,
+        completion_tokens,
+        duration_secs: info.as_ref().and_then(|i| i.duration_secs),
+        error: run_err.map(|e| e.to_string()),
     }
+}
+
+fn read_trajectory_info(path: &std::path::Path) -> Option<crate::trajectory::TrajectoryInfo> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let traj: Trajectory = serde_json::from_str(&text).ok()?;
+    Some(traj.info)
 }
 
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
     use super::*;
+
+    #[test]
+    fn cost_estimate_uses_sonnet_pricing() {
+        // 1M prompt + 1M completion = $3 + $15 = $18.
+        let c = estimate_cost_usd(1_000_000, 1_000_000);
+        assert!((c - 18.0).abs() < 1e-9, "got {c}");
+        // Zero in, zero out.
+        assert!(estimate_cost_usd(0, 0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn summary_table_includes_required_fields() {
+        let s = SweepResults {
+            total: 10,
+            submitted: 4,
+            errored: 1,
+            total_prompt_tokens: 250_000,
+            total_completion_tokens: 50_000,
+            estimated_cost_usd: estimate_cost_usd(250_000, 50_000),
+            instances: vec![],
+        };
+        let t = s.summary_table();
+        assert!(t.contains("Total tasks:        10"));
+        assert!(t.contains("Submitted:          4"));
+        assert!(t.contains("Submit rate:        40.00%"));
+        assert!(t.contains("Total tokens:       300000"));
+        assert!(t.contains("Estimated cost:     $1.5000"));
+    }
 
     #[test]
     fn loads_jsonl() {

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -12,6 +12,21 @@ use crate::model::{Message, MessageExtra};
 
 pub const FORMAT_VERSION: &str = "mini-swe-agent-1.1";
 
+/// Coarse run outcome. Exactly one of three values, suitable for computing
+/// pass@1-style metrics from trajectory files alone:
+/// `"submitted"` | `"step_limit_reached"` | `"error"`.
+pub mod outcome {
+    pub const SUBMITTED: &str = "submitted";
+    pub const STEP_LIMIT_REACHED: &str = "step_limit_reached";
+    pub const ERROR: &str = "error";
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TokenUsage {
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TrajectoryInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -21,9 +36,15 @@ pub struct TrajectoryInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exit_reason: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub final_output: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub total_cost_usd: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_usage: Option<TokenUsage>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_secs: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub steps: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -154,6 +175,43 @@ mod tests {
             back.messages[1].extra.actions.as_deref(),
             Some(&["echo hi".to_owned()][..])
         );
+    }
+
+    #[test]
+    fn outcome_token_usage_duration_round_trip() {
+        let mut t = Trajectory::new();
+        t.info.outcome = Some(outcome::SUBMITTED.into());
+        t.info.token_usage = Some(TokenUsage {
+            prompt_tokens: 1234,
+            completion_tokens: 56,
+        });
+        t.info.duration_secs = Some(12.5);
+
+        let json = t.to_json_pretty().unwrap();
+        assert!(json.contains("\"outcome\": \"submitted\""));
+        assert!(json.contains("\"prompt_tokens\": 1234"));
+        assert!(json.contains("\"completion_tokens\": 56"));
+        assert!(json.contains("\"duration_secs\": 12.5"));
+
+        let back: Trajectory = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.info.outcome.as_deref(), Some("submitted"));
+        assert_eq!(
+            back.info.token_usage,
+            Some(TokenUsage {
+                prompt_tokens: 1234,
+                completion_tokens: 56
+            })
+        );
+        assert_eq!(back.info.duration_secs, Some(12.5));
+    }
+
+    #[test]
+    fn new_fields_optional_omitted_when_none() {
+        let t = Trajectory::new();
+        let json = t.to_json_pretty().unwrap();
+        assert!(!json.contains("outcome"));
+        assert!(!json.contains("token_usage"));
+        assert!(!json.contains("duration_secs"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This PR adds comprehensive token usage tracking and cost estimation to SWE-bench sweep runs. Token counts and wall-clock duration are now captured in trajectory files, enabling accurate cost reporting and downstream analysis without requiring API calls.

## Key Changes

- **Token Usage Tracking**: Added `prompt_tokens` and `completion_tokens` fields to `DefaultAgent` to accumulate tokens across all model calls in a run. These are now persisted in trajectory files via the new `TokenUsage` struct.

- **Coarse Outcome Classification**: Introduced a three-value outcome enum (`submitted` | `step_limit_reached` | `error`) in trajectory files for computing pass@1-style metrics directly from trajectory data without external context.

- **Cost Estimation**: Implemented `estimate_cost_usd()` function using Claude 3.5 Sonnet pricing ($3/MTok input, $15/MTok output) to calculate estimated costs from token counts.

- **Run Duration Tracking**: Added `started_at_instant` to `DefaultAgent` and `duration_secs` to trajectory info to capture wall-clock execution time.

- **Sweep Summary Table**: Added `SweepResults::summary_table()` method that renders a human-readable summary including task counts, submission rate, token totals, and estimated cost. This is printed to stdout after each sweep.

- **Enhanced Result Aggregation**: Updated `SweepResults` to track `total_prompt_tokens`, `total_completion_tokens`, and `estimated_cost_usd` across all instances.

- **Trajectory Finalization**: Added `finalize_run_metadata()` method to ensure every trajectory file (success or error) carries outcome, token usage, and duration fields by calling it from all terminal paths.

- **Error Path Handling**: Modified `mini::run()` to finalize trajectory metadata even on error, ensuring partial runs are self-contained records.

## Notable Implementation Details

- Token accumulation includes cache-related tokens (`cache_read_tokens` + `cache_creation_tokens`) in prompt token totals to reflect actual API usage.
- Deterministic model now returns zero token counts to avoid implying API spend in test/replay scenarios.
- Trajectory info fields use `#[serde(skip_serializing_if = "Option::is_none")]` to keep JSON clean when fields are absent.
- Cost estimation uses `mul_add()` for numerical stability and includes explicit clippy allowances for f64 casts.
- Summary table uses `writeln!` macro with `let _ =` pattern to handle formatting without panicking on write errors.

https://claude.ai/code/session_01V6EzcL9dbSsYZGjE6JKwAt