### PR TITLE
Add --resume flag to skip completed tasks in swebench sweeps

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -107,4 +107,12 @@ pub struct SwebenchCmd {
 
     #[arg(long)]
     pub config: Option<PathBuf>,
+
+    /// Skip tasks whose output trajectory file already exists on disk and
+    /// parses as valid JSON. Lets an interrupted sweep resume without
+    /// re-spending API budget on already-completed work. Files that fail
+    /// JSON parsing (e.g. truncated by a mid-write crash) are treated as
+    /// absent and re-run.
+    #[arg(long, default_value_t = false)]
+    pub resume: bool,
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -153,12 +153,15 @@ async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
         output_dir: s.output,
         parallel: s.parallel,
         config: cfg,
+        resume: s.resume,
+        deterministic_responses: None,
     })
     .await?;
 
     tracing::info!(
         total = results.total,
         submitted = results.submitted,
+        skipped = results.skipped,
         errored = results.errored,
         prompt_tokens = results.total_prompt_tokens,
         completion_tokens = results.total_completion_tokens,

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -65,6 +65,7 @@ pub struct InstanceResult {
 pub struct SweepResults {
     pub total: usize,
     pub submitted: usize,
+    pub skipped: usize,
     pub errored: usize,
     pub total_prompt_tokens: u64,
     pub total_completion_tokens: u64,
@@ -90,6 +91,11 @@ impl SweepResults {
         s.push_str("\n=== SWE-bench sweep summary ===\n");
         let _ = writeln!(s, "Total tasks:        {}", self.total);
         let _ = writeln!(s, "Submitted:          {}", self.submitted);
+        let _ = writeln!(
+            s,
+            "Skipped:            {} — trajectory already on disk",
+            self.skipped
+        );
         let _ = writeln!(s, "Submit rate:        {submit_rate_pct:.2}%");
         let _ = writeln!(s, "Prompt tokens:      {}", self.total_prompt_tokens);
         let _ = writeln!(
@@ -112,6 +118,32 @@ pub struct SwebenchArgs {
     pub output_dir: PathBuf,
     pub parallel: usize,
     pub config: Config,
+    /// When true, tasks whose trajectory file already exists and parses as
+    /// valid JSON are skipped before any agent (or Docker container, or
+    /// model API call) is launched for them.
+    pub resume: bool,
+    /// Per-task deterministic responses, cloned into each spawned `MiniArgs`.
+    /// Lets sweeps run end-to-end against a scripted model without network
+    /// I/O — mainly useful for tests and local smoke checks.
+    pub deterministic_responses: Option<Vec<String>>,
+}
+
+/// Path where `run_one` writes the trajectory for an instance. Centralized so
+/// the resume-skip check stays in lockstep with the writer.
+#[must_use]
+pub fn trajectory_path_for(output_dir: &std::path::Path, instance_id: &str) -> PathBuf {
+    output_dir.join(format!("{instance_id}.traj.json"))
+}
+
+/// Inspect a trajectory path on disk. Returns `Some(info)` only when the file
+/// exists *and* parses as valid trajectory JSON; truncated or corrupt files
+/// (e.g. a mid-write crash) yield `None` so the task re-runs.
+#[must_use]
+pub fn existing_trajectory_info(
+    output_dir: &std::path::Path,
+    instance_id: &str,
+) -> Option<crate::trajectory::TrajectoryInfo> {
+    read_trajectory_info(&trajectory_path_for(output_dir, instance_id))
 }
 
 pub fn load_dataset(path: &std::path::Path) -> Result<Vec<SweBenchInstance>, Error> {
@@ -139,11 +171,23 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     let total = instances.len();
     let sem = Arc::new(Semaphore::new(args.parallel.max(1)));
     let mut set = tokio::task::JoinSet::new();
+    let mut skipped_results: Vec<InstanceResult> = Vec::new();
 
     for inst in instances {
+        // Resume short-circuit: a valid on-disk trajectory means this task
+        // already completed in a prior sweep. Skip it before we spawn — no
+        // semaphore slot, no Docker container, no model API call.
+        if args.resume {
+            if let Some(info) = existing_trajectory_info(&args.output_dir, &inst.instance_id) {
+                skipped_results.push(skipped_result_from_info(&inst.instance_id, &info));
+                continue;
+            }
+        }
+
         let permit_sem = Arc::clone(&sem);
         let output_dir = args.output_dir.clone();
         let cfg = args.config.clone();
+        let deterministic = args.deterministic_responses.clone();
         set.spawn(async move {
             let _permit = match permit_sem.acquire_owned().await {
                 Ok(p) => p,
@@ -161,15 +205,18 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
                     };
                 }
             };
-            run_one(inst, output_dir, cfg).await
+            run_one(inst, output_dir, cfg, deterministic).await
         });
     }
 
-    let mut results = Vec::new();
+    let mut results = skipped_results;
+    let skipped = results.len();
     let mut submitted = 0;
     let mut errored = 0;
     let mut total_prompt = 0u64;
     let mut total_completion = 0u64;
+    // Skipped tasks are excluded from token totals: those API calls were
+    // billed in the original sweep and shouldn't be counted again here.
     while let Some(j) = set.join_next().await {
         match j {
             Ok(r) => {
@@ -206,6 +253,7 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     let sweep = SweepResults {
         total,
         submitted,
+        skipped,
         errored,
         total_prompt_tokens: total_prompt,
         total_completion_tokens: total_completion,
@@ -218,12 +266,48 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     Ok(sweep)
 }
 
-async fn run_one(inst: SweBenchInstance, output_dir: PathBuf, mut cfg: Config) -> InstanceResult {
+/// Build an `InstanceResult` for a task skipped via `--resume`. Mirrors what
+/// `run_one` would have produced from the on-disk trajectory, with
+/// `exit_reason = "skipped_resume"` so summaries can distinguish a fresh run
+/// from a resumed one.
+fn skipped_result_from_info(
+    instance_id: &str,
+    info: &crate::trajectory::TrajectoryInfo,
+) -> InstanceResult {
+    let (prompt_tokens, completion_tokens) = info
+        .token_usage
+        .as_ref()
+        .map_or((None, None), |t| {
+            (Some(t.prompt_tokens), Some(t.completion_tokens))
+        });
+    InstanceResult {
+        instance_id: instance_id.to_owned(),
+        exit_reason: "skipped_resume".into(),
+        outcome: info.outcome.clone(),
+        steps: info.steps,
+        cost_usd: info.total_cost_usd,
+        prompt_tokens,
+        completion_tokens,
+        duration_secs: info.duration_secs,
+        error: None,
+    }
+}
+
+async fn run_one(
+    inst: SweBenchInstance,
+    output_dir: PathBuf,
+    mut cfg: Config,
+    deterministic_responses: Option<Vec<String>>,
+) -> InstanceResult {
     let id = inst.instance_id.clone();
     let task = inst.problem_statement.clone().unwrap_or_default();
-    if let Some(img) = &inst.image {
-        cfg.root.environment.docker_image = Some(img.clone());
-        cfg.root.environment.kind = crate::config::EnvKind::Docker;
+    // A scripted model implies a local-only sweep — `image` from the dataset
+    // would otherwise force the Docker env, which is wrong for tests.
+    if deterministic_responses.is_none() {
+        if let Some(img) = &inst.image {
+            cfg.root.environment.docker_image = Some(img.clone());
+            cfg.root.environment.kind = crate::config::EnvKind::Docker;
+        }
     }
     let args = crate::run::mini::MiniArgs {
         task,
@@ -231,7 +315,7 @@ async fn run_one(inst: SweBenchInstance, output_dir: PathBuf, mut cfg: Config) -
         config: cfg,
         output_dir: output_dir.clone(),
         trajectory_name: id.clone(),
-        deterministic_responses: None,
+        deterministic_responses,
         stream_addr: None,
     };
     let run_err = crate::run::mini::run(args).await.err();
@@ -297,6 +381,7 @@ mod tests {
         let s = SweepResults {
             total: 10,
             submitted: 4,
+            skipped: 3,
             errored: 1,
             total_prompt_tokens: 250_000,
             total_completion_tokens: 50_000,
@@ -306,9 +391,47 @@ mod tests {
         let t = s.summary_table();
         assert!(t.contains("Total tasks:        10"));
         assert!(t.contains("Submitted:          4"));
+        assert!(
+            t.contains("Skipped:            3 — trajectory already on disk"),
+            "missing skipped row in: {t}"
+        );
         assert!(t.contains("Submit rate:        40.00%"));
         assert!(t.contains("Total tokens:       300000"));
         assert!(t.contains("Estimated cost:     $1.5000"));
+    }
+
+    #[test]
+    fn existing_trajectory_info_returns_some_for_valid_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let traj = Trajectory {
+            trajectory_format: crate::trajectory::FORMAT_VERSION.into(),
+            info: crate::trajectory::TrajectoryInfo {
+                outcome: Some(outcome::SUBMITTED.into()),
+                exit_reason: Some("submitted".into()),
+                steps: Some(2),
+                ..Default::default()
+            },
+            messages: vec![],
+        };
+        let path = trajectory_path_for(dir.path(), "inst-1");
+        std::fs::write(&path, serde_json::to_string(&traj).unwrap()).unwrap();
+
+        let info = existing_trajectory_info(dir.path(), "inst-1").unwrap();
+        assert_eq!(info.outcome.as_deref(), Some(outcome::SUBMITTED));
+    }
+
+    #[test]
+    fn existing_trajectory_info_returns_none_for_truncated_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = trajectory_path_for(dir.path(), "inst-2");
+        std::fs::write(&path, "{\"trajectory_format\": \"mini-swe-agent-1.").unwrap();
+        assert!(existing_trajectory_info(dir.path(), "inst-2").is_none());
+    }
+
+    #[test]
+    fn existing_trajectory_info_returns_none_for_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(existing_trajectory_info(dir.path(), "no-such-id").is_none());
     }
 
     #[test]

--- a/tests/swebench_resume.rs
+++ b/tests/swebench_resume.rs
@@ -1,0 +1,150 @@
+//! Resume behavior for the `bench swebench` sweep:
+//!   * pre-existing valid trajectory → task is skipped (no agent runs)
+//!   * pre-existing invalid trajectory → file is treated as absent and the
+//!     task re-runs, producing a fresh, valid trajectory
+//!   * without `--resume`, valid pre-existing files are *not* skipped
+
+#![allow(clippy::unwrap_used)]
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+use rust_swe_agent::Config;
+use rust_swe_agent::run::swebench::{SwebenchArgs, run};
+use rust_swe_agent::trajectory::{FORMAT_VERSION, Trajectory, TrajectoryInfo, outcome};
+
+fn write_dataset(path: &Path, instance_ids: &[&str]) {
+    let mut s = String::new();
+    for id in instance_ids {
+        // A no-op problem statement is fine — the deterministic model never
+        // reads it; only the instance_id matters for trajectory naming.
+        let _ = writeln!(
+            s,
+            "{{\"instance_id\":\"{id}\",\"problem_statement\":\"noop\"}}"
+        );
+    }
+    std::fs::write(path, s).unwrap();
+}
+
+fn write_valid_trajectory(path: &Path, marker: &str) {
+    let mut info = TrajectoryInfo {
+        outcome: Some(outcome::SUBMITTED.into()),
+        exit_reason: Some("submitted".into()),
+        steps: Some(0),
+        ..Default::default()
+    };
+    info.other.insert(
+        "test_marker".into(),
+        serde_json::Value::String(marker.into()),
+    );
+    let traj = Trajectory {
+        trajectory_format: FORMAT_VERSION.into(),
+        info,
+        messages: vec![],
+    };
+    std::fs::write(path, serde_json::to_string_pretty(&traj).unwrap()).unwrap();
+}
+
+fn submit_only_responses() -> Vec<String> {
+    // First model turn already submits — no shell action required, so the
+    // local environment is never invoked beyond template setup.
+    vec!["COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfresh-run\n```".into()]
+}
+
+#[tokio::test]
+async fn resume_skips_valid_trajectory_and_reruns_invalid() {
+    let work = tempfile::tempdir().unwrap();
+    let dataset = work.path().join("dataset.jsonl");
+    let output = work.path().join("runs");
+    std::fs::create_dir_all(&output).unwrap();
+
+    write_dataset(&dataset, &["pre-valid", "pre-invalid", "fresh"]);
+
+    // Instance 1: pre-existing *valid* trajectory → must be skipped.
+    let valid_path = output.join("pre-valid.traj.json");
+    write_valid_trajectory(&valid_path, "preserved");
+    let valid_before = std::fs::read(&valid_path).unwrap();
+
+    // Instance 2: pre-existing *invalid* trajectory → treated as absent.
+    let invalid_path = output.join("pre-invalid.traj.json");
+    std::fs::write(&invalid_path, "{\"trajectory_format\":\"mini-swe-").unwrap();
+
+    // Instance 3: no pre-existing file → fresh run.
+
+    let cfg = Config::defaults().unwrap();
+    let results = run(SwebenchArgs {
+        dataset_path: dataset,
+        output_dir: output.clone(),
+        parallel: 2,
+        config: cfg,
+        resume: true,
+        deterministic_responses: Some(submit_only_responses()),
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(results.total, 3);
+    assert_eq!(results.skipped, 1, "exactly one task should be skipped");
+
+    // Skipped instance: trajectory file is byte-identical to what we wrote.
+    let valid_after = std::fs::read(&valid_path).unwrap();
+    assert_eq!(
+        valid_before, valid_after,
+        "skipped trajectory should be untouched"
+    );
+
+    // Invalid pre-existing trajectory was overwritten with a fresh, parseable one.
+    let reread: Trajectory =
+        serde_json::from_str(&std::fs::read_to_string(&invalid_path).unwrap()).unwrap();
+    assert_eq!(reread.trajectory_format, FORMAT_VERSION);
+    assert_eq!(reread.info.outcome.as_deref(), Some(outcome::SUBMITTED));
+
+    // Fresh instance got a brand-new trajectory file too.
+    let fresh_path = output.join("fresh.traj.json");
+    let fresh: Trajectory =
+        serde_json::from_str(&std::fs::read_to_string(&fresh_path).unwrap()).unwrap();
+    assert_eq!(fresh.info.outcome.as_deref(), Some(outcome::SUBMITTED));
+
+    // Summary table mentions the skipped count.
+    let table = results.summary_table();
+    assert!(
+        table.contains("Skipped:            1 — trajectory already on disk"),
+        "missing skipped row: {table}"
+    );
+}
+
+#[tokio::test]
+async fn without_resume_existing_trajectories_are_overwritten() {
+    let work = tempfile::tempdir().unwrap();
+    let dataset = work.path().join("dataset.jsonl");
+    let output = work.path().join("runs");
+    std::fs::create_dir_all(&output).unwrap();
+
+    write_dataset(&dataset, &["only"]);
+
+    let traj_path = output.join("only.traj.json");
+    write_valid_trajectory(&traj_path, "stale");
+
+    let cfg = Config::defaults().unwrap();
+    let results = run(SwebenchArgs {
+        dataset_path: dataset,
+        output_dir: output.clone(),
+        parallel: 1,
+        config: cfg,
+        resume: false,
+        deterministic_responses: Some(submit_only_responses()),
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(results.total, 1);
+    assert_eq!(results.skipped, 0, "no tasks may be skipped without --resume");
+
+    // The stale marker we wrote should have been overwritten by a fresh run.
+    let reread: Trajectory =
+        serde_json::from_str(&std::fs::read_to_string(&traj_path).unwrap()).unwrap();
+    assert!(
+        !reread.info.other.contains_key("test_marker"),
+        "stale trajectory was not overwritten without --resume"
+    );
+}


### PR DESCRIPTION
## Summary
Adds a `--resume` flag to the `bench swebench` command that allows interrupted sweeps to resume without re-running tasks that have already completed. This prevents wasting API budget on work that's already been done.

## Key Changes

- **Resume logic**: When `--resume` is enabled, tasks with valid trajectory files on disk are skipped before spawning any agent, Docker container, or model API calls. Invalid/truncated trajectory files are treated as absent and re-run to produce fresh results.

- **Trajectory validation**: Added `existing_trajectory_info()` and `trajectory_path_for()` helper functions that safely check for valid trajectory JSON on disk. Corrupt or truncated files (e.g., from mid-write crashes) return `None` to trigger a re-run.

- **Results tracking**: Extended `SweepResults` to include a `skipped` field and updated the summary table to report skipped task counts with context ("trajectory already on disk").

- **Deterministic responses support**: Added `deterministic_responses` field to `SwebenchArgs` to support scripted model responses for testing. This allows end-to-end sweep testing without network I/O or Docker containers.

- **CLI integration**: Added `--resume` flag to `SwebenchCmd` with documentation explaining the behavior and how truncated files are handled.

## Implementation Details

- Skipped tasks are excluded from token usage totals since those API calls were already billed in the original sweep
- Skipped results are distinguished with `exit_reason = "skipped_resume"` for clarity in summaries
- The resume check happens before semaphore acquisition, avoiding unnecessary resource allocation
- When deterministic responses are provided, Docker image configuration is skipped to allow local-only test sweeps
- Comprehensive test coverage includes: valid trajectory skipping, invalid trajectory re-running, and behavior without `--resume` flag

https://claude.ai/code/session_01WSZcVePSrNLvtRsUkaFiGS