### PR TITLE
Add bench evaluate and resolved-rate aware compare

### DIFF
--- a/docs/spec-evaluation.md
+++ b/docs/spec-evaluation.md
@@ -1,0 +1,61 @@
+# `bench evaluate` / `evaluation.json` contract
+
+`bench swebench` writes sweep execution artifacts (`results.json`, per-instance
+`*.traj.json`, `all_preds.jsonl`). `bench evaluate` is a post-processing step
+that scores those artifacts using an evaluation backend and writes
+`evaluation.json` in the same sweep directory.
+
+## Command
+
+```bash
+rust-swe-agent bench evaluate \
+  --sweep <sweep_dir> \
+  [--dataset <dataset.jsonl>] \
+  [--backend sb-cli|none] \
+  [--timeout-per-instance 600] \
+  [--parallel 4]
+```
+
+- `--backend sb-cli` shells out to `sb-cli` and parses its report.
+- `--backend none` writes placeholder unresolved rows (useful where `sb-cli`
+  is unavailable).
+
+## `evaluation.json` schema
+
+```json
+{
+  "instances": [
+    {
+      "instance_id": "<id>",
+      "resolved": true,
+      "tests_passed": ["..."],
+      "tests_failed": ["..."],
+      "eval_exit_reason": "resolved|unresolved|patch_apply_failed|eval_error|skipped_no_patch",
+      "eval_log_path": "optional/path/or/url"
+    }
+  ]
+}
+```
+
+`evaluation.json` is keyed by `instance_id` logically (stored as a list).
+Every instance in `results.json` should have a corresponding evaluation row.
+Rows missing from backend output are synthesized as:
+
+- `skipped_no_patch` when the instance was not submitted (or had no patch), or
+- `eval_error` when it was submitted but evaluator output was missing.
+
+## `bench compare` interaction
+
+`bench compare` now reads `evaluation.json` when present and uses
+`resolved` as the pass/fail source of truth. If no `evaluation.json` exists,
+behavior is unchanged and compare falls back to the legacy heuristic
+`outcome == submitted && failure_category == null`.
+
+This affects:
+
+- resolved counts (`baseline_resolved`, `candidate_resolved`, `resolved_delta`)
+- transition classification (`pass->fail`, etc.)
+- regression gating (`--max-regressions`)
+
+So a sweep with high submission-rate but zero resolved instances is treated as
+fully regressed against a baseline that resolved everything.

--- a/docs/spec-evaluation.md
+++ b/docs/spec-evaluation.md
@@ -11,12 +11,16 @@ that scores those artifacts using an evaluation backend and writes
 rust-swe-agent bench evaluate \
   --sweep <sweep_dir> \
   [--dataset <dataset.jsonl>] \
+  [--sb-subset swe-bench-m] \
+  [--sb-split dev] \
+  [--run-id <custom_run_id>] \
   [--backend sb-cli|none] \
   [--timeout-per-instance 600] \
   [--parallel 4]
 ```
 
-- `--backend sb-cli` shells out to `sb-cli` and parses its report.
+- `--backend sb-cli` shells out via `sb-cli submit ...` (and `get-report` as a
+  fallback) then parses the generated report JSON.
 - `--backend none` writes placeholder unresolved rows (useful where `sb-cli`
   is unavailable).
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -168,6 +168,18 @@ pub struct EvaluateCmd {
     #[arg(long)]
     pub dataset: Option<PathBuf>,
 
+    /// SWE-bench subset for sb-cli (`swe-bench-m`, `swe-bench_lite`, ...).
+    #[arg(long, default_value = "swe-bench-m")]
+    pub sb_subset: String,
+
+    /// SWE-bench split for sb-cli (`dev` or `test` depending on subset).
+    #[arg(long, default_value = "dev")]
+    pub sb_split: String,
+
+    /// Optional sb-cli run id. When unset, one is generated automatically.
+    #[arg(long)]
+    pub run_id: Option<String>,
+
     /// Evaluation backend: `sb-cli` or `none`.
     #[arg(long, default_value = "sb-cli")]
     pub backend: String,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -89,6 +89,8 @@ pub enum BenchCmd {
     /// Diff two completed sweep runs by instance id; surfaces regressions
     /// and (with `--max-regressions`) gates CI on prompt/harness changes.
     Compare(CompareCmd),
+    /// Evaluate a completed sweep with an evaluation backend (e.g. sb-cli).
+    Evaluate(EvaluateCmd),
 }
 
 #[derive(Debug, Args)]
@@ -154,4 +156,27 @@ pub struct SwebenchCmd {
     /// `submitted` / `errored`. When unset, behavior is unchanged.
     #[arg(long)]
     pub sweep_cost_limit_usd: Option<f64>,
+}
+
+#[derive(Debug, Args)]
+pub struct EvaluateCmd {
+    /// Completed sweep directory produced by `bench swebench`.
+    #[arg(long)]
+    pub sweep: PathBuf,
+
+    /// Optional dataset JSONL path passed through to the evaluator.
+    #[arg(long)]
+    pub dataset: Option<PathBuf>,
+
+    /// Evaluation backend: `sb-cli` or `none`.
+    #[arg(long, default_value = "sb-cli")]
+    pub backend: String,
+
+    /// Per-instance evaluation timeout in seconds.
+    #[arg(long, default_value_t = 600)]
+    pub timeout_per_instance: u64,
+
+    /// Parallel worker count for evaluation backend.
+    #[arg(long, default_value_t = 4)]
+    pub parallel: usize,
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -55,7 +55,7 @@ pub async fn run() -> Result<(), Error> {
         } => bench_compare(c),
         Command::Bench {
             cmd: args::BenchCmd::Evaluate(e),
-        } => bench_evaluate(e).await,
+        } => bench_evaluate(e),
         #[cfg(feature = "docker")]
         Command::Cleanup => cleanup_cmd().await,
         #[cfg(not(feature = "docker"))]
@@ -74,7 +74,7 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         Some(p) => Config::load(p)?,
         None => Config::defaults()?,
     };
-    cfg.root.model.name = m.model.clone();
+    cfg.root.model.name.clone_from(&m.model);
     cfg.root.agent.step_limit = m.step_limit;
     if let Some(kind) = &m.env {
         cfg.root.environment.kind = match kind.as_str() {
@@ -153,7 +153,7 @@ async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
         Some(p) => Config::load(p)?,
         None => Config::defaults()?,
     };
-    cfg.root.model.name = s.model.clone();
+    cfg.root.model.name.clone_from(&s.model);
     cfg.root.agent.step_limit = s.step_limit;
 
     let results = crate::run::swebench::run(crate::run::swebench::SwebenchArgs {
@@ -236,7 +236,7 @@ fn cleanup_cmd() -> Result<(), Error> {
     )))
 }
 
-async fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
+fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
     let backend = match e.backend.as_str() {
         "sb-cli" => crate::run::evaluate::EvaluateBackend::SbCli,
         "none" => crate::run::evaluate::EvaluateBackend::None,
@@ -247,14 +247,14 @@ async fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
         }
     };
 
-    let eval = crate::run::evaluate::run(crate::run::evaluate::EvaluateArgs {
+    let args = crate::run::evaluate::EvaluateArgs {
         sweep_dir: e.sweep.clone(),
         dataset_path: e.dataset,
         backend,
         timeout_per_instance_secs: e.timeout_per_instance,
         parallel: e.parallel,
-    })
-    .await?;
+    };
+    let eval = crate::run::evaluate::run(&args)?;
 
     let resolved = eval.instances.iter().filter(|x| x.resolved).count();
     tracing::info!(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -53,6 +53,9 @@ pub async fn run() -> Result<(), Error> {
         Command::Bench {
             cmd: args::BenchCmd::Compare(c),
         } => bench_compare(c),
+        Command::Bench {
+            cmd: args::BenchCmd::Evaluate(e),
+        } => bench_evaluate(e).await,
         #[cfg(feature = "docker")]
         Command::Cleanup => cleanup_cmd().await,
         #[cfg(not(feature = "docker"))]
@@ -231,4 +234,34 @@ fn cleanup_cmd() -> Result<(), Error> {
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "docker feature not compiled in".into(),
     )))
+}
+
+async fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
+    let backend = match e.backend.as_str() {
+        "sb-cli" => crate::run::evaluate::EvaluateBackend::SbCli,
+        "none" => crate::run::evaluate::EvaluateBackend::None,
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "unknown --backend `{other}` (expected `sb-cli` or `none`)"
+            ))));
+        }
+    };
+
+    let eval = crate::run::evaluate::run(crate::run::evaluate::EvaluateArgs {
+        sweep_dir: e.sweep.clone(),
+        dataset_path: e.dataset,
+        backend,
+        timeout_per_instance_secs: e.timeout_per_instance,
+        parallel: e.parallel,
+    })
+    .await?;
+
+    let resolved = eval.instances.iter().filter(|x| x.resolved).count();
+    tracing::info!(
+        instances = eval.instances.len(),
+        resolved,
+        evaluation_path = %crate::run::evaluate::evaluation_path(&e.sweep).display(),
+        "evaluation complete"
+    );
+    Ok(())
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -253,6 +253,9 @@ fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
         backend,
         timeout_per_instance_secs: e.timeout_per_instance,
         parallel: e.parallel,
+        sb_subset: e.sb_subset,
+        sb_split: e.sb_split,
+        run_id: e.run_id,
     };
     let eval = crate::run::evaluate::run(&args)?;
 

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
+use crate::run::evaluate::EvaluationResults;
 use crate::run::swebench::{InstanceResult, SweepResults};
 use crate::trajectory::{FailureCategory, Trajectory, outcome};
 
@@ -286,7 +287,16 @@ pub fn load_run(dir: &Path) -> Result<HashMap<String, InstanceResult>, Error> {
 pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
     let baseline = load_run(&args.baseline)?;
     let candidate = load_run(&args.candidate)?;
-    Ok(diff(&args.baseline, &args.candidate, &baseline, &candidate))
+    let baseline_eval = load_resolved_overrides(&args.baseline)?;
+    let candidate_eval = load_resolved_overrides(&args.candidate)?;
+    Ok(diff_with_overrides(
+        &args.baseline,
+        &args.candidate,
+        &baseline,
+        &candidate,
+        baseline_eval.as_ref(),
+        candidate_eval.as_ref(),
+    ))
 }
 
 /// Pure diff over two already-loaded id->result maps. Split out so tests
@@ -297,6 +307,17 @@ pub fn diff<S: std::hash::BuildHasher>(
     candidate_dir: &Path,
     baseline: &HashMap<String, InstanceResult, S>,
     candidate: &HashMap<String, InstanceResult, S>,
+) -> CompareReport {
+    diff_with_overrides(baseline_dir, candidate_dir, baseline, candidate, None, None)
+}
+
+fn diff_with_overrides<S: std::hash::BuildHasher>(
+    baseline_dir: &Path,
+    candidate_dir: &Path,
+    baseline: &HashMap<String, InstanceResult, S>,
+    candidate: &HashMap<String, InstanceResult, S>,
+    baseline_resolved_override: Option<&HashMap<String, bool>>,
+    candidate_resolved_override: Option<&HashMap<String, bool>>,
 ) -> CompareReport {
     let mut all_ids: BTreeSet<&str> = BTreeSet::new();
     all_ids.extend(baseline.keys().map(String::as_str));
@@ -318,7 +339,13 @@ pub fn diff<S: std::hash::BuildHasher>(
     for id in &all_ids {
         let b = baseline.get(*id);
         let c = candidate.get(*id);
-        let kind = classify(b, c);
+        let kind = classify(
+            id,
+            b,
+            c,
+            baseline_resolved_override,
+            candidate_resolved_override,
+        );
         *transitions.entry(kind).or_insert(0) += 1;
         if matches!(kind, TransitionKind::PassFail) {
             regressions.push(TaskTransition {
@@ -334,8 +361,14 @@ pub fn diff<S: std::hash::BuildHasher>(
         }
     }
 
-    let baseline_resolved = baseline.values().filter(|r| is_pass(r)).count();
-    let candidate_resolved = candidate.values().filter(|r| is_pass(r)).count();
+    let baseline_resolved = baseline
+        .iter()
+        .filter(|(id, r)| resolved_for(id, r, baseline_resolved_override))
+        .count();
+    let candidate_resolved = candidate
+        .iter()
+        .filter(|(id, r)| resolved_for(id, r, candidate_resolved_override))
+        .count();
 
     let baseline_total_cost: f64 = baseline.values().filter_map(|r| r.cost_usd).sum();
     let candidate_total_cost: f64 = candidate.values().filter_map(|r| r.cost_usd).sum();
@@ -384,11 +417,20 @@ pub fn diff<S: std::hash::BuildHasher>(
     }
 }
 
-fn classify(b: Option<&InstanceResult>, c: Option<&InstanceResult>) -> TransitionKind {
+fn classify(
+    id: &str,
+    b: Option<&InstanceResult>,
+    c: Option<&InstanceResult>,
+    baseline_resolved_override: Option<&HashMap<String, bool>>,
+    candidate_resolved_override: Option<&HashMap<String, bool>>,
+) -> TransitionKind {
     match (b, c) {
         (None, Some(_)) => TransitionKind::MissingPresent,
         (None | Some(_), None) => TransitionKind::PresentMissing,
-        (Some(b), Some(c)) => match (is_pass(b), is_pass(c)) {
+        (Some(b), Some(c)) => match (
+            resolved_for(id, b, baseline_resolved_override),
+            resolved_for(id, c, candidate_resolved_override),
+        ) {
             (true, true) => TransitionKind::PassPass,
             (true, false) => TransitionKind::PassFail,
             (false, true) => TransitionKind::FailPass,
@@ -401,6 +443,30 @@ fn is_pass(r: &InstanceResult) -> bool {
     r.outcome.as_deref() == Some(outcome::SUBMITTED) && r.failure_category.is_none()
 }
 
+fn resolved_for(
+    id: &str,
+    r: &InstanceResult,
+    resolved_override: Option<&HashMap<String, bool>>,
+) -> bool {
+    resolved_override
+        .and_then(|m| m.get(id).copied())
+        .unwrap_or_else(|| is_pass(r))
+}
+
+fn load_resolved_overrides(dir: &Path) -> Result<Option<HashMap<String, bool>>, Error> {
+    let path = crate::run::evaluate::evaluation_path(dir);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let text = std::fs::read_to_string(path)?;
+    let eval: EvaluationResults = serde_json::from_str(&text)?;
+    Ok(Some(
+        eval.instances
+            .into_iter()
+            .map(|row| (row.instance_id, row.resolved))
+            .collect(),
+    ))
+}
 fn mean_steps<S: std::hash::BuildHasher>(map: &HashMap<String, InstanceResult, S>) -> Option<f64> {
     let xs: Vec<u32> = map.values().filter_map(|r| r.steps).collect();
     if xs.is_empty() {
@@ -649,6 +715,80 @@ mod tests {
         assert!(t.contains("Regressions (1):"), "got:\n{t}");
         assert!(t.contains("- b"), "got:\n{t}");
         assert!(t.contains("category=step_limit"), "got:\n{t}");
+    }
+
+    #[test]
+    fn prefers_evaluation_json_resolved_over_submission_proxy() {
+        let dir_b = tempfile::tempdir().unwrap();
+        let dir_c = tempfile::tempdir().unwrap();
+        let baseline_sweep = SweepResults {
+            total: 1,
+            submitted: 1,
+            skipped: 0,
+            errored: 0,
+            failures_by_category: BTreeMap::new(),
+            budget_halted: 0,
+            with_patch: 1,
+            total_prompt_tokens: 0,
+            total_completion_tokens: 0,
+            estimated_cost_usd: 0.0,
+            cost_limit_usd: None,
+            instances: vec![submitted("a")],
+        };
+        let candidate_sweep = baseline_sweep.clone();
+        std::fs::write(
+            dir_b.path().join("results.json"),
+            serde_json::to_string_pretty(&baseline_sweep).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            dir_c.path().join("results.json"),
+            serde_json::to_string_pretty(&candidate_sweep).unwrap(),
+        )
+        .unwrap();
+
+        let baseline_eval = crate::run::evaluate::EvaluationResults {
+            instances: vec![crate::run::evaluate::InstanceEvaluation {
+                instance_id: "a".into(),
+                resolved: true,
+                tests_passed: vec![],
+                tests_failed: vec![],
+                eval_exit_reason: crate::run::evaluate::EvalExitReason::Resolved,
+                eval_log_path: None,
+            }],
+        };
+        let candidate_eval = crate::run::evaluate::EvaluationResults {
+            instances: vec![crate::run::evaluate::InstanceEvaluation {
+                instance_id: "a".into(),
+                resolved: false,
+                tests_passed: vec![],
+                tests_failed: vec![],
+                eval_exit_reason: crate::run::evaluate::EvalExitReason::Unresolved,
+                eval_log_path: None,
+            }],
+        };
+
+        std::fs::write(
+            crate::run::evaluate::evaluation_path(dir_b.path()),
+            serde_json::to_string_pretty(&baseline_eval).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            crate::run::evaluate::evaluation_path(dir_c.path()),
+            serde_json::to_string_pretty(&candidate_eval).unwrap(),
+        )
+        .unwrap();
+
+        let r = compute(&CompareArgs {
+            baseline: dir_b.path().to_path_buf(),
+            candidate: dir_c.path().to_path_buf(),
+            format: CompareFormat::Json,
+            max_regressions: None,
+        })
+        .unwrap();
+        assert_eq!(r.baseline_resolved, 1);
+        assert_eq!(r.candidate_resolved, 0);
+        assert_eq!(r.regressions.len(), 1);
     }
 
     #[test]

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -24,6 +24,9 @@ pub struct EvaluateArgs {
     pub backend: EvaluateBackend,
     pub timeout_per_instance_secs: u64,
     pub parallel: usize,
+    pub sb_subset: String,
+    pub sb_split: String,
+    pub run_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -109,13 +112,24 @@ fn run_sb_cli(
         )));
     }
 
-    let out_file = args.sweep_dir.join("sb_cli_eval_raw.json");
+    let report_dir = args.sweep_dir.join("sb_cli_reports");
+    std::fs::create_dir_all(&report_dir)?;
+    let run_id = args.run_id.clone().unwrap_or_else(generated_run_id);
+
     let mut cmd = Command::new("sb-cli");
-    cmd.arg("eval")
-        .arg("--predictions")
+    cmd.arg("submit")
+        .arg(&args.sb_subset)
+        .arg(&args.sb_split)
+        .arg("--predictions_path")
         .arg(&preds)
-        .arg("--output")
-        .arg(&out_file)
+        .arg("--run_id")
+        .arg(&run_id)
+        .arg("--output_dir")
+        .arg(&report_dir)
+        .arg("--wait_for_evaluation")
+        .arg("1")
+        .arg("--gen_report")
+        .arg("1")
         .arg("--timeout-per-instance")
         .arg(args.timeout_per_instance_secs.to_string())
         .arg("--parallel")
@@ -137,13 +151,38 @@ fn run_sb_cli(
 
     if !output.status.success() {
         return Err(Error::Trajectory(format!(
-            "bench evaluate: sb-cli failed (status={}): {}",
+            "bench evaluate: sb-cli submit failed (status={}): {}",
             output.status,
             String::from_utf8_lossy(&output.stderr)
         )));
     }
 
-    let parsed = parse_sb_cli_results(&out_file)?;
+    let report_path = report_dir.join(format!(
+        "{}__{}__{}.json",
+        args.sb_subset, args.sb_split, run_id
+    ));
+
+    if !report_path.exists() {
+        let output = Command::new("sb-cli")
+            .arg("get-report")
+            .arg(&args.sb_subset)
+            .arg(&args.sb_split)
+            .arg(&run_id)
+            .arg("--output_dir")
+            .arg(&report_dir)
+            .arg("--overwrite")
+            .arg("1")
+            .output()?;
+        if !output.status.success() {
+            return Err(Error::Trajectory(format!(
+                "bench evaluate: sb-cli get-report failed (status={}): {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+    }
+
+    let parsed = parse_sb_cli_results(&report_path)?;
     Ok(merge_with_results(results, &parsed))
 }
 
@@ -175,10 +214,70 @@ fn parse_sb_cli_results(path: &Path) -> Result<HashMap<String, InstanceEvaluatio
                     }
                 }
             }
+            // sb-cli report shape: `resolved_ids` and sometimes `submitted_ids`.
+            if map.is_empty() {
+                let resolved_ids = obj
+                    .get("resolved_ids")
+                    .and_then(serde_json::Value::as_array)
+                    .map(|xs| {
+                        xs.iter()
+                            .filter_map(|v| v.as_str().map(ToOwned::to_owned))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                let submitted_ids = obj
+                    .get("submitted_ids")
+                    .and_then(serde_json::Value::as_array)
+                    .map(|xs| {
+                        xs.iter()
+                            .filter_map(|v| v.as_str().map(ToOwned::to_owned))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                for id in &submitted_ids {
+                    map.insert(
+                        id.clone(),
+                        InstanceEvaluation {
+                            instance_id: id.clone(),
+                            resolved: resolved_ids.contains(id),
+                            tests_passed: vec![],
+                            tests_failed: vec![],
+                            eval_exit_reason: if resolved_ids.contains(id) {
+                                EvalExitReason::Resolved
+                            } else {
+                                EvalExitReason::Unresolved
+                            },
+                            eval_log_path: None,
+                        },
+                    );
+                }
+                if submitted_ids.is_empty() {
+                    for id in resolved_ids {
+                        map.insert(
+                            id.clone(),
+                            InstanceEvaluation {
+                                instance_id: id,
+                                resolved: true,
+                                tests_passed: vec![],
+                                tests_failed: vec![],
+                                eval_exit_reason: EvalExitReason::Resolved,
+                                eval_log_path: None,
+                            },
+                        );
+                    }
+                }
+            }
         }
         _ => {}
     }
     Ok(map)
+}
+
+fn generated_run_id() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    format!("rust_swe_agent_{secs}")
 }
 
 fn parse_generic_eval_row(v: &serde_json::Value) -> Option<InstanceEvaluation> {
@@ -319,5 +418,20 @@ mod tests {
             eval.instances[1].eval_exit_reason,
             EvalExitReason::SkippedNoPatch
         ));
+    }
+
+    #[test]
+    fn parses_sb_cli_report_with_resolved_and_submitted_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("report.json");
+        let report = serde_json::json!({
+            "resolved_ids": ["inst-a"],
+            "submitted_ids": ["inst-a", "inst-b"]
+        });
+        std::fs::write(&path, serde_json::to_string_pretty(&report).unwrap()).unwrap();
+        let parsed = parse_sb_cli_results(&path).unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed.get("inst-a").map(|r| r.resolved), Some(true));
+        assert_eq!(parsed.get("inst-b").map(|r| r.resolved), Some(false));
     }
 }

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -59,11 +59,11 @@ pub fn evaluation_path(sweep_dir: &Path) -> PathBuf {
     sweep_dir.join("evaluation.json")
 }
 
-pub async fn run(args: EvaluateArgs) -> Result<EvaluationResults, Error> {
+pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
     let results = load_run(&args.sweep_dir)?;
     let eval = match args.backend {
         EvaluateBackend::None => build_none_eval(&results),
-        EvaluateBackend::SbCli => run_sb_cli(&args, &results)?,
+        EvaluateBackend::SbCli => run_sb_cli(args, &results)?,
     };
     std::fs::write(
         evaluation_path(&args.sweep_dir),
@@ -144,7 +144,7 @@ fn run_sb_cli(
     }
 
     let parsed = parse_sb_cli_results(&out_file)?;
-    Ok(merge_with_results(results, parsed))
+    Ok(merge_with_results(results, &parsed))
 }
 
 fn parse_sb_cli_results(path: &Path) -> Result<HashMap<String, InstanceEvaluation>, Error> {
@@ -234,7 +234,7 @@ fn as_string_vec(v: Option<&serde_json::Value>) -> Vec<String> {
 
 fn merge_with_results(
     results: &HashMap<String, InstanceResult>,
-    parsed: HashMap<String, InstanceEvaluation>,
+    parsed: &HashMap<String, InstanceEvaluation>,
 ) -> EvaluationResults {
     let mut instances: Vec<InstanceEvaluation> = Vec::new();
     for (id, r) in results {

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -1,0 +1,323 @@
+//! `bench evaluate`: score an existing sweep by real resolved-rate.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Error;
+use crate::run::compare::load_run;
+use crate::run::swebench::{self, InstanceResult};
+use crate::trajectory::outcome;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvaluateBackend {
+    SbCli,
+    None,
+}
+
+#[derive(Debug, Clone)]
+pub struct EvaluateArgs {
+    pub sweep_dir: PathBuf,
+    pub dataset_path: Option<PathBuf>,
+    pub backend: EvaluateBackend,
+    pub timeout_per_instance_secs: u64,
+    pub parallel: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalExitReason {
+    Resolved,
+    Unresolved,
+    PatchApplyFailed,
+    EvalError,
+    SkippedNoPatch,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstanceEvaluation {
+    pub instance_id: String,
+    pub resolved: bool,
+    #[serde(default)]
+    pub tests_passed: Vec<String>,
+    #[serde(default)]
+    pub tests_failed: Vec<String>,
+    pub eval_exit_reason: EvalExitReason,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eval_log_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluationResults {
+    pub instances: Vec<InstanceEvaluation>,
+}
+
+#[must_use]
+pub fn evaluation_path(sweep_dir: &Path) -> PathBuf {
+    sweep_dir.join("evaluation.json")
+}
+
+pub async fn run(args: EvaluateArgs) -> Result<EvaluationResults, Error> {
+    let results = load_run(&args.sweep_dir)?;
+    let eval = match args.backend {
+        EvaluateBackend::None => build_none_eval(&results),
+        EvaluateBackend::SbCli => run_sb_cli(&args, &results)?,
+    };
+    std::fs::write(
+        evaluation_path(&args.sweep_dir),
+        serde_json::to_string_pretty(&eval)?,
+    )?;
+    Ok(eval)
+}
+
+fn build_none_eval(results: &HashMap<String, InstanceResult>) -> EvaluationResults {
+    let mut instances: Vec<InstanceEvaluation> = results
+        .iter()
+        .map(|(id, r)| none_eval_for_result(id, r))
+        .collect();
+    instances.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
+    EvaluationResults { instances }
+}
+
+fn none_eval_for_result(id: &str, r: &InstanceResult) -> InstanceEvaluation {
+    let skipped = r.outcome.as_deref() != Some(outcome::SUBMITTED) || !r.patch_present;
+    InstanceEvaluation {
+        instance_id: id.to_owned(),
+        resolved: false,
+        tests_passed: vec![],
+        tests_failed: vec![],
+        eval_exit_reason: if skipped {
+            EvalExitReason::SkippedNoPatch
+        } else {
+            EvalExitReason::EvalError
+        },
+        eval_log_path: None,
+    }
+}
+
+fn run_sb_cli(
+    args: &EvaluateArgs,
+    results: &HashMap<String, InstanceResult>,
+) -> Result<EvaluationResults, Error> {
+    let preds = swebench::predictions_path(&args.sweep_dir);
+    if !preds.exists() {
+        return Err(Error::Trajectory(format!(
+            "bench evaluate: missing predictions file at {}",
+            preds.display()
+        )));
+    }
+
+    let out_file = args.sweep_dir.join("sb_cli_eval_raw.json");
+    let mut cmd = Command::new("sb-cli");
+    cmd.arg("eval")
+        .arg("--predictions")
+        .arg(&preds)
+        .arg("--output")
+        .arg(&out_file)
+        .arg("--timeout-per-instance")
+        .arg(args.timeout_per_instance_secs.to_string())
+        .arg("--parallel")
+        .arg(args.parallel.to_string());
+    if let Some(dataset) = &args.dataset_path {
+        cmd.arg("--dataset").arg(dataset);
+    }
+
+    let output = cmd.output().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            Error::Trajectory(
+                "bench evaluate: `sb-cli` not found on PATH; install it or run --backend none"
+                    .into(),
+            )
+        } else {
+            Error::Io(e)
+        }
+    })?;
+
+    if !output.status.success() {
+        return Err(Error::Trajectory(format!(
+            "bench evaluate: sb-cli failed (status={}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    let parsed = parse_sb_cli_results(&out_file)?;
+    Ok(merge_with_results(results, parsed))
+}
+
+fn parse_sb_cli_results(path: &Path) -> Result<HashMap<String, InstanceEvaluation>, Error> {
+    let text = std::fs::read_to_string(path)?;
+    if let Ok(eval) = serde_json::from_str::<EvaluationResults>(&text) {
+        return Ok(eval
+            .instances
+            .into_iter()
+            .map(|x| (x.instance_id.clone(), x))
+            .collect());
+    }
+
+    let value: serde_json::Value = serde_json::from_str(&text)?;
+    let mut map = HashMap::new();
+    match value {
+        serde_json::Value::Array(rows) => {
+            for row in rows {
+                if let Some(eval) = parse_generic_eval_row(&row) {
+                    map.insert(eval.instance_id.clone(), eval);
+                }
+            }
+        }
+        serde_json::Value::Object(obj) => {
+            if let Some(rows) = obj.get("instances").and_then(serde_json::Value::as_array) {
+                for row in rows {
+                    if let Some(eval) = parse_generic_eval_row(row) {
+                        map.insert(eval.instance_id.clone(), eval);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(map)
+}
+
+fn parse_generic_eval_row(v: &serde_json::Value) -> Option<InstanceEvaluation> {
+    let id = v.get("instance_id")?.as_str()?.to_owned();
+    let resolved = v
+        .get("resolved")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let tests_passed = as_string_vec(v.get("tests_passed"));
+    let tests_failed = as_string_vec(v.get("tests_failed"));
+    let eval_exit_reason = match v
+        .get("eval_exit_reason")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+    {
+        "resolved" => EvalExitReason::Resolved,
+        "unresolved" => EvalExitReason::Unresolved,
+        "patch_apply_failed" => EvalExitReason::PatchApplyFailed,
+        "eval_error" => EvalExitReason::EvalError,
+        "skipped_no_patch" => EvalExitReason::SkippedNoPatch,
+        _ => {
+            if resolved {
+                EvalExitReason::Resolved
+            } else {
+                EvalExitReason::Unresolved
+            }
+        }
+    };
+    let eval_log_path = v
+        .get("eval_log_path")
+        .or_else(|| v.get("log_path"))
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned);
+    Some(InstanceEvaluation {
+        instance_id: id,
+        resolved,
+        tests_passed,
+        tests_failed,
+        eval_exit_reason,
+        eval_log_path,
+    })
+}
+
+fn as_string_vec(v: Option<&serde_json::Value>) -> Vec<String> {
+    v.and_then(serde_json::Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|x| x.as_str().map(ToOwned::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn merge_with_results(
+    results: &HashMap<String, InstanceResult>,
+    parsed: HashMap<String, InstanceEvaluation>,
+) -> EvaluationResults {
+    let mut instances: Vec<InstanceEvaluation> = Vec::new();
+    for (id, r) in results {
+        if let Some(row) = parsed.get(id) {
+            instances.push(row.clone());
+            continue;
+        }
+        let skipped = r.outcome.as_deref() != Some(outcome::SUBMITTED) || !r.patch_present;
+        instances.push(InstanceEvaluation {
+            instance_id: id.clone(),
+            resolved: false,
+            tests_passed: vec![],
+            tests_failed: vec![],
+            eval_exit_reason: if skipped {
+                EvalExitReason::SkippedNoPatch
+            } else {
+                EvalExitReason::EvalError
+            },
+            eval_log_path: None,
+        });
+    }
+    instances.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
+    EvaluationResults { instances }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+    use crate::trajectory::FailureCategory;
+
+    fn submitted(id: &str) -> InstanceResult {
+        InstanceResult {
+            instance_id: id.into(),
+            exit_reason: "submitted".into(),
+            outcome: Some(outcome::SUBMITTED.into()),
+            failure_category: None,
+            steps: None,
+            cost_usd: None,
+            prompt_tokens: None,
+            completion_tokens: None,
+            duration_secs: None,
+            error: None,
+            patch_present: true,
+            non_empty_patch: true,
+        }
+    }
+
+    fn errored(id: &str) -> InstanceResult {
+        InstanceResult {
+            instance_id: id.into(),
+            exit_reason: "error".into(),
+            outcome: Some(outcome::ERROR.into()),
+            failure_category: Some(FailureCategory::Unknown),
+            steps: None,
+            cost_usd: None,
+            prompt_tokens: None,
+            completion_tokens: None,
+            duration_secs: None,
+            error: Some("boom".into()),
+            patch_present: false,
+            non_empty_patch: false,
+        }
+    }
+
+    #[test]
+    fn none_backend_marks_non_submitted_as_skipped_no_patch() {
+        let map = HashMap::from([
+            ("a".to_string(), submitted("a")),
+            ("b".to_string(), errored("b")),
+        ]);
+        let eval = build_none_eval(&map);
+        assert_eq!(eval.instances.len(), 2);
+        assert_eq!(eval.instances[0].instance_id, "a");
+        assert!(matches!(
+            eval.instances[0].eval_exit_reason,
+            EvalExitReason::EvalError
+        ));
+        assert_eq!(eval.instances[1].instance_id, "b");
+        assert!(matches!(
+            eval.instances[1].eval_exit_reason,
+            EvalExitReason::SkippedNoPatch
+        ));
+    }
+}

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -2,6 +2,7 @@
 //! and writes trajectories to disk.
 
 pub mod compare;
+pub mod evaluate;
 pub mod hello_world;
 pub mod mini;
 pub mod replay;

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -384,3 +384,106 @@ fn cli_disjoint_id_sets_bucketed_not_dropped() {
     assert_eq!(v["transitions"]["present_missing"], 1);
     assert_eq!(v["regressions"].as_array().unwrap().len(), 0);
 }
+
+#[test]
+fn compare_gate_uses_evaluation_resolved_when_present() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    write_results(baseline_dir.path(), vec![submitted("a"), submitted("b")]);
+    write_results(candidate_dir.path(), vec![submitted("a"), submitted("b")]);
+
+    let baseline_eval = serde_json::json!({
+        "instances": [
+            {"instance_id": "a", "resolved": true, "tests_passed": [], "tests_failed": [], "eval_exit_reason": "resolved"},
+            {"instance_id": "b", "resolved": true, "tests_passed": [], "tests_failed": [], "eval_exit_reason": "resolved"}
+        ]
+    });
+    let candidate_eval = serde_json::json!({
+        "instances": [
+            {"instance_id": "a", "resolved": false, "tests_passed": [], "tests_failed": [], "eval_exit_reason": "unresolved"},
+            {"instance_id": "b", "resolved": false, "tests_passed": [], "tests_failed": [], "eval_exit_reason": "unresolved"}
+        ]
+    });
+    std::fs::write(
+        baseline_dir.path().join("evaluation.json"),
+        serde_json::to_string_pretty(&baseline_eval).unwrap(),
+    )
+    .unwrap();
+    std::fs::write(
+        candidate_dir.path().join("evaluation.json"),
+        serde_json::to_string_pretty(&candidate_eval).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--max-regressions",
+            "0",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "expected non-zero with resolved regressions; stdout:
+{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["baseline_resolved"], 2);
+    assert_eq!(v["candidate_resolved"], 0);
+    assert_eq!(v["resolved_delta"], -2);
+    assert_eq!(v["regressions"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn evaluate_none_backend_writes_evaluation_json() {
+    let sweep_dir = tempfile::tempdir().unwrap();
+    write_results(
+        sweep_dir.path(),
+        vec![submitted("a"), errored("b", FailureCategory::ModelApi)],
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "evaluate",
+            "--sweep",
+            sweep_dir.path().to_str().unwrap(),
+            "--backend",
+            "none",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let eval_path = sweep_dir.path().join("evaluation.json");
+    assert!(eval_path.exists());
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(eval_path).unwrap()).unwrap();
+    assert_eq!(v["instances"].as_array().unwrap().len(), 2);
+}


### PR DESCRIPTION
### Motivation
- Provide a post-hoc evaluation step to score completed sweeps (e.g. via `sb-cli`) so resolved-rate (real test results) can be used instead of the submission/proxy heuristic. 
- Let `bench compare` use that authoritative `resolved` signal for transition classification and CI regression gating while preserving legacy behavior when no evaluation data exists.

### Description
- Add a new `bench evaluate` CLI subcommand with `--sweep`, `--dataset`, `--backend`, `--timeout-per-instance`, and `--parallel` flags and an async handler wired into the CLI. 
- Implement `src/run/evaluate.rs` with `EvaluationResults`/`InstanceEvaluation` schema, `none` backend (placeholder), and an `sb-cli` backend that shells out, parses, normalizes and merges evaluator output; writes `evaluation.json` into the sweep dir. 
- Update `src/run/compare.rs` to read `evaluation.json` when present and prefer `resolved` as the pass/fail source of truth via an override map, falling back to the legacy `outcome == submitted && failure_category == null` heuristic otherwise. 
- Export the new module in `src/run/mod.rs`, add tests that exercise the compare gate and evaluate behavior, and add documentation `docs/spec-evaluation.md` describing the `evaluation.json` contract and compare interaction.

### Testing
- Ran `cargo fmt` successfully. 
- Ran `cargo test --test bench_compare` and observed all 8 integration tests in that file pass. 
- Ran targeted unit tests `run::compare::tests::prefers_evaluation_json_resolved_over_submission_proxy` and `run::evaluate::tests::none_backend_marks_non_submitted_as_skipped_no_patch`, both of which passed. 
- Noted a mistaken combined `cargo test` invocation with two bare test names failed due to invalid CLI usage (command invocation error), but subsequent correct test invocations succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef4db8870832ab5682f5eeb897dd0)