### PR TITLE
Add `bench compare` subcommand for diffing sweep runs

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -86,6 +86,36 @@ pub struct ReplayCmd {
 pub enum BenchCmd {
     /// Run a SWE-bench sweep over a local JSONL dataset.
     Swebench(SwebenchCmd),
+    /// Diff two completed sweep runs by instance id; surfaces regressions
+    /// and (with `--max-regressions`) gates CI on prompt/harness changes.
+    Compare(CompareCmd),
+}
+
+#[derive(Debug, Args)]
+pub struct CompareCmd {
+    /// Sweep output directory written by a prior `bench swebench` run
+    /// (must contain `results.json` or per-instance `*.traj.json` files).
+    /// Treated as the "before" side of the diff.
+    #[arg(long)]
+    pub baseline: PathBuf,
+
+    /// Sweep output directory to compare against the baseline. Treated as
+    /// the "after" side; regressions are tasks that passed in baseline
+    /// but failed here.
+    #[arg(long)]
+    pub candidate: PathBuf,
+
+    /// Output format: `text` (default, terminal-friendly) or `json`
+    /// (machine-readable diff document).
+    #[arg(long, default_value = "text")]
+    pub format: String,
+
+    /// Exit non-zero when regressed-task count strictly exceeds N. Unset
+    /// (default) is informational only — the report prints regardless,
+    /// but the process always exits 0. Set to 0 for a strict gate that
+    /// fails on any regression.
+    #[arg(long)]
+    pub max_regressions: Option<usize>,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -50,6 +50,9 @@ pub async fn run() -> Result<(), Error> {
         Command::Bench {
             cmd: args::BenchCmd::Swebench(s),
         } => bench_swebench(s).await,
+        Command::Bench {
+            cmd: args::BenchCmd::Compare(c),
+        } => bench_compare(c),
         #[cfg(feature = "docker")]
         Command::Cleanup => cleanup_cmd().await,
         #[cfg(not(feature = "docker"))]
@@ -175,6 +178,41 @@ async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
         "sweep complete"
     );
     print!("{}", results.summary_table());
+    Ok(())
+}
+
+fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
+    let format = match c.format.as_str() {
+        "text" => crate::run::compare::CompareFormat::Text,
+        "json" => crate::run::compare::CompareFormat::Json,
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "unknown --format `{other}` (expected `text` or `json`)"
+            ))));
+        }
+    };
+    let report = crate::run::compare::compute(&crate::run::compare::CompareArgs {
+        baseline: c.baseline,
+        candidate: c.candidate,
+        format,
+        max_regressions: c.max_regressions,
+    })?;
+    match format {
+        crate::run::compare::CompareFormat::Text => print!("{}", report.human_table()),
+        crate::run::compare::CompareFormat::Json => {
+            println!("{}", report.to_json_pretty()?);
+        }
+    }
+    if let Some(max) = c.max_regressions {
+        if report.regression_count() > max {
+            tracing::error!(
+                regressions = report.regression_count(),
+                max = max,
+                "compare: regression count exceeds --max-regressions threshold"
+            );
+            std::process::exit(1);
+        }
+    }
     Ok(())
 }
 

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -39,9 +39,7 @@ pub struct CompareArgs {
 /// Per-task transition between baseline and candidate. `pass` is defined
 /// as `outcome == "submitted"` AND `failure_category` is `None`, which
 /// matches what `run::swebench::run_one` writes for a clean submission.
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TransitionKind {
     PassPass,
@@ -203,9 +201,7 @@ impl CompareReport {
         } else {
             let _ = writeln!(s, "\nRegressions ({}):", self.regressions.len());
             for r in &self.regressions {
-                let cat = r
-                    .candidate_failure_category
-                    .map_or("none", failure_label);
+                let cat = r.candidate_failure_category.map_or("none", failure_label);
                 let exit = r.candidate_exit_reason.as_deref().unwrap_or("?");
                 let old = r.baseline_outcome.as_deref().unwrap_or("?");
                 let new = r.candidate_outcome.as_deref().unwrap_or("?");
@@ -358,20 +354,10 @@ pub fn diff<S: std::hash::BuildHasher>(
         .keys()
         .chain(failure_category_candidate.keys())
     {
-        let b = i64::try_from(
-            failure_category_baseline
-                .get(cat)
-                .copied()
-                .unwrap_or(0),
-        )
-        .unwrap_or(i64::MAX);
-        let c = i64::try_from(
-            failure_category_candidate
-                .get(cat)
-                .copied()
-                .unwrap_or(0),
-        )
-        .unwrap_or(i64::MAX);
+        let b = i64::try_from(failure_category_baseline.get(cat).copied().unwrap_or(0))
+            .unwrap_or(i64::MAX);
+        let c = i64::try_from(failure_category_candidate.get(cat).copied().unwrap_or(0))
+            .unwrap_or(i64::MAX);
         failure_category_delta.insert(*cat, c - b);
     }
 
@@ -415,9 +401,7 @@ fn is_pass(r: &InstanceResult) -> bool {
     r.outcome.as_deref() == Some(outcome::SUBMITTED) && r.failure_category.is_none()
 }
 
-fn mean_steps<S: std::hash::BuildHasher>(
-    map: &HashMap<String, InstanceResult, S>,
-) -> Option<f64> {
+fn mean_steps<S: std::hash::BuildHasher>(map: &HashMap<String, InstanceResult, S>) -> Option<f64> {
     let xs: Vec<u32> = map.values().filter_map(|r| r.steps).collect();
     if xs.is_empty() {
         return None;
@@ -532,12 +516,7 @@ mod tests {
             errored("ff", FailureCategory::AgentInternal),
             submitted("mp"),
         ]);
-        let r = diff(
-            Path::new("/b"),
-            Path::new("/c"),
-            &baseline,
-            &candidate,
-        );
+        let r = diff(Path::new("/b"), Path::new("/c"), &baseline, &candidate);
         assert_eq!(r.transitions[&TransitionKind::PassPass], 1);
         assert_eq!(r.transitions[&TransitionKind::PassFail], 1);
         assert_eq!(r.transitions[&TransitionKind::FailPass], 1);
@@ -548,7 +527,11 @@ mod tests {
 
     #[test]
     fn regressions_list_only_pass_fail() {
-        let baseline = map_of([submitted("a"), submitted("b"), errored("c", FailureCategory::ModelApi)]);
+        let baseline = map_of([
+            submitted("a"),
+            submitted("b"),
+            errored("c", FailureCategory::ModelApi),
+        ]);
         let candidate = map_of([
             submitted("a"),
             errored("b", FailureCategory::StepLimit),
@@ -569,7 +552,11 @@ mod tests {
 
     #[test]
     fn aggregates_resolved_and_cost_deltas() {
-        let baseline = map_of([submitted("a"), submitted("b"), errored("c", FailureCategory::ModelApi)]);
+        let baseline = map_of([
+            submitted("a"),
+            submitted("b"),
+            errored("c", FailureCategory::ModelApi),
+        ]);
         let candidate = map_of([submitted("a"), submitted("b"), submitted("c")]);
         let r = diff(Path::new("/b"), Path::new("/c"), &baseline, &candidate);
         assert_eq!(r.baseline_resolved, 2);

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -1,0 +1,695 @@
+//! `bench compare`: diff two completed sweep runs.
+//!
+//! Reads a baseline and candidate sweep output directory (each holding a
+//! `results.json` written by `run::swebench::run`), joins per-instance
+//! results by `instance_id`, and emits a transition matrix + regression
+//! list. Optionally exits non-zero when regressions exceed a threshold,
+//! enabling CI gating on prompt/harness changes.
+//!
+//! Read-only over existing artifacts: no model, env, or runtime
+//! concurrency. The diff is deterministic given the same inputs.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Error;
+use crate::run::swebench::{InstanceResult, SweepResults};
+use crate::trajectory::{FailureCategory, Trajectory, outcome};
+
+/// Output format for the compare report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompareFormat {
+    Text,
+    Json,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompareArgs {
+    pub baseline: PathBuf,
+    pub candidate: PathBuf,
+    pub format: CompareFormat,
+    /// When `Some(n)`, the binary exits non-zero if regressed-task count
+    /// strictly exceeds `n`. `None` is informational only.
+    pub max_regressions: Option<usize>,
+}
+
+/// Per-task transition between baseline and candidate. `pass` is defined
+/// as `outcome == "submitted"` AND `failure_category` is `None`, which
+/// matches what `run::swebench::run_one` writes for a clean submission.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum TransitionKind {
+    PassPass,
+    PassFail,
+    FailPass,
+    FailFail,
+    MissingPresent,
+    PresentMissing,
+}
+
+impl TransitionKind {
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::PassPass => "pass->pass",
+            Self::PassFail => "pass->fail",
+            Self::FailPass => "fail->pass",
+            Self::FailFail => "fail->fail",
+            Self::MissingPresent => "missing->present",
+            Self::PresentMissing => "present->missing",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskTransition {
+    pub instance_id: String,
+    pub kind: TransitionKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_outcome: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub candidate_outcome: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_failure_category: Option<FailureCategory>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub candidate_failure_category: Option<FailureCategory>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_exit_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub candidate_exit_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CompareReport {
+    pub baseline_dir: PathBuf,
+    pub candidate_dir: PathBuf,
+    pub baseline_total: usize,
+    pub candidate_total: usize,
+    /// Counts of each transition kind. Always contains every variant,
+    /// with zero for absent buckets — keeps downstream JSON consumers
+    /// from having to special-case missing keys.
+    pub transitions: BTreeMap<TransitionKind, usize>,
+    pub baseline_resolved: usize,
+    pub candidate_resolved: usize,
+    pub resolved_delta: i64,
+    pub baseline_total_cost_usd: f64,
+    pub candidate_total_cost_usd: f64,
+    pub cost_delta_usd: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_mean_steps: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub candidate_mean_steps: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mean_steps_delta: Option<f64>,
+    pub failure_category_baseline: BTreeMap<FailureCategory, usize>,
+    pub failure_category_candidate: BTreeMap<FailureCategory, usize>,
+    pub failure_category_delta: BTreeMap<FailureCategory, i64>,
+    /// Tasks that passed in the baseline but failed in the candidate.
+    /// This is the high-signal artifact for CI gating; sorted by
+    /// `instance_id` for stable output.
+    pub regressions: Vec<TaskTransition>,
+}
+
+impl CompareReport {
+    #[must_use]
+    pub fn regression_count(&self) -> usize {
+        self.regressions.len()
+    }
+
+    pub fn to_json_pretty(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Compact human-readable table for terminal output.
+    #[must_use]
+    pub fn human_table(&self) -> String {
+        let mut s = String::new();
+        s.push_str("\n=== bench compare ===\n");
+        let _ = writeln!(s, "Baseline:           {}", self.baseline_dir.display());
+        let _ = writeln!(s, "Candidate:          {}", self.candidate_dir.display());
+        let _ = writeln!(
+            s,
+            "Tasks (b/c/union):  {} / {} / {}",
+            self.baseline_total,
+            self.candidate_total,
+            self.transitions.values().sum::<usize>()
+        );
+        let _ = writeln!(
+            s,
+            "Resolved:           {} -> {} ({:+})",
+            self.baseline_resolved, self.candidate_resolved, self.resolved_delta
+        );
+        let _ = writeln!(
+            s,
+            "Total cost USD:     ${:.4} -> ${:.4} ({:+.4})",
+            self.baseline_total_cost_usd, self.candidate_total_cost_usd, self.cost_delta_usd
+        );
+        match (
+            self.baseline_mean_steps,
+            self.candidate_mean_steps,
+            self.mean_steps_delta,
+        ) {
+            (Some(b), Some(c), Some(d)) => {
+                let _ = writeln!(s, "Mean steps:         {b:.2} -> {c:.2} ({d:+.2})");
+            }
+            _ => {
+                s.push_str("Mean steps:         n/a\n");
+            }
+        }
+
+        s.push_str("\nTransition matrix:\n");
+        for kind in [
+            TransitionKind::PassPass,
+            TransitionKind::PassFail,
+            TransitionKind::FailPass,
+            TransitionKind::FailFail,
+            TransitionKind::MissingPresent,
+            TransitionKind::PresentMissing,
+        ] {
+            let n = self.transitions.get(&kind).copied().unwrap_or(0);
+            let _ = writeln!(s, "  {:<18} {n}", kind.label());
+        }
+
+        let nonzero: Vec<(FailureCategory, i64)> = self
+            .failure_category_delta
+            .iter()
+            .filter(|(_, v)| **v != 0)
+            .map(|(k, v)| (*k, *v))
+            .collect();
+        if !nonzero.is_empty() {
+            s.push_str("\nFailure category delta (candidate - baseline):\n");
+            for (cat, d) in nonzero {
+                let b = self
+                    .failure_category_baseline
+                    .get(&cat)
+                    .copied()
+                    .unwrap_or(0);
+                let c = self
+                    .failure_category_candidate
+                    .get(&cat)
+                    .copied()
+                    .unwrap_or(0);
+                let _ = writeln!(s, "  {:<14} {b} -> {c} ({d:+})", failure_label(cat));
+            }
+        }
+
+        if self.regressions.is_empty() {
+            s.push_str("\nRegressions:        none\n");
+        } else {
+            let _ = writeln!(s, "\nRegressions ({}):", self.regressions.len());
+            for r in &self.regressions {
+                let cat = r
+                    .candidate_failure_category
+                    .map_or("none", failure_label);
+                let exit = r.candidate_exit_reason.as_deref().unwrap_or("?");
+                let old = r.baseline_outcome.as_deref().unwrap_or("?");
+                let new = r.candidate_outcome.as_deref().unwrap_or("?");
+                let _ = writeln!(
+                    s,
+                    "  - {id}  {old} -> {new}  category={cat}  exit_reason={exit}",
+                    id = r.instance_id
+                );
+            }
+        }
+        s
+    }
+}
+
+/// Load all `InstanceResult`s from a sweep output directory.
+///
+/// Tries `results.json` first (the canonical end-of-sweep summary). Falls
+/// back to scanning per-instance `*.traj.json` files when no `results.json`
+/// exists, reconstructing minimal `InstanceResult`s. Tolerant of missing
+/// newer fields: defaults flow through serde.
+pub fn load_run(dir: &Path) -> Result<HashMap<String, InstanceResult>, Error> {
+    let results_path = dir.join("results.json");
+    if results_path.exists() {
+        let text = std::fs::read_to_string(&results_path)?;
+        let sweep: SweepResults = serde_json::from_str(&text)?;
+        return Ok(sweep
+            .instances
+            .into_iter()
+            .map(|r| (r.instance_id.clone(), r))
+            .collect());
+    }
+    if !dir.exists() {
+        return Err(Error::Trajectory(format!(
+            "compare: directory does not exist: {}",
+            dir.display()
+        )));
+    }
+
+    let mut out = HashMap::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if !name_str.ends_with(".traj.json") {
+            continue;
+        }
+        let id = name_str.trim_end_matches(".traj.json").to_owned();
+        let text = std::fs::read_to_string(entry.path())?;
+        let traj: Trajectory = match serde_json::from_str(&text) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let info = traj.info;
+        let (prompt_tokens, completion_tokens) =
+            info.token_usage.as_ref().map_or((None, None), |t| {
+                (Some(t.prompt_tokens), Some(t.completion_tokens))
+            });
+        out.insert(
+            id.clone(),
+            InstanceResult {
+                instance_id: id,
+                exit_reason: info.exit_reason.clone().unwrap_or_default(),
+                outcome: info.outcome.clone(),
+                failure_category: info.failure_category,
+                steps: info.steps,
+                cost_usd: info.total_cost_usd,
+                prompt_tokens,
+                completion_tokens,
+                duration_secs: info.duration_secs,
+                error: None,
+                patch_present: false,
+                non_empty_patch: false,
+            },
+        );
+    }
+    Ok(out)
+}
+
+/// Compute a `CompareReport` from two on-disk sweep directories.
+pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
+    let baseline = load_run(&args.baseline)?;
+    let candidate = load_run(&args.candidate)?;
+    Ok(diff(&args.baseline, &args.candidate, &baseline, &candidate))
+}
+
+/// Pure diff over two already-loaded id->result maps. Split out so tests
+/// can drive it without touching the filesystem.
+#[must_use]
+pub fn diff<S: std::hash::BuildHasher>(
+    baseline_dir: &Path,
+    candidate_dir: &Path,
+    baseline: &HashMap<String, InstanceResult, S>,
+    candidate: &HashMap<String, InstanceResult, S>,
+) -> CompareReport {
+    let mut all_ids: BTreeSet<&str> = BTreeSet::new();
+    all_ids.extend(baseline.keys().map(String::as_str));
+    all_ids.extend(candidate.keys().map(String::as_str));
+
+    let mut transitions: BTreeMap<TransitionKind, usize> = BTreeMap::new();
+    for kind in [
+        TransitionKind::PassPass,
+        TransitionKind::PassFail,
+        TransitionKind::FailPass,
+        TransitionKind::FailFail,
+        TransitionKind::MissingPresent,
+        TransitionKind::PresentMissing,
+    ] {
+        transitions.insert(kind, 0);
+    }
+    let mut regressions: Vec<TaskTransition> = Vec::new();
+
+    for id in &all_ids {
+        let b = baseline.get(*id);
+        let c = candidate.get(*id);
+        let kind = classify(b, c);
+        *transitions.entry(kind).or_insert(0) += 1;
+        if matches!(kind, TransitionKind::PassFail) {
+            regressions.push(TaskTransition {
+                instance_id: (*id).to_owned(),
+                kind,
+                baseline_outcome: b.and_then(|r| r.outcome.clone()),
+                candidate_outcome: c.and_then(|r| r.outcome.clone()),
+                baseline_failure_category: b.and_then(|r| r.failure_category),
+                candidate_failure_category: c.and_then(|r| r.failure_category),
+                baseline_exit_reason: b.map(|r| r.exit_reason.clone()),
+                candidate_exit_reason: c.map(|r| r.exit_reason.clone()),
+            });
+        }
+    }
+
+    let baseline_resolved = baseline.values().filter(|r| is_pass(r)).count();
+    let candidate_resolved = candidate.values().filter(|r| is_pass(r)).count();
+
+    let baseline_total_cost: f64 = baseline.values().filter_map(|r| r.cost_usd).sum();
+    let candidate_total_cost: f64 = candidate.values().filter_map(|r| r.cost_usd).sum();
+
+    let baseline_mean_steps = mean_steps(baseline);
+    let candidate_mean_steps = mean_steps(candidate);
+    let mean_steps_delta = match (baseline_mean_steps, candidate_mean_steps) {
+        (Some(b), Some(c)) => Some(c - b),
+        _ => None,
+    };
+
+    let failure_category_baseline = histogram(baseline);
+    let failure_category_candidate = histogram(candidate);
+    let mut failure_category_delta: BTreeMap<FailureCategory, i64> = BTreeMap::new();
+    for cat in failure_category_baseline
+        .keys()
+        .chain(failure_category_candidate.keys())
+    {
+        let b = i64::try_from(
+            failure_category_baseline
+                .get(cat)
+                .copied()
+                .unwrap_or(0),
+        )
+        .unwrap_or(i64::MAX);
+        let c = i64::try_from(
+            failure_category_candidate
+                .get(cat)
+                .copied()
+                .unwrap_or(0),
+        )
+        .unwrap_or(i64::MAX);
+        failure_category_delta.insert(*cat, c - b);
+    }
+
+    CompareReport {
+        baseline_dir: baseline_dir.to_path_buf(),
+        candidate_dir: candidate_dir.to_path_buf(),
+        baseline_total: baseline.len(),
+        candidate_total: candidate.len(),
+        transitions,
+        baseline_resolved,
+        candidate_resolved,
+        resolved_delta: i64::try_from(candidate_resolved).unwrap_or(i64::MAX)
+            - i64::try_from(baseline_resolved).unwrap_or(i64::MAX),
+        baseline_total_cost_usd: baseline_total_cost,
+        candidate_total_cost_usd: candidate_total_cost,
+        cost_delta_usd: candidate_total_cost - baseline_total_cost,
+        baseline_mean_steps,
+        candidate_mean_steps,
+        mean_steps_delta,
+        failure_category_baseline,
+        failure_category_candidate,
+        failure_category_delta,
+        regressions,
+    }
+}
+
+fn classify(b: Option<&InstanceResult>, c: Option<&InstanceResult>) -> TransitionKind {
+    match (b, c) {
+        (None, Some(_)) => TransitionKind::MissingPresent,
+        (None | Some(_), None) => TransitionKind::PresentMissing,
+        (Some(b), Some(c)) => match (is_pass(b), is_pass(c)) {
+            (true, true) => TransitionKind::PassPass,
+            (true, false) => TransitionKind::PassFail,
+            (false, true) => TransitionKind::FailPass,
+            (false, false) => TransitionKind::FailFail,
+        },
+    }
+}
+
+fn is_pass(r: &InstanceResult) -> bool {
+    r.outcome.as_deref() == Some(outcome::SUBMITTED) && r.failure_category.is_none()
+}
+
+fn mean_steps<S: std::hash::BuildHasher>(
+    map: &HashMap<String, InstanceResult, S>,
+) -> Option<f64> {
+    let xs: Vec<u32> = map.values().filter_map(|r| r.steps).collect();
+    if xs.is_empty() {
+        return None;
+    }
+    let sum: u64 = xs.iter().map(|x| u64::from(*x)).sum();
+    #[allow(clippy::cast_precision_loss)]
+    let mean = sum as f64 / xs.len() as f64;
+    Some(mean)
+}
+
+fn histogram<S: std::hash::BuildHasher>(
+    map: &HashMap<String, InstanceResult, S>,
+) -> BTreeMap<FailureCategory, usize> {
+    let mut out: BTreeMap<FailureCategory, usize> = BTreeMap::new();
+    for r in map.values() {
+        if let Some(cat) = r.failure_category {
+            *out.entry(cat).or_insert(0) += 1;
+        }
+    }
+    out
+}
+
+fn failure_label(cat: FailureCategory) -> &'static str {
+    match cat {
+        FailureCategory::EnvSetup => "env_setup",
+        FailureCategory::ModelApi => "model_api",
+        FailureCategory::ModelParse => "model_parse",
+        FailureCategory::StepLimit => "step_limit",
+        FailureCategory::CostLimit => "cost_limit",
+        FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::Unknown => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+
+    fn submitted(id: &str) -> InstanceResult {
+        InstanceResult {
+            instance_id: id.into(),
+            exit_reason: "submitted".into(),
+            outcome: Some(outcome::SUBMITTED.into()),
+            failure_category: None,
+            steps: Some(5),
+            cost_usd: Some(0.10),
+            prompt_tokens: Some(1000),
+            completion_tokens: Some(200),
+            duration_secs: Some(12.0),
+            error: None,
+            patch_present: true,
+            non_empty_patch: true,
+        }
+    }
+
+    fn errored(id: &str, cat: FailureCategory) -> InstanceResult {
+        InstanceResult {
+            instance_id: id.into(),
+            exit_reason: "error".into(),
+            outcome: Some(outcome::ERROR.into()),
+            failure_category: Some(cat),
+            steps: Some(7),
+            cost_usd: Some(0.20),
+            prompt_tokens: Some(2000),
+            completion_tokens: Some(400),
+            duration_secs: Some(20.0),
+            error: Some("boom".into()),
+            patch_present: false,
+            non_empty_patch: false,
+        }
+    }
+
+    fn legacy_unknown(id: &str) -> InstanceResult {
+        // Pre-#15 baseline: ERROR with no failure_category. Per AC,
+        // the diff must classify this as a non-pass without panicking.
+        InstanceResult {
+            instance_id: id.into(),
+            exit_reason: "error".into(),
+            outcome: Some(outcome::ERROR.into()),
+            failure_category: None,
+            steps: None,
+            cost_usd: None,
+            prompt_tokens: None,
+            completion_tokens: None,
+            duration_secs: None,
+            error: None,
+            patch_present: false,
+            non_empty_patch: false,
+        }
+    }
+
+    fn map_of<I: IntoIterator<Item = InstanceResult>>(it: I) -> HashMap<String, InstanceResult> {
+        it.into_iter().map(|r| (r.instance_id.clone(), r)).collect()
+    }
+
+    #[test]
+    fn classifies_all_six_transitions() {
+        // Baseline:  pp(pass), pf(pass), fp(fail), ff(fail), pm(pass)
+        // Candidate: pp(pass), pf(fail), fp(pass), ff(fail), mp(pass)
+        let baseline = map_of([
+            submitted("pp"),
+            submitted("pf"),
+            errored("fp", FailureCategory::ModelApi),
+            errored("ff", FailureCategory::ModelApi),
+            submitted("pm"),
+        ]);
+        let candidate = map_of([
+            submitted("pp"),
+            errored("pf", FailureCategory::ModelApi),
+            submitted("fp"),
+            errored("ff", FailureCategory::AgentInternal),
+            submitted("mp"),
+        ]);
+        let r = diff(
+            Path::new("/b"),
+            Path::new("/c"),
+            &baseline,
+            &candidate,
+        );
+        assert_eq!(r.transitions[&TransitionKind::PassPass], 1);
+        assert_eq!(r.transitions[&TransitionKind::PassFail], 1);
+        assert_eq!(r.transitions[&TransitionKind::FailPass], 1);
+        assert_eq!(r.transitions[&TransitionKind::FailFail], 1);
+        assert_eq!(r.transitions[&TransitionKind::MissingPresent], 1);
+        assert_eq!(r.transitions[&TransitionKind::PresentMissing], 1);
+    }
+
+    #[test]
+    fn regressions_list_only_pass_fail() {
+        let baseline = map_of([submitted("a"), submitted("b"), errored("c", FailureCategory::ModelApi)]);
+        let candidate = map_of([
+            submitted("a"),
+            errored("b", FailureCategory::StepLimit),
+            errored("c", FailureCategory::ModelApi),
+        ]);
+        let r = diff(Path::new("/b"), Path::new("/c"), &baseline, &candidate);
+        assert_eq!(r.regressions.len(), 1);
+        assert_eq!(r.regressions[0].instance_id, "b");
+        assert_eq!(
+            r.regressions[0].candidate_failure_category,
+            Some(FailureCategory::StepLimit)
+        );
+        assert_eq!(
+            r.regressions[0].candidate_exit_reason.as_deref(),
+            Some("error")
+        );
+    }
+
+    #[test]
+    fn aggregates_resolved_and_cost_deltas() {
+        let baseline = map_of([submitted("a"), submitted("b"), errored("c", FailureCategory::ModelApi)]);
+        let candidate = map_of([submitted("a"), submitted("b"), submitted("c")]);
+        let r = diff(Path::new("/b"), Path::new("/c"), &baseline, &candidate);
+        assert_eq!(r.baseline_resolved, 2);
+        assert_eq!(r.candidate_resolved, 3);
+        assert_eq!(r.resolved_delta, 1);
+        // baseline cost = 0.10+0.10+0.20 = 0.40; candidate = 0.30
+        assert!((r.baseline_total_cost_usd - 0.40).abs() < 1e-9);
+        assert!((r.candidate_total_cost_usd - 0.30).abs() < 1e-9);
+        assert!((r.cost_delta_usd - (-0.10)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn legacy_baseline_without_failure_category_does_not_panic() {
+        // Per AC: tolerate trajectories missing newer fields.
+        let baseline = map_of([legacy_unknown("a"), submitted("b")]);
+        let candidate = map_of([submitted("a"), errored("b", FailureCategory::ModelApi)]);
+        let r = diff(Path::new("/b"), Path::new("/c"), &baseline, &candidate);
+        assert_eq!(r.transitions[&TransitionKind::FailPass], 1);
+        assert_eq!(r.transitions[&TransitionKind::PassFail], 1);
+    }
+
+    #[test]
+    fn missing_and_extra_ids_are_bucketed_not_dropped() {
+        let baseline = map_of([submitted("only_b")]);
+        let candidate = map_of([submitted("only_c")]);
+        let r = diff(Path::new("/b"), Path::new("/c"), &baseline, &candidate);
+        assert_eq!(r.transitions[&TransitionKind::PresentMissing], 1);
+        assert_eq!(r.transitions[&TransitionKind::MissingPresent], 1);
+        assert_eq!(r.regressions.len(), 0);
+    }
+
+    #[test]
+    fn json_round_trip_via_results_json() {
+        // End-to-end: write a synthetic results.json on disk, load with
+        // `load_run`, compute diff, ensure structure is preserved.
+        let dir_b = tempfile::tempdir().unwrap();
+        let dir_c = tempfile::tempdir().unwrap();
+        let baseline_sweep = SweepResults {
+            total: 2,
+            submitted: 1,
+            skipped: 0,
+            errored: 1,
+            failures_by_category: BTreeMap::new(),
+            budget_halted: 0,
+            with_patch: 1,
+            total_prompt_tokens: 0,
+            total_completion_tokens: 0,
+            estimated_cost_usd: 0.0,
+            cost_limit_usd: None,
+            instances: vec![submitted("a"), errored("b", FailureCategory::ModelApi)],
+        };
+        let candidate_sweep = SweepResults {
+            instances: vec![errored("a", FailureCategory::StepLimit), submitted("b")],
+            ..baseline_sweep.clone()
+        };
+        std::fs::write(
+            dir_b.path().join("results.json"),
+            serde_json::to_string_pretty(&baseline_sweep).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            dir_c.path().join("results.json"),
+            serde_json::to_string_pretty(&candidate_sweep).unwrap(),
+        )
+        .unwrap();
+
+        let r = compute(&CompareArgs {
+            baseline: dir_b.path().to_path_buf(),
+            candidate: dir_c.path().to_path_buf(),
+            format: CompareFormat::Json,
+            max_regressions: None,
+        })
+        .unwrap();
+        assert_eq!(r.regressions.len(), 1);
+        assert_eq!(r.regressions[0].instance_id, "a");
+        let json = r.to_json_pretty().unwrap();
+        assert!(json.contains("\"pass_fail\""), "got: {json}");
+        assert!(json.contains("\"regressions\""), "got: {json}");
+    }
+
+    #[test]
+    fn human_table_lists_regressions_and_deltas() {
+        let baseline = map_of([submitted("a"), submitted("b")]);
+        let candidate = map_of([submitted("a"), errored("b", FailureCategory::StepLimit)]);
+        let r = diff(Path::new("/b"), Path::new("/c"), &baseline, &candidate);
+        let t = r.human_table();
+        assert!(t.contains("=== bench compare ==="));
+        assert!(t.contains("Resolved:           2 -> 1 (-1)"));
+        assert!(t.contains("pass->fail"));
+        assert!(t.contains("Regressions (1):"), "got:\n{t}");
+        assert!(t.contains("- b"), "got:\n{t}");
+        assert!(t.contains("category=step_limit"), "got:\n{t}");
+    }
+
+    #[test]
+    fn falls_back_to_trajectory_files_when_no_results_json() {
+        // Exercises the load_run fallback path used when an operator
+        // points compare at a directory that only has per-task trajectories
+        // (e.g. a sweep that crashed before writing results.json).
+        use crate::trajectory::{FORMAT_VERSION, TrajectoryInfo};
+        let dir = tempfile::tempdir().unwrap();
+        let traj = Trajectory {
+            trajectory_format: FORMAT_VERSION.into(),
+            info: TrajectoryInfo {
+                outcome: Some(outcome::SUBMITTED.into()),
+                exit_reason: Some("submitted".into()),
+                steps: Some(3),
+                ..Default::default()
+            },
+            messages: vec![],
+        };
+        std::fs::write(
+            dir.path().join("inst-1.traj.json"),
+            serde_json::to_string_pretty(&traj).unwrap(),
+        )
+        .unwrap();
+        let map = load_run(dir.path()).unwrap();
+        assert_eq!(map.len(), 1);
+        let r = map.get("inst-1").unwrap();
+        assert_eq!(r.outcome.as_deref(), Some(outcome::SUBMITTED));
+        assert_eq!(r.steps, Some(3));
+    }
+}

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,6 +1,7 @@
 //! Runners: thin glue that wires (config + model + env + agent) together
 //! and writes trajectories to disk.
 
+pub mod compare;
 pub mod hello_world;
 pub mod mini;
 pub mod replay;

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -59,20 +59,27 @@ pub struct SweBenchInstance {
     pub other: serde_json::Map<String, serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstanceResult {
     pub instance_id: String,
     pub exit_reason: String,
     /// Coarse outcome from the trajectory: `submitted` | `step_limit_reached`
     /// | `error`. `None` when the trajectory file could not be read.
+    #[serde(default)]
     pub outcome: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_category: Option<FailureCategory>,
+    #[serde(default)]
     pub steps: Option<u32>,
+    #[serde(default)]
     pub cost_usd: Option<f64>,
+    #[serde(default)]
     pub prompt_tokens: Option<u64>,
+    #[serde(default)]
     pub completion_tokens: Option<u64>,
+    #[serde(default)]
     pub duration_secs: Option<f64>,
+    #[serde(default)]
     pub error: Option<String>,
     /// `true` once the runner persisted a `.patch` artifact for this
     /// instance — even an empty diff. Submitted instances missing a
@@ -88,7 +95,7 @@ pub struct InstanceResult {
     pub non_empty_patch: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SweepResults {
     pub total: usize,
     pub submitted: usize,
@@ -99,18 +106,24 @@ pub struct SweepResults {
     /// Tasks that never started because the sweep-level USD budget was
     /// exhausted before they could acquire a worker permit. Counted in
     /// `total` but excluded from `submitted` and `errored`.
+    #[serde(default)]
     pub budget_halted: usize,
     /// Submitted instances whose captured patch had non-zero length.
     /// Equal to `submitted` minus the count of empty-diff submissions.
+    #[serde(default)]
     pub with_patch: usize,
+    #[serde(default)]
     pub total_prompt_tokens: u64,
+    #[serde(default)]
     pub total_completion_tokens: u64,
+    #[serde(default)]
     pub estimated_cost_usd: f64,
     /// The USD ceiling enforced for this sweep, echoed from
     /// `SwebenchArgs::cost_limit_usd`. `None` when no limit was set —
     /// distinguishes "ran without a budget" from "budget was infinite".
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost_limit_usd: Option<f64>,
+    #[serde(default)]
     pub instances: Vec<InstanceResult>,
 }
 

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -1,0 +1,370 @@
+//! `bench compare`: end-to-end + CLI-binary integration tests.
+//!
+//! Covers the AC from issue #16:
+//!   * subcommand exists in `--help`
+//!   * regression list + transition matrix are correct
+//!   * `--max-regressions` flips the process exit code
+//!   * `--format json` emits a structured document
+//!   * baseline missing newer fields (legacy) does not panic
+
+#![allow(clippy::unwrap_used)]
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::Command;
+
+use rust_swe_agent::run::swebench::{InstanceResult, SweepResults};
+use rust_swe_agent::trajectory::{FailureCategory, outcome};
+
+fn binary_path() -> std::path::PathBuf {
+    // CARGO_BIN_EXE_<name> is set by cargo when running integration tests.
+    // Fallback covers `cargo test --bin rust-swe-agent` invocations that
+    // don't set it (rare in practice but harmless).
+    std::env::var("CARGO_BIN_EXE_rust-swe-agent").map_or_else(
+        |_| {
+            let mut p = std::env::current_exe().unwrap();
+            p.pop(); // tests/deps
+            p.pop(); // debug
+            p.push("rust-swe-agent");
+            p
+        },
+        std::path::PathBuf::from,
+    )
+}
+
+fn submitted(id: &str) -> InstanceResult {
+    InstanceResult {
+        instance_id: id.into(),
+        exit_reason: "submitted".into(),
+        outcome: Some(outcome::SUBMITTED.into()),
+        failure_category: None,
+        steps: Some(4),
+        cost_usd: Some(0.05),
+        prompt_tokens: Some(500),
+        completion_tokens: Some(100),
+        duration_secs: Some(8.0),
+        error: None,
+        patch_present: true,
+        non_empty_patch: true,
+    }
+}
+
+fn errored(id: &str, cat: FailureCategory) -> InstanceResult {
+    InstanceResult {
+        instance_id: id.into(),
+        exit_reason: "error".into(),
+        outcome: Some(outcome::ERROR.into()),
+        failure_category: Some(cat),
+        steps: Some(6),
+        cost_usd: Some(0.10),
+        prompt_tokens: Some(1500),
+        completion_tokens: Some(200),
+        duration_secs: Some(15.0),
+        error: Some("stub".into()),
+        patch_present: false,
+        non_empty_patch: false,
+    }
+}
+
+fn write_results(dir: &Path, instances: Vec<InstanceResult>) {
+    let sweep = SweepResults {
+        total: instances.len(),
+        submitted: instances
+            .iter()
+            .filter(|r| r.outcome.as_deref() == Some(outcome::SUBMITTED))
+            .count(),
+        skipped: 0,
+        errored: instances
+            .iter()
+            .filter(|r| r.outcome.as_deref() == Some(outcome::ERROR))
+            .count(),
+        failures_by_category: BTreeMap::new(),
+        budget_halted: 0,
+        with_patch: 0,
+        total_prompt_tokens: 0,
+        total_completion_tokens: 0,
+        estimated_cost_usd: 0.0,
+        cost_limit_usd: None,
+        instances,
+    };
+    std::fs::write(
+        dir.join("results.json"),
+        serde_json::to_string_pretty(&sweep).unwrap(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn help_lists_compare_subcommand() {
+    let out = Command::new(binary_path())
+        .args(["bench", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("compare"),
+        "expected `compare` in `bench --help`, got:\n{stdout}"
+    );
+
+    let out = Command::new(binary_path())
+        .args(["bench", "compare", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in ["--baseline", "--candidate", "--format", "--max-regressions"] {
+        assert!(
+            stdout.contains(flag),
+            "expected `{flag}` in compare --help, got:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn cli_text_output_lists_regressions() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+
+    write_results(
+        baseline_dir.path(),
+        vec![submitted("a"), submitted("b"), errored("c", FailureCategory::ModelApi)],
+    );
+    write_results(
+        candidate_dir.path(),
+        vec![
+            submitted("a"),
+            errored("b", FailureCategory::StepLimit),
+            submitted("c"),
+        ],
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(stdout.contains("=== bench compare ==="), "got: {stdout}");
+    assert!(stdout.contains("Resolved:           2 -> 2 (+0)"), "got: {stdout}");
+    assert!(stdout.contains("pass->fail"), "got: {stdout}");
+    assert!(stdout.contains("Regressions (1):"), "got: {stdout}");
+    assert!(stdout.contains("- b"), "got: {stdout}");
+    assert!(stdout.contains("category=step_limit"), "got: {stdout}");
+}
+
+#[test]
+fn cli_json_output_is_machine_readable() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+
+    write_results(
+        baseline_dir.path(),
+        vec![submitted("a"), submitted("b")],
+    );
+    write_results(
+        candidate_dir.path(),
+        vec![submitted("a"), errored("b", FailureCategory::AgentInternal)],
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("expected valid JSON; err={e}; got:\n{stdout}");
+    });
+    assert_eq!(v["regressions"].as_array().unwrap().len(), 1);
+    assert_eq!(v["regressions"][0]["instance_id"], "b");
+    assert_eq!(v["regressions"][0]["kind"], "pass_fail");
+    assert_eq!(v["resolved_delta"], -1);
+    assert_eq!(v["transitions"]["pass_fail"], 1);
+}
+
+#[test]
+fn cli_max_regressions_flips_exit_code() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    write_results(baseline_dir.path(), vec![submitted("a"), submitted("b")]);
+    write_results(
+        candidate_dir.path(),
+        vec![
+            errored("a", FailureCategory::StepLimit),
+            errored("b", FailureCategory::StepLimit),
+        ],
+    );
+
+    // Threshold 0 -> any regression fails the gate (2 regressions > 0).
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--max-regressions",
+            "0",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit when regressions > max; stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    // Threshold 5 -> 2 regressions <= 5; informational only, exit 0.
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--max-regressions",
+            "5",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "expected zero exit under threshold; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Unset -> always exit 0 even with regressions.
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "expected zero exit when --max-regressions unset; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn cli_legacy_baseline_without_failure_category_does_not_panic() {
+    // Per AC: tolerate trajectories missing newer fields. We synthesize
+    // a baseline `results.json` that pre-dates #15 — no `failure_category`
+    // anywhere, and missing `failures_by_category`/`budget_halted`/
+    // `with_patch` keys at the top level.
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+
+    let legacy = serde_json::json!({
+        "total": 2,
+        "submitted": 1,
+        "skipped": 0,
+        "errored": 1,
+        "instances": [
+            {
+                "instance_id": "a",
+                "exit_reason": "submitted",
+                "outcome": "submitted"
+            },
+            {
+                "instance_id": "b",
+                "exit_reason": "error",
+                "outcome": "error"
+            }
+        ]
+    });
+    std::fs::write(
+        baseline_dir.path().join("results.json"),
+        serde_json::to_string_pretty(&legacy).unwrap(),
+    )
+    .unwrap();
+    write_results(
+        candidate_dir.path(),
+        vec![errored("a", FailureCategory::StepLimit), submitted("b")],
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    // `a` was submitted in baseline, errored in candidate -> regression.
+    // `b` was errored in baseline, submitted in candidate -> fail->pass.
+    assert_eq!(v["regressions"].as_array().unwrap().len(), 1);
+    assert_eq!(v["regressions"][0]["instance_id"], "a");
+    assert_eq!(v["transitions"]["fail_pass"], 1);
+}
+
+#[test]
+fn cli_disjoint_id_sets_bucketed_not_dropped() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    write_results(
+        baseline_dir.path(),
+        vec![submitted("only_in_baseline"), submitted("shared")],
+    );
+    write_results(
+        candidate_dir.path(),
+        vec![submitted("only_in_candidate"), submitted("shared")],
+    );
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(v["transitions"]["pass_pass"], 1);
+    assert_eq!(v["transitions"]["missing_present"], 1);
+    assert_eq!(v["transitions"]["present_missing"], 1);
+    assert_eq!(v["regressions"].as_array().unwrap().len(), 0);
+}

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -100,7 +100,11 @@ fn help_lists_compare_subcommand() {
         .args(["bench", "--help"])
         .output()
         .unwrap();
-    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
         stdout.contains("compare"),
@@ -128,7 +132,11 @@ fn cli_text_output_lists_regressions() {
 
     write_results(
         baseline_dir.path(),
-        vec![submitted("a"), submitted("b"), errored("c", FailureCategory::ModelApi)],
+        vec![
+            submitted("a"),
+            submitted("b"),
+            errored("c", FailureCategory::ModelApi),
+        ],
     );
     write_results(
         candidate_dir.path(),
@@ -151,9 +159,16 @@ fn cli_text_output_lists_regressions() {
         .output()
         .unwrap();
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     assert!(stdout.contains("=== bench compare ==="), "got: {stdout}");
-    assert!(stdout.contains("Resolved:           2 -> 2 (+0)"), "got: {stdout}");
+    assert!(
+        stdout.contains("Resolved:           2 -> 2 (+0)"),
+        "got: {stdout}"
+    );
     assert!(stdout.contains("pass->fail"), "got: {stdout}");
     assert!(stdout.contains("Regressions (1):"), "got: {stdout}");
     assert!(stdout.contains("- b"), "got: {stdout}");
@@ -165,10 +180,7 @@ fn cli_json_output_is_machine_readable() {
     let baseline_dir = tempfile::tempdir().unwrap();
     let candidate_dir = tempfile::tempdir().unwrap();
 
-    write_results(
-        baseline_dir.path(),
-        vec![submitted("a"), submitted("b")],
-    );
+    write_results(baseline_dir.path(), vec![submitted("a"), submitted("b")]);
     write_results(
         candidate_dir.path(),
         vec![submitted("a"), errored("b", FailureCategory::AgentInternal)],
@@ -187,7 +199,11 @@ fn cli_json_output_is_machine_readable() {
         ])
         .output()
         .unwrap();
-    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let stdout = String::from_utf8_lossy(&out.stdout);
     let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
         panic!("expected valid JSON; err={e}; got:\n{stdout}");


### PR DESCRIPTION
## Summary
Implements a new `bench compare` subcommand that diffs two completed SWE-bench sweep runs, enabling regression detection and CI gating on prompt/harness changes.

## Key Changes

- **New `src/run/compare.rs` module** (~695 lines):
  - `CompareReport` struct capturing transition matrices, regression lists, cost/resolution deltas, and failure category histograms
  - `TransitionKind` enum classifying per-task state changes (pass→pass, pass→fail, fail→pass, fail→fail, missing→present, present→missing)
  - `compute()` function that loads two sweep output directories and produces a diff
  - `load_run()` function that reads `results.json` (preferred) or falls back to scanning per-instance `*.traj.json` files for backward compatibility
  - `diff()` pure function for testability, accepting pre-loaded result maps
  - Human-readable table output via `human_table()` and JSON serialization via `to_json_pretty()`
  - Comprehensive unit tests covering all six transition types, legacy baseline tolerance, and edge cases

- **New `tests/bench_compare.rs` integration tests** (~370 lines):
  - CLI help text validation
  - Text and JSON output format verification
  - `--max-regressions` threshold gating (exits non-zero when exceeded)
  - Legacy baseline compatibility (missing `failure_category` fields)
  - Disjoint instance ID set handling

- **CLI integration** (`src/cli/args.rs` and `src/cli/mod.rs`):
  - New `CompareCmd` struct with `--baseline`, `--candidate`, `--format`, and `--max-regressions` flags
  - `bench_compare()` handler that formats output and gates exit code on regression threshold

- **Type updates** (`src/run/swebench.rs`):
  - Added `Deserialize` derive to `InstanceResult` for loading from JSON
  - Added `#[serde(default)]` attributes for backward compatibility with older sweep outputs missing newer fields

## Notable Implementation Details

- **Backward compatible**: Tolerates baseline sweeps missing `failure_category`, `failures_by_category`, `budget_halted`, and `with_patch` fields via serde defaults
- **Deterministic**: Pure diff function enables reproducible comparisons; no model/env/runtime concurrency
- **Regression definition**: A task is a regression if it passed in baseline (outcome="submitted" AND no failure_category) but failed in candidate
- **Stable output**: Regressions sorted by instance_id for consistent CI reports
- **Flexible loading**: Prefers canonical `results.json` but reconstructs minimal results from trajectory files when needed (e.g., after sweep crash)

https://claude.ai/code/session_01H36BpZvsYDcs4KUd28k32G