### PR TITLE
Add breakdown reporting to `bench evaluate` and `bench compare`

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -120,6 +120,14 @@ pub struct CompareCmd {
     /// fails on any regression.
     #[arg(long)]
     pub max_regressions: Option<usize>,
+
+    /// Optional metric breakdown axes (`repo,failure_category`) or `none`.
+    #[arg(long, default_value = "none")]
+    pub breakdown: String,
+
+    /// Threshold in percentage points used to highlight large breakdown deltas.
+    #[arg(long = "breakdown-min-delta-pp", default_value_t = 5.0)]
+    pub breakdown_min_delta_pp: f64,
 }
 
 #[derive(Debug, Args)]
@@ -233,6 +241,10 @@ pub struct EvaluateCmd {
     /// Parallel worker count for evaluation backend.
     #[arg(long, default_value_t = 4)]
     pub parallel: usize,
+
+    /// Optional metric breakdown axes (`repo,failure_category`) or `none`.
+    #[arg(long, default_value = "repo,failure_category")]
+    pub breakdown: String,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -209,11 +209,14 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
             ))));
         }
     };
+    let breakdown = parse_breakdown_selection(&c.breakdown, false)?;
     let report = crate::run::compare::compute(&crate::run::compare::CompareArgs {
         baseline: c.baseline,
         candidate: c.candidate,
         format,
         max_regressions: c.max_regressions,
+        breakdown,
+        min_delta_pp: c.breakdown_min_delta_pp / 100.0,
     })?;
     match format {
         crate::run::compare::CompareFormat::Text => print!("{}", report.human_table()),
@@ -262,6 +265,7 @@ fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
         }
     };
 
+    let breakdown = parse_breakdown_selection(&e.breakdown, true)?;
     let args = crate::run::evaluate::EvaluateArgs {
         sweep_dir: e.sweep.clone(),
         dataset_path: e.dataset,
@@ -271,6 +275,7 @@ fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
         sb_subset: e.sb_subset,
         sb_split: e.sb_split,
         run_id: e.run_id,
+        breakdown,
     };
     let eval = crate::run::evaluate::run(&args)?;
 
@@ -281,7 +286,42 @@ fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
         evaluation_path = %crate::run::evaluate::evaluation_path(&e.sweep).display(),
         "evaluation complete"
     );
+    println!("resolved: {resolved}");
+    if !eval.breakdown.is_empty() {
+        print!(
+            "{}",
+            crate::run::evaluate::render_breakdown_table(&eval.breakdown)
+        );
+    }
     Ok(())
+}
+
+fn parse_breakdown_selection(
+    raw: &str,
+    allow_default: bool,
+) -> Result<crate::run::evaluate::BreakdownSelection, Error> {
+    if raw == "none" {
+        return Ok(crate::run::evaluate::BreakdownSelection::none());
+    }
+    let mut axes = Vec::new();
+    for tok in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        let axis = match tok {
+            "repo" => crate::run::evaluate::BreakdownAxis::Repo,
+            "failure_category" => crate::run::evaluate::BreakdownAxis::FailureCategory,
+            other => {
+                return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "unknown --breakdown axis `{other}`"
+                ))));
+            }
+        };
+        if !axes.contains(&axis) {
+            axes.push(axis);
+        }
+    }
+    if axes.is_empty() && allow_default {
+        return Ok(crate::run::evaluate::BreakdownSelection::default_axes());
+    }
+    Ok(crate::run::evaluate::BreakdownSelection { axes })
 }
 
 fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -305,7 +305,7 @@ fn parse_breakdown_selection(
     }
     let mut axes = Vec::new();
     for tok in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
-        let axis = match tok {
+        let axis_kind = match tok {
             "repo" => crate::run::evaluate::BreakdownAxis::Repo,
             "failure_category" => crate::run::evaluate::BreakdownAxis::FailureCategory,
             other => {
@@ -314,8 +314,8 @@ fn parse_breakdown_selection(
                 ))));
             }
         };
-        if !axes.contains(&axis) {
-            axes.push(axis);
+        if !axes.contains(&axis_kind) {
+            axes.push(axis_kind);
         }
     }
     if axes.is_empty() && allow_default {

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -760,7 +760,8 @@ fn subset_warnings(baseline: Option<&FilterSpec>, candidate: Option<&FilterSpec>
     let (Some(b), Some(c)) = (baseline, candidate) else {
         return Vec::new();
     };
-    if b.instance_ids == c.instance_ids
+    if b.instance_ids.as_deref().map(normalize_instance_ids)
+        == c.instance_ids.as_deref().map(normalize_instance_ids)
         && b.sample == c.sample
         && b.seed == c.seed
         && b.limit == c.limit
@@ -771,6 +772,10 @@ fn subset_warnings(baseline: Option<&FilterSpec>, candidate: Option<&FilterSpec>
         "dataset subset differs (baseline selected_count={}, candidate selected_count={})",
         b.selected_count, c.selected_count
     )]
+}
+
+fn normalize_instance_ids(ids: &[String]) -> BTreeSet<&str> {
+    ids.iter().map(String::as_str).collect()
 }
 
 fn build_breakdown_delta<S: std::hash::BuildHasher>(
@@ -1135,6 +1140,27 @@ mod tests {
                 .any(|d| d.contains("prompt_template.sha256 changed"))
         );
         b.clear();
+    }
+
+    #[test]
+    fn subset_warning_ignores_instance_id_order() {
+        let baseline = crate::run::swebench::FilterSpec {
+            original_count: 10,
+            selected_count: 2,
+            instance_ids: Some(vec!["a".into(), "b".into()]),
+            limit: None,
+            sample: None,
+            seed: None,
+        };
+        let candidate = crate::run::swebench::FilterSpec {
+            original_count: 10,
+            selected_count: 2,
+            instance_ids: Some(vec!["b".into(), "a".into()]),
+            limit: None,
+            sample: None,
+            seed: None,
+        };
+        assert!(subset_warnings(Some(&baseline), Some(&candidate)).is_empty());
     }
 
     #[test]

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -318,6 +318,10 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
     let results_path = dir.join("results.json");
     if results_path.exists() {
         let text = std::fs::read_to_string(&results_path)?;
+        let filter_spec_present = serde_json::from_str::<serde_json::Value>(&text)
+            .ok()
+            .and_then(|v| v.get("filter_spec").cloned())
+            .is_some();
         let sweep: SweepResults = serde_json::from_str(&text)?;
         let partial_incomplete = sweep
             .manifest
@@ -352,7 +356,11 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
                     scanned
                 },
                 manifest,
-                filter_spec: Some(sweep.filter_spec),
+                filter_spec: if filter_spec_present {
+                    Some(sweep.filter_spec)
+                } else {
+                    None
+                },
             });
         }
         return Ok(LoadedSweep {
@@ -362,7 +370,11 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
                 .map(|r| (r.instance_id.clone(), r))
                 .collect(),
             manifest: sweep.manifest,
-            filter_spec: Some(sweep.filter_spec),
+            filter_spec: if filter_spec_present {
+                Some(sweep.filter_spec)
+            } else {
+                None
+            },
         });
     }
     if !dir.exists() {
@@ -1413,6 +1425,38 @@ mod tests {
         .unwrap();
         let loaded = load_sweep(dir.path()).unwrap();
         assert!(loaded.instances.contains_key("x"));
+    }
+
+    #[test]
+    fn legacy_results_json_without_filter_spec_preserves_unavailable_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let sweep = SweepResults {
+            total: 1,
+            submitted: 1,
+            skipped: 0,
+            errored: 0,
+            failures_by_category: BTreeMap::new(),
+            budget_halted: 0,
+            with_patch: 1,
+            total_prompt_tokens: 0,
+            total_completion_tokens: 0,
+            estimated_cost_usd: 0.0,
+            retries: 0,
+            retried_instances: 0,
+            filter_spec: crate::run::swebench::FilterSpec::default(),
+            manifest: None,
+            cost_limit_usd: None,
+            instances: vec![submitted("a")],
+        };
+        let mut value = serde_json::to_value(&sweep).unwrap();
+        value.as_object_mut().unwrap().remove("filter_spec");
+        std::fs::write(
+            dir.path().join("results.json"),
+            serde_json::to_string_pretty(&value).unwrap(),
+        )
+        .unwrap();
+        let loaded = load_sweep(dir.path()).unwrap();
+        assert!(loaded.filter_spec.is_none());
     }
 
     #[test]

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -159,14 +159,7 @@ impl CompareReport {
             self.candidate_total,
             self.transitions.values().sum::<usize>()
         );
-        if self.manifest_deltas.is_empty() {
-            s.push_str("Manifest delta:     none\n");
-        } else {
-            s.push_str("Manifest delta:\n");
-            for d in &self.manifest_deltas {
-                let _ = writeln!(s, "  - {d}");
-            }
-        }
+        write_manifest_delta_section(&mut s, &self.manifest_deltas);
         let _ = writeln!(
             s,
             "Resolved:           {} -> {} ({:+})",
@@ -189,86 +182,118 @@ impl CompareReport {
                 s.push_str("Mean steps:         n/a\n");
             }
         }
-
-        s.push_str("\nTransition matrix:\n");
-        for kind in [
-            TransitionKind::PassPass,
-            TransitionKind::PassFail,
-            TransitionKind::FailPass,
-            TransitionKind::FailFail,
-            TransitionKind::MissingPresent,
-            TransitionKind::PresentMissing,
-        ] {
-            let n = self.transitions.get(&kind).copied().unwrap_or(0);
-            let _ = writeln!(s, "  {:<18} {n}", kind.label());
-        }
-
-        let nonzero: Vec<(FailureCategory, i64)> = self
-            .failure_category_delta
-            .iter()
-            .filter(|(_, v)| **v != 0)
-            .map(|(k, v)| (*k, *v))
-            .collect();
-        if !nonzero.is_empty() {
-            s.push_str("\nFailure category delta (candidate - baseline):\n");
-            for (cat, d) in nonzero {
-                let b = self
-                    .failure_category_baseline
-                    .get(&cat)
-                    .copied()
-                    .unwrap_or(0);
-                let c = self
-                    .failure_category_candidate
-                    .get(&cat)
-                    .copied()
-                    .unwrap_or(0);
-                let _ = writeln!(s, "  {:<14} {b} -> {c} ({d:+})", failure_label(cat));
-            }
-        }
-        if !self.subset_warnings.is_empty() {
-            s.push_str("\nSubset warnings:\n");
-            for w in &self.subset_warnings {
-                let _ = writeln!(s, "  ! {w}");
-            }
-        }
-        if !self.breakdown_delta.is_empty() {
-            s.push_str("\nBreakdown deltas:\n");
-            for row in &self.breakdown_delta {
-                let _ = writeln!(
-                    s,
-                    "  {} {}={}  n: {} -> {}  resolved_rate: {:.1}% -> {:.1}%  delta={:+.1}pp",
-                    if row.exceeds_threshold { "*" } else { "-" },
-                    match row.bucket_axis {
-                        BreakdownAxis::Repo => "repo",
-                        BreakdownAxis::FailureCategory => "failure_category",
-                    },
-                    row.bucket_value,
-                    row.baseline_n,
-                    row.candidate_n,
-                    row.baseline_resolved_rate * 100.0,
-                    row.candidate_resolved_rate * 100.0,
-                    row.delta_resolved_rate * 100.0
-                );
-            }
-        }
-
-        if self.regressions.is_empty() {
-            s.push_str("\nRegressions:        none\n");
-        } else {
-            let _ = writeln!(s, "\nRegressions ({}):", self.regressions.len());
-            for r in &self.regressions {
-                let cat = r.candidate_failure_category.map_or("none", failure_label);
-                let exit = r.candidate_exit_reason.as_deref().unwrap_or("?");
-                let old = r.baseline_outcome.as_deref().unwrap_or("?");
-                let new = r.candidate_outcome.as_deref().unwrap_or("?");
-                let _ = writeln!(
-                    s,
-                    "  - {id}  {old} -> {new}  category={cat}  exit_reason={exit}",
-                    id = r.instance_id
-                );
-            }
-        }
+        write_transition_matrix(&mut s, &self.transitions);
+        write_failure_delta_section(
+            &mut s,
+            &self.failure_category_baseline,
+            &self.failure_category_candidate,
+            &self.failure_category_delta,
+        );
+        write_subset_warnings(&mut s, &self.subset_warnings);
+        write_breakdown_delta_section(&mut s, &self.breakdown_delta);
+        write_regressions(&mut s, &self.regressions);
         s
+    }
+}
+
+fn write_manifest_delta_section(s: &mut String, manifest_deltas: &[String]) {
+    if manifest_deltas.is_empty() {
+        s.push_str("Manifest delta:     none\n");
+    } else {
+        s.push_str("Manifest delta:\n");
+        for d in manifest_deltas {
+            let _ = writeln!(s, "  - {d}");
+        }
+    }
+}
+
+fn write_transition_matrix(s: &mut String, transitions: &BTreeMap<TransitionKind, usize>) {
+    s.push_str("\nTransition matrix:\n");
+    for kind in [
+        TransitionKind::PassPass,
+        TransitionKind::PassFail,
+        TransitionKind::FailPass,
+        TransitionKind::FailFail,
+        TransitionKind::MissingPresent,
+        TransitionKind::PresentMissing,
+    ] {
+        let n = transitions.get(&kind).copied().unwrap_or(0);
+        let _ = writeln!(s, "  {:<18} {n}", kind.label());
+    }
+}
+
+fn write_failure_delta_section(
+    s: &mut String,
+    baseline: &BTreeMap<FailureCategory, usize>,
+    candidate: &BTreeMap<FailureCategory, usize>,
+    delta: &BTreeMap<FailureCategory, i64>,
+) {
+    let nonzero: Vec<(FailureCategory, i64)> = delta
+        .iter()
+        .filter(|(_, v)| **v != 0)
+        .map(|(k, v)| (*k, *v))
+        .collect();
+    if nonzero.is_empty() {
+        return;
+    }
+    s.push_str("\nFailure category delta (candidate - baseline):\n");
+    for (cat, d) in nonzero {
+        let b = baseline.get(&cat).copied().unwrap_or(0);
+        let c = candidate.get(&cat).copied().unwrap_or(0);
+        let _ = writeln!(s, "  {:<14} {b} -> {c} ({d:+})", failure_label(cat));
+    }
+}
+
+fn write_subset_warnings(s: &mut String, warnings: &[String]) {
+    if warnings.is_empty() {
+        return;
+    }
+    s.push_str("\nSubset warnings:\n");
+    for w in warnings {
+        let _ = writeln!(s, "  ! {w}");
+    }
+}
+
+fn write_breakdown_delta_section(s: &mut String, rows: &[BreakdownDeltaRow]) {
+    if rows.is_empty() {
+        return;
+    }
+    s.push_str("\nBreakdown deltas:\n");
+    for row in rows {
+        let _ = writeln!(
+            s,
+            "  {} {}={}  n: {} -> {}  resolved_rate: {:.1}% -> {:.1}%  delta={:+.1}pp",
+            if row.exceeds_threshold { "*" } else { "-" },
+            match row.bucket_axis {
+                BreakdownAxis::Repo => "repo",
+                BreakdownAxis::FailureCategory => "failure_category",
+            },
+            row.bucket_value,
+            row.baseline_n,
+            row.candidate_n,
+            row.baseline_resolved_rate * 100.0,
+            row.candidate_resolved_rate * 100.0,
+            row.delta_resolved_rate * 100.0
+        );
+    }
+}
+
+fn write_regressions(s: &mut String, regressions: &[TaskTransition]) {
+    if regressions.is_empty() {
+        s.push_str("\nRegressions:        none\n");
+        return;
+    }
+    let _ = writeln!(s, "\nRegressions ({}):", regressions.len());
+    for r in regressions {
+        let cat = r.candidate_failure_category.map_or("none", failure_label);
+        let exit = r.candidate_exit_reason.as_deref().unwrap_or("?");
+        let old = r.baseline_outcome.as_deref().unwrap_or("?");
+        let new = r.candidate_outcome.as_deref().unwrap_or("?");
+        let _ = writeln!(
+            s,
+            "  - {id}  {old} -> {new}  category={cat}  exit_reason={exit}",
+            id = r.instance_id
+        );
     }
 }
 
@@ -804,8 +829,7 @@ fn breakdown_map<S: std::hash::BuildHasher>(
                 .unwrap_or_else(|| "unknown".to_owned()),
             BreakdownAxis::FailureCategory => r
                 .failure_category
-                .map(crate::run::evaluate::failure_label)
-                .unwrap_or("none")
+                .map_or("none", crate::run::evaluate::failure_label)
                 .to_owned(),
         };
         let entry = out.entry(key).or_insert((0, 0));

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -17,8 +17,8 @@ use std::time::SystemTime;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
-use crate::run::evaluate::EvaluationResults;
-use crate::run::swebench::{InstanceResult, ProvenanceManifest, SweepResults};
+use crate::run::evaluate::{BreakdownAxis, EvaluationResults, pct};
+use crate::run::swebench::{FilterSpec, InstanceResult, ProvenanceManifest, SweepResults};
 use crate::trajectory::{FailureCategory, Trajectory, outcome};
 
 /// Output format for the compare report.
@@ -36,6 +36,8 @@ pub struct CompareArgs {
     /// When `Some(n)`, the binary exits non-zero if regressed-task count
     /// strictly exceeds `n`. `None` is informational only.
     pub max_regressions: Option<usize>,
+    pub breakdown: crate::run::evaluate::BreakdownSelection,
+    pub min_delta_pp: f64,
 }
 
 /// Per-task transition between baseline and candidate. `pass` is defined
@@ -111,10 +113,26 @@ pub struct CompareReport {
     pub failure_category_delta: BTreeMap<FailureCategory, i64>,
     #[serde(default)]
     pub manifest_deltas: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub subset_warnings: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub breakdown_delta: Vec<BreakdownDeltaRow>,
     /// Tasks that passed in the baseline but failed in the candidate.
     /// This is the high-signal artifact for CI gating; sorted by
     /// `instance_id` for stable output.
     pub regressions: Vec<TaskTransition>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BreakdownDeltaRow {
+    pub bucket_axis: BreakdownAxis,
+    pub bucket_value: String,
+    pub baseline_n: usize,
+    pub baseline_resolved_rate: f64,
+    pub candidate_n: usize,
+    pub candidate_resolved_rate: f64,
+    pub delta_resolved_rate: f64,
+    pub exceeds_threshold: bool,
 }
 
 impl CompareReport {
@@ -207,6 +225,29 @@ impl CompareReport {
                 let _ = writeln!(s, "  {:<14} {b} -> {c} ({d:+})", failure_label(cat));
             }
         }
+        if !self.breakdown_delta.is_empty() {
+            s.push_str("\nBreakdown deltas:\n");
+            for w in &self.subset_warnings {
+                let _ = writeln!(s, "  ! {w}");
+            }
+            for row in &self.breakdown_delta {
+                let _ = writeln!(
+                    s,
+                    "  {} {}={}  n: {} -> {}  resolved_rate: {:.1}% -> {:.1}%  delta={:+.1}pp",
+                    if row.exceeds_threshold { "*" } else { "-" },
+                    match row.bucket_axis {
+                        BreakdownAxis::Repo => "repo",
+                        BreakdownAxis::FailureCategory => "failure_category",
+                    },
+                    row.bucket_value,
+                    row.baseline_n,
+                    row.candidate_n,
+                    row.baseline_resolved_rate * 100.0,
+                    row.candidate_resolved_rate * 100.0,
+                    row.delta_resolved_rate * 100.0
+                );
+            }
+        }
 
         if self.regressions.is_empty() {
             s.push_str("\nRegressions:        none\n");
@@ -242,6 +283,7 @@ pub fn load_run(dir: &Path) -> Result<HashMap<String, InstanceResult>, Error> {
 pub struct LoadedSweep {
     pub instances: HashMap<String, InstanceResult>,
     pub manifest: Option<ProvenanceManifest>,
+    pub filter_spec: Option<FilterSpec>,
 }
 
 pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
@@ -282,6 +324,7 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
                     scanned
                 },
                 manifest,
+                filter_spec: Some(sweep.filter_spec),
             });
         }
         return Ok(LoadedSweep {
@@ -291,6 +334,7 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
                 .map(|r| (r.instance_id.clone(), r))
                 .collect(),
             manifest: sweep.manifest,
+            filter_spec: Some(sweep.filter_spec),
         });
     }
     if !dir.exists() {
@@ -304,6 +348,7 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
     Ok(LoadedSweep {
         instances: out,
         manifest: None,
+        filter_spec: None,
     })
 }
 
@@ -373,7 +418,7 @@ pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
     let candidate = load_sweep(&args.candidate)?;
     let baseline_eval = load_resolved_overrides(&args.baseline)?;
     let candidate_eval = load_resolved_overrides(&args.candidate)?;
-    Ok(diff_with_overrides(
+    let mut report = diff_with_overrides(
         &args.baseline,
         &args.candidate,
         &baseline.instances,
@@ -381,7 +426,20 @@ pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
         baseline_eval.as_ref(),
         candidate_eval.as_ref(),
         manifest_delta_lines(baseline.manifest.as_ref(), candidate.manifest.as_ref()),
-    ))
+    );
+    report.subset_warnings = subset_warnings(
+        baseline.filter_spec.as_ref(),
+        candidate.filter_spec.as_ref(),
+    );
+    report.breakdown_delta = build_breakdown_delta(
+        &baseline.instances,
+        &candidate.instances,
+        baseline_eval.as_ref(),
+        candidate_eval.as_ref(),
+        &args.breakdown.axes,
+        args.min_delta_pp,
+    );
+    Ok(report)
 }
 
 /// Pure diff over two already-loaded id->result maps. Split out so tests
@@ -508,6 +566,8 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
         failure_category_candidate,
         failure_category_delta,
         manifest_deltas,
+        subset_warnings: Vec::new(),
+        breakdown_delta: Vec::new(),
         regressions,
     }
 }
@@ -666,6 +726,92 @@ fn failure_label(cat: FailureCategory) -> &'static str {
         FailureCategory::AgentInternal => "agent_internal",
         FailureCategory::Unknown => "unknown",
     }
+}
+
+fn subset_warnings(baseline: Option<&FilterSpec>, candidate: Option<&FilterSpec>) -> Vec<String> {
+    let (Some(b), Some(c)) = (baseline, candidate) else {
+        return Vec::new();
+    };
+    if b.instance_ids == c.instance_ids
+        && b.sample == c.sample
+        && b.seed == c.seed
+        && b.limit == c.limit
+    {
+        return Vec::new();
+    }
+    vec![format!(
+        "dataset subset differs (baseline selected_count={}, candidate selected_count={})",
+        b.selected_count, c.selected_count
+    )]
+}
+
+fn build_breakdown_delta<S: std::hash::BuildHasher>(
+    baseline: &HashMap<String, InstanceResult, S>,
+    candidate: &HashMap<String, InstanceResult, S>,
+    baseline_override: Option<&HashMap<String, bool>>,
+    candidate_override: Option<&HashMap<String, bool>>,
+    axes: &[BreakdownAxis],
+    min_delta_pp: f64,
+) -> Vec<BreakdownDeltaRow> {
+    let mut out = Vec::new();
+    for axis in axes {
+        let b = breakdown_map(baseline, baseline_override, *axis);
+        let c = breakdown_map(candidate, candidate_override, *axis);
+        let mut keys: BTreeSet<String> = BTreeSet::new();
+        keys.extend(b.keys().cloned());
+        keys.extend(c.keys().cloned());
+        for key in keys {
+            let (bn, br) = b.get(&key).copied().unwrap_or((0, 0));
+            let (cn, cr) = c.get(&key).copied().unwrap_or((0, 0));
+            let b_rate = pct(br, bn);
+            let c_rate = pct(cr, cn);
+            let delta = c_rate - b_rate;
+            out.push(BreakdownDeltaRow {
+                bucket_axis: *axis,
+                bucket_value: key,
+                baseline_n: bn,
+                baseline_resolved_rate: b_rate,
+                candidate_n: cn,
+                candidate_resolved_rate: c_rate,
+                delta_resolved_rate: delta,
+                exceeds_threshold: delta.abs() >= min_delta_pp,
+            });
+        }
+    }
+    out.sort_by(|a, b| {
+        b.delta_resolved_rate
+            .abs()
+            .partial_cmp(&a.delta_resolved_rate.abs())
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.bucket_axis.cmp(&b.bucket_axis))
+            .then_with(|| a.bucket_value.cmp(&b.bucket_value))
+    });
+    out
+}
+
+fn breakdown_map<S: std::hash::BuildHasher>(
+    items: &HashMap<String, InstanceResult, S>,
+    resolved_override: Option<&HashMap<String, bool>>,
+    axis: BreakdownAxis,
+) -> HashMap<String, (usize, usize)> {
+    let mut out = HashMap::new();
+    for (id, r) in items {
+        let key = match axis {
+            BreakdownAxis::Repo => crate::run::evaluate::parse_repo_from_instance_id(id)
+                .unwrap_or_else(|| "unknown".to_owned()),
+            BreakdownAxis::FailureCategory => r
+                .failure_category
+                .map(crate::run::evaluate::failure_label)
+                .unwrap_or("none")
+                .to_owned(),
+        };
+        let entry = out.entry(key).or_insert((0, 0));
+        entry.0 += 1;
+        if resolved_for(id, r, resolved_override) {
+            entry.1 += 1;
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -870,6 +1016,8 @@ mod tests {
             candidate: dir_c.path().to_path_buf(),
             format: CompareFormat::Json,
             max_regressions: None,
+            breakdown: crate::run::evaluate::BreakdownSelection::none(),
+            min_delta_pp: 0.0,
         })
         .unwrap();
         assert_eq!(r.regressions.len(), 1);
@@ -993,6 +1141,7 @@ mod tests {
                 eval_exit_reason: crate::run::evaluate::EvalExitReason::Resolved,
                 eval_log_path: None,
             }],
+            breakdown: Vec::new(),
         };
         let candidate_eval = crate::run::evaluate::EvaluationResults {
             instances: vec![crate::run::evaluate::InstanceEvaluation {
@@ -1003,6 +1152,7 @@ mod tests {
                 eval_exit_reason: crate::run::evaluate::EvalExitReason::Unresolved,
                 eval_log_path: None,
             }],
+            breakdown: Vec::new(),
         };
 
         std::fs::write(
@@ -1021,6 +1171,8 @@ mod tests {
             candidate: dir_c.path().to_path_buf(),
             format: CompareFormat::Json,
             max_regressions: None,
+            breakdown: crate::run::evaluate::BreakdownSelection::none(),
+            min_delta_pp: 0.0,
         })
         .unwrap();
         assert_eq!(r.baseline_resolved, 1);

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -832,10 +832,15 @@ fn breakdown_map<S: std::hash::BuildHasher>(
         let key = match axis {
             BreakdownAxis::Repo => crate::run::evaluate::parse_repo_from_instance_id(id)
                 .unwrap_or_else(|| "unknown".to_owned()),
-            BreakdownAxis::FailureCategory => r
-                .failure_category
-                .map_or("none", crate::run::evaluate::failure_label)
-                .to_owned(),
+            BreakdownAxis::FailureCategory => {
+                if resolved_for(id, r, resolved_override) {
+                    "resolved".to_owned()
+                } else {
+                    r.failure_category
+                        .map_or("none", crate::run::evaluate::failure_label)
+                        .to_owned()
+                }
+            }
         };
         let entry = out.entry(key).or_insert((0, 0));
         entry.0 += 1;
@@ -1161,6 +1166,31 @@ mod tests {
             seed: None,
         };
         assert!(subset_warnings(Some(&baseline), Some(&candidate)).is_empty());
+    }
+
+    #[test]
+    fn failure_category_breakdown_keeps_resolved_separate_from_none() {
+        let baseline = map_of([submitted("a")]);
+        let candidate = map_of([submitted("a")]);
+        let baseline_override = HashMap::from([("a".to_string(), true)]);
+        let candidate_override = HashMap::from([("a".to_string(), false)]);
+
+        let rows = build_breakdown_delta(
+            &baseline,
+            &candidate,
+            Some(&baseline_override),
+            Some(&candidate_override),
+            &[BreakdownAxis::FailureCategory],
+            0.0,
+        );
+        assert!(
+            rows.iter()
+                .any(|r| r.bucket_value == "resolved" && r.baseline_n == 1 && r.candidate_n == 0)
+        );
+        assert!(
+            rows.iter()
+                .any(|r| r.bucket_value == "none" && r.baseline_n == 0 && r.candidate_n == 1)
+        );
     }
 
     #[test]

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -225,11 +225,14 @@ impl CompareReport {
                 let _ = writeln!(s, "  {:<14} {b} -> {c} ({d:+})", failure_label(cat));
             }
         }
-        if !self.breakdown_delta.is_empty() {
-            s.push_str("\nBreakdown deltas:\n");
+        if !self.subset_warnings.is_empty() {
+            s.push_str("\nSubset warnings:\n");
             for w in &self.subset_warnings {
                 let _ = writeln!(s, "  ! {w}");
             }
+        }
+        if !self.breakdown_delta.is_empty() {
+            s.push_str("\nBreakdown deltas:\n");
             for row in &self.breakdown_delta {
                 let _ = writeln!(
                     s,
@@ -1039,6 +1042,18 @@ mod tests {
         assert!(t.contains("Regressions (1):"), "got:\n{t}");
         assert!(t.contains("- b"), "got:\n{t}");
         assert!(t.contains("category=step_limit"), "got:\n{t}");
+    }
+
+    #[test]
+    fn human_table_shows_subset_warnings_without_breakdown_rows() {
+        let baseline = map_of([submitted("a")]);
+        let candidate = map_of([submitted("a")]);
+        let mut r = diff(Path::new("/b"), Path::new("/c"), &baseline, &candidate);
+        r.subset_warnings = vec!["dataset subset differs".into()];
+        r.breakdown_delta.clear();
+        let t = r.human_table();
+        assert!(t.contains("Subset warnings:"), "got:\n{t}");
+        assert!(t.contains("dataset subset differs"), "got:\n{t}");
     }
 
     #[test]

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -758,7 +758,10 @@ fn failure_label(cat: FailureCategory) -> &'static str {
 
 fn subset_warnings(baseline: Option<&FilterSpec>, candidate: Option<&FilterSpec>) -> Vec<String> {
     let (Some(b), Some(c)) = (baseline, candidate) else {
-        return Vec::new();
+        return vec![
+            "subset metadata unavailable (missing filter_spec for baseline and/or candidate)"
+                .into(),
+        ];
     };
     if b.instance_ids.as_deref().map(normalize_instance_ids)
         == c.instance_ids.as_deref().map(normalize_instance_ids)
@@ -1166,6 +1169,32 @@ mod tests {
             seed: None,
         };
         assert!(subset_warnings(Some(&baseline), Some(&candidate)).is_empty());
+    }
+
+    #[test]
+    fn subset_warning_when_filter_spec_missing() {
+        let present = crate::run::swebench::FilterSpec {
+            original_count: 10,
+            selected_count: 2,
+            instance_ids: Some(vec!["a".into(), "b".into()]),
+            limit: None,
+            sample: None,
+            seed: None,
+        };
+        let missing_baseline = subset_warnings(None, Some(&present));
+        assert!(
+            missing_baseline
+                .iter()
+                .any(|w| w.contains("subset metadata unavailable")),
+            "{missing_baseline:?}"
+        );
+        let missing_candidate = subset_warnings(Some(&present), None);
+        assert!(
+            missing_candidate
+                .iter()
+                .any(|w| w.contains("subset metadata unavailable")),
+            "{missing_candidate:?}"
+        );
     }
 
     #[test]

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -1,6 +1,7 @@
 //! `bench evaluate`: score an existing sweep by real resolved-rate.
 
 use std::collections::{BTreeMap, HashMap};
+use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -415,13 +416,14 @@ fn build_breakdown(
         let mut unknown_repo = 0usize;
         for row in evals {
             let bucket_value = match axis {
-                BreakdownAxis::Repo => match parse_repo_from_instance_id(&row.instance_id) {
-                    Some(repo) => repo,
-                    None => {
+                BreakdownAxis::Repo => {
+                    if let Some(repo) = parse_repo_from_instance_id(&row.instance_id) {
+                        repo
+                    } else {
                         unknown_repo += 1;
                         "unknown".to_owned()
                     }
-                },
+                }
                 BreakdownAxis::FailureCategory => {
                     if row.resolved {
                         "resolved".to_owned()
@@ -429,8 +431,7 @@ fn build_breakdown(
                         results
                             .get(&row.instance_id)
                             .and_then(|r| r.failure_category)
-                            .map(failure_label)
-                            .unwrap_or("unknown")
+                            .map_or("unknown", failure_label)
                             .to_owned()
                     }
                 }
@@ -508,10 +509,11 @@ pub fn render_breakdown_table(rows: &[BreakdownBucket]) -> String {
             BreakdownAxis::Repo => "repo",
             BreakdownAxis::FailureCategory => "failure_category",
         };
-        out.push_str(&format!(
-            "{axis},{},{},{},{:.4}\n",
+        let _ = writeln!(
+            out,
+            "{axis},{},{},{},{:.4}",
             row.bucket_value, row.n, row.resolved, row.resolved_rate
-        ));
+        );
     }
     out
 }

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -1,6 +1,6 @@
 //! `bench evaluate`: score an existing sweep by real resolved-rate.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::Error;
 use crate::run::compare::load_run;
 use crate::run::swebench::{self, InstanceResult};
-use crate::trajectory::outcome;
+use crate::trajectory::{FailureCategory, outcome};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EvaluateBackend {
@@ -27,6 +27,33 @@ pub struct EvaluateArgs {
     pub sb_subset: String,
     pub sb_split: String,
     pub run_id: Option<String>,
+    pub breakdown: BreakdownSelection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BreakdownAxis {
+    Repo,
+    FailureCategory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BreakdownSelection {
+    pub axes: Vec<BreakdownAxis>,
+}
+
+impl BreakdownSelection {
+    #[must_use]
+    pub fn none() -> Self {
+        Self { axes: Vec::new() }
+    }
+
+    #[must_use]
+    pub fn default_axes() -> Self {
+        Self {
+            axes: vec![BreakdownAxis::Repo, BreakdownAxis::FailureCategory],
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -55,6 +82,17 @@ pub struct InstanceEvaluation {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvaluationResults {
     pub instances: Vec<InstanceEvaluation>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub breakdown: Vec<BreakdownBucket>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BreakdownBucket {
+    pub bucket_axis: BreakdownAxis,
+    pub bucket_value: String,
+    pub n: usize,
+    pub resolved: usize,
+    pub resolved_rate: f64,
 }
 
 #[must_use]
@@ -64,10 +102,11 @@ pub fn evaluation_path(sweep_dir: &Path) -> PathBuf {
 
 pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
     let results = load_run(&args.sweep_dir)?;
-    let eval = match args.backend {
+    let mut eval = match args.backend {
         EvaluateBackend::None => build_none_eval(&results),
         EvaluateBackend::SbCli => run_sb_cli(args, &results)?,
     };
+    eval.breakdown = build_breakdown(&eval.instances, &results, &args.breakdown);
     std::fs::write(
         evaluation_path(&args.sweep_dir),
         serde_json::to_string_pretty(&eval)?,
@@ -81,7 +120,10 @@ fn build_none_eval(results: &HashMap<String, InstanceResult>) -> EvaluationResul
         .map(|(id, r)| none_eval_for_result(id, r))
         .collect();
     instances.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
-    EvaluationResults { instances }
+    EvaluationResults {
+        instances,
+        breakdown: Vec::new(),
+    }
 }
 
 fn none_eval_for_result(id: &str, r: &InstanceResult) -> InstanceEvaluation {
@@ -356,7 +398,122 @@ fn merge_with_results(
         });
     }
     instances.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
-    EvaluationResults { instances }
+    EvaluationResults {
+        instances,
+        breakdown: Vec::new(),
+    }
+}
+
+fn build_breakdown(
+    evals: &[InstanceEvaluation],
+    results: &HashMap<String, InstanceResult>,
+    selection: &BreakdownSelection,
+) -> Vec<BreakdownBucket> {
+    let mut out = Vec::new();
+    for axis in &selection.axes {
+        let mut buckets: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+        let mut unknown_repo = 0usize;
+        for row in evals {
+            let bucket_value = match axis {
+                BreakdownAxis::Repo => match parse_repo_from_instance_id(&row.instance_id) {
+                    Some(repo) => repo,
+                    None => {
+                        unknown_repo += 1;
+                        "unknown".to_owned()
+                    }
+                },
+                BreakdownAxis::FailureCategory => {
+                    if row.resolved {
+                        "resolved".to_owned()
+                    } else {
+                        results
+                            .get(&row.instance_id)
+                            .and_then(|r| r.failure_category)
+                            .map(failure_label)
+                            .unwrap_or("unknown")
+                            .to_owned()
+                    }
+                }
+            };
+            let entry = buckets.entry(bucket_value).or_insert((0, 0));
+            entry.0 += 1;
+            if row.resolved {
+                entry.1 += 1;
+            }
+        }
+        if matches!(axis, BreakdownAxis::Repo) && unknown_repo > 0 {
+            tracing::warn!(
+                unknown_repo_instances = unknown_repo,
+                "bench evaluate: repo parse failed for some ids; using repo=unknown"
+            );
+        }
+        let mut rows: Vec<BreakdownBucket> = buckets
+            .into_iter()
+            .map(|(bucket_value, (n, resolved))| BreakdownBucket {
+                bucket_axis: *axis,
+                bucket_value,
+                n,
+                resolved,
+                resolved_rate: pct(resolved, n),
+            })
+            .collect();
+        rows.sort_by(|a, b| {
+            b.n.cmp(&a.n)
+                .then_with(|| a.bucket_value.cmp(&b.bucket_value))
+        });
+        out.extend(rows);
+    }
+    out
+}
+
+#[must_use]
+pub fn parse_repo_from_instance_id(instance_id: &str) -> Option<String> {
+    let (owner, rest) = instance_id.split_once("__")?;
+    let (repo, _) = rest.rsplit_once('-')?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
+}
+
+#[must_use]
+pub fn failure_label(cat: FailureCategory) -> &'static str {
+    match cat {
+        FailureCategory::EnvSetup => "env_setup",
+        FailureCategory::ModelApi => "model_api",
+        FailureCategory::ModelParse => "model_parse",
+        FailureCategory::StepLimit => "step_limit",
+        FailureCategory::CostLimit => "cost_limit",
+        FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::Unknown => "unknown",
+    }
+}
+
+#[must_use]
+pub fn pct(numer: usize, denom: usize) -> f64 {
+    if denom == 0 {
+        return 0.0;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    {
+        numer as f64 / denom as f64
+    }
+}
+
+#[must_use]
+pub fn render_breakdown_table(rows: &[BreakdownBucket]) -> String {
+    let mut out = String::from("axis,bucket,n,resolved,resolved_rate\n");
+    for row in rows {
+        let axis = match row.bucket_axis {
+            BreakdownAxis::Repo => "repo",
+            BreakdownAxis::FailureCategory => "failure_category",
+        };
+        out.push_str(&format!(
+            "{axis},{},{},{},{:.4}\n",
+            row.bucket_value, row.n, row.resolved, row.resolved_rate
+        ));
+    }
+    out
 }
 
 #[cfg(test)]
@@ -437,5 +594,14 @@ mod tests {
         assert_eq!(parsed.len(), 2);
         assert_eq!(parsed.get("inst-a").map(|r| r.resolved), Some(true));
         assert_eq!(parsed.get("inst-b").map(|r| r.resolved), Some(false));
+    }
+
+    #[test]
+    fn parses_repo_from_instance_id() {
+        assert_eq!(
+            parse_repo_from_instance_id("django__django-10087"),
+            Some("django/django".into())
+        );
+        assert_eq!(parse_repo_from_instance_id("invalid"), None);
     }
 }

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -431,7 +431,7 @@ fn build_breakdown(
                         results
                             .get(&row.instance_id)
                             .and_then(|r| r.failure_category)
-                            .map_or("unknown", failure_label)
+                            .map_or("none", failure_label)
                             .to_owned()
                     }
                 }
@@ -605,5 +605,27 @@ mod tests {
             Some("django/django".into())
         );
         assert_eq!(parse_repo_from_instance_id("invalid"), None);
+    }
+
+    #[test]
+    fn failure_category_breakdown_uses_none_for_missing_category() {
+        let results = HashMap::from([("a".to_string(), submitted("a"))]);
+        let evals = vec![InstanceEvaluation {
+            instance_id: "a".into(),
+            resolved: false,
+            tests_passed: vec![],
+            tests_failed: vec![],
+            eval_exit_reason: EvalExitReason::Unresolved,
+            eval_log_path: None,
+        }];
+        let rows = build_breakdown(
+            &evals,
+            &results,
+            &BreakdownSelection {
+                axes: vec![BreakdownAxis::FailureCategory],
+            },
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].bucket_value, "none");
     }
 }

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -495,3 +495,77 @@ fn evaluate_none_backend_writes_evaluation_json() {
         serde_json::from_str(&std::fs::read_to_string(eval_path).unwrap()).unwrap();
     assert_eq!(v["instances"].as_array().unwrap().len(), 2);
 }
+
+#[test]
+fn evaluate_breakdown_none_is_headline_only() {
+    let sweep_dir = tempfile::tempdir().unwrap();
+    write_results(sweep_dir.path(), vec![submitted("django__django-1")]);
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "evaluate",
+            "--sweep",
+            sweep_dir.path().to_str().unwrap(),
+            "--backend",
+            "none",
+            "--breakdown",
+            "none",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("resolved: 0"), "{stdout}");
+    assert!(
+        !stdout.contains("axis,bucket,n,resolved,resolved_rate"),
+        "{stdout}"
+    );
+}
+
+#[test]
+fn compare_breakdown_json_includes_all_buckets_and_threshold_flag() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    write_results(
+        baseline_dir.path(),
+        vec![submitted("django__django-1"), submitted("psf__requests-2")],
+    );
+    write_results(
+        candidate_dir.path(),
+        vec![
+            errored("django__django-1", FailureCategory::StepLimit),
+            submitted("psf__requests-2"),
+        ],
+    );
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "--breakdown",
+            "repo",
+            "--breakdown-min-delta-pp",
+            "5",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let rows = v["breakdown_delta"].as_array().unwrap();
+    assert_eq!(rows.len(), 2, "expected both repos, got: {rows:?}");
+    assert!(rows.iter().any(|r| {
+        r["bucket_value"] == "django/django"
+            && r["delta_resolved_rate"] == -1.0
+            && r["exceeds_threshold"] == true
+    }));
+    assert!(rows.iter().any(|r| {
+        r["bucket_value"] == "psf/requests"
+            && r["delta_resolved_rate"] == 0.0
+            && r["exceeds_threshold"] == false
+    }));
+}


### PR DESCRIPTION
### Motivation

- Provide per-axis metric breakdowns (e.g. by `repo` or `failure_category`) for both evaluation and compare flows so operators can inspect resolved-rate changes across meaningful buckets.
- Surface dataset-subset mismatches between baseline and candidate runs to avoid misleading comparisons when different subsets were selected.
- Allow highlighting large breakdown deltas with a configurable threshold to focus attention on important shifts.

### Description

- Added CLI flags `--breakdown` and `--breakdown-min-delta-pp` to `bench compare`, and `--breakdown` to `bench evaluate`, and wired parsing via `parse_breakdown_selection` in `cli/mod.rs` and `cli/args.rs`.
- Extended `EvaluateArgs` with a `BreakdownSelection` and implemented `build_breakdown` to produce `BreakdownBucket` rows stored in `EvaluationResults` and emitted to `evaluation.json`, plus `render_breakdown_table` for human output.
- Extended `CompareArgs` and `CompareReport` to include breakdown deltas and subset warnings, and implemented `build_breakdown_delta`, `breakdown_map`, and `subset_warnings` to compute per-bucket resolved-rate deltas and flag threshold breaches.
- Added helper utilities `BreakdownAxis`, `BreakdownSelection`, `BreakdownBucket`, `parse_repo_from_instance_id`, `failure_label`, and `pct`, and updated `load_sweep` to propagate `filter_spec` so subset differences can be detected.
- Updated human-readable output for `bench evaluate` to print the breakdown table when present and for `bench compare` to include breakdown delta rows and subset warnings, and adapted tests/fixtures and JSON shapes accordingly.

### Testing

- Ran the test suite via `cargo test`, which exercises unit tests in `src/run/evaluate.rs` and `src/run/compare.rs` and the integration tests in `tests/bench_compare.rs`, and all tests passed.
- Added integration tests `evaluate_breakdown_none_is_headline_only` and `compare_breakdown_json_includes_all_buckets_and_threshold_flag` which verify CLI output and JSON breakdown semantics and they succeeded.
- Existing compare/evaluate unit tests were updated to include the new `breakdown` field and continued to pass under the new behavior.

Closes #26 

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d1db4570832a8b1ae584c90859d4)