### PR TITLE
Add `bench inspect` subcommand for per-instance trajectory triage

### DIFF
--- a/docs/spec-inspect.md
+++ b/docs/spec-inspect.md
@@ -1,0 +1,102 @@
+# `bench inspect` spec
+
+`bench inspect` is a read-only post-run debugging surface for SWE-bench sweeps.
+It renders one trajectory as a human-readable transcript, or lists matching
+instances in filter mode.
+
+## CLI
+
+```bash
+rust-swe-agent bench inspect --sweep <dir> --instance <instance_id>
+rust-swe-agent bench inspect --sweep <dir> --instance <instance_id> --full
+rust-swe-agent bench inspect --sweep <dir> --instance <instance_id> --format json
+rust-swe-agent bench inspect --sweep <dir> --filter resolved=false
+rust-swe-agent bench inspect --sweep <dir> --filter failure_category=step_limit
+```
+
+### Inputs
+
+* `--sweep`: output directory from `bench swebench`.
+* `--instance`: render one instance transcript.
+* `--filter`: summary-table mode (`resolved=true|false` or `failure_category=<snake_case>`).
+* `--format`: `text` (default) or `json`.
+* `--full`: disable stdout/stderr truncation in transcript mode.
+
+Exactly one of `--instance` or `--filter` is required.
+
+## Transcript behavior
+
+Header fields:
+
+* `instance_id`
+* `model`
+* `outcome`
+* `failure_category`
+* `total_cost_usd`
+* token totals (`prompt`, `completion`)
+* `resolved` when `evaluation.json` exists
+
+Step rendering:
+
+* Assistant messages render as `[step N] assistant` and raw model content.
+* Bash observations render as `[step N] bash` with:
+  * command (inferred from prior assistant action),
+  * exit code,
+  * stdout/stderr (possibly truncated).
+
+Truncation defaults:
+
+* Truncate when stdout/stderr exceeds **40 lines** or **2 KiB**.
+* Marker: `… [N more lines, full output at trajectory.json#/steps/N]`.
+* `--full` disables truncation.
+
+## Worked examples
+
+### Resolved instance (text)
+
+```text
+=== bench inspect ===
+instance_id:      astropy__astropy-12907
+model:            claude-opus-4-7
+outcome:          submitted
+failure_category: none
+total_cost_usd:   0.123456
+tokens:           prompt=45123 completion=3987
+resolved:         true
+
+[step 2] assistant
+```bash
+pytest -q
+```
+
+[step 3] bash
+$ pytest -q
+exit_code: 0
+stdout:
+2 passed in 0.74s
+```
+
+### Unresolved instance (text)
+
+```text
+=== bench inspect ===
+instance_id:      astropy__astropy-12908
+model:            claude-opus-4-7
+outcome:          error
+failure_category: patch_apply_failed
+total_cost_usd:   0.098732
+tokens:           prompt=38011 completion=3502
+resolved:         false
+
+[step 8] assistant
+```bash
+git apply fix.patch
+```
+
+[step 9] bash
+$ git apply fix.patch
+exit_code: 1
+stderr:
+error: patch failed: src/core.py:10
+… [77 more lines, full output at trajectory.json#/steps/9]
+```

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -91,6 +91,8 @@ pub enum BenchCmd {
     Compare(CompareCmd),
     /// Evaluate a completed sweep with an evaluation backend (e.g. sb-cli).
     Evaluate(EvaluateCmd),
+    /// Inspect a single trajectory or list filtered instance summaries.
+    Inspect(InspectCmd),
 }
 
 #[derive(Debug, Args)]
@@ -191,4 +193,27 @@ pub struct EvaluateCmd {
     /// Parallel worker count for evaluation backend.
     #[arg(long, default_value_t = 4)]
     pub parallel: usize,
+}
+
+#[derive(Debug, Args)]
+pub struct InspectCmd {
+    /// Completed sweep directory produced by `bench swebench`.
+    #[arg(long)]
+    pub sweep: PathBuf,
+
+    /// One specific instance id to render as a human-readable transcript.
+    #[arg(long)]
+    pub instance: Option<String>,
+
+    /// Filter mode: `resolved=false` or `failure_category=patch_apply_failed`.
+    #[arg(long)]
+    pub filter: Option<String>,
+
+    /// Output format: `text` (default) or `json`.
+    #[arg(long, default_value = "text")]
+    pub format: String,
+
+    /// Disable stdout/stderr truncation in transcript mode.
+    #[arg(long, default_value_t = false)]
+    pub full: bool,
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -56,6 +56,9 @@ pub async fn run() -> Result<(), Error> {
         Command::Bench {
             cmd: args::BenchCmd::Evaluate(e),
         } => bench_evaluate(e),
+        Command::Bench {
+            cmd: args::BenchCmd::Inspect(i),
+        } => bench_inspect(i),
         #[cfg(feature = "docker")]
         Command::Cleanup => cleanup_cmd().await,
         #[cfg(not(feature = "docker"))]
@@ -266,5 +269,32 @@ fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
         evaluation_path = %crate::run::evaluate::evaluation_path(&e.sweep).display(),
         "evaluation complete"
     );
+    Ok(())
+}
+
+fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
+    let format = match i.format.as_str() {
+        "text" => crate::run::inspect::InspectFormat::Text,
+        "json" => crate::run::inspect::InspectFormat::Json,
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "unknown --format `{other}` (expected `text` or `json`)"
+            ))));
+        }
+    };
+    let out = crate::run::inspect::run(&crate::run::inspect::InspectArgs {
+        sweep: i.sweep,
+        instance: i.instance,
+        filter: i.filter,
+        full: i.full,
+    })?;
+    match format {
+        crate::run::inspect::InspectFormat::Text => {
+            print!("{}", crate::run::inspect::render_text(&out));
+        }
+        crate::run::inspect::InspectFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&out)?);
+        }
+    }
     Ok(())
 }

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -1,0 +1,504 @@
+//! `bench inspect`: inspect one trajectory or list filtered instances.
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::io::IsTerminal as _;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::env::RunResult;
+use crate::error::Error;
+use crate::run::evaluate::EvaluationResults;
+use crate::run::swebench::InstanceResult;
+use crate::trajectory::{FailureCategory, Trajectory};
+
+const TRUNCATE_MAX_LINES: usize = 40;
+const TRUNCATE_MAX_BYTES: usize = 2 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InspectFormat {
+    Text,
+    Json,
+}
+
+#[derive(Debug, Clone)]
+pub struct InspectArgs {
+    pub sweep: PathBuf,
+    pub instance: Option<String>,
+    pub filter: Option<String>,
+    pub full: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct InspectStep {
+    pub index: usize,
+    pub role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stdout: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stderr: Option<String>,
+    #[serde(default)]
+    pub truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncation_note: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct InspectReport {
+    pub sweep_dir: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_category: Option<FailureCategory>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_cost_usd: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved: Option<bool>,
+    #[serde(default)]
+    pub warnings: Vec<String>,
+    #[serde(default)]
+    pub steps: Vec<InspectStep>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SummaryRow {
+    pub instance_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_category: Option<FailureCategory>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SummaryReport {
+    pub sweep_dir: PathBuf,
+    pub filter: String,
+    pub rows: Vec<SummaryRow>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum InspectOutput {
+    Instance(InspectReport),
+    Summary(SummaryReport),
+}
+
+pub fn run(args: &InspectArgs) -> Result<InspectOutput, Error> {
+    if !args.sweep.exists() {
+        return Err(Error::Trajectory(format!(
+            "inspect: sweep directory does not exist: {}",
+            args.sweep.display()
+        )));
+    }
+    match (&args.instance, &args.filter) {
+        (Some(_), Some(_)) => {
+            return Err(Error::Trajectory(
+                "inspect: pass exactly one of --instance or --filter".into(),
+            ));
+        }
+        (None, None) => {
+            return Err(Error::Trajectory(
+                "inspect: one of --instance or --filter is required".into(),
+            ));
+        }
+        _ => {}
+    }
+
+    if let Some(filter) = &args.filter {
+        return build_summary(&args.sweep, filter).map(InspectOutput::Summary);
+    }
+
+    let instance_id = args.instance.clone().unwrap_or_default();
+    let resolved_map = load_resolved_overrides(&args.sweep)?;
+    let report =
+        build_instance_report(&args.sweep, &instance_id, args.full, resolved_map.as_ref())?;
+    Ok(InspectOutput::Instance(report))
+}
+
+fn build_summary(sweep: &Path, filter: &str) -> Result<SummaryReport, Error> {
+    let filter = parse_filter(filter)?;
+    let mut rows: Vec<SummaryRow> = Vec::new();
+    let run = crate::run::compare::load_run(sweep)?;
+    let resolved = load_resolved_overrides(sweep)?.unwrap_or_default();
+    for r in run.values() {
+        let res = resolved.get(&r.instance_id).copied();
+        if !filter.matches(r, res) {
+            continue;
+        }
+        rows.push(SummaryRow {
+            instance_id: r.instance_id.clone(),
+            outcome: r.outcome.clone(),
+            failure_category: r.failure_category,
+            cost_usd: r.cost_usd,
+            resolved: res,
+        });
+    }
+    rows.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
+    Ok(SummaryReport {
+        sweep_dir: sweep.to_path_buf(),
+        filter: filter.raw,
+        rows,
+    })
+}
+
+fn build_instance_report(
+    sweep: &Path,
+    instance_id: &str,
+    full: bool,
+    resolved_map: Option<&HashMap<String, bool>>,
+) -> Result<InspectReport, Error> {
+    let traj_path = resolve_trajectory_path(sweep, instance_id).ok_or_else(|| {
+        Error::Trajectory(format!(
+            "inspect: trajectory not found for instance `{instance_id}` in {}",
+            sweep.display()
+        ))
+    })?;
+    let text = std::fs::read_to_string(&traj_path)?;
+    let mut warnings = Vec::new();
+    let traj: Trajectory = match serde_json::from_str(&text) {
+        Ok(t) => t,
+        Err(err) => {
+            warnings.push(format!(
+                "failed to parse trajectory as canonical schema: {err}; rendering minimal report"
+            ));
+            return Ok(InspectReport {
+                sweep_dir: sweep.to_path_buf(),
+                instance_id: Some(instance_id.to_owned()),
+                model: None,
+                outcome: None,
+                failure_category: None,
+                total_cost_usd: None,
+                prompt_tokens: None,
+                completion_tokens: None,
+                resolved: resolved_map.and_then(|m| m.get(instance_id).copied()),
+                warnings,
+                steps: vec![],
+            });
+        }
+    };
+
+    let mut steps = Vec::new();
+    for (msg_idx, msg) in traj.messages.iter().enumerate() {
+        let current_index = steps.len();
+        let role = msg.role.clone();
+        if role == "assistant" {
+            steps.push(InspectStep {
+                index: current_index,
+                role,
+                message: Some(msg.content.clone()),
+                bash: None,
+                exit_code: None,
+                stdout: None,
+                stderr: None,
+                truncated: false,
+                truncation_note: None,
+            });
+            continue;
+        }
+
+        if role == "user" {
+            if let Some(run_result) = msg
+                .extra
+                .other
+                .get("run_result")
+                .and_then(|v| serde_json::from_value::<RunResult>(v.clone()).ok())
+            {
+                let bash = infer_bash_from_previous_assistant(&traj, msg_idx);
+                let (stdout, stdout_note, stdout_truncated) =
+                    maybe_truncate(&run_result.stdout, full, current_index);
+                let (stderr, stderr_note, stderr_truncated) =
+                    maybe_truncate(&run_result.stderr, full, current_index);
+                let mut note_parts = Vec::new();
+                if let Some(n) = stdout_note {
+                    note_parts.push(format!("stdout: {n}"));
+                }
+                if let Some(n) = stderr_note {
+                    note_parts.push(format!("stderr: {n}"));
+                }
+                steps.push(InspectStep {
+                    index: current_index,
+                    role: "bash".into(),
+                    message: None,
+                    bash,
+                    exit_code: Some(run_result.exit_code),
+                    stdout: Some(stdout),
+                    stderr: Some(stderr),
+                    truncated: stdout_truncated || stderr_truncated,
+                    truncation_note: (!note_parts.is_empty()).then(|| note_parts.join("; ")),
+                });
+            }
+        }
+    }
+
+    Ok(InspectReport {
+        sweep_dir: sweep.to_path_buf(),
+        instance_id: Some(instance_id.to_owned()),
+        model: traj.info.model_name,
+        outcome: traj.info.outcome,
+        failure_category: traj.info.failure_category,
+        total_cost_usd: traj.info.total_cost_usd,
+        prompt_tokens: traj.info.token_usage.as_ref().map(|t| t.prompt_tokens),
+        completion_tokens: traj.info.token_usage.as_ref().map(|t| t.completion_tokens),
+        resolved: resolved_map.and_then(|m| m.get(instance_id).copied()),
+        warnings,
+        steps,
+    })
+}
+
+pub fn render_text(output: &InspectOutput) -> String {
+    match output {
+        InspectOutput::Instance(r) => render_instance_text(r),
+        InspectOutput::Summary(s) => render_summary_text(s),
+    }
+}
+
+fn render_summary_text(report: &SummaryReport) -> String {
+    let mut s = String::new();
+    s.push_str("\n=== bench inspect summary ===\n");
+    let _ = writeln!(s, "Sweep:   {}", report.sweep_dir.display());
+    let _ = writeln!(s, "Filter:  {}", report.filter);
+    s.push_str("\ninstance_id | outcome | failure_category | cost_usd | resolved\n");
+    s.push_str("----------------------------------------------------------------\n");
+    for row in &report.rows {
+        let _ = writeln!(
+            s,
+            "{} | {} | {} | {} | {}",
+            row.instance_id,
+            row.outcome.as_deref().unwrap_or("?"),
+            row.failure_category.map(failure_label).unwrap_or("none"),
+            row.cost_usd
+                .map(|c| format!("{c:.4}"))
+                .unwrap_or_else(|| "?".into()),
+            row.resolved
+                .map(|v| if v { "true" } else { "false" })
+                .unwrap_or("?")
+        );
+    }
+    s
+}
+
+fn render_instance_text(report: &InspectReport) -> String {
+    let mut s = String::new();
+    let color = std::io::stdout().is_terminal();
+    s.push_str("\n=== bench inspect ===\n");
+    let _ = writeln!(
+        s,
+        "instance_id:      {}",
+        report.instance_id.as_deref().unwrap_or("?")
+    );
+    let _ = writeln!(
+        s,
+        "model:            {}",
+        report.model.as_deref().unwrap_or("?")
+    );
+    let _ = writeln!(
+        s,
+        "outcome:          {}",
+        report.outcome.as_deref().unwrap_or("?")
+    );
+    let _ = writeln!(
+        s,
+        "failure_category: {}",
+        report.failure_category.map(failure_label).unwrap_or("none")
+    );
+    let _ = writeln!(
+        s,
+        "total_cost_usd:   {}",
+        report
+            .total_cost_usd
+            .map(|v| format!("{v:.6}"))
+            .unwrap_or_else(|| "?".into())
+    );
+    let _ = writeln!(
+        s,
+        "tokens:           prompt={} completion={}",
+        report
+            .prompt_tokens
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "?".into()),
+        report
+            .completion_tokens
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "?".into()),
+    );
+    if let Some(r) = report.resolved {
+        let _ = writeln!(s, "resolved:         {r}");
+    }
+    for w in &report.warnings {
+        let _ = writeln!(s, "warning:          {w}");
+    }
+
+    for step in &report.steps {
+        let header = format!("[step {}] {}", step.index, step.role);
+        if color {
+            let _ = writeln!(s, "\n\x1b[1;36m{header}\x1b[0m");
+        } else {
+            let _ = writeln!(s, "\n{header}");
+        }
+
+        if let Some(msg) = &step.message {
+            s.push_str(msg);
+            if !msg.ends_with('\n') {
+                s.push('\n');
+            }
+            continue;
+        }
+
+        if let Some(cmd) = &step.bash {
+            let _ = writeln!(s, "$ {cmd}");
+        }
+        if let Some(code) = step.exit_code {
+            let _ = writeln!(s, "exit_code: {code}");
+        }
+        if let Some(out) = &step.stdout {
+            let _ = writeln!(s, "stdout:\n{out}");
+        }
+        if let Some(err) = &step.stderr {
+            if !err.is_empty() {
+                let _ = writeln!(s, "stderr:\n{err}");
+            }
+        }
+        if let Some(note) = &step.truncation_note {
+            let _ = writeln!(s, "… {note}");
+        }
+    }
+    s
+}
+
+fn infer_bash_from_previous_assistant(traj: &Trajectory, msg_idx: usize) -> Option<String> {
+    traj.messages
+        .iter()
+        .take(msg_idx)
+        .rev()
+        .find(|m| m.role == "assistant")
+        .and_then(|m| m.extra.actions.as_ref())
+        .and_then(|actions| actions.first())
+        .and_then(|a| (a != "__SUBMIT__").then(|| a.clone()))
+}
+
+fn maybe_truncate(text: &str, full: bool, step_index: usize) -> (String, Option<String>, bool) {
+    if full {
+        return (text.to_owned(), None, false);
+    }
+    let line_count = text.lines().count();
+    if text.len() <= TRUNCATE_MAX_BYTES && line_count <= TRUNCATE_MAX_LINES {
+        return (text.to_owned(), None, false);
+    }
+
+    let max_bytes = TRUNCATE_MAX_BYTES.min(text.len());
+    let mut truncated = text[..max_bytes].to_owned();
+    if let Some(last_newline) = truncated.rfind('\n') {
+        truncated.truncate(last_newline);
+    }
+    let shown_lines = truncated.lines().count();
+    let more_lines = line_count.saturating_sub(shown_lines);
+    let note = format!(
+        "[{} more lines, full output at trajectory.json#/steps/{}]",
+        more_lines, step_index
+    );
+    (truncated, Some(note), true)
+}
+
+fn resolve_trajectory_path(sweep: &Path, instance_id: &str) -> Option<PathBuf> {
+    let nested = sweep.join(instance_id).join("trajectory.json");
+    if nested.exists() {
+        return Some(nested);
+    }
+    let flat = sweep.join(format!("{instance_id}.traj.json"));
+    flat.exists().then_some(flat)
+}
+
+fn load_resolved_overrides(dir: &Path) -> Result<Option<HashMap<String, bool>>, Error> {
+    let eval_path = crate::run::evaluate::evaluation_path(dir);
+    if !eval_path.exists() {
+        return Ok(None);
+    }
+    let text = std::fs::read_to_string(eval_path)?;
+    let eval: EvaluationResults = serde_json::from_str(&text)?;
+    Ok(Some(
+        eval.instances
+            .into_iter()
+            .map(|x| (x.instance_id, x.resolved))
+            .collect(),
+    ))
+}
+
+#[derive(Debug, Clone)]
+struct FilterSpec {
+    raw: String,
+    key: String,
+    value: String,
+}
+
+impl FilterSpec {
+    fn matches(&self, row: &InstanceResult, resolved: Option<bool>) -> bool {
+        match self.key.as_str() {
+            "resolved" => {
+                let expected = self.value == "true";
+                resolved == Some(expected)
+            }
+            "failure_category" => row
+                .failure_category
+                .map(|c| failure_label(c) == self.value)
+                .unwrap_or(false),
+            _ => false,
+        }
+    }
+}
+
+fn parse_filter(s: &str) -> Result<FilterSpec, Error> {
+    let mut it = s.splitn(2, '=');
+    let key = it.next().unwrap_or_default().trim().to_owned();
+    let value = it.next().unwrap_or_default().trim().to_owned();
+    if key.is_empty() || value.is_empty() {
+        return Err(Error::Trajectory(
+            "inspect: --filter expects key=value (e.g. resolved=false)".into(),
+        ));
+    }
+    if key != "resolved" && key != "failure_category" {
+        return Err(Error::Trajectory(
+            "inspect: supported filters are `resolved` and `failure_category`".into(),
+        ));
+    }
+    if key == "resolved" && value != "true" && value != "false" {
+        return Err(Error::Trajectory(
+            "inspect: resolved filter must be true or false".into(),
+        ));
+    }
+    Ok(FilterSpec {
+        raw: s.to_owned(),
+        key,
+        value,
+    })
+}
+
+fn failure_label(c: FailureCategory) -> &'static str {
+    match c {
+        FailureCategory::EnvSetup => "env_setup",
+        FailureCategory::ModelApi => "model_api",
+        FailureCategory::ModelParse => "model_parse",
+        FailureCategory::StepLimit => "step_limit",
+        FailureCategory::CostLimit => "cost_limit",
+        FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::Unknown => "unknown",
+    }
+}

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -399,16 +399,50 @@ fn maybe_truncate(text: &str, full: bool, step_index: usize) -> (String, Option<
         return (text.to_owned(), None, false);
     }
 
-    let max_bytes = TRUNCATE_MAX_BYTES.min(text.len());
-    let mut truncated = text[..max_bytes].to_owned();
-    if let Some(last_newline) = truncated.rfind('\n') {
-        truncated.truncate(last_newline);
+    let mut truncated = String::new();
+    let mut consumed_bytes = 0usize;
+    let mut shown_lines = 0usize;
+    for line in text.split_inclusive('\n') {
+        if shown_lines >= TRUNCATE_MAX_LINES || consumed_bytes >= TRUNCATE_MAX_BYTES {
+            break;
+        }
+        let remaining = TRUNCATE_MAX_BYTES - consumed_bytes;
+        let head = utf8_prefix_within_bytes(line, remaining);
+        if head.is_empty() {
+            break;
+        }
+        truncated.push_str(head);
+        consumed_bytes += head.len();
+        shown_lines += 1;
+        if head.len() < line.len() {
+            break;
+        }
     }
-    let shown_lines = truncated.lines().count();
+    while truncated.ends_with('\n') {
+        truncated.pop();
+    }
+    if shown_lines == 0 && !truncated.is_empty() {
+        shown_lines = truncated.lines().count();
+    }
     let more_lines = line_count.saturating_sub(shown_lines);
     let note =
         format!("[{more_lines} more lines, full output at trajectory.json#/steps/{step_index}]");
     (truncated, Some(note), true)
+}
+
+fn utf8_prefix_within_bytes(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = 0usize;
+    for (idx, ch) in s.char_indices() {
+        let next = idx + ch.len_utf8();
+        if next > max_bytes {
+            break;
+        }
+        end = next;
+    }
+    &s[..end]
 }
 
 fn resolve_trajectory_path(sweep: &Path, instance_id: &str) -> Option<PathBuf> {

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -284,13 +284,11 @@ fn render_summary_text(report: &SummaryReport) -> String {
             "{} | {} | {} | {} | {}",
             row.instance_id,
             row.outcome.as_deref().unwrap_or("?"),
-            row.failure_category.map(failure_label).unwrap_or("none"),
+            row.failure_category.map_or("none", failure_label),
             row.cost_usd
-                .map(|c| format!("{c:.4}"))
-                .unwrap_or_else(|| "?".into()),
+                .map_or_else(|| "?".into(), |c| format!("{c:.4}")),
             row.resolved
-                .map(|v| if v { "true" } else { "false" })
-                .unwrap_or("?")
+                .map_or("?", |v| if v { "true" } else { "false" })
         );
     }
     s
@@ -318,27 +316,24 @@ fn render_instance_text(report: &InspectReport) -> String {
     let _ = writeln!(
         s,
         "failure_category: {}",
-        report.failure_category.map(failure_label).unwrap_or("none")
+        report.failure_category.map_or("none", failure_label)
     );
     let _ = writeln!(
         s,
         "total_cost_usd:   {}",
         report
             .total_cost_usd
-            .map(|v| format!("{v:.6}"))
-            .unwrap_or_else(|| "?".into())
+            .map_or_else(|| "?".into(), |v| format!("{v:.6}"))
     );
     let _ = writeln!(
         s,
         "tokens:           prompt={} completion={}",
         report
             .prompt_tokens
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "?".into()),
+            .map_or_else(|| "?".into(), |v| v.to_string()),
         report
             .completion_tokens
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "?".into()),
+            .map_or_else(|| "?".into(), |v| v.to_string()),
     );
     if let Some(r) = report.resolved {
         let _ = writeln!(s, "resolved:         {r}");
@@ -411,10 +406,8 @@ fn maybe_truncate(text: &str, full: bool, step_index: usize) -> (String, Option<
     }
     let shown_lines = truncated.lines().count();
     let more_lines = line_count.saturating_sub(shown_lines);
-    let note = format!(
-        "[{} more lines, full output at trajectory.json#/steps/{}]",
-        more_lines, step_index
-    );
+    let note =
+        format!("[{more_lines} more lines, full output at trajectory.json#/steps/{step_index}]");
     (truncated, Some(note), true)
 }
 
@@ -458,8 +451,7 @@ impl FilterSpec {
             }
             "failure_category" => row
                 .failure_category
-                .map(|c| failure_label(c) == self.value)
-                .unwrap_or(false),
+                .is_some_and(|c| failure_label(c) == self.value),
             _ => false,
         }
     }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -4,6 +4,7 @@
 pub mod compare;
 pub mod evaluate;
 pub mod hello_world;
+pub mod inspect;
 pub mod mini;
 pub mod replay;
 pub mod swebench;

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -62,6 +62,35 @@ fn write_traj(dir: &Path, instance_id: &str, huge_stderr: bool) {
     .unwrap();
 }
 
+fn write_traj_with_stderr(dir: &Path, instance_id: &str, stderr: &str) {
+    let mut t = Trajectory::new();
+    t.info.model_name = Some("deterministic-test".into());
+    t.info.outcome = Some(outcome::ERROR.into());
+    t.info.failure_category = Some(FailureCategory::StepLimit);
+
+    let mut asst = rust_swe_agent::model::Message::assistant("```bash\necho hi\n```");
+    asst.extra.actions = Some(vec!["echo hi".into()]);
+    t.record_message(&asst);
+
+    let mut obs = rust_swe_agent::model::Message::user("Exit code: 0\nOutput:\nhi");
+    obs.extra.other.insert(
+        "run_result".into(),
+        serde_json::json!({
+            "stdout": "hi\n",
+            "stderr": stderr,
+            "exit_code": 0,
+            "timed_out": false
+        }),
+    );
+    t.record_message(&obs);
+
+    std::fs::write(
+        dir.join(format!("{instance_id}.traj.json")),
+        serde_json::to_string_pretty(&t).unwrap(),
+    )
+    .unwrap();
+}
+
 #[test]
 fn help_lists_inspect_subcommand_and_flags() {
     let out = Command::new(binary_path())
@@ -144,6 +173,19 @@ fn truncates_long_output_unless_full() {
         stdout.contains("full output at trajectory.json#/steps/1"),
         "{stdout}"
     );
+    let stderr_block = stdout
+        .split("stderr:\n")
+        .nth(1)
+        .and_then(|s| s.split("\n… [").next())
+        .unwrap_or_default();
+    let stderr_lines = stderr_block
+        .lines()
+        .filter(|l| l.starts_with("line-"))
+        .count();
+    assert!(
+        stderr_lines <= 40,
+        "expected at most 40 lines of stderr, got {stderr_lines}\n{stdout}"
+    );
 
     let out = Command::new(binary_path())
         .args([
@@ -164,6 +206,35 @@ fn truncates_long_output_unless_full() {
         "{stdout}"
     );
     assert!(stdout.contains("line-89"), "{stdout}");
+}
+
+#[test]
+fn truncation_is_utf8_safe_for_multibyte_logs() {
+    let sweep = tempfile::tempdir().unwrap();
+    let stderr: String = (0..300).map(|_| "测试🙂").collect();
+    write_traj_with_stderr(sweep.path(), "utf8", &stderr);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "utf8",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "expected success for UTF-8 logs; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("full output at trajectory.json#/steps/1"),
+        "{stdout}"
+    );
 }
 
 #[test]

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -1,0 +1,227 @@
+//! `bench inspect`: CLI integration tests.
+
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+use rust_swe_agent::trajectory::{FailureCategory, Trajectory, outcome};
+
+fn binary_path() -> std::path::PathBuf {
+    std::env::var("CARGO_BIN_EXE_rust-swe-agent").map_or_else(
+        |_| {
+            let mut p = std::env::current_exe().unwrap();
+            p.pop();
+            p.pop();
+            p.push("rust-swe-agent");
+            p
+        },
+        std::path::PathBuf::from,
+    )
+}
+
+fn write_traj(dir: &Path, instance_id: &str, huge_stderr: bool) {
+    let mut t = Trajectory::new();
+    t.info.model_name = Some("deterministic-test".into());
+    t.info.outcome = Some(outcome::ERROR.into());
+    t.info.failure_category = Some(FailureCategory::StepLimit);
+    t.info.total_cost_usd = Some(0.55);
+    t.info.token_usage = Some(rust_swe_agent::trajectory::TokenUsage {
+        prompt_tokens: 123,
+        completion_tokens: 45,
+    });
+
+    let mut asst = rust_swe_agent::model::Message::assistant("```bash\necho hi\n```");
+    asst.extra.actions = Some(vec!["echo hi".into()]);
+    t.record_message(&asst);
+
+    let mut obs = rust_swe_agent::model::Message::user("Exit code: 0\nOutput:\nhi");
+    let stderr = if huge_stderr {
+        (0..90)
+            .map(|i| format!("line-{i}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        String::new()
+    };
+    obs.extra.other.insert(
+        "run_result".into(),
+        serde_json::json!({
+            "stdout": "hi\n",
+            "stderr": stderr,
+            "exit_code": 0,
+            "timed_out": false
+        }),
+    );
+    t.record_message(&obs);
+
+    std::fs::write(
+        dir.join(format!("{instance_id}.traj.json")),
+        serde_json::to_string_pretty(&t).unwrap(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn help_lists_inspect_subcommand_and_flags() {
+    let out = Command::new(binary_path())
+        .args(["bench", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("inspect"), "stdout:\n{stdout}");
+
+    let out = Command::new(binary_path())
+        .args(["bench", "inspect", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in ["--sweep", "--instance", "--filter", "--format", "--full"] {
+        assert!(stdout.contains(flag), "missing {flag} in:\n{stdout}");
+    }
+}
+
+#[test]
+fn instance_mode_renders_header_and_steps() {
+    let sweep = tempfile::tempdir().unwrap();
+    write_traj(sweep.path(), "abc", false);
+    std::fs::write(
+        sweep.path().join("evaluation.json"),
+        serde_json::json!({
+            "instances": [{
+                "instance_id": "abc",
+                "resolved": false,
+                "tests_passed": [],
+                "tests_failed": [],
+                "eval_exit_reason": "unresolved"
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "abc",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("=== bench inspect ==="), "{stdout}");
+    assert!(stdout.contains("instance_id:      abc"), "{stdout}");
+    assert!(stdout.contains("[step 0] assistant"), "{stdout}");
+    assert!(stdout.contains("[step 1] bash"), "{stdout}");
+    assert!(stdout.contains("resolved:         false"), "{stdout}");
+}
+
+#[test]
+fn truncates_long_output_unless_full() {
+    let sweep = tempfile::tempdir().unwrap();
+    write_traj(sweep.path(), "abc", true);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "abc",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("full output at trajectory.json#/steps/1"),
+        "{stdout}"
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "abc",
+            "--full",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("full output at trajectory.json#/steps/1"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("line-89"), "{stdout}");
+}
+
+#[test]
+fn filter_mode_lists_matching_instances() {
+    let sweep = tempfile::tempdir().unwrap();
+    write_traj(sweep.path(), "a", false);
+    write_traj(sweep.path(), "b", false);
+    let results = serde_json::json!({
+        "total": 2,
+        "submitted": 0,
+        "skipped": 0,
+        "errored": 2,
+        "budget_halted": 0,
+        "with_patch": 0,
+        "total_prompt_tokens": 0,
+        "total_completion_tokens": 0,
+        "estimated_cost_usd": 0.0,
+        "instances": [
+            {
+                "instance_id": "a",
+                "exit_reason": "error",
+                "outcome": "error",
+                "failure_category": "step_limit",
+                "cost_usd": 0.1,
+                "patch_present": false,
+                "non_empty_patch": false
+            },
+            {
+                "instance_id": "b",
+                "exit_reason": "error",
+                "outcome": "error",
+                "failure_category": "model_api",
+                "cost_usd": 0.2,
+                "patch_present": false,
+                "non_empty_patch": false
+            }
+        ]
+    });
+    std::fs::write(
+        sweep.path().join("results.json"),
+        serde_json::to_string_pretty(&results).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--filter",
+            "failure_category=step_limit",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("instance_id | outcome"), "{stdout}");
+    assert!(stdout.contains("a | error | step_limit"), "{stdout}");
+    assert!(!stdout.contains("b | error | model_api"), "{stdout}");
+}


### PR DESCRIPTION
### Motivation

- Provide a read-only diagnostic surface to inspect individual trajectories or list filtered instance summaries from SWE-bench sweep outputs for faster triage.

### Description

- Add a new `run::inspect` module (`src/run/inspect.rs`) that implements two modes: instance transcript rendering and filter-based summary listing, and emits JSON-serializable report structs.
- Wire a new `bench inspect` CLI subcommand (clap args in `src/cli/args.rs`, dispatch in `src/cli/mod.rs`) with flags `--sweep`, `--instance`, `--filter`, `--format`, and `--full`.
- Support both sweep layouts by resolving trajectories from `<sweep>/<instance>/trajectory.json` and `<sweep>/<instance>.traj.json`, and optionally load `evaluation.json` to include a `resolved` flag per instance.
- Implement default truncation of long stdout/stderr (40 lines or 2 KiB) with a `--full` escape hatch, render human-readable transcripts, and provide a compact summary table; add `docs/spec-inspect.md` documenting CLI usage and examples.

### Testing

- Ran `cargo fmt --all` successfully.
- Ran the new CLI integration tests with `cargo test -q --test bench_inspect` and all tests passed (4/4).
- Ran full test suite with `cargo test -q` and observed all tests passed (74 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeff320284832a951f09a8a5eed5c9)