### PR TITLE
Add SWE-bench patch artifact capture and predictions file generation

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -107,6 +107,7 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         trajectory_name,
         deterministic_responses: None,
         stream_addr,
+        patch_capture: None,
     };
     crate::run::mini::run(args).await
 }

--- a/src/run/hello_world.rs
+++ b/src/run/hello_world.rs
@@ -20,6 +20,7 @@ pub async fn main(output_dir: PathBuf) -> Result<(), Error> {
             "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
         ]),
         stream_addr: None,
+        patch_capture: None,
     };
     run(args).await
 }

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -5,16 +5,36 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::agent::{Agent, DefaultAgent, default::DefaultAgentBuilder};
 use crate::config::{Config, EnvKind};
 #[cfg(feature = "docker")]
 use crate::env::DockerEnvironment;
-use crate::env::{Environment, LocalEnvironment};
+use crate::env::{Environment, LocalEnvironment, RunRequest};
 use crate::error::Error;
 use crate::model::litellm::LitellmBackend;
 use crate::model::{DeterministicModel, Model};
 use crate::stream::{BroadcastSink, SseServer, StreamSink};
+
+/// How a runner should snapshot the agent's working tree as a unified diff
+/// after submission. Optional on `MiniArgs` because patch capture only
+/// makes sense for benchmark sweeps; the standalone `bench mini` CLI run
+/// has no baseline to diff against.
+pub struct PatchCaptureSpec {
+    /// The dataset's stated baseline. When `None`, diff is taken against
+    /// `HEAD`. SWE-bench instances typically carry the resolved SHA.
+    pub base_commit: Option<String>,
+    /// Working tree where `git diff` runs. For docker envs this matches
+    /// the container's `-w`; for local envs it must point at a real git
+    /// checkout.
+    pub workdir: PathBuf,
+    /// Where to write the `.patch` artifact. Empty diffs are still
+    /// persisted (zero-byte file) so downstream tooling can distinguish
+    /// "agent ran and changed nothing" from "agent never reached this
+    /// instance".
+    pub patch_path: PathBuf,
+}
 
 pub struct MiniArgs {
     pub task: String,
@@ -26,6 +46,11 @@ pub struct MiniArgs {
     /// Optional SSE stream endpoint to bind. When `Some`, the runner
     /// starts a server before the agent runs and shuts it down after.
     pub stream_addr: Option<SocketAddr>,
+    /// When `Some` and the agent submits, the runner captures a `git
+    /// diff` of `workdir` against `base_commit` and writes it to
+    /// `patch_path`. Capture failures downgrade the run's recorded
+    /// outcome to `error` rather than crashing the runner.
+    pub patch_capture: Option<PatchCaptureSpec>,
 }
 
 pub async fn run(args: MiniArgs) -> Result<(), Error> {
@@ -83,6 +108,41 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         agent.finalize_run_metadata(crate::trajectory::outcome::ERROR);
     }
 
+    // Patch capture happens before the trajectory is saved so any
+    // capture failure can be reflected as `outcome: "error"` rather
+    // than leaving a stale `submitted` record on disk.
+    let mut patch_written = false;
+    if let (Ok(crate::agent::ExitReason::Submitted { .. }), Some(spec)) =
+        (run_result.as_ref(), args.patch_capture.as_ref())
+    {
+        match capture_patch(agent.env.as_ref(), spec).await {
+            Ok(diff) => {
+                if diff.is_empty() {
+                    tracing::warn!(
+                        instance = %args.trajectory_name,
+                        "agent submitted but produced an empty diff"
+                    );
+                }
+                std::fs::write(&spec.patch_path, &diff)?;
+                patch_written = true;
+            }
+            Err(reason) => {
+                tracing::warn!(
+                    instance = %args.trajectory_name,
+                    error = %reason,
+                    "patch capture failed; downgrading outcome to error"
+                );
+                agent.trajectory.info.exit_reason = Some("error".into());
+                agent
+                    .trajectory
+                    .info
+                    .other
+                    .insert("patch_error".into(), serde_json::Value::String(reason));
+                agent.finalize_run_metadata(crate::trajectory::outcome::ERROR);
+            }
+        }
+    }
+
     agent.trajectory.save_pretty(&traj_path)?;
 
     let exit = run_result?;
@@ -94,12 +154,66 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         std::fs::write(&out_path, final_output)?;
     }
 
-    tracing::info!(?traj_path, "trajectory written");
+    tracing::info!(?traj_path, patch_written, "trajectory written");
 
     if let Some(server) = server {
         server.shutdown().await;
     }
     Ok(())
+}
+
+/// Snapshot the working tree at `spec.workdir` as a unified diff against
+/// `spec.base_commit` (or `HEAD`). Returns the diff text on success or a
+/// human-readable reason string on failure. Pure: writes nothing.
+///
+/// We use `--no-color`, `--binary`, and `--unified=3` to match the format
+/// the SWE-bench evaluator (`sb-cli`) consumes and `git apply` accepts.
+async fn capture_patch(env: &dyn Environment, spec: &PatchCaptureSpec) -> Result<String, String> {
+    // `git -C <workdir>` keeps us independent of the env's idea of cwd
+    // (the local env inherits the process cwd, the docker env uses `-w`).
+    // The `--` ensures the trailing argument is a pathspec rather than a
+    // ref, which matters when the workdir is empty or unborn.
+    let base = spec.base_commit.as_deref().unwrap_or("HEAD");
+    // Quote `base` to defuse hostile dataset values; SWE-bench commits are
+    // hex SHAs but a malformed instance shouldn't be able to inject shell.
+    let cmd = format!(
+        "git -C {workdir} diff --no-color --binary --unified=3 {base} -- .",
+        workdir = shell_quote(&spec.workdir.to_string_lossy()),
+        base = shell_quote(base),
+    );
+    let req = RunRequest::new(cmd).with_timeout(Duration::from_secs(60));
+    let result = env
+        .run(req)
+        .await
+        .map_err(|e| format!("env exec failed: {e}"))?;
+    if result.timed_out {
+        return Err(format!("git diff timed out: {}", result.stderr.trim()));
+    }
+    if result.exit_code != 0 {
+        return Err(format!(
+            "git diff exited {} ({})",
+            result.exit_code,
+            result.stderr.trim()
+        ));
+    }
+    Ok(result.stdout)
+}
+
+/// Single-quote-escape a string for safe inclusion in a `bash -c` argv.
+/// Closes the quote, emits an escaped literal `'`, reopens — the standard
+/// POSIX shell idiom.
+fn shell_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for c in s.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
 }
 
 fn build_model(cfg: &Config, deterministic: Option<Vec<String>>) -> Arc<dyn Model> {
@@ -164,5 +278,14 @@ mod tests {
         assert_eq!(slugify("Hello, World!"), "hello-world");
         assert_eq!(slugify("   "), "task");
         assert_eq!(slugify("A/B/C"), "a-b-c");
+    }
+
+    #[test]
+    fn shell_quote_escapes_single_quotes() {
+        assert_eq!(shell_quote("a"), "'a'");
+        assert_eq!(shell_quote("a b"), "'a b'");
+        assert_eq!(shell_quote("a'b"), "'a'\\''b'");
+        // Already-quoted-looking strings round-trip safely.
+        assert_eq!(shell_quote("$(rm -rf /)"), "'$(rm -rf /)'");
     }
 }

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -59,6 +59,18 @@ pub struct InstanceResult {
     pub completion_tokens: Option<u64>,
     pub duration_secs: Option<f64>,
     pub error: Option<String>,
+    /// `true` once the runner persisted a `.patch` artifact for this
+    /// instance — even an empty diff. Submitted instances missing a
+    /// patch indicate a capture failure (which downgrades `outcome` to
+    /// `error`); non-submitted outcomes never write a patch.
+    #[serde(default)]
+    pub patch_present: bool,
+    /// `true` if the captured patch had any content. Distinct from
+    /// `patch_present`: a submitted instance always sets `patch_present`
+    /// after a successful capture, but `non_empty_patch` only when the
+    /// agent's working tree actually diverged from `base_commit`.
+    #[serde(default)]
+    pub non_empty_patch: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -67,6 +79,9 @@ pub struct SweepResults {
     pub submitted: usize,
     pub skipped: usize,
     pub errored: usize,
+    /// Submitted instances whose captured patch had non-zero length.
+    /// Equal to `submitted` minus the count of empty-diff submissions.
+    pub with_patch: usize,
     pub total_prompt_tokens: u64,
     pub total_completion_tokens: u64,
     pub estimated_cost_usd: f64,
@@ -93,16 +108,17 @@ impl SweepResults {
         let _ = writeln!(s, "Submitted:          {}", self.submitted);
         let _ = writeln!(
             s,
+            "With patch:         {} — non-empty diff against base_commit",
+            self.with_patch
+        );
+        let _ = writeln!(
+            s,
             "Skipped:            {} — trajectory already on disk",
             self.skipped
         );
         let _ = writeln!(s, "Submit rate:        {submit_rate_pct:.2}%");
         let _ = writeln!(s, "Prompt tokens:      {}", self.total_prompt_tokens);
-        let _ = writeln!(
-            s,
-            "Completion tokens:  {}",
-            self.total_completion_tokens
-        );
+        let _ = writeln!(s, "Completion tokens:  {}", self.total_completion_tokens);
         let _ = writeln!(s, "Total tokens:       {total_tokens}");
         let _ = writeln!(
             s,
@@ -135,6 +151,22 @@ pub fn trajectory_path_for(output_dir: &std::path::Path, instance_id: &str) -> P
     output_dir.join(format!("{instance_id}.traj.json"))
 }
 
+/// Path where the SWE-bench-style unified diff is written for an instance.
+/// File presence is the resume-mode signal that the patch artifact was
+/// captured for a previously-submitted run.
+#[must_use]
+pub fn patch_path_for(output_dir: &std::path::Path, instance_id: &str) -> PathBuf {
+    output_dir.join(format!("{instance_id}.patch"))
+}
+
+/// Path of the aggregated SWE-bench predictions file written at the end of
+/// a sweep. One JSONL line per submitted instance, in the schema sb-cli
+/// expects (`instance_id`, `model_patch`, `model_name_or_path`).
+#[must_use]
+pub fn predictions_path(output_dir: &std::path::Path) -> PathBuf {
+    output_dir.join("all_preds.jsonl")
+}
+
 /// Inspect a trajectory path on disk. Returns `Some(info)` only when the file
 /// exists *and* parses as valid trajectory JSON; truncated or corrupt files
 /// (e.g. a mid-write crash) yield `None` so the task re-runs.
@@ -164,6 +196,10 @@ pub fn load_dataset(path: &std::path::Path) -> Result<Vec<SweBenchInstance>, Err
 /// Run the sweep. This scaffolds the parallelism + trajectory emission; the
 /// per-instance body calls through to `run::mini::run` using a Docker env
 /// (when the `docker` feature is enabled).
+// The body is a single sequential pipeline (load → resume-skip → spawn →
+// join → aggregate → emit). Splitting it would obscure the linear flow
+// without yielding reusable pieces.
+#[allow(clippy::too_many_lines)]
 pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     std::fs::create_dir_all(&args.output_dir)?;
 
@@ -174,13 +210,26 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     let mut skipped_results: Vec<InstanceResult> = Vec::new();
 
     for inst in instances {
-        // Resume short-circuit: a valid on-disk trajectory means this task
-        // already completed in a prior sweep. Skip it before we spawn — no
-        // semaphore slot, no Docker container, no model API call.
+        // Resume short-circuit: a valid on-disk trajectory + (when the run
+        // was submitted) a patch file mean this task is fully archived
+        // from a prior sweep. Skip it before we spawn — no semaphore slot,
+        // no Docker container, no model API call.
         if args.resume {
             if let Some(info) = existing_trajectory_info(&args.output_dir, &inst.instance_id) {
-                skipped_results.push(skipped_result_from_info(&inst.instance_id, &info));
-                continue;
+                let patch_path = patch_path_for(&args.output_dir, &inst.instance_id);
+                let needs_patch = info.outcome.as_deref() == Some(outcome::SUBMITTED);
+                if !needs_patch || patch_path.exists() {
+                    skipped_results.push(skipped_result_from_info(
+                        &inst.instance_id,
+                        &info,
+                        &patch_path,
+                    ));
+                    continue;
+                }
+                tracing::info!(
+                    instance = %inst.instance_id,
+                    "resume: trajectory present but patch missing — re-running"
+                );
             }
         }
 
@@ -202,6 +251,8 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
                         completion_tokens: None,
                         duration_secs: None,
                         error: Some(e.to_string()),
+                        patch_present: false,
+                        non_empty_patch: false,
                     };
                 }
             };
@@ -213,6 +264,7 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     let skipped = results.len();
     let mut submitted = 0;
     let mut errored = 0;
+    let mut with_patch = 0;
     let mut total_prompt = 0u64;
     let mut total_completion = 0u64;
     // Skipped tasks are excluded from token totals: those API calls were
@@ -224,6 +276,9 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
                     Some(outcome::SUBMITTED) => submitted += 1,
                     Some(outcome::ERROR) => errored += 1,
                     _ => {}
+                }
+                if r.non_empty_patch {
+                    with_patch += 1;
                 }
                 if let Some(p) = r.prompt_tokens {
                     total_prompt = total_prompt.saturating_add(p);
@@ -245,16 +300,29 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
                     completion_tokens: None,
                     duration_secs: None,
                     error: Some(e.to_string()),
+                    patch_present: false,
+                    non_empty_patch: false,
                 });
             }
         }
     }
+
+    // Skipped instances loaded from disk also contribute to the patch
+    // counter so resumed sweeps report cumulative `with_patch` correctly.
+    for r in &results {
+        if r.exit_reason == "skipped_resume" && r.non_empty_patch {
+            with_patch += 1;
+        }
+    }
+
+    write_predictions_file(&args.output_dir, &results, &args.config.root.model.name)?;
 
     let sweep = SweepResults {
         total,
         submitted,
         skipped,
         errored,
+        with_patch,
         total_prompt_tokens: total_prompt,
         total_completion_tokens: total_completion,
         estimated_cost_usd: estimate_cost_usd(total_prompt, total_completion),
@@ -266,6 +334,42 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     Ok(sweep)
 }
 
+/// Write `all_preds.jsonl` containing one line per *submitted* instance
+/// with a patch artifact on disk. Schema: `{instance_id, model_patch,
+/// model_name_or_path}` — the minimum sb-cli accepts. Non-submitted and
+/// patch-capture-failed instances are excluded by design so sb-cli
+/// reports them as unresolved rather than misattributes a stale diff.
+fn write_predictions_file(
+    output_dir: &std::path::Path,
+    results: &[InstanceResult],
+    model_name: &str,
+) -> Result<(), Error> {
+    let path = predictions_path(output_dir);
+    let mut text = String::new();
+    for r in results {
+        if r.outcome.as_deref() != Some(outcome::SUBMITTED) {
+            continue;
+        }
+        if !r.patch_present {
+            // A submitted-but-patch-missing instance only happens on a
+            // resume that found the trajectory but no `.patch`; we already
+            // re-queued it above so this branch is defensive.
+            continue;
+        }
+        let patch_path = patch_path_for(output_dir, &r.instance_id);
+        let model_patch = std::fs::read_to_string(&patch_path).unwrap_or_default();
+        let line = serde_json::json!({
+            "instance_id": r.instance_id,
+            "model_patch": model_patch,
+            "model_name_or_path": model_name,
+        });
+        text.push_str(&serde_json::to_string(&line)?);
+        text.push('\n');
+    }
+    std::fs::write(&path, text)?;
+    Ok(())
+}
+
 /// Build an `InstanceResult` for a task skipped via `--resume`. Mirrors what
 /// `run_one` would have produced from the on-disk trajectory, with
 /// `exit_reason = "skipped_resume"` so summaries can distinguish a fresh run
@@ -273,13 +377,15 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
 fn skipped_result_from_info(
     instance_id: &str,
     info: &crate::trajectory::TrajectoryInfo,
+    patch_path: &std::path::Path,
 ) -> InstanceResult {
-    let (prompt_tokens, completion_tokens) = info
-        .token_usage
-        .as_ref()
-        .map_or((None, None), |t| {
-            (Some(t.prompt_tokens), Some(t.completion_tokens))
-        });
+    let (prompt_tokens, completion_tokens) = info.token_usage.as_ref().map_or((None, None), |t| {
+        (Some(t.prompt_tokens), Some(t.completion_tokens))
+    });
+    let (patch_present, non_empty_patch) = match std::fs::metadata(patch_path) {
+        Ok(m) => (true, m.len() > 0),
+        Err(_) => (false, false),
+    };
     InstanceResult {
         instance_id: instance_id.to_owned(),
         exit_reason: "skipped_resume".into(),
@@ -290,6 +396,8 @@ fn skipped_result_from_info(
         completion_tokens,
         duration_secs: info.duration_secs,
         error: None,
+        patch_present,
+        non_empty_patch,
     }
 }
 
@@ -309,6 +417,13 @@ async fn run_one(
             cfg.root.environment.kind = crate::config::EnvKind::Docker;
         }
     }
+    let workdir = PathBuf::from(cfg.root.environment.workdir.clone());
+    let patch_path = patch_path_for(&output_dir, &id);
+    let patch_capture = Some(crate::run::mini::PatchCaptureSpec {
+        base_commit: inst.base_commit.clone(),
+        workdir,
+        patch_path: patch_path.clone(),
+    });
     let args = crate::run::mini::MiniArgs {
         task,
         extra_context: None,
@@ -317,6 +432,7 @@ async fn run_one(
         trajectory_name: id.clone(),
         deterministic_responses,
         stream_addr: None,
+        patch_capture,
     };
     let run_err = crate::run::mini::run(args).await.err();
 
@@ -343,6 +459,11 @@ async fn run_one(
             (Some(t.prompt_tokens), Some(t.completion_tokens))
         });
 
+    let (patch_present, non_empty_patch) = match std::fs::metadata(&patch_path) {
+        Ok(m) => (true, m.len() > 0),
+        Err(_) => (false, false),
+    };
+
     InstanceResult {
         instance_id: id,
         exit_reason,
@@ -353,6 +474,8 @@ async fn run_one(
         completion_tokens,
         duration_secs: info.as_ref().and_then(|i| i.duration_secs),
         error: run_err.map(|e| e.to_string()),
+        patch_present,
+        non_empty_patch,
     }
 }
 
@@ -383,6 +506,7 @@ mod tests {
             submitted: 4,
             skipped: 3,
             errored: 1,
+            with_patch: 3,
             total_prompt_tokens: 250_000,
             total_completion_tokens: 50_000,
             estimated_cost_usd: estimate_cost_usd(250_000, 50_000),
@@ -391,6 +515,10 @@ mod tests {
         let t = s.summary_table();
         assert!(t.contains("Total tasks:        10"));
         assert!(t.contains("Submitted:          4"));
+        assert!(
+            t.contains("With patch:         3 — non-empty diff against base_commit"),
+            "missing with_patch row in: {t}"
+        );
         assert!(
             t.contains("Skipped:            3 — trajectory already on disk"),
             "missing skipped row in: {t}"

--- a/tests/swebench_patch.rs
+++ b/tests/swebench_patch.rs
@@ -1,0 +1,256 @@
+//! End-to-end sweep produces SWE-bench submission artifacts:
+//!   * per-instance `<id>.patch` files (unified diff vs. base_commit)
+//!   * aggregated `all_preds.jsonl` whose lines parse as the predictions
+//!     schema sb-cli expects
+//!
+//! Runs against a deterministic model + a temp git repo (no network, no
+//! Docker) so the harness invariants — not patch *quality* — are what
+//! gets exercised.
+
+#![allow(clippy::unwrap_used)]
+
+use std::fmt::Write as _;
+use std::path::Path;
+use std::process::Command;
+
+use rust_swe_agent::Config;
+use rust_swe_agent::run::swebench::{SwebenchArgs, run};
+use rust_swe_agent::trajectory::{Trajectory, outcome};
+
+/// Initialize a git repo at `dir` with one tracked file at the base
+/// commit. The file's existence is what makes the working tree's
+/// post-modification state diff-able.
+fn init_repo_with_file(dir: &Path, filename: &str, contents: &str) -> String {
+    fn git(dir: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    git(dir, &["init", "-q", "-b", "main"]);
+    git(dir, &["config", "user.email", "test@test"]);
+    git(dir, &["config", "user.name", "test"]);
+    // Some CI environments configure a global commit signing hook that
+    // can't reach its signing server from a sandbox; force it off.
+    git(dir, &["config", "commit.gpgSign", "false"]);
+    git(dir, &["config", "tag.gpgSign", "false"]);
+    std::fs::write(dir.join(filename), contents).unwrap();
+    git(dir, &["add", filename]);
+    git(dir, &["commit", "-q", "-m", "base"]);
+
+    let out = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+fn write_dataset(path: &Path, instance_ids: &[&str], base_commit: &str) {
+    let mut s = String::new();
+    for id in instance_ids {
+        let _ = writeln!(
+            s,
+            "{{\"instance_id\":\"{id}\",\"problem_statement\":\"noop\",\"base_commit\":\"{base_commit}\"}}"
+        );
+    }
+    std::fs::write(path, s).unwrap();
+}
+
+#[tokio::test]
+async fn sweep_emits_patch_artifact_for_modifying_agent() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    let base_commit = init_repo_with_file(&repo, "hello.txt", "before\n");
+
+    let dataset = work.path().join("dataset.jsonl");
+    let output = work.path().join("runs");
+    std::fs::create_dir_all(&output).unwrap();
+    write_dataset(&dataset, &["mod-instance"], &base_commit);
+
+    // Agent modifies hello.txt with an absolute path — `LocalEnvironment`
+    // runs commands in the test process's CWD, not `repo`, so we anchor
+    // the path explicitly. Patch capture then runs `git diff` from
+    // `repo` (the configured workdir) and sees the change.
+    let mod_cmd = format!("echo after > {}/hello.txt", repo.display());
+    let responses = vec![
+        format!("```bash\n{mod_cmd}\n```"),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nmodified\n```".into(),
+    ];
+
+    let yaml = format!(
+        "environment:\n  workdir: {}\nmodel:\n  name: scripted-test-model\n",
+        repo.display()
+    );
+    let cfg = Config::from_yaml_str(&yaml).unwrap();
+    let results = run(SwebenchArgs {
+        dataset_path: dataset,
+        output_dir: output.clone(),
+        parallel: 1,
+        config: cfg,
+        resume: false,
+        deterministic_responses: Some(responses),
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(results.total, 1);
+    assert_eq!(results.submitted, 1);
+    assert_eq!(results.with_patch, 1);
+
+    let mod_patch = output.join("mod-instance.patch");
+    assert!(mod_patch.exists());
+    let patch_text = std::fs::read_to_string(&mod_patch).unwrap();
+    assert!(!patch_text.is_empty(), "expected non-empty diff");
+    assert!(
+        patch_text.contains("hello.txt"),
+        "diff should mention the modified file: {patch_text}"
+    );
+    assert!(
+        patch_text.contains("-before") && patch_text.contains("+after"),
+        "diff should show old and new content: {patch_text}"
+    );
+
+    // Predictions schema: one line, valid JSON, required fields present.
+    let preds_text = std::fs::read_to_string(output.join("all_preds.jsonl")).unwrap();
+    let lines: Vec<&str> = preds_text.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 1, "expected one prediction line: {preds_text}");
+
+    let v: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    let obj = v.as_object().unwrap();
+    assert_eq!(
+        obj.get("instance_id").and_then(|v| v.as_str()),
+        Some("mod-instance")
+    );
+    assert_eq!(
+        obj.get("model_name_or_path").and_then(|v| v.as_str()),
+        Some("scripted-test-model")
+    );
+    // `model_patch` round-trips byte-for-byte from `<id>.patch`.
+    assert_eq!(
+        obj.get("model_patch").and_then(|v| v.as_str()).unwrap(),
+        patch_text
+    );
+
+    // Spec invariant: submitted count == predictions line count.
+    assert_eq!(results.submitted, lines.len());
+}
+
+#[tokio::test]
+async fn sweep_emits_empty_patch_when_agent_changes_nothing() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    let base_commit = init_repo_with_file(&repo, "hello.txt", "untouched\n");
+
+    let dataset = work.path().join("dataset.jsonl");
+    let output = work.path().join("runs");
+    std::fs::create_dir_all(&output).unwrap();
+    write_dataset(&dataset, &["noop-instance"], &base_commit);
+
+    let yaml = format!(
+        "environment:\n  workdir: {}\nmodel:\n  name: scripted-test-model\n",
+        repo.display()
+    );
+    let cfg = Config::from_yaml_str(&yaml).unwrap();
+    let results = run(SwebenchArgs {
+        dataset_path: dataset,
+        output_dir: output.clone(),
+        parallel: 1,
+        config: cfg,
+        resume: false,
+        deterministic_responses: Some(vec![
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nnoop\n```".into(),
+        ]),
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(results.submitted, 1);
+    // Empty diff still counts as submitted but not as `with_patch`.
+    assert_eq!(results.with_patch, 0);
+
+    let patch_path = output.join("noop-instance.patch");
+    assert!(patch_path.exists(), "empty patch must still be written");
+    assert!(
+        std::fs::read_to_string(&patch_path).unwrap().is_empty(),
+        "diff should be empty"
+    );
+
+    // Predictions: empty agent still gets a row with `model_patch: ""`,
+    // so sb-cli reports it as unresolved rather than missing.
+    let preds_text = std::fs::read_to_string(output.join("all_preds.jsonl")).unwrap();
+    let lines: Vec<&str> = preds_text.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 1);
+    let v: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(v.get("model_patch").and_then(|v| v.as_str()), Some(""));
+
+    let traj: Trajectory = serde_json::from_str(
+        &std::fs::read_to_string(output.join("noop-instance.traj.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(traj.info.outcome.as_deref(), Some(outcome::SUBMITTED));
+}
+
+#[tokio::test]
+async fn missing_workdir_marks_outcome_as_error() {
+    // Patch capture must not crash the sweep when the working tree is
+    // unreachable (e.g. dataset typo, container teardown). The instance
+    // is downgraded to outcome=error and excluded from all_preds.jsonl.
+    let work = tempfile::tempdir().unwrap();
+    let dataset = work.path().join("dataset.jsonl");
+    let output = work.path().join("runs");
+    std::fs::create_dir_all(&output).unwrap();
+    write_dataset(&dataset, &["broken"], "deadbeef");
+
+    // Workdir points at a path that doesn't exist; `git diff` will fail.
+    let yaml = format!(
+        "environment:\n  workdir: {}\n",
+        work.path().join("does-not-exist").display()
+    );
+    let cfg = Config::from_yaml_str(&yaml).unwrap();
+    let results = run(SwebenchArgs {
+        dataset_path: dataset,
+        output_dir: output.clone(),
+        parallel: 1,
+        config: cfg,
+        resume: false,
+        deterministic_responses: Some(vec![
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
+        ]),
+    })
+    .await
+    .unwrap();
+
+    // Sweep finished cleanly even though one instance's patch capture
+    // failed.
+    assert_eq!(results.total, 1);
+    assert_eq!(results.errored, 1);
+    assert_eq!(results.submitted, 0);
+
+    // Trajectory records the patch_error in `info.other` and outcome=error.
+    let traj_path = output.join("broken.traj.json");
+    let traj: Trajectory =
+        serde_json::from_str(&std::fs::read_to_string(&traj_path).unwrap()).unwrap();
+    assert_eq!(traj.info.outcome.as_deref(), Some(outcome::ERROR));
+    assert!(
+        traj.info.other.contains_key("patch_error"),
+        "expected patch_error key in info.other: {:?}",
+        traj.info.other
+    );
+
+    // No `.patch` file written for the failed capture.
+    assert!(!output.join("broken.patch").exists());
+
+    // all_preds.jsonl exists but contains no lines (no submitted instances).
+    let preds = std::fs::read_to_string(output.join("all_preds.jsonl")).unwrap();
+    assert!(preds.is_empty(), "expected empty predictions, got: {preds}");
+}

--- a/tests/swebench_resume.rs
+++ b/tests/swebench_resume.rs
@@ -1,5 +1,5 @@
 //! Resume behavior for the `bench swebench` sweep:
-//!   * pre-existing valid trajectory → task is skipped (no agent runs)
+//!   * pre-existing valid trajectory + patch → task is skipped (no agent runs)
 //!   * pre-existing invalid trajectory → file is treated as absent and the
 //!     task re-runs, producing a fresh, valid trajectory
 //!   * without `--resume`, valid pre-existing files are *not* skipped
@@ -8,6 +8,7 @@
 
 use std::fmt::Write as _;
 use std::path::Path;
+use std::process::Command;
 
 use rust_swe_agent::Config;
 use rust_swe_agent::run::swebench::{SwebenchArgs, run};
@@ -51,19 +52,56 @@ fn submit_only_responses() -> Vec<String> {
     vec!["COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfresh-run\n```".into()]
 }
 
+/// Initialize a git working tree at `dir` with a single empty commit.
+/// Patch capture wires `git diff <base> -- .` against this directory, so
+/// every test that exercises a fresh sweep needs one — otherwise patch
+/// capture would fail and downgrade the run's outcome to `error`.
+fn init_repo(dir: &Path) {
+    fn git(dir: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    git(dir, &["init", "-q", "-b", "main"]);
+    git(dir, &["config", "user.email", "test@test"]);
+    git(dir, &["config", "user.name", "test"]);
+    git(dir, &["config", "commit.gpgSign", "false"]);
+    git(dir, &["config", "tag.gpgSign", "false"]);
+    git(dir, &["commit", "-q", "--allow-empty", "-m", "base"]);
+}
+
+fn config_with_workdir(dir: &Path) -> Config {
+    let yaml = format!("environment:\n  workdir: {}\n", dir.display());
+    Config::from_yaml_str(&yaml).unwrap()
+}
+
 #[tokio::test]
 async fn resume_skips_valid_trajectory_and_reruns_invalid() {
     let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
     let dataset = work.path().join("dataset.jsonl");
     let output = work.path().join("runs");
     std::fs::create_dir_all(&output).unwrap();
 
     write_dataset(&dataset, &["pre-valid", "pre-invalid", "fresh"]);
 
-    // Instance 1: pre-existing *valid* trajectory → must be skipped.
+    // Instance 1: pre-existing *valid* trajectory + patch → must be skipped.
     let valid_path = output.join("pre-valid.traj.json");
     write_valid_trajectory(&valid_path, "preserved");
     let valid_before = std::fs::read(&valid_path).unwrap();
+    let valid_patch_path = output.join("pre-valid.patch");
+    std::fs::write(&valid_patch_path, "preserved-diff\n").unwrap();
+    let valid_patch_before = std::fs::read(&valid_patch_path).unwrap();
 
     // Instance 2: pre-existing *invalid* trajectory → treated as absent.
     let invalid_path = output.join("pre-invalid.traj.json");
@@ -71,7 +109,7 @@ async fn resume_skips_valid_trajectory_and_reruns_invalid() {
 
     // Instance 3: no pre-existing file → fresh run.
 
-    let cfg = Config::defaults().unwrap();
+    let cfg = config_with_workdir(&repo);
     let results = run(SwebenchArgs {
         dataset_path: dataset,
         output_dir: output.clone(),
@@ -86,11 +124,17 @@ async fn resume_skips_valid_trajectory_and_reruns_invalid() {
     assert_eq!(results.total, 3);
     assert_eq!(results.skipped, 1, "exactly one task should be skipped");
 
-    // Skipped instance: trajectory file is byte-identical to what we wrote.
+    // Skipped instance: trajectory + patch files are byte-identical to what
+    // we wrote.
     let valid_after = std::fs::read(&valid_path).unwrap();
     assert_eq!(
         valid_before, valid_after,
         "skipped trajectory should be untouched"
+    );
+    let valid_patch_after = std::fs::read(&valid_patch_path).unwrap();
+    assert_eq!(
+        valid_patch_before, valid_patch_after,
+        "skipped patch should be untouched"
     );
 
     // Invalid pre-existing trajectory was overwritten with a fresh, parseable one.
@@ -105,6 +149,11 @@ async fn resume_skips_valid_trajectory_and_reruns_invalid() {
         serde_json::from_str(&std::fs::read_to_string(&fresh_path).unwrap()).unwrap();
     assert_eq!(fresh.info.outcome.as_deref(), Some(outcome::SUBMITTED));
 
+    // Both freshly-run instances got a `.patch` file (empty, since the agent
+    // submitted without modifying anything in `repo`).
+    assert!(output.join("pre-invalid.patch").exists());
+    assert!(output.join("fresh.patch").exists());
+
     // Summary table mentions the skipped count.
     let table = results.summary_table();
     assert!(
@@ -114,8 +163,54 @@ async fn resume_skips_valid_trajectory_and_reruns_invalid() {
 }
 
 #[tokio::test]
+async fn resume_reruns_submitted_trajectory_with_missing_patch() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+    let dataset = work.path().join("dataset.jsonl");
+    let output = work.path().join("runs");
+    std::fs::create_dir_all(&output).unwrap();
+
+    write_dataset(&dataset, &["needs-patch"]);
+
+    // Submitted trajectory but the patch file is missing — common shape
+    // for sweeps run before #9 landed. Resume must re-run rather than
+    // emit `all_preds.jsonl` with an absent diff.
+    let traj = output.join("needs-patch.traj.json");
+    write_valid_trajectory(&traj, "stale-without-patch");
+
+    let cfg = config_with_workdir(&repo);
+    let results = run(SwebenchArgs {
+        dataset_path: dataset,
+        output_dir: output.clone(),
+        parallel: 1,
+        config: cfg,
+        resume: true,
+        deterministic_responses: Some(submit_only_responses()),
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(results.skipped, 0, "missing patch must trigger a re-run");
+
+    // After the re-run both files exist.
+    assert!(output.join("needs-patch.patch").exists());
+    let reread: Trajectory =
+        serde_json::from_str(&std::fs::read_to_string(&traj).unwrap()).unwrap();
+    assert_eq!(reread.info.outcome.as_deref(), Some(outcome::SUBMITTED));
+    assert!(
+        !reread.info.other.contains_key("test_marker"),
+        "stale trajectory was not overwritten"
+    );
+}
+
+#[tokio::test]
 async fn without_resume_existing_trajectories_are_overwritten() {
     let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
     let dataset = work.path().join("dataset.jsonl");
     let output = work.path().join("runs");
     std::fs::create_dir_all(&output).unwrap();
@@ -125,7 +220,7 @@ async fn without_resume_existing_trajectories_are_overwritten() {
     let traj_path = output.join("only.traj.json");
     write_valid_trajectory(&traj_path, "stale");
 
-    let cfg = Config::defaults().unwrap();
+    let cfg = config_with_workdir(&repo);
     let results = run(SwebenchArgs {
         dataset_path: dataset,
         output_dir: output.clone(),
@@ -138,7 +233,10 @@ async fn without_resume_existing_trajectories_are_overwritten() {
     .unwrap();
 
     assert_eq!(results.total, 1);
-    assert_eq!(results.skipped, 0, "no tasks may be skipped without --resume");
+    assert_eq!(
+        results.skipped, 0,
+        "no tasks may be skipped without --resume"
+    );
 
     // The stale marker we wrote should have been overwritten by a fresh run.
     let reread: Trajectory =


### PR DESCRIPTION
## Summary

This PR adds comprehensive patch artifact capture and SWE-bench predictions file generation to the sweep runner. When agents submit solutions, the runner now captures a unified diff of the working tree against the base commit and writes it to per-instance `.patch` files. An aggregated `all_preds.jsonl` file is generated containing the predictions schema that `sb-cli` expects.

## Key Changes

- **Patch Capture**: Added `PatchCaptureSpec` to `mini.rs` that specifies how to snapshot the working tree as a unified diff after agent submission. The `capture_patch()` function runs `git diff` with appropriate flags (`--no-color`, `--binary`, `--unified=3`) to match SWE-bench evaluator expectations.

- **Patch Artifact Files**: Per-instance `.patch` files are written to the output directory for all submitted instances, including empty diffs when agents make no changes. This allows downstream tooling to distinguish "agent ran but changed nothing" from "agent never reached this instance."

- **Predictions File**: Added `write_predictions_file()` that generates `all_preds.jsonl` with one JSONL line per submitted instance containing `instance_id`, `model_patch`, and `model_name_or_path` — the minimum schema `sb-cli` accepts.

- **Resume Mode Enhancement**: Resume logic now checks for both trajectory file *and* patch file presence. If a submitted trajectory exists but its patch is missing (common in pre-patch sweeps), the instance is re-run to capture the missing artifact.

- **Result Tracking**: Extended `InstanceResult` with `patch_present` and `non_empty_patch` flags, and `SweepResults` with a `with_patch` counter tracking submitted instances with non-empty diffs.

- **Error Handling**: Patch capture failures gracefully downgrade the run's outcome to `error` rather than crashing the sweep, with the error reason stored in trajectory metadata.

- **Shell Escaping**: Added `shell_quote()` utility to safely escape hostile dataset values in git commands, preventing injection attacks.

## Notable Implementation Details

- Patch capture happens *before* trajectory save so failures can be reflected as `outcome: "error"` rather than leaving stale `submitted` records.
- Empty diffs are still persisted as zero-byte files so `sb-cli` reports them as unresolved rather than missing.
- Non-submitted and patch-capture-failed instances are excluded from `all_preds.jsonl` by design.
- Comprehensive test coverage in new `tests/swebench_patch.rs` validates patch generation, empty diffs, and error handling.
- Resume tests updated to verify patch file handling and re-run behavior when patches are missing.

https://claude.ai/code/session_015R9f5727TD4MuiFRu7bZab