### PR TITLE
Add FailureCategory to trajectories and SWE-bench summary reporting

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -20,7 +20,7 @@ use crate::error::Error;
 use crate::model::{CacheHint, Message, MessageExtra, Model, QueryOpts, Role};
 use crate::stream::{NullSink, StreamEvent, StreamSink};
 use crate::template::Renderer;
-use crate::trajectory::{TokenUsage, Trajectory, outcome};
+use crate::trajectory::{FailureCategory, TokenUsage, Trajectory, outcome};
 
 pub struct DefaultAgent {
     pub config: Config,
@@ -144,9 +144,10 @@ impl Agent for DefaultAgent {
         // 1. Limit checks.
         if self.steps >= self.config.root.agent.step_limit {
             self.trajectory.info.exit_reason = Some("step_limit".into());
+            self.trajectory.info.failure_category = Some(FailureCategory::StepLimit);
             self.trajectory.info.steps = Some(self.steps);
             self.finalize_run_metadata(outcome::STEP_LIMIT_REACHED);
-            self.emit_run_ended("step_limit", None);
+            self.emit_run_ended("step_limit", Some(FailureCategory::StepLimit), None);
             return Ok(StepOutcome::Terminate(ExitReason::StepLimit {
                 limit: self.config.root.agent.step_limit,
             }));
@@ -154,12 +155,13 @@ impl Agent for DefaultAgent {
         if let Some(limit) = self.config.root.agent.cost_limit_usd {
             if self.total_cost_usd >= limit {
                 self.trajectory.info.exit_reason = Some("cost_limit".into());
+                self.trajectory.info.failure_category = Some(FailureCategory::CostLimit);
                 self.trajectory.info.steps = Some(self.steps);
                 self.trajectory.info.total_cost_usd = Some(self.total_cost_usd);
                 // Cost limit is also a resource limit; map to the same
                 // coarse outcome as step limit per the three-value spec.
                 self.finalize_run_metadata(outcome::STEP_LIMIT_REACHED);
-                self.emit_run_ended("cost_limit", None);
+                self.emit_run_ended("cost_limit", Some(FailureCategory::CostLimit), None);
                 return Ok(StepOutcome::Terminate(ExitReason::CostLimit {
                     limit_usd: limit,
                     spent_usd: self.total_cost_usd,
@@ -209,12 +211,13 @@ impl Agent for DefaultAgent {
                 self.history.push(Message::assistant(resp.content.clone()));
                 self.trajectory.record_message(&asst);
                 self.trajectory.info.exit_reason = Some("submitted".into());
+                self.trajectory.info.failure_category = None;
                 self.trajectory.info.final_output = Some(output.clone());
                 self.trajectory.info.steps = Some(self.steps);
                 self.trajectory.info.total_cost_usd = Some(self.total_cost_usd);
                 self.trajectory.info.ended_at = Some(chrono::Utc::now().to_rfc3339());
                 self.finalize_run_metadata(outcome::SUBMITTED);
-                self.emit_run_ended("submitted", Some(output.clone()));
+                self.emit_run_ended("submitted", None, Some(output.clone()));
                 return Ok(StepOutcome::Terminate(ExitReason::Submitted {
                     final_output: output.clone(),
                 }));
@@ -223,6 +226,14 @@ impl Agent for DefaultAgent {
                 asst.extra.actions = Some(vec![cmd.clone()]);
             }
             Action::None => {
+                // Keep a breadcrumb that at least one model response could
+                // not be parsed into a valid action. Terminal limit checks
+                // above still take precedence if the run eventually ends on
+                // step/cost exhaustion.
+                self.trajectory
+                    .info
+                    .failure_category
+                    .get_or_insert(FailureCategory::ModelParse);
                 self.history.push(Message::assistant(resp.content.clone()));
                 self.trajectory.record_message(&asst);
                 // Observation = format_error_template, verbatim (no vars in
@@ -307,9 +318,15 @@ impl Agent for DefaultAgent {
 }
 
 impl DefaultAgent {
-    fn emit_run_ended(&self, exit_reason: &str, final_output: Option<String>) {
+    fn emit_run_ended(
+        &self,
+        exit_reason: &str,
+        failure_category: Option<FailureCategory>,
+        final_output: Option<String>,
+    ) {
         self.stream.emit(StreamEvent::RunEnded {
             exit_reason: exit_reason.to_owned(),
+            failure_category,
             final_output,
             steps: self.steps,
             total_cost_usd: self.total_cost_usd,
@@ -327,8 +344,7 @@ impl DefaultAgent {
             prompt_tokens: self.prompt_tokens,
             completion_tokens: self.completion_tokens,
         });
-        self.trajectory.info.duration_secs =
-            Some(self.started_at_instant.elapsed().as_secs_f64());
+        self.trajectory.info.duration_secs = Some(self.started_at_instant.elapsed().as_secs_f64());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,4 +25,6 @@ pub use model::{
     ModelResponse, ModelUsage, QueryOpts, Role,
 };
 pub use stream::{BroadcastSink, NullSink, SseServer, StreamEvent, StreamSink};
-pub use trajectory::{FORMAT_VERSION, MessageRecord, TokenUsage, Trajectory, TrajectoryInfo};
+pub use trajectory::{
+    FORMAT_VERSION, FailureCategory, MessageRecord, TokenUsage, Trajectory, TrajectoryInfo,
+};

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -16,6 +16,7 @@ use crate::error::Error;
 use crate::model::litellm::LitellmBackend;
 use crate::model::{DeterministicModel, Model, ModelUsage};
 use crate::stream::{BroadcastSink, SseServer, StreamSink};
+use crate::trajectory::FailureCategory;
 
 /// How a runner should snapshot the agent's working tree as a unified diff
 /// after submission. Optional on `MiniArgs` because patch capture only
@@ -107,6 +108,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
             .info
             .exit_reason
             .get_or_insert_with(|| "error".into());
+        agent.trajectory.info.failure_category = Some(classify_error(e));
         agent
             .trajectory
             .info
@@ -141,6 +143,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
                     "patch capture failed; downgrading outcome to error"
                 );
                 agent.trajectory.info.exit_reason = Some("error".into());
+                agent.trajectory.info.failure_category = Some(FailureCategory::EnvSetup);
                 agent
                     .trajectory
                     .info
@@ -168,6 +171,15 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         server.shutdown().await;
     }
     Ok(())
+}
+
+fn classify_error(err: &Error) -> FailureCategory {
+    match err {
+        Error::Env(_) => FailureCategory::EnvSetup,
+        Error::Model(crate::error::ModelError::Malformed(_)) => FailureCategory::ModelParse,
+        Error::Model(_) => FailureCategory::ModelApi,
+        _ => FailureCategory::AgentInternal,
+    }
 }
 
 /// Snapshot the working tree at `spec.workdir` as a unified diff against

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -10,6 +10,7 @@
 //! cumulative cost — which would silently overshoot the cap by one
 //! task's worth of API spend per worker.
 
+use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use std::path::PathBuf;
 
@@ -18,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use crate::config::Config;
 use crate::error::Error;
 use crate::model::ModelUsage;
-use crate::trajectory::{Trajectory, outcome};
+use crate::trajectory::{FailureCategory, Trajectory, outcome};
 
 /// Sentinel `exit_reason` for tasks that never started because the
 /// sweep-level USD budget was exhausted. Distinct from `error` and
@@ -65,6 +66,8 @@ pub struct InstanceResult {
     /// Coarse outcome from the trajectory: `submitted` | `step_limit_reached`
     /// | `error`. `None` when the trajectory file could not be read.
     pub outcome: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_category: Option<FailureCategory>,
     pub steps: Option<u32>,
     pub cost_usd: Option<f64>,
     pub prompt_tokens: Option<u64>,
@@ -91,6 +94,8 @@ pub struct SweepResults {
     pub submitted: usize,
     pub skipped: usize,
     pub errored: usize,
+    #[serde(default)]
+    pub failures_by_category: BTreeMap<FailureCategory, usize>,
     /// Tasks that never started because the sweep-level USD budget was
     /// exhausted before they could acquire a worker permit. Counted in
     /// `total` but excluded from `submitted` and `errored`.
@@ -160,6 +165,26 @@ impl SweepResults {
                     self.estimated_cost_usd, limit, self.budget_halted
                 );
             }
+        }
+        let mut nonzero: Vec<(FailureCategory, usize)> = self
+            .failures_by_category
+            .iter()
+            .filter_map(|(k, v)| (*v > 0).then_some((*k, *v)))
+            .collect();
+        nonzero.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        if !nonzero.is_empty() {
+            s.push_str("Failures by category:\n");
+            for (k, v) in nonzero {
+                let _ = writeln!(s, "  - {}: {}", failure_category_label(k), v);
+            }
+        }
+        let unclassified_legacy = self
+            .instances
+            .iter()
+            .filter(|r| is_failed_instance(r) && r.failure_category.is_none())
+            .count();
+        if unclassified_legacy > 0 {
+            let _ = writeln!(s, "  - unclassified (legacy): {unclassified_legacy}");
         }
         s
     }
@@ -329,9 +354,7 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
         let cfg = args.config.clone();
         let deterministic = args.deterministic_responses.clone();
         let det_usage = args.deterministic_usage_per_call.clone();
-        set.spawn(async move {
-            run_one(inst, output_dir, cfg, deterministic, det_usage).await
-        });
+        set.spawn(async move { run_one(inst, output_dir, cfg, deterministic, det_usage).await });
     };
 
     if halted {
@@ -395,6 +418,7 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
                     instance_id: "<join_error>".into(),
                     exit_reason: "error".into(),
                     outcome: Some(outcome::ERROR.into()),
+                    failure_category: Some(FailureCategory::AgentInternal),
                     steps: None,
                     cost_usd: None,
                     prompt_tokens: None,
@@ -428,6 +452,12 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
             with_patch += 1;
         }
     }
+    let mut failures_by_category: BTreeMap<FailureCategory, usize> = BTreeMap::new();
+    for r in &results {
+        if let Some(cat) = r.failure_category {
+            *failures_by_category.entry(cat).or_insert(0) += 1;
+        }
+    }
 
     write_predictions_file(&args.output_dir, &results, &args.config.root.model.name)?;
 
@@ -436,6 +466,7 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
         submitted,
         skipped,
         errored,
+        failures_by_category,
         budget_halted,
         with_patch,
         total_prompt_tokens: total_prompt,
@@ -458,6 +489,7 @@ fn budget_halt_result(instance_id: &str) -> InstanceResult {
         instance_id: instance_id.to_owned(),
         exit_reason: EXIT_REASON_BUDGET_HALT.into(),
         outcome: None,
+        failure_category: None,
         steps: None,
         cost_usd: None,
         prompt_tokens: None,
@@ -525,6 +557,7 @@ fn skipped_result_from_info(
         instance_id: instance_id.to_owned(),
         exit_reason: "skipped_resume".into(),
         outcome: info.outcome.clone(),
+        failure_category: info.failure_category,
         steps: info.steps,
         cost_usd: info.total_cost_usd,
         prompt_tokens,
@@ -601,10 +634,26 @@ async fn run_one(
         Err(_) => (false, false),
     };
 
+    let failure_category = if outcome_str == outcome::SUBMITTED {
+        None
+    } else {
+        info.as_ref()
+            .and_then(|i| i.failure_category)
+            .or_else(|| match exit_reason.as_str() {
+                "step_limit" => Some(FailureCategory::StepLimit),
+                "cost_limit" => Some(FailureCategory::CostLimit),
+                _ => run_err
+                    .as_ref()
+                    .map(classify_error)
+                    .or(Some(FailureCategory::Unknown)),
+            })
+    };
+
     InstanceResult {
         instance_id: id,
         exit_reason,
         outcome: Some(outcome_str),
+        failure_category,
         steps: info.as_ref().and_then(|i| i.steps),
         cost_usd: info.as_ref().and_then(|i| i.total_cost_usd),
         prompt_tokens,
@@ -613,6 +662,38 @@ async fn run_one(
         error: run_err.map(|e| e.to_string()),
         patch_present,
         non_empty_patch,
+    }
+}
+
+fn classify_error(err: &Error) -> FailureCategory {
+    match err {
+        // Docker build/start/exec or local command execution plumbing.
+        Error::Env(_) => FailureCategory::EnvSetup,
+        // Model transport/auth/rate-limit/5xx style failures.
+        Error::Model(crate::error::ModelError::Malformed(_)) => FailureCategory::ModelParse,
+        Error::Model(_) => FailureCategory::ModelApi,
+        // Any remaining typed error in the runner/agent.
+        _ => FailureCategory::AgentInternal,
+    }
+}
+
+fn is_failed_instance(r: &InstanceResult) -> bool {
+    r.outcome.as_deref() == Some(outcome::ERROR)
+        || matches!(
+            r.failure_category,
+            Some(FailureCategory::StepLimit | FailureCategory::CostLimit)
+        )
+}
+
+fn failure_category_label(cat: FailureCategory) -> &'static str {
+    match cat {
+        FailureCategory::EnvSetup => "env_setup",
+        FailureCategory::ModelApi => "model_api",
+        FailureCategory::ModelParse => "model_parse",
+        FailureCategory::StepLimit => "step_limit",
+        FailureCategory::CostLimit => "cost_limit",
+        FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::Unknown => "unknown",
     }
 }
 
@@ -643,6 +724,7 @@ mod tests {
             submitted: 4,
             skipped: 3,
             errored: 1,
+            failures_by_category: BTreeMap::new(),
             budget_halted: 0,
             with_patch: 3,
             total_prompt_tokens: 250_000,
@@ -663,9 +745,7 @@ mod tests {
             "missing skipped row in: {t}"
         );
         assert!(
-            t.contains(
-                "Budget-halted:      0 — never started; sweep-level USD limit reached"
-            ),
+            t.contains("Budget-halted:      0 — never started; sweep-level USD limit reached"),
             "missing budget_halted row in: {t}"
         );
         assert!(t.contains("Submit rate:        40.00%"));
@@ -686,6 +766,7 @@ mod tests {
             submitted: 3,
             skipped: 0,
             errored: 0,
+            failures_by_category: BTreeMap::new(),
             budget_halted: 2,
             with_patch: 0,
             total_prompt_tokens: 0,

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -71,6 +71,8 @@ pub enum StreamEvent {
     /// Agent loop ended.
     RunEnded {
         exit_reason: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        failure_category: Option<crate::trajectory::FailureCategory>,
         final_output: Option<String>,
         steps: u32,
         total_cost_usd: f64,

--- a/src/stream/sse.rs
+++ b/src/stream/sse.rs
@@ -161,7 +161,9 @@ async fn handle_connection(
             }
             Err(broadcast::error::RecvError::Closed) => {
                 // Sink dropped (agent run completed and CLI is exiting).
-                let _ = stream.write_all(b"event: stream_closed\ndata: {}\n\n").await;
+                let _ = stream
+                    .write_all(b"event: stream_closed\ndata: {}\n\n")
+                    .await;
                 let _ = stream.shutdown().await;
                 return;
             }
@@ -291,10 +293,7 @@ mod tests {
             .unwrap()
             .unwrap();
         let s = String::from_utf8_lossy(&buf[..n]).to_string();
-        assert!(
-            s.contains("HTTP/1.1 200 OK"),
-            "missing status, got: {s:?}"
-        );
+        assert!(s.contains("HTTP/1.1 200 OK"), "missing status, got: {s:?}");
         assert!(
             s.contains("text/event-stream"),
             "missing content-type, got: {s:?}"

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -21,6 +21,19 @@ pub mod outcome {
     pub const ERROR: &str = "error";
 }
 
+/// Closed set of non-success terminal failure modes for sweeps.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureCategory {
+    EnvSetup,
+    ModelApi,
+    ModelParse,
+    StepLimit,
+    CostLimit,
+    AgentInternal,
+    Unknown,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TokenUsage {
     pub prompt_tokens: u64,
@@ -35,6 +48,8 @@ pub struct TrajectoryInfo {
     pub model_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exit_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_category: Option<FailureCategory>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub outcome: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/tests/streaming.rs
+++ b/tests/streaming.rs
@@ -60,7 +60,10 @@ async fn broadcast_sink_receives_step_outcomes() {
         events.push(e);
     }
 
-    assert!(matches!(events.first(), Some(StreamEvent::RunStarted { .. })));
+    assert!(matches!(
+        events.first(),
+        Some(StreamEvent::RunStarted { .. })
+    ));
 
     let saw_bash_start = events
         .iter()
@@ -83,7 +86,11 @@ async fn broadcast_sink_receives_step_outcomes() {
 
     let last = events.last().unwrap();
     match last {
-        StreamEvent::RunEnded { exit_reason, final_output, .. } => {
+        StreamEvent::RunEnded {
+            exit_reason,
+            final_output,
+            ..
+        } => {
             assert_eq!(exit_reason, "submitted");
             assert_eq!(final_output.as_deref(), Some("final"));
         }

--- a/tests/swebench_budget.rs
+++ b/tests/swebench_budget.rs
@@ -175,11 +175,7 @@ async fn sweep_halts_when_cumulative_cost_reaches_limit() {
 
     // (d) Total recorded cost is ≥ limit but bounded by
     //     limit + (parallel - 1) * per_task_cost.
-    let recorded_cost: f64 = results
-        .instances
-        .iter()
-        .filter_map(|r| r.cost_usd)
-        .sum();
+    let recorded_cost: f64 = results.instances.iter().filter_map(|r| r.cost_usd).sum();
     let bound_overshoot = (parallel as f64 - 1.0) * per_task_cost;
     assert!(
         recorded_cost >= limit,
@@ -220,9 +216,7 @@ async fn sweep_halts_when_cumulative_cost_reaches_limit() {
     for r in &results.instances {
         if r.exit_reason == EXIT_REASON_BUDGET_HALT {
             assert!(
-                !output
-                    .join(format!("{}.traj.json", r.instance_id))
-                    .exists(),
+                !output.join(format!("{}.traj.json", r.instance_id)).exists(),
                 "budget_halt task must not write a trajectory"
             );
             assert!(

--- a/tests/swebench_failure_categories.rs
+++ b/tests/swebench_failure_categories.rs
@@ -1,0 +1,149 @@
+#![allow(clippy::unwrap_used)]
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+use rust_swe_agent::Config;
+use rust_swe_agent::run::swebench::{SwebenchArgs, run};
+use rust_swe_agent::trajectory::{
+    FORMAT_VERSION, FailureCategory, Trajectory, TrajectoryInfo, outcome,
+};
+
+fn write_dataset(path: &Path, instance_ids: &[&str]) {
+    let mut s = String::new();
+    for id in instance_ids {
+        let _ = writeln!(
+            s,
+            "{{\"instance_id\":\"{id}\",\"problem_statement\":\"noop\"}}"
+        );
+    }
+    std::fs::write(path, s).unwrap();
+}
+
+fn write_traj(output: &Path, id: &str, info: TrajectoryInfo) {
+    let traj = Trajectory {
+        trajectory_format: FORMAT_VERSION.into(),
+        info,
+        messages: vec![],
+    };
+    std::fs::write(
+        output.join(format!("{id}.traj.json")),
+        serde_json::to_string_pretty(&traj).unwrap(),
+    )
+    .unwrap();
+}
+
+#[tokio::test]
+async fn sweep_counts_failure_categories_and_preserves_legacy_unclassified() {
+    let work = tempfile::tempdir().unwrap();
+    let dataset = work.path().join("dataset.jsonl");
+    let output = work.path().join("runs");
+    std::fs::create_dir_all(&output).unwrap();
+
+    let ids = [
+        "ok", "env", "api", "parse", "step", "cost", "internal", "unknown", "legacy",
+    ];
+    write_dataset(&dataset, &ids);
+
+    write_traj(
+        &output,
+        "ok",
+        TrajectoryInfo {
+            outcome: Some(outcome::SUBMITTED.into()),
+            exit_reason: Some("submitted".into()),
+            ..Default::default()
+        },
+    );
+    std::fs::write(output.join("ok.patch"), b"").unwrap();
+
+    for (id, cat) in [
+        ("env", FailureCategory::EnvSetup),
+        ("api", FailureCategory::ModelApi),
+        ("parse", FailureCategory::ModelParse),
+        ("step", FailureCategory::StepLimit),
+        ("cost", FailureCategory::CostLimit),
+        ("internal", FailureCategory::AgentInternal),
+        ("unknown", FailureCategory::Unknown),
+    ] {
+        write_traj(
+            &output,
+            id,
+            TrajectoryInfo {
+                outcome: Some(outcome::ERROR.into()),
+                exit_reason: Some("error".into()),
+                failure_category: Some(cat),
+                ..Default::default()
+            },
+        );
+    }
+
+    // Simulate a legacy trajectory from before `failure_category` existed.
+    write_traj(
+        &output,
+        "legacy",
+        TrajectoryInfo {
+            outcome: Some(outcome::ERROR.into()),
+            exit_reason: Some("error".into()),
+            failure_category: None,
+            ..Default::default()
+        },
+    );
+
+    let cfg = Config::defaults().unwrap();
+    let results = run(SwebenchArgs {
+        dataset_path: dataset,
+        output_dir: output,
+        parallel: 2,
+        config: cfg,
+        resume: true,
+        cost_limit_usd: None,
+        deterministic_responses: None,
+        deterministic_usage_per_call: None,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(results.total, ids.len());
+    assert_eq!(results.skipped, ids.len());
+
+    for cat in [
+        FailureCategory::EnvSetup,
+        FailureCategory::ModelApi,
+        FailureCategory::ModelParse,
+        FailureCategory::StepLimit,
+        FailureCategory::CostLimit,
+        FailureCategory::AgentInternal,
+        FailureCategory::Unknown,
+    ] {
+        assert_eq!(results.failures_by_category.get(&cat), Some(&1));
+    }
+
+    for r in &results.instances {
+        match r.instance_id.as_str() {
+            "ok" => assert!(r.failure_category.is_none()),
+            "legacy" => assert!(r.failure_category.is_none()),
+            "env" => assert_eq!(r.failure_category, Some(FailureCategory::EnvSetup)),
+            "api" => assert_eq!(r.failure_category, Some(FailureCategory::ModelApi)),
+            "parse" => assert_eq!(r.failure_category, Some(FailureCategory::ModelParse)),
+            "step" => assert_eq!(r.failure_category, Some(FailureCategory::StepLimit)),
+            "cost" => assert_eq!(r.failure_category, Some(FailureCategory::CostLimit)),
+            "internal" => assert_eq!(r.failure_category, Some(FailureCategory::AgentInternal)),
+            "unknown" => assert_eq!(r.failure_category, Some(FailureCategory::Unknown)),
+            other => panic!("unexpected id: {other}"),
+        }
+    }
+
+    let table = results.summary_table();
+    assert!(table.contains("Failures by category:"), "got: {table}");
+    assert!(table.contains("  - env_setup: 1"), "got: {table}");
+    assert!(table.contains("  - model_api: 1"), "got: {table}");
+    assert!(table.contains("  - model_parse: 1"), "got: {table}");
+    assert!(table.contains("  - step_limit: 1"), "got: {table}");
+    assert!(table.contains("  - cost_limit: 1"), "got: {table}");
+    assert!(table.contains("  - agent_internal: 1"), "got: {table}");
+    assert!(table.contains("  - unknown: 1"), "got: {table}");
+    assert!(
+        table.contains("  - unclassified (legacy): 1"),
+        "got: {table}"
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide a structured, stable classification for non-success terminal failures so sweeps can aggregate and surface failure types rather than rely on free-form `exit_reason` strings.
- Preserve backwards compatibility with existing trajectories while enabling tooling and summaries to report counts per failure class and to distinguish legacy unclassified errors.

### Description
- Add `FailureCategory` enum to `trajectory` and thread `failure_category: Option<FailureCategory>` into `TrajectoryInfo`, `InstanceResult`, and the SSE `RunEnded` payload.
- Classify errors from runner/agent paths (env/setup, model API, model parse, step/cost limits, agent-internal, unknown) via `classify_error` helpers in `run/mini.rs` and `run/swebench.rs`, and set categories at patch-capture, run error, and limit paths; mark parse-malformed responses with `ModelParse` as a breadcrumb.
- Extend `SweepResults` with `failures_by_category` and aggregate per-instance categories into this map; add sorted "Failures by category:" lines and an explicit `unclassified (legacy)` line to the summary output without rebucketing pre-existing trajectories.
- Update API surface export in `lib.rs`, adjust `DefaultAgent::emit_run_ended` signature to include optional `failure_category`, and add an integration test `tests/swebench_failure_categories.rs` asserting per-instance categories and summary text.

### Testing
- Ran `cargo fmt` to apply formatting changes and ensure style consistency (succeeded).
- Ran `cargo test -q`, which executed the unit and integration suite including the new `tests/swebench_failure_categories.rs`, and all tests passed (`ok. 63 passed; 0 failed` plus the additional integration tests all passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed4358404832ab10bbe63e843da27)