### PR TITLE
Record provenance manifest for sweeps and surface manifest diffs in inspect/compare

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,6 +1617,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ litellm-rs = { version = "*", default-features = false }
 
 # Misc
 chrono = { version = "0.4", features = ["serde"] }
+sha2 = "0.10"
 
 # NOTE on model backend:
 # `litellm-rs` ships a library API (`completion`, message constructors,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -177,6 +177,7 @@ async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
         retry_on_resume: s.retry_on_resume,
         deterministic_responses: None,
         deterministic_usage_per_call: None,
+        config_overlay_paths: s.config.into_iter().collect(),
     })
     .await?;
 

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -12,6 +12,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 
@@ -253,7 +254,12 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
             .as_ref()
             .is_some_and(|m| m.runtime.finished_at_utc.is_none());
         if partial_incomplete {
-            let scanned = scan_trajectory_instances(dir)?;
+            let min_mtime = sweep
+                .manifest
+                .as_ref()
+                .and_then(|m| chrono::DateTime::parse_from_rfc3339(&m.runtime.started_at_utc).ok())
+                .map(std::convert::Into::into);
+            let scanned = scan_trajectory_instances(dir, min_mtime)?;
             let manifest = sweep.manifest;
             return Ok(LoadedSweep {
                 instances: if scanned.is_empty() {
@@ -284,17 +290,28 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
         )));
     }
 
-    let out = scan_trajectory_instances(dir)?;
+    let out = scan_trajectory_instances(dir, None)?;
     Ok(LoadedSweep {
         instances: out,
         manifest: None,
     })
 }
 
-fn scan_trajectory_instances(dir: &Path) -> Result<HashMap<String, InstanceResult>, Error> {
+fn scan_trajectory_instances(
+    dir: &Path,
+    min_mtime: Option<SystemTime>,
+) -> Result<HashMap<String, InstanceResult>, Error> {
     let mut out = HashMap::new();
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
+        if let Some(min) = min_mtime {
+            let Some(modified) = entry.metadata().ok().and_then(|m| m.modified().ok()) else {
+                continue;
+            };
+            if modified < min {
+                continue;
+            }
+        }
         let name = entry.file_name();
         let Some(name_str) = name.to_str() else {
             continue;
@@ -1102,5 +1119,87 @@ mod tests {
         .unwrap();
         let loaded = load_sweep(dir.path()).unwrap();
         assert!(loaded.instances.contains_key("x"));
+    }
+
+    #[test]
+    fn incomplete_results_json_ignores_stale_trajectories_before_started_at() {
+        use crate::trajectory::{FORMAT_VERSION, TrajectoryInfo};
+        let dir = tempfile::tempdir().unwrap();
+        let traj = Trajectory {
+            trajectory_format: FORMAT_VERSION.into(),
+            info: TrajectoryInfo {
+                outcome: Some(outcome::SUBMITTED.into()),
+                exit_reason: Some("submitted".into()),
+                ..Default::default()
+            },
+            messages: vec![],
+        };
+        std::fs::write(
+            dir.path().join("old.traj.json"),
+            serde_json::to_string_pretty(&traj).unwrap(),
+        )
+        .unwrap();
+        let started = chrono::Utc::now() + chrono::Duration::seconds(10);
+        let sweep = SweepResults {
+            total: 1,
+            submitted: 0,
+            skipped: 0,
+            errored: 0,
+            failures_by_category: BTreeMap::new(),
+            budget_halted: 0,
+            with_patch: 0,
+            total_prompt_tokens: 0,
+            total_completion_tokens: 0,
+            estimated_cost_usd: 0.0,
+            retries: 0,
+            retried_instances: 0,
+            filter_spec: crate::run::swebench::FilterSpec::default(),
+            manifest: Some(ProvenanceManifest {
+                harness: crate::run::swebench::HarnessManifest {
+                    name: "h".into(),
+                    version: "v".into(),
+                    git_sha: None,
+                    git_dirty: None,
+                    git_resolution: "unavailable".into(),
+                },
+                dataset: crate::run::swebench::DatasetManifest {
+                    path: "d".into(),
+                    sha256: "x".into(),
+                    instance_count: 1,
+                    filter_spec: None,
+                },
+                prompt_template: crate::run::swebench::PromptTemplateManifest {
+                    source: "builtin".into(),
+                    path: None,
+                    sha256: "p".into(),
+                },
+                config: crate::run::swebench::ConfigManifest {
+                    resolved: "{}".into(),
+                    overlay_paths: Vec::new(),
+                },
+                model: crate::run::swebench::ModelManifest {
+                    name: "m".into(),
+                    backend: "litellm".into(),
+                    backend_version: None,
+                    base_url: None,
+                },
+                runtime: crate::run::swebench::RuntimeManifest {
+                    started_at_utc: started.to_rfc3339(),
+                    finished_at_utc: None,
+                    host_os: "linux".into(),
+                    rust_version: None,
+                },
+                cli: crate::run::swebench::CliManifest { argv: Vec::new() },
+            }),
+            cost_limit_usd: None,
+            instances: Vec::new(),
+        };
+        std::fs::write(
+            dir.path().join("results.json"),
+            serde_json::to_string_pretty(&sweep).unwrap(),
+        )
+        .unwrap();
+        let loaded = load_sweep(dir.path()).unwrap();
+        assert!(!loaded.instances.contains_key("old"));
     }
 }

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
 use crate::run::evaluate::EvaluationResults;
-use crate::run::swebench::{InstanceResult, SweepResults};
+use crate::run::swebench::{InstanceResult, ProvenanceManifest, SweepResults};
 use crate::trajectory::{FailureCategory, Trajectory, outcome};
 
 /// Output format for the compare report.
@@ -108,6 +108,8 @@ pub struct CompareReport {
     pub failure_category_baseline: BTreeMap<FailureCategory, usize>,
     pub failure_category_candidate: BTreeMap<FailureCategory, usize>,
     pub failure_category_delta: BTreeMap<FailureCategory, i64>,
+    #[serde(default)]
+    pub manifest_deltas: Vec<String>,
     /// Tasks that passed in the baseline but failed in the candidate.
     /// This is the high-signal artifact for CI gating; sorted by
     /// `instance_id` for stable output.
@@ -138,6 +140,14 @@ impl CompareReport {
             self.candidate_total,
             self.transitions.values().sum::<usize>()
         );
+        if self.manifest_deltas.is_empty() {
+            s.push_str("Manifest delta:     none\n");
+        } else {
+            s.push_str("Manifest delta:\n");
+            for d in &self.manifest_deltas {
+                let _ = writeln!(s, "  - {d}");
+            }
+        }
         let _ = writeln!(
             s,
             "Resolved:           {} -> {} ({:+})",
@@ -224,15 +234,28 @@ impl CompareReport {
 /// exists, reconstructing minimal `InstanceResult`s. Tolerant of missing
 /// newer fields: defaults flow through serde.
 pub fn load_run(dir: &Path) -> Result<HashMap<String, InstanceResult>, Error> {
+    Ok(load_sweep(dir)?.instances)
+}
+
+#[derive(Debug, Clone)]
+pub struct LoadedSweep {
+    pub instances: HashMap<String, InstanceResult>,
+    pub manifest: Option<ProvenanceManifest>,
+}
+
+pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
     let results_path = dir.join("results.json");
     if results_path.exists() {
         let text = std::fs::read_to_string(&results_path)?;
         let sweep: SweepResults = serde_json::from_str(&text)?;
-        return Ok(sweep
-            .instances
-            .into_iter()
-            .map(|r| (r.instance_id.clone(), r))
-            .collect());
+        return Ok(LoadedSweep {
+            instances: sweep
+                .instances
+                .into_iter()
+                .map(|r| (r.instance_id.clone(), r))
+                .collect(),
+            manifest: sweep.manifest,
+        });
     }
     if !dir.exists() {
         return Err(Error::Trajectory(format!(
@@ -282,22 +305,26 @@ pub fn load_run(dir: &Path) -> Result<HashMap<String, InstanceResult>, Error> {
             },
         );
     }
-    Ok(out)
+    Ok(LoadedSweep {
+        instances: out,
+        manifest: None,
+    })
 }
 
 /// Compute a `CompareReport` from two on-disk sweep directories.
 pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
-    let baseline = load_run(&args.baseline)?;
-    let candidate = load_run(&args.candidate)?;
+    let baseline = load_sweep(&args.baseline)?;
+    let candidate = load_sweep(&args.candidate)?;
     let baseline_eval = load_resolved_overrides(&args.baseline)?;
     let candidate_eval = load_resolved_overrides(&args.candidate)?;
     Ok(diff_with_overrides(
         &args.baseline,
         &args.candidate,
-        &baseline,
-        &candidate,
+        &baseline.instances,
+        &candidate.instances,
         baseline_eval.as_ref(),
         candidate_eval.as_ref(),
+        manifest_delta_lines(baseline.manifest.as_ref(), candidate.manifest.as_ref()),
     ))
 }
 
@@ -310,7 +337,15 @@ pub fn diff<S: std::hash::BuildHasher>(
     baseline: &HashMap<String, InstanceResult, S>,
     candidate: &HashMap<String, InstanceResult, S>,
 ) -> CompareReport {
-    diff_with_overrides(baseline_dir, candidate_dir, baseline, candidate, None, None)
+    diff_with_overrides(
+        baseline_dir,
+        candidate_dir,
+        baseline,
+        candidate,
+        None,
+        None,
+        Vec::new(),
+    )
 }
 
 fn diff_with_overrides<S: std::hash::BuildHasher>(
@@ -320,6 +355,7 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
     candidate: &HashMap<String, InstanceResult, S>,
     baseline_resolved_override: Option<&HashMap<String, bool>>,
     candidate_resolved_override: Option<&HashMap<String, bool>>,
+    manifest_deltas: Vec<String>,
 ) -> CompareReport {
     let mut all_ids: BTreeSet<&str> = BTreeSet::new();
     all_ids.extend(baseline.keys().map(String::as_str));
@@ -415,6 +451,7 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
         failure_category_baseline,
         failure_category_candidate,
         failure_category_delta,
+        manifest_deltas,
         regressions,
     }
 }
@@ -468,6 +505,75 @@ fn load_resolved_overrides(dir: &Path) -> Result<Option<HashMap<String, bool>>, 
             .map(|row| (row.instance_id, row.resolved))
             .collect(),
     ))
+}
+
+fn manifest_delta_lines(
+    baseline: Option<&ProvenanceManifest>,
+    candidate: Option<&ProvenanceManifest>,
+) -> Vec<String> {
+    let (Some(b), Some(c)) = (baseline, candidate) else {
+        return vec!["manifest unavailable".into()];
+    };
+    let mut out = Vec::new();
+    if b.harness.git_sha != c.harness.git_sha {
+        out.push(format!(
+            "harness.git_sha: {:?} -> {:?}",
+            b.harness.git_sha, c.harness.git_sha
+        ));
+    }
+    if b.prompt_template.sha256 != c.prompt_template.sha256 {
+        out.push("prompt_template.sha256 changed".into());
+    }
+    if b.dataset.sha256 != c.dataset.sha256 {
+        out.push("dataset.sha256 changed".into());
+    }
+    if b.model.name != c.model.name {
+        out.push(format!("model.name: {} -> {}", b.model.name, c.model.name));
+    }
+    let b_cfg: serde_json::Value = serde_yaml::from_str(&b.config.resolved).unwrap_or_default();
+    let c_cfg: serde_json::Value = serde_yaml::from_str(&c.config.resolved).unwrap_or_default();
+    let mut changed = Vec::new();
+    diff_config_keys("", &b_cfg, &c_cfg, &mut changed);
+    if !changed.is_empty() {
+        out.push(format!(
+            "config.resolved keys changed: {}",
+            changed.join(", ")
+        ));
+    }
+    out
+}
+
+fn diff_config_keys(
+    prefix: &str,
+    a: &serde_json::Value,
+    b: &serde_json::Value,
+    out: &mut Vec<String>,
+) {
+    match (a, b) {
+        (serde_json::Value::Object(ma), serde_json::Value::Object(mb)) => {
+            let keys: BTreeSet<&str> = ma
+                .keys()
+                .map(String::as_str)
+                .chain(mb.keys().map(String::as_str))
+                .collect();
+            for k in keys {
+                let p = if prefix.is_empty() {
+                    k.to_owned()
+                } else {
+                    format!("{prefix}.{k}")
+                };
+                match (ma.get(k), mb.get(k)) {
+                    (Some(x), Some(y)) => diff_config_keys(&p, x, y, out),
+                    _ => out.push(p),
+                }
+            }
+        }
+        _ => {
+            if a != b {
+                out.push(prefix.to_owned());
+            }
+        }
+    }
 }
 fn mean_steps<S: std::hash::BuildHasher>(map: &HashMap<String, InstanceResult, S>) -> Option<f64> {
     let xs: Vec<u32> = map.values().filter_map(|r| r.steps).collect();
@@ -682,6 +788,7 @@ mod tests {
             retries: 0,
             retried_instances: 0,
             filter_spec: crate::run::swebench::FilterSpec::default(),
+            manifest: None,
             cost_limit_usd: None,
             instances: vec![submitted("a"), errored("b", FailureCategory::ModelApi)],
         };
@@ -729,6 +836,62 @@ mod tests {
     }
 
     #[test]
+    fn compare_reports_manifest_delta_when_prompt_hash_changes() {
+        let mut b = map_of([submitted("a")]);
+        let c = b.clone();
+        let mut report = diff(Path::new("/b"), Path::new("/c"), &b, &c);
+        assert!(report.manifest_deltas.is_empty());
+        // sanity: direct helper detects prompt hash-only changes
+        let baseline = ProvenanceManifest {
+            harness: crate::run::swebench::HarnessManifest {
+                name: "x".into(),
+                version: "1".into(),
+                git_sha: Some("a".into()),
+                git_dirty: Some(false),
+                git_resolution: "ok".into(),
+            },
+            dataset: crate::run::swebench::DatasetManifest {
+                path: "d".into(),
+                sha256: "d1".into(),
+                instance_count: 1,
+                filter_spec: None,
+            },
+            prompt_template: crate::run::swebench::PromptTemplateManifest {
+                source: "builtin".into(),
+                path: None,
+                sha256: "p1".into(),
+            },
+            config: crate::run::swebench::ConfigManifest {
+                resolved: "{}".into(),
+                overlay_paths: Vec::new(),
+            },
+            model: crate::run::swebench::ModelManifest {
+                name: "m".into(),
+                backend: "litellm".into(),
+                backend_version: None,
+                base_url: None,
+            },
+            runtime: crate::run::swebench::RuntimeManifest {
+                started_at_utc: "s".into(),
+                finished_at_utc: None,
+                host_os: "linux".into(),
+                rust_version: None,
+            },
+            cli: crate::run::swebench::CliManifest { argv: Vec::new() },
+        };
+        let mut candidate = baseline.clone();
+        candidate.prompt_template.sha256 = "p2".into();
+        report.manifest_deltas = manifest_delta_lines(Some(&baseline), Some(&candidate));
+        assert!(
+            report
+                .manifest_deltas
+                .iter()
+                .any(|d| d.contains("prompt_template.sha256 changed"))
+        );
+        b.clear();
+    }
+
+    #[test]
     fn prefers_evaluation_json_resolved_over_submission_proxy() {
         let dir_b = tempfile::tempdir().unwrap();
         let dir_c = tempfile::tempdir().unwrap();
@@ -746,6 +909,7 @@ mod tests {
             retries: 0,
             retried_instances: 0,
             filter_spec: crate::run::swebench::FilterSpec::default(),
+            manifest: None,
             cost_limit_usd: None,
             instances: vec![submitted("a")],
         };

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -248,6 +248,26 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
     if results_path.exists() {
         let text = std::fs::read_to_string(&results_path)?;
         let sweep: SweepResults = serde_json::from_str(&text)?;
+        let partial_incomplete = sweep
+            .manifest
+            .as_ref()
+            .is_some_and(|m| m.runtime.finished_at_utc.is_none());
+        if partial_incomplete {
+            let scanned = scan_trajectory_instances(dir)?;
+            let manifest = sweep.manifest;
+            return Ok(LoadedSweep {
+                instances: if scanned.is_empty() {
+                    sweep
+                        .instances
+                        .into_iter()
+                        .map(|r| (r.instance_id.clone(), r))
+                        .collect()
+                } else {
+                    scanned
+                },
+                manifest,
+            });
+        }
         return Ok(LoadedSweep {
             instances: sweep
                 .instances
@@ -264,6 +284,14 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
         )));
     }
 
+    let out = scan_trajectory_instances(dir)?;
+    Ok(LoadedSweep {
+        instances: out,
+        manifest: None,
+    })
+}
+
+fn scan_trajectory_instances(dir: &Path) -> Result<HashMap<String, InstanceResult>, Error> {
     let mut out = HashMap::new();
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
@@ -305,10 +333,7 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
             },
         );
     }
-    Ok(LoadedSweep {
-        instances: out,
-        manifest: None,
-    })
+    Ok(out)
 }
 
 /// Compute a `CompareReport` from two on-disk sweep directories.
@@ -996,5 +1021,86 @@ mod tests {
         let r = map.get("inst-1").unwrap();
         assert_eq!(r.outcome.as_deref(), Some(outcome::SUBMITTED));
         assert_eq!(r.steps, Some(3));
+    }
+
+    #[test]
+    fn incomplete_results_json_falls_back_to_trajectory_scan() {
+        use crate::trajectory::{FORMAT_VERSION, TrajectoryInfo};
+        let dir = tempfile::tempdir().unwrap();
+        let sweep = SweepResults {
+            total: 1,
+            submitted: 0,
+            skipped: 0,
+            errored: 0,
+            failures_by_category: BTreeMap::new(),
+            budget_halted: 0,
+            with_patch: 0,
+            total_prompt_tokens: 0,
+            total_completion_tokens: 0,
+            estimated_cost_usd: 0.0,
+            retries: 0,
+            retried_instances: 0,
+            filter_spec: crate::run::swebench::FilterSpec::default(),
+            manifest: Some(ProvenanceManifest {
+                harness: crate::run::swebench::HarnessManifest {
+                    name: "h".into(),
+                    version: "v".into(),
+                    git_sha: None,
+                    git_dirty: None,
+                    git_resolution: "unavailable".into(),
+                },
+                dataset: crate::run::swebench::DatasetManifest {
+                    path: "d".into(),
+                    sha256: "x".into(),
+                    instance_count: 1,
+                    filter_spec: None,
+                },
+                prompt_template: crate::run::swebench::PromptTemplateManifest {
+                    source: "builtin".into(),
+                    path: None,
+                    sha256: "p".into(),
+                },
+                config: crate::run::swebench::ConfigManifest {
+                    resolved: "{}".into(),
+                    overlay_paths: Vec::new(),
+                },
+                model: crate::run::swebench::ModelManifest {
+                    name: "m".into(),
+                    backend: "litellm".into(),
+                    backend_version: None,
+                    base_url: None,
+                },
+                runtime: crate::run::swebench::RuntimeManifest {
+                    started_at_utc: "s".into(),
+                    finished_at_utc: None,
+                    host_os: "linux".into(),
+                    rust_version: None,
+                },
+                cli: crate::run::swebench::CliManifest { argv: Vec::new() },
+            }),
+            cost_limit_usd: None,
+            instances: Vec::new(),
+        };
+        std::fs::write(
+            dir.path().join("results.json"),
+            serde_json::to_string_pretty(&sweep).unwrap(),
+        )
+        .unwrap();
+        let traj = Trajectory {
+            trajectory_format: FORMAT_VERSION.into(),
+            info: TrajectoryInfo {
+                outcome: Some(outcome::SUBMITTED.into()),
+                exit_reason: Some("submitted".into()),
+                ..Default::default()
+            },
+            messages: vec![],
+        };
+        std::fs::write(
+            dir.path().join("x.traj.json"),
+            serde_json::to_string_pretty(&traj).unwrap(),
+        )
+        .unwrap();
+        let loaded = load_sweep(dir.path()).unwrap();
+        assert!(loaded.instances.contains_key("x"));
     }
 }

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -308,7 +308,7 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
 }
 
 fn manifest_indicates_resume(manifest: &ProvenanceManifest) -> bool {
-    manifest.cli.argv.iter().any(|arg| arg == "--resume")
+    manifest.runtime.resume_mode || manifest.cli.argv.iter().any(|arg| arg == "--resume")
 }
 
 fn scan_trajectory_instances(
@@ -933,6 +933,7 @@ mod tests {
                 started_at_utc: "s".into(),
                 finished_at_utc: None,
                 host_os: "linux".into(),
+                resume_mode: false,
                 rust_version: None,
             },
             cli: crate::run::swebench::CliManifest { argv: Vec::new() },
@@ -1107,6 +1108,7 @@ mod tests {
                     started_at_utc: "s".into(),
                     finished_at_utc: None,
                     host_os: "linux".into(),
+                    resume_mode: false,
                     rust_version: None,
                 },
                 cli: crate::run::swebench::CliManifest { argv: Vec::new() },
@@ -1203,6 +1205,7 @@ mod tests {
                     started_at_utc: started.to_rfc3339(),
                     finished_at_utc: None,
                     host_os: "linux".into(),
+                    resume_mode: false,
                     rust_version: None,
                 },
                 cli: crate::run::swebench::CliManifest { argv: Vec::new() },
@@ -1285,10 +1288,11 @@ mod tests {
                     started_at_utc: started.to_rfc3339(),
                     finished_at_utc: None,
                     host_os: "linux".into(),
+                    resume_mode: true,
                     rust_version: None,
                 },
                 cli: crate::run::swebench::CliManifest {
-                    argv: vec!["rust-swe-agent".into(), "--resume".into()],
+                    argv: vec!["rust-swe-agent".into()],
                 },
             }),
             cost_limit_usd: None,

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -601,31 +601,33 @@ fn manifest_delta_lines(
 
 fn diff_config_keys(
     prefix: &str,
-    a: &serde_json::Value,
-    b: &serde_json::Value,
+    left_value: &serde_json::Value,
+    right_value: &serde_json::Value,
     out: &mut Vec<String>,
 ) {
-    match (a, b) {
-        (serde_json::Value::Object(ma), serde_json::Value::Object(mb)) => {
-            let keys: BTreeSet<&str> = ma
+    match (left_value, right_value) {
+        (serde_json::Value::Object(left_map), serde_json::Value::Object(right_map)) => {
+            let keys: BTreeSet<&str> = left_map
                 .keys()
                 .map(String::as_str)
-                .chain(mb.keys().map(String::as_str))
+                .chain(right_map.keys().map(String::as_str))
                 .collect();
             for k in keys {
-                let p = if prefix.is_empty() {
+                let path = if prefix.is_empty() {
                     k.to_owned()
                 } else {
                     format!("{prefix}.{k}")
                 };
-                match (ma.get(k), mb.get(k)) {
-                    (Some(x), Some(y)) => diff_config_keys(&p, x, y, out),
-                    _ => out.push(p),
+                match (left_map.get(k), right_map.get(k)) {
+                    (Some(left_child), Some(right_child)) => {
+                        diff_config_keys(&path, left_child, right_child, out);
+                    }
+                    _ => out.push(path),
                 }
             }
         }
         _ => {
-            if a != b {
+            if left_value != right_value {
                 out.push(prefix.to_owned());
             }
         }

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -254,11 +254,21 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
             .as_ref()
             .is_some_and(|m| m.runtime.finished_at_utc.is_none());
         if partial_incomplete {
-            let min_mtime = sweep
+            let resume_mode = sweep
                 .manifest
                 .as_ref()
-                .and_then(|m| chrono::DateTime::parse_from_rfc3339(&m.runtime.started_at_utc).ok())
-                .map(std::convert::Into::into);
+                .is_some_and(manifest_indicates_resume);
+            let min_mtime = if resume_mode {
+                None
+            } else {
+                sweep
+                    .manifest
+                    .as_ref()
+                    .and_then(|m| {
+                        chrono::DateTime::parse_from_rfc3339(&m.runtime.started_at_utc).ok()
+                    })
+                    .map(std::convert::Into::into)
+            };
             let scanned = scan_trajectory_instances(dir, min_mtime)?;
             let manifest = sweep.manifest;
             return Ok(LoadedSweep {
@@ -295,6 +305,10 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
         instances: out,
         manifest: None,
     })
+}
+
+fn manifest_indicates_resume(manifest: &ProvenanceManifest) -> bool {
+    manifest.cli.argv.iter().any(|arg| arg == "--resume")
 }
 
 fn scan_trajectory_instances(
@@ -1201,5 +1215,89 @@ mod tests {
         .unwrap();
         let loaded = load_sweep(dir.path()).unwrap();
         assert!(!loaded.instances.contains_key("old"));
+    }
+
+    #[test]
+    fn incomplete_resume_results_include_preexisting_trajectories() {
+        use crate::trajectory::{FORMAT_VERSION, TrajectoryInfo};
+        let dir = tempfile::tempdir().unwrap();
+        let traj = Trajectory {
+            trajectory_format: FORMAT_VERSION.into(),
+            info: TrajectoryInfo {
+                outcome: Some(outcome::SUBMITTED.into()),
+                exit_reason: Some("submitted".into()),
+                ..Default::default()
+            },
+            messages: vec![],
+        };
+        std::fs::write(
+            dir.path().join("resume-old.traj.json"),
+            serde_json::to_string_pretty(&traj).unwrap(),
+        )
+        .unwrap();
+        let started = chrono::Utc::now() + chrono::Duration::seconds(10);
+        let sweep = SweepResults {
+            total: 1,
+            submitted: 0,
+            skipped: 0,
+            errored: 0,
+            failures_by_category: BTreeMap::new(),
+            budget_halted: 0,
+            with_patch: 0,
+            total_prompt_tokens: 0,
+            total_completion_tokens: 0,
+            estimated_cost_usd: 0.0,
+            retries: 0,
+            retried_instances: 0,
+            filter_spec: crate::run::swebench::FilterSpec::default(),
+            manifest: Some(ProvenanceManifest {
+                harness: crate::run::swebench::HarnessManifest {
+                    name: "h".into(),
+                    version: "v".into(),
+                    git_sha: None,
+                    git_dirty: None,
+                    git_resolution: "unavailable".into(),
+                },
+                dataset: crate::run::swebench::DatasetManifest {
+                    path: "d".into(),
+                    sha256: "x".into(),
+                    instance_count: 1,
+                    filter_spec: None,
+                },
+                prompt_template: crate::run::swebench::PromptTemplateManifest {
+                    source: "builtin".into(),
+                    path: None,
+                    sha256: "p".into(),
+                },
+                config: crate::run::swebench::ConfigManifest {
+                    resolved: "{}".into(),
+                    overlay_paths: Vec::new(),
+                },
+                model: crate::run::swebench::ModelManifest {
+                    name: "m".into(),
+                    backend: "litellm".into(),
+                    backend_version: None,
+                    base_url: None,
+                },
+                runtime: crate::run::swebench::RuntimeManifest {
+                    started_at_utc: started.to_rfc3339(),
+                    finished_at_utc: None,
+                    host_os: "linux".into(),
+                    rust_version: None,
+                },
+                cli: crate::run::swebench::CliManifest {
+                    argv: vec!["rust-swe-agent".into(), "--resume".into()],
+                },
+            }),
+            cost_limit_usd: None,
+            instances: Vec::new(),
+        };
+        std::fs::write(
+            dir.path().join("results.json"),
+            serde_json::to_string_pretty(&sweep).unwrap(),
+        )
+        .unwrap();
+        let loaded = load_sweep(dir.path()).unwrap();
+        assert!(loaded.instances.contains_key("resume-old"));
     }
 }

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -101,7 +101,7 @@ pub struct SummaryReport {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum InspectOutput {
     Instance(InspectReport),
-    Summary(SummaryReport),
+    Summary(Box<SummaryReport>),
 }
 
 pub fn run(args: &InspectArgs) -> Result<InspectOutput, Error> {
@@ -126,7 +126,7 @@ pub fn run(args: &InspectArgs) -> Result<InspectOutput, Error> {
     }
 
     if let Some(filter) = &args.filter {
-        return build_summary(&args.sweep, filter).map(InspectOutput::Summary);
+        return build_summary(&args.sweep, filter).map(|r| InspectOutput::Summary(Box::new(r)));
     }
 
     let instance_id = args.instance.clone().unwrap_or_default();

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use crate::env::RunResult;
 use crate::error::Error;
 use crate::run::evaluate::EvaluationResults;
-use crate::run::swebench::InstanceResult;
+use crate::run::swebench::{InstanceResult, ProvenanceManifest};
 use crate::trajectory::{FailureCategory, Trajectory};
 
 const TRUNCATE_MAX_LINES: usize = 40;
@@ -92,6 +92,8 @@ pub struct SummaryRow {
 pub struct SummaryReport {
     pub sweep_dir: PathBuf,
     pub filter: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest: Option<ProvenanceManifest>,
     pub rows: Vec<SummaryRow>,
 }
 
@@ -137,9 +139,9 @@ pub fn run(args: &InspectArgs) -> Result<InspectOutput, Error> {
 fn build_summary(sweep: &Path, filter: &str) -> Result<SummaryReport, Error> {
     let filter = parse_filter(filter)?;
     let mut rows: Vec<SummaryRow> = Vec::new();
-    let run = crate::run::compare::load_run(sweep)?;
+    let loaded = crate::run::compare::load_sweep(sweep)?;
     let resolved = load_resolved_overrides(sweep)?.unwrap_or_default();
-    for r in run.values() {
+    for r in loaded.instances.values() {
         let res = resolved.get(&r.instance_id).copied();
         if !filter.matches(r, res) {
             continue;
@@ -156,6 +158,7 @@ fn build_summary(sweep: &Path, filter: &str) -> Result<SummaryReport, Error> {
     Ok(SummaryReport {
         sweep_dir: sweep.to_path_buf(),
         filter: filter.raw,
+        manifest: loaded.manifest,
         rows,
     })
 }
@@ -276,6 +279,18 @@ fn render_summary_text(report: &SummaryReport) -> String {
     s.push_str("\n=== bench inspect summary ===\n");
     let _ = writeln!(s, "Sweep:   {}", report.sweep_dir.display());
     let _ = writeln!(s, "Filter:  {}", report.filter);
+    if let Some(m) = &report.manifest {
+        let _ = writeln!(
+            s,
+            "Manifest: harness_sha={} prompt_sha={} dataset_sha={} model={}",
+            m.harness.git_sha.as_deref().unwrap_or("unavailable"),
+            m.prompt_template.sha256,
+            m.dataset.sha256,
+            m.model.name
+        );
+    } else {
+        s.push_str("Manifest: unavailable\n");
+    }
     s.push_str("\ninstance_id | outcome | failure_category | cost_usd | resolved\n");
     s.push_str("----------------------------------------------------------------\n");
     for row in &report.rows {

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -495,9 +495,10 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     };
     std::fs::write(&summary_path, serde_json::to_string_pretty(&initial)?)?;
     #[cfg(test)]
-    if PANIC_AFTER_INITIAL_MANIFEST_WRITE.load(Ordering::Relaxed) {
-        panic!("test panic after initial manifest write");
-    }
+    assert!(
+        !PANIC_AFTER_INITIAL_MANIFEST_WRITE.load(Ordering::Relaxed),
+        "test panic after initial manifest write"
+    );
     let mut set = tokio::task::JoinSet::new();
     let mut skipped_results: Vec<InstanceResult> = Vec::new();
     let mut pending: std::collections::VecDeque<SweBenchInstance> =
@@ -980,13 +981,12 @@ fn redact_json_secrets_inner(v: &mut serde_json::Value, secret_values: &[String]
                 redact_json_secrets_inner(x, secret_values);
             }
         }
-        serde_json::Value::String(s) => {
+        serde_json::Value::String(s)
             if secret_values
                 .iter()
-                .any(|secret| !secret.is_empty() && s.contains(secret))
-            {
-                *s = "<redacted>".into();
-            }
+                .any(|secret| !secret.is_empty() && s.contains(secret)) =>
+        {
+            *s = "<redacted>".into();
         }
         _ => {}
     }

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -12,10 +12,14 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Write as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::config::Config;
 use crate::error::Error;
@@ -134,6 +138,8 @@ pub struct SweepResults {
     /// Resolved dataset subset spec used for this run.
     #[serde(default)]
     pub filter_spec: FilterSpec,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manifest: Option<ProvenanceManifest>,
     /// The USD ceiling enforced for this sweep, echoed from
     /// `SwebenchArgs::cost_limit_usd`. `None` when no limit was set —
     /// distinguishes "ran without a budget" from "budget was infinite".
@@ -157,6 +163,78 @@ pub struct FilterSpec {
     pub sample: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub seed: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProvenanceManifest {
+    pub harness: HarnessManifest,
+    pub dataset: DatasetManifest,
+    pub prompt_template: PromptTemplateManifest,
+    pub config: ConfigManifest,
+    pub model: ModelManifest,
+    pub runtime: RuntimeManifest,
+    pub cli: CliManifest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HarnessManifest {
+    pub name: String,
+    pub version: String,
+    pub git_sha: Option<String>,
+    pub git_dirty: Option<bool>,
+    pub git_resolution: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DatasetManifest {
+    pub path: String,
+    pub sha256: String,
+    pub instance_count: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filter_spec: Option<FilterSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptTemplateManifest {
+    pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    pub sha256: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConfigManifest {
+    pub resolved: String,
+    #[serde(default)]
+    pub overlay_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelManifest {
+    pub name: String,
+    pub backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+}
+
+#[cfg(test)]
+static PANIC_AFTER_INITIAL_MANIFEST_WRITE: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeManifest {
+    pub started_at_utc: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finished_at_utc: Option<String>,
+    pub host_os: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rust_version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CliManifest {
+    pub argv: Vec<String>,
 }
 
 impl SweepResults {
@@ -288,6 +366,8 @@ pub struct SwebenchArgs {
     /// deterministically. Only meaningful when `deterministic_responses`
     /// is `Some`.
     pub deterministic_usage_per_call: Option<ModelUsage>,
+    /// CLI-provided config overlay paths used to construct `config`.
+    pub config_overlay_paths: Vec<PathBuf>,
 }
 
 fn default_attempts() -> u32 {
@@ -330,6 +410,16 @@ pub fn existing_trajectory_info(
 
 pub fn load_dataset(path: &std::path::Path) -> Result<Vec<SweBenchInstance>, Error> {
     let text = std::fs::read_to_string(path)?;
+    parse_dataset_lines(&text)
+}
+
+fn load_dataset_from_bytes(bytes: &[u8]) -> Result<Vec<SweBenchInstance>, Error> {
+    let text = std::str::from_utf8(bytes)
+        .map_err(|e| Error::Trajectory(format!("dataset utf8 decode: {e}")))?;
+    parse_dataset_lines(text)
+}
+
+fn parse_dataset_lines(text: &str) -> Result<Vec<SweBenchInstance>, Error> {
     let mut out = Vec::new();
     for (i, line) in text.lines().enumerate() {
         let line = line.trim();
@@ -352,6 +442,7 @@ pub fn load_dataset(path: &std::path::Path) -> Result<Vec<SweBenchInstance>, Err
 #[allow(clippy::too_many_lines)]
 pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     std::fs::create_dir_all(&args.output_dir)?;
+    let started_at_utc = chrono::Utc::now().to_rfc3339();
     let prior_results = if args.resume {
         load_prior_results_by_instance(&args.output_dir)
     } else {
@@ -364,7 +455,9 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
         args.retry_backoff_cap_s,
     )?;
 
-    let instances = load_dataset(&args.dataset_path)?;
+    let dataset_bytes = std::fs::read(&args.dataset_path)?;
+    let dataset_sha = sha256_hex(&dataset_bytes);
+    let instances = load_dataset_from_bytes(&dataset_bytes)?;
     let (instances, filter_spec) = apply_subset(
         instances,
         args.instance_ids.as_deref(),
@@ -373,6 +466,38 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
         args.seed,
     )?;
     let total = instances.len();
+    let summary_path = args.output_dir.join("results.json");
+    let initial_manifest = build_manifest(
+        &args,
+        &dataset_sha,
+        total,
+        &filter_spec,
+        &started_at_utc,
+        None,
+    );
+    let initial = SweepResults {
+        total,
+        submitted: 0,
+        skipped: 0,
+        errored: 0,
+        failures_by_category: BTreeMap::new(),
+        budget_halted: 0,
+        with_patch: 0,
+        total_prompt_tokens: 0,
+        total_completion_tokens: 0,
+        estimated_cost_usd: 0.0,
+        retries: 0,
+        retried_instances: 0,
+        filter_spec: filter_spec.clone(),
+        manifest: Some(initial_manifest),
+        cost_limit_usd: args.cost_limit_usd,
+        instances: Vec::new(),
+    };
+    std::fs::write(&summary_path, serde_json::to_string_pretty(&initial)?)?;
+    #[cfg(test)]
+    if PANIC_AFTER_INITIAL_MANIFEST_WRITE.load(Ordering::Relaxed) {
+        panic!("test panic after initial manifest write");
+    }
     let mut set = tokio::task::JoinSet::new();
     let mut skipped_results: Vec<InstanceResult> = Vec::new();
     let mut pending: std::collections::VecDeque<SweBenchInstance> =
@@ -623,13 +748,253 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
         retries: total_retries,
         retried_instances,
         filter_spec,
+        manifest: Some(build_manifest(
+            &args,
+            &dataset_sha,
+            total,
+            &initial.filter_spec,
+            &started_at_utc,
+            Some(chrono::Utc::now().to_rfc3339()),
+        )),
         cost_limit_usd: args.cost_limit_usd,
         instances: results,
     };
-    let summary_path = args.output_dir.join("results.json");
     std::fs::write(&summary_path, serde_json::to_string_pretty(&sweep)?)?;
 
     Ok(sweep)
+}
+
+fn build_manifest(
+    args: &SwebenchArgs,
+    dataset_sha: &str,
+    dataset_instance_count: usize,
+    filter_spec: &FilterSpec,
+    started_at_utc: &str,
+    finished_at_utc: Option<String>,
+) -> ProvenanceManifest {
+    let prompt_source = format!(
+        "{}\n---\n{}",
+        args.config.root.prompts.system, args.config.root.prompts.instance
+    );
+    let mut config_raw = args.config.raw.clone();
+    redact_json_secrets(&mut config_raw);
+    let resolved = serde_yaml::to_string(&config_raw).unwrap_or_else(|_| "--- {}\n".to_owned());
+    ProvenanceManifest {
+        harness: resolve_harness_manifest(),
+        dataset: DatasetManifest {
+            path: args.dataset_path.display().to_string(),
+            sha256: dataset_sha.to_owned(),
+            instance_count: dataset_instance_count,
+            filter_spec: Some(filter_spec.clone()),
+        },
+        prompt_template: PromptTemplateManifest {
+            source: "builtin".into(),
+            path: None,
+            sha256: sha256_hex(prompt_source.as_bytes()),
+        },
+        config: ConfigManifest {
+            resolved,
+            overlay_paths: args
+                .config_overlay_paths
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect(),
+        },
+        model: ModelManifest {
+            name: args.config.root.model.name.clone(),
+            backend: if args.deterministic_responses.is_some() {
+                "deterministic".into()
+            } else {
+                "litellm".into()
+            },
+            backend_version: if args.deterministic_responses.is_some() {
+                None
+            } else {
+                litellm_rs_version()
+            },
+            base_url: model_base_url(),
+        },
+        runtime: RuntimeManifest {
+            started_at_utc: started_at_utc.to_owned(),
+            finished_at_utc,
+            host_os: std::env::consts::OS.into(),
+            rust_version: rust_version(),
+        },
+        cli: CliManifest {
+            argv: redact_argv(std::env::args().collect()),
+        },
+    }
+}
+
+fn resolve_harness_manifest() -> HarnessManifest {
+    resolve_harness_manifest_for_dir(None)
+}
+
+fn resolve_harness_manifest_for_dir(cwd: Option<&Path>) -> HarnessManifest {
+    let name = env!("CARGO_PKG_NAME").to_owned();
+    let version = env!("CARGO_PKG_VERSION").to_owned();
+    let sha_res = run_git(cwd, &["rev-parse", "HEAD"], false);
+    let status_res = run_git(cwd, &["status", "--porcelain"], true);
+    let sha = sha_res.as_ref().ok().cloned();
+    let dirty = status_res.as_ref().ok().map(|s| !s.trim().is_empty());
+    let git_resolution = match (&sha_res, &status_res) {
+        (Ok(_), Ok(_)) => "ok".to_owned(),
+        (Err(a), Err(b)) => format!("rev_parse_failed:{a};status_failed:{b}"),
+        (Err(a), Ok(_)) => format!("rev_parse_failed:{a}"),
+        (Ok(_), Err(b)) => format!("status_failed:{b}"),
+    };
+    HarnessManifest {
+        name,
+        version,
+        git_sha: sha,
+        git_dirty: dirty,
+        git_resolution,
+    }
+}
+
+fn run_git(cwd: Option<&Path>, args: &[&str], allow_empty: bool) -> Result<String, String> {
+    let mut cmd = Command::new("git");
+    cmd.args(args);
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+    let out = cmd.output().map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        let stderr = String::from_utf8(out.stderr).unwrap_or_else(|_| "non-utf8 stderr".into());
+        return Err(stderr.trim().to_owned());
+    }
+    let text = String::from_utf8(out.stdout).map_err(|e| e.to_string())?;
+    let trimmed = text.trim().to_owned();
+    if trimmed.is_empty() && !allow_empty {
+        return Err("empty output".into());
+    }
+    Ok(trimmed)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    format!("{:x}", h.finalize())
+}
+
+fn rust_version() -> Option<String> {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|o| o.status.success().then_some(o.stdout))
+        .and_then(|s| String::from_utf8(s).ok())
+        .map(|s| s.trim().to_owned())
+}
+
+fn model_base_url() -> Option<String> {
+    let base = std::env::var("LITELLM_BASE_URL")
+        .ok()
+        .or_else(|| std::env::var("OPENAI_BASE_URL").ok());
+    base.and_then(|b| {
+        let lb = b.trim().to_ascii_lowercase();
+        (lb != "https://api.openai.com/v1").then_some(b)
+    })
+}
+
+fn redact_argv(argv: Vec<String>) -> Vec<String> {
+    let secret_values: Vec<String> = std::env::vars()
+        .filter_map(|(k, v)| {
+            let key = k.to_ascii_lowercase();
+            ((key.ends_with("_key") || key.ends_with("_token") || key.ends_with("_secret"))
+                && !v.is_empty())
+            .then_some(v)
+        })
+        .collect();
+    let mut out = Vec::with_capacity(argv.len());
+    let mut redact_next = false;
+    for arg in argv {
+        let lower = arg.to_ascii_lowercase();
+        if redact_next {
+            out.push("<redacted>".into());
+            redact_next = false;
+            continue;
+        }
+        if lower.starts_with("--") && (lower.contains("-key") || lower.contains("-token")) {
+            if let Some((k, _)) = arg.split_once('=') {
+                out.push(format!("{k}=<redacted>"));
+            } else {
+                out.push(arg);
+                redact_next = true;
+            }
+            continue;
+        }
+        if secret_values.iter().any(|s| arg.contains(s)) {
+            out.push("<redacted>".into());
+            continue;
+        }
+        out.push(arg);
+    }
+    out
+}
+
+fn redact_json_secrets(v: &mut serde_json::Value) {
+    let secret_values: Vec<String> = std::env::vars()
+        .filter_map(|(k, v)| {
+            let key = k.to_ascii_lowercase();
+            ((key.ends_with("_key") || key.ends_with("_token") || key.ends_with("_secret"))
+                && !v.is_empty())
+            .then_some(v)
+        })
+        .collect();
+    redact_json_secrets_inner(v, &secret_values);
+}
+
+fn redact_json_secrets_inner(v: &mut serde_json::Value, secret_values: &[String]) {
+    match v {
+        serde_json::Value::Object(m) => {
+            for (k, val) in m.iter_mut() {
+                let key = k.to_ascii_lowercase();
+                if key.contains("key") || key.contains("token") || key.contains("secret") {
+                    *val = serde_json::Value::String("<redacted>".into());
+                } else {
+                    redact_json_secrets_inner(val, secret_values);
+                }
+            }
+        }
+        serde_json::Value::Array(xs) => {
+            for x in xs {
+                redact_json_secrets_inner(x, secret_values);
+            }
+        }
+        serde_json::Value::String(s) => {
+            if secret_values
+                .iter()
+                .any(|secret| !secret.is_empty() && s.contains(secret))
+            {
+                *s = "<redacted>".into();
+            }
+        }
+        _ => {}
+    }
+}
+
+fn litellm_rs_version() -> Option<String> {
+    let lock = include_str!("../../Cargo.lock");
+    let mut lines = lock.lines().peekable();
+    while let Some(line) = lines.next() {
+        if line.trim() == "name = \"litellm-rs\"" {
+            while let Some(next) = lines.peek() {
+                let n = next.trim();
+                if n.starts_with("version = \"") {
+                    return n
+                        .strip_prefix("version = \"")
+                        .and_then(|s| s.strip_suffix('"'))
+                        .map(ToOwned::to_owned);
+                }
+                if n.starts_with("name = ") || n == "[[package]]" {
+                    break;
+                }
+                lines.next();
+            }
+        }
+    }
+    None
 }
 
 /// Build the `InstanceResult` returned for a task that never started
@@ -1241,6 +1606,7 @@ impl XorShift64 {
 mod tests {
     #![allow(clippy::unwrap_used)]
     use super::*;
+    use futures::FutureExt;
 
     #[test]
     fn cost_estimate_uses_sonnet_pricing() {
@@ -1271,6 +1637,7 @@ mod tests {
                 selected_count: 10,
                 ..FilterSpec::default()
             },
+            manifest: None,
             cost_limit_usd: None,
             instances: vec![],
         };
@@ -1320,6 +1687,7 @@ mod tests {
                 selected_count: 5,
                 ..FilterSpec::default()
             },
+            manifest: None,
             cost_limit_usd: Some(1.0),
             instances: vec![],
         };
@@ -1330,6 +1698,157 @@ mod tests {
             "missing budget halt line: {t}"
         );
         assert!(t.contains("2 task(s) never started"));
+    }
+
+    #[test]
+    fn redact_argv_masks_secret_flags() {
+        let redacted = redact_argv(vec![
+            "rust-swe-agent".into(),
+            "--anthropic-api-key".into(),
+            "sk-test".into(),
+            "--github-token=ghp_123".into(),
+        ]);
+        assert_eq!(redacted[2], "<redacted>");
+        assert_eq!(redacted[3], "--github-token=<redacted>");
+    }
+
+    #[test]
+    fn dataset_sha256_is_stable_for_identical_bytes() {
+        let a = sha256_hex(br#"{"instance_id":"x"}"#);
+        let b = sha256_hex(br#"{"instance_id":"x"}"#);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn prompt_template_hash_changes_when_overlay_edits_prompt() {
+        let cfg_a = Config::from_yaml_str(
+            r#"
+prompts:
+  system: "sys-a"
+  instance: "inst"
+"#,
+        )
+        .unwrap();
+        let cfg_b = Config::from_yaml_str(
+            r#"
+prompts:
+  system: "sys-b"
+  instance: "inst"
+"#,
+        )
+        .unwrap();
+        let args_a = SwebenchArgs {
+            dataset_path: PathBuf::from("dataset.jsonl"),
+            output_dir: PathBuf::from("out"),
+            parallel: 1,
+            config: cfg_a,
+            resume: false,
+            cost_limit_usd: None,
+            instance_ids: None,
+            limit: None,
+            sample: None,
+            seed: None,
+            max_retries: 0,
+            retry_on: None,
+            retry_backoff_base_ms: 1,
+            retry_backoff_cap_s: 1,
+            retry_on_resume: false,
+            deterministic_responses: None,
+            deterministic_usage_per_call: None,
+            config_overlay_paths: Vec::new(),
+        };
+        let filter = FilterSpec::default();
+        let m_a = build_manifest(&args_a, "dataset", 1, &filter, "2026-01-01T00:00:00Z", None);
+        let args_b = SwebenchArgs {
+            config: cfg_b,
+            ..args_a
+        };
+        let m_b = build_manifest(&args_b, "dataset", 1, &filter, "2026-01-01T00:00:00Z", None);
+        assert_ne!(m_a.prompt_template.sha256, m_b.prompt_template.sha256);
+    }
+
+    #[test]
+    fn harness_dirty_flag_detects_uncommitted_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path();
+        std::fs::write(p.join("a.txt"), "v1\n").unwrap();
+        Command::new("git")
+            .arg("init")
+            .current_dir(p)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "tester"])
+            .current_dir(p)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.email", "tester@example.com"])
+            .current_dir(p)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["add", "a.txt"])
+            .current_dir(p)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(p)
+            .output()
+            .unwrap();
+        std::fs::write(p.join("a.txt"), "dirty\n").unwrap();
+        let m = resolve_harness_manifest_for_dir(Some(p));
+        assert_eq!(m.git_resolution, "ok");
+        assert_eq!(m.git_dirty, Some(true));
+        assert!(m.git_sha.is_some());
+    }
+
+    #[tokio::test]
+    async fn panic_after_initial_manifest_still_leaves_manifest_on_disk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dataset = tmp.path().join("d.jsonl");
+        std::fs::write(&dataset, r#"{"instance_id":"x"}"#).unwrap();
+        let out = tmp.path().join("out");
+        let args = SwebenchArgs {
+            dataset_path: dataset,
+            output_dir: out.clone(),
+            parallel: 1,
+            config: Config::defaults().unwrap(),
+            resume: false,
+            cost_limit_usd: None,
+            instance_ids: None,
+            limit: None,
+            sample: None,
+            seed: None,
+            max_retries: 0,
+            retry_on: None,
+            retry_backoff_base_ms: 1,
+            retry_backoff_cap_s: 1,
+            retry_on_resume: false,
+            deterministic_responses: None,
+            deterministic_usage_per_call: None,
+            config_overlay_paths: Vec::new(),
+        };
+        PANIC_AFTER_INITIAL_MANIFEST_WRITE.store(true, Ordering::Relaxed);
+        let panicked = std::panic::AssertUnwindSafe(run(args))
+            .catch_unwind()
+            .await
+            .is_err();
+        PANIC_AFTER_INITIAL_MANIFEST_WRITE.store(false, Ordering::Relaxed);
+        assert!(panicked);
+        let text = std::fs::read_to_string(out.join("results.json")).unwrap();
+        let parsed: SweepResults = serde_json::from_str(&text).unwrap();
+        assert!(parsed.manifest.is_some());
+        assert!(
+            parsed
+                .manifest
+                .as_ref()
+                .unwrap()
+                .runtime
+                .finished_at_utc
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -228,6 +228,8 @@ pub struct RuntimeManifest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub finished_at_utc: Option<String>,
     pub host_os: String,
+    #[serde(default)]
+    pub resume_mode: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rust_version: Option<String>,
 }
@@ -819,6 +821,7 @@ fn build_manifest(
             started_at_utc: started_at_utc.to_owned(),
             finished_at_utc,
             host_os: std::env::consts::OS.into(),
+            resume_mode: args.resume,
             rust_version: rust_version(),
         },
         cli: CliManifest {
@@ -1836,6 +1839,39 @@ mod tests {
         );
         assert!(manifest.config.resolved.contains("step_limit: 7"));
         assert!(manifest.config.resolved.contains("name: override-model"));
+    }
+
+    #[test]
+    fn manifest_records_resume_mode_from_args() {
+        let args = SwebenchArgs {
+            dataset_path: PathBuf::from("dataset.jsonl"),
+            output_dir: PathBuf::from("out"),
+            parallel: 1,
+            config: Config::defaults().unwrap(),
+            resume: true,
+            cost_limit_usd: None,
+            instance_ids: None,
+            limit: None,
+            sample: None,
+            seed: None,
+            max_retries: 0,
+            retry_on: None,
+            retry_backoff_base_ms: 1,
+            retry_backoff_cap_s: 1,
+            retry_on_resume: false,
+            deterministic_responses: None,
+            deterministic_usage_per_call: None,
+            config_overlay_paths: Vec::new(),
+        };
+        let manifest = build_manifest(
+            &args,
+            "dataset",
+            1,
+            &FilterSpec::default(),
+            "2026-01-01T00:00:00Z",
+            None,
+        );
+        assert!(manifest.runtime.resume_mode);
     }
 
     #[test]

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -776,7 +776,7 @@ fn build_manifest(
         "{}\n---\n{}",
         args.config.root.prompts.system, args.config.root.prompts.instance
     );
-    let mut config_raw = args.config.raw.clone();
+    let mut config_raw = effective_runtime_config(&args.config);
     redact_json_secrets(&mut config_raw);
     let resolved = serde_yaml::to_string(&config_raw).unwrap_or_else(|_| "--- {}\n".to_owned());
     ProvenanceManifest {
@@ -824,6 +824,25 @@ fn build_manifest(
             argv: redact_argv(std::env::args().collect()),
         },
     }
+}
+
+fn effective_runtime_config(cfg: &Config) -> serde_json::Value {
+    let mut raw = cfg.raw.clone();
+    if let serde_json::Value::Object(ref mut m) = raw {
+        if let Ok(agent) = serde_json::to_value(&cfg.root.agent) {
+            m.insert("agent".into(), agent);
+        }
+        if let Ok(model) = serde_json::to_value(&cfg.root.model) {
+            m.insert("model".into(), model);
+        }
+        if let Ok(environment) = serde_json::to_value(&cfg.root.environment) {
+            m.insert("environment".into(), environment);
+        }
+        if let Ok(prompts) = serde_json::to_value(&cfg.root.prompts) {
+            m.insert("prompts".into(), prompts);
+        }
+    }
+    raw
 }
 
 fn resolve_harness_manifest() -> HarnessManifest {
@@ -1780,6 +1799,43 @@ mod tests {
         redact_json_secrets(&mut cfg);
         assert_eq!(cfg["model"]["max_tokens"], 4096);
         assert_eq!(cfg["model"]["api_key"], "<redacted>");
+    }
+
+    #[test]
+    fn manifest_config_uses_effective_runtime_overrides() {
+        let mut cfg = Config::defaults().unwrap();
+        cfg.root.agent.step_limit = 7;
+        cfg.root.model.name = "override-model".into();
+        let args = SwebenchArgs {
+            dataset_path: PathBuf::from("dataset.jsonl"),
+            output_dir: PathBuf::from("out"),
+            parallel: 1,
+            config: cfg,
+            resume: false,
+            cost_limit_usd: None,
+            instance_ids: None,
+            limit: None,
+            sample: None,
+            seed: None,
+            max_retries: 0,
+            retry_on: None,
+            retry_backoff_base_ms: 1,
+            retry_backoff_cap_s: 1,
+            retry_on_resume: false,
+            deterministic_responses: None,
+            deterministic_usage_per_call: None,
+            config_overlay_paths: Vec::new(),
+        };
+        let manifest = build_manifest(
+            &args,
+            "dataset",
+            1,
+            &FilterSpec::default(),
+            "2026-01-01T00:00:00Z",
+            None,
+        );
+        assert!(manifest.config.resolved.contains("step_limit: 7"));
+        assert!(manifest.config.resolved.contains("name: override-model"));
     }
 
     #[test]

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -915,7 +915,7 @@ fn redact_argv(argv: Vec<String>) -> Vec<String> {
             redact_next = false;
             continue;
         }
-        if lower.starts_with("--") && (lower.contains("-key") || lower.contains("-token")) {
+        if lower.starts_with("--") && flag_name_is_sensitive(&arg) {
             if let Some((k, _)) = arg.split_once('=') {
                 out.push(format!("{k}=<redacted>"));
             } else {
@@ -949,8 +949,7 @@ fn redact_json_secrets_inner(v: &mut serde_json::Value, secret_values: &[String]
     match v {
         serde_json::Value::Object(m) => {
             for (k, val) in m.iter_mut() {
-                let key = k.to_ascii_lowercase();
-                if key.contains("key") || key.contains("token") || key.contains("secret") {
+                if json_key_is_sensitive(k) {
                     *val = serde_json::Value::String("<redacted>".into());
                 } else {
                     redact_json_secrets_inner(val, secret_values);
@@ -972,6 +971,49 @@ fn redact_json_secrets_inner(v: &mut serde_json::Value, secret_values: &[String]
         }
         _ => {}
     }
+}
+
+fn json_key_is_sensitive(key: &str) -> bool {
+    let k = key.to_ascii_lowercase();
+    matches!(
+        k.as_str(),
+        "api_key"
+            | "apikey"
+            | "key"
+            | "token"
+            | "secret"
+            | "password"
+            | "access_token"
+            | "auth_token"
+            | "bearer_token"
+    ) || k.ends_with("_key")
+        || k.ends_with("_token")
+        || k.ends_with("_secret")
+        || k.ends_with("_password")
+}
+
+fn flag_name_is_sensitive(flag: &str) -> bool {
+    let body = flag
+        .trim_start_matches('-')
+        .split('=')
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    matches!(
+        body.as_str(),
+        "api-key"
+            | "apikey"
+            | "key"
+            | "token"
+            | "secret"
+            | "password"
+            | "access-token"
+            | "auth-token"
+            | "bearer-token"
+    ) || body.ends_with("-key")
+        || body.ends_with("-token")
+        || body.ends_with("-secret")
+        || body.ends_with("-password")
 }
 
 fn litellm_rs_version() -> Option<String> {
@@ -1713,10 +1755,31 @@ mod tests {
     }
 
     #[test]
+    fn redact_argv_does_not_mask_max_tokens_flag() {
+        let redacted = redact_argv(vec![
+            "rust-swe-agent".into(),
+            "--max-tokens".into(),
+            "4096".into(),
+        ]);
+        assert_eq!(redacted[1], "--max-tokens");
+        assert_eq!(redacted[2], "4096");
+    }
+
+    #[test]
     fn dataset_sha256_is_stable_for_identical_bytes() {
         let a = sha256_hex(br#"{"instance_id":"x"}"#);
         let b = sha256_hex(br#"{"instance_id":"x"}"#);
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn json_redaction_preserves_max_tokens_knob() {
+        let mut cfg = serde_json::json!({
+            "model": { "max_tokens": 4096, "api_key": "sk-test" }
+        });
+        redact_json_secrets(&mut cfg);
+        assert_eq!(cfg["model"]["max_tokens"], 4096);
+        assert_eq!(cfg["model"]["api_key"], "<redacted>");
     }
 
     #[test]

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -91,6 +91,7 @@ fn write_results(dir: &Path, instances: Vec<InstanceResult>) {
         retries: 0,
         retried_instances: 0,
         filter_spec: rust_swe_agent::run::swebench::FilterSpec::default(),
+        manifest: None,
         cost_limit_usd: None,
         instances,
     };

--- a/tests/swebench_budget.rs
+++ b/tests/swebench_budget.rs
@@ -124,6 +124,7 @@ async fn sweep_halts_when_cumulative_cost_reaches_limit() {
         retry_on_resume: false,
         deterministic_responses: Some(submit_only_responses_for(5)),
         deterministic_usage_per_call: Some(usage),
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -280,6 +281,7 @@ async fn sweep_without_limit_runs_all_tasks() {
         retry_on_resume: false,
         deterministic_responses: Some(submit_only_responses_for(3)),
         deterministic_usage_per_call: Some(usage),
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -362,6 +364,7 @@ async fn resume_skipped_costs_count_against_budget() {
         retry_on_resume: false,
         deterministic_responses: Some(submit_only_responses_for(2)),
         deterministic_usage_per_call: Some(usage),
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -425,6 +428,7 @@ async fn resume_uses_prior_results_token_totals_for_budget_accounting() {
         retries: 1,
         retried_instances: 1,
         filter_spec: rust_swe_agent::run::swebench::FilterSpec::default(),
+        manifest: None,
         cost_limit_usd: Some(0.10),
         instances: vec![InstanceResult {
             instance_id: "already-on-disk".into(),
@@ -476,6 +480,7 @@ async fn resume_uses_prior_results_token_totals_for_budget_accounting() {
         retry_on_resume: false,
         deterministic_responses: Some(submit_only_responses_for(1)),
         deterministic_usage_per_call: Some(usage),
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -535,6 +540,7 @@ async fn retry_on_resume_instances_are_precharged_before_rerun() {
         retries: 2,
         retried_instances: 1,
         filter_spec: rust_swe_agent::run::swebench::FilterSpec::default(),
+        manifest: None,
         cost_limit_usd: Some(0.10),
         instances: vec![InstanceResult {
             instance_id: "retryable".into(),
@@ -578,6 +584,7 @@ async fn retry_on_resume_instances_are_precharged_before_rerun() {
         retry_on_resume: true,
         deterministic_responses: Some(submit_only_responses_for(1)),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -618,6 +625,7 @@ async fn stale_results_json_is_not_trusted_over_newer_trajectory() {
         retries: 2,
         retried_instances: 1,
         filter_spec: rust_swe_agent::run::swebench::FilterSpec::default(),
+        manifest: None,
         cost_limit_usd: Some(0.10),
         instances: vec![InstanceResult {
             instance_id: "already-on-disk".into(),
@@ -685,6 +693,7 @@ async fn stale_results_json_is_not_trusted_over_newer_trajectory() {
         retry_on_resume: false,
         deterministic_responses: Some(submit_only_responses_for(1)),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();

--- a/tests/swebench_failure_categories.rs
+++ b/tests/swebench_failure_categories.rs
@@ -108,6 +108,7 @@ async fn sweep_counts_failure_categories_and_preserves_legacy_unclassified() {
         retry_on_resume: false,
         deterministic_responses: None,
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();

--- a/tests/swebench_patch.rs
+++ b/tests/swebench_patch.rs
@@ -109,6 +109,7 @@ async fn sweep_emits_patch_artifact_for_modifying_agent() {
         retry_on_resume: false,
         deterministic_responses: Some(responses),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -192,6 +193,7 @@ async fn sweep_emits_empty_patch_when_agent_changes_nothing() {
             "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nnoop\n```".into(),
         ]),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -259,6 +261,7 @@ async fn missing_workdir_marks_outcome_as_error() {
             "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
         ]),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();

--- a/tests/swebench_resume.rs
+++ b/tests/swebench_resume.rs
@@ -128,6 +128,7 @@ async fn resume_skips_valid_trajectory_and_reruns_invalid() {
         retry_on_resume: false,
         deterministic_responses: Some(submit_only_responses()),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -210,6 +211,7 @@ async fn resume_reruns_submitted_trajectory_with_missing_patch() {
         retry_on_resume: false,
         deterministic_responses: Some(submit_only_responses()),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -261,6 +263,7 @@ async fn without_resume_existing_trajectories_are_overwritten() {
         retry_on_resume: false,
         deterministic_responses: Some(submit_only_responses()),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -312,6 +315,7 @@ async fn malformed_results_json_does_not_block_new_non_resume_sweep() {
         retry_on_resume: false,
         deterministic_responses: Some(submit_only_responses()),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -392,6 +396,7 @@ async fn resume_uses_on_disk_patch_flags_even_if_prior_summary_is_false() {
         retry_on_resume: false,
         deterministic_responses: Some(submit_only_responses()),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();

--- a/tests/swebench_retry.rs
+++ b/tests/swebench_retry.rs
@@ -94,6 +94,7 @@ async fn instance_cost_prefers_recorded_trajectory_cost() {
         retry_on_resume: false,
         deterministic_responses: Some(vec![submit_response()]),
         deterministic_usage_per_call: Some(usage),
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -130,6 +131,7 @@ async fn retries_on_injected_transient_category_then_recovers() {
         retry_on_resume: false,
         deterministic_responses: Some(vec![malformed_action_response(), submit_response()]),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -173,6 +175,7 @@ async fn max_retries_zero_disables_retry() {
         retry_on_resume: false,
         deterministic_responses: Some(vec![malformed_action_response()]),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -220,6 +223,7 @@ async fn max_retries_cap_stops_without_infinite_loop_and_non_retryable_is_not_re
             malformed_action_response(),
         ]),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -245,6 +249,7 @@ async fn max_retries_cap_stops_without_infinite_loop_and_non_retryable_is_not_re
         retry_on_resume: false,
         deterministic_responses: Some(vec![malformed_action_response()]),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -288,6 +293,7 @@ async fn cost_cap_can_trip_mid_retry_and_retry_on_resume_round_trip() {
         retry_on_resume: false,
         deterministic_responses: Some(vec![malformed_action_response(), submit_response()]),
         deterministic_usage_per_call: Some(usage),
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -335,6 +341,7 @@ async fn cost_cap_can_trip_mid_retry_and_retry_on_resume_round_trip() {
         retry_on_resume: false,
         deterministic_responses: Some(vec![submit_response()]),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();
@@ -358,6 +365,7 @@ async fn cost_cap_can_trip_mid_retry_and_retry_on_resume_round_trip() {
         retry_on_resume: true,
         deterministic_responses: Some(vec![submit_response()]),
         deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
     })
     .await
     .unwrap();


### PR DESCRIPTION
### Motivation

- Improve reproducibility and traceability by recording a provenance manifest (harness, dataset, prompt template, config, model, runtime, CLI) for every SWE-bench sweep.
- Make manifests available to inspection and comparison tooling so users can quickly see dataset/prompt/config/model changes between runs.
- Persist an initial manifest early (so it survives crashes) and provide manifest-delta reporting for CI gating and human-readable summaries.

### Description

- Add `ProvenanceManifest` and related structs to `run::swebench` and embed an optional `manifest` field in `SweepResults`, and add `sha2 = "0.10"` to `Cargo.toml` to compute SHA-256 digests.
- Compute and write an initial `results.json` with a manifest at sweep start, then write a final manifest when the sweep completes, including dataset SHA-256 and a prompt/template hash, config resolved text, model/backend info, runtime info and CLI argv with secrets redacted.
- Add helper utilities: `sha256_hex`, `run_git`/harness resolution, `rust_version`, `litellm_rs_version`, `redact_argv`, and JSON secret redaction; propagate `config_overlay_paths` from the CLI into `SwebenchArgs` and the manifest.
- Surface manifests in `inspect::SummaryReport` and `compare::CompareReport`, implement `manifest_delta_lines` and config-key diffing, and include manifest delta lines in the human-readable compare table; refactor run-loading to return manifest with instances.
- Update many tests and test helpers to pass the new `config_overlay_paths` field and add unit tests for hashing, redaction, harness detection, manifest behavior, and a panic-after-initial-manifest test ensuring the manifest is present on disk.

### Testing

- Ran the test suite via `cargo test`, covering unit tests and the integration-style swebench tests (including `bench_compare` and multiple `swebench_*` async tests).
- Added and exercised new unit tests for `sha256_hex`, `redact_argv`, prompt hash changes, harness dirty detection, and manifest persistence during panics; the sweep-level integration tests exercise the new manifest presence and the `inspect`/`compare` code paths.
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00ea3aa20832aa7fc56c2f27dbb15)