### PR TITLE
🌟 Nova: ChaosEnvironment Feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ tokio = { version = "1", features = ["full", "test-util"] }
 [features]
 default = []
 docker = []
+chaos = []
 live-anthropic = []
 
 [lints.clippy]

--- a/src/env/chaos.rs
+++ b/src/env/chaos.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::env::{Environment, RunRequest, RunResult};
 use crate::error::EnvError;

--- a/src/env/chaos.rs
+++ b/src/env/chaos.rs
@@ -1,0 +1,74 @@
+use async_trait::async_trait;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use crate::env::{Environment, RunRequest, RunResult};
+use crate::error::EnvError;
+
+/// A decorator that wraps an inner `Environment` and injects failures deterministically.
+pub struct ChaosEnvironment {
+    inner: Box<dyn Environment>,
+    invocation_count: Arc<AtomicUsize>,
+    fail_every: usize,
+}
+
+impl ChaosEnvironment {
+    pub fn new(inner: Box<dyn Environment>, fail_every: usize) -> Self {
+        Self {
+            inner,
+            invocation_count: Arc::new(AtomicUsize::new(0)),
+            fail_every,
+        }
+    }
+}
+
+#[async_trait]
+impl Environment for ChaosEnvironment {
+    async fn run(&self, req: RunRequest) -> Result<RunResult, EnvError> {
+        let count = self.invocation_count.fetch_add(1, Ordering::SeqCst) + 1;
+
+        if self.fail_every > 0 && count % self.fail_every == 0 {
+            // Inject a simulated timeout failure
+            return Ok(RunResult {
+                stdout: String::new(),
+                stderr: "simulated chaos failure: timed out".to_string(),
+                exit_code: -1,
+                timed_out: true,
+            });
+        }
+
+        self.inner.run(req).await
+    }
+
+    async fn shutdown(&mut self) -> Result<(), EnvError> {
+        self.inner.shutdown().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use crate::env::local::LocalEnvironment;
+
+    #[tokio::test]
+    async fn test_chaos_environment_injects_failures() {
+        let inner = Box::new(LocalEnvironment::new());
+        let env = ChaosEnvironment::new(inner, 3); // Fail every 3rd command
+
+        let req = RunRequest::new("echo hello");
+
+        // 1st request - Should succeed
+        let res1 = env.run(req.clone()).await.unwrap();
+        assert_eq!(res1.exit_code, 0);
+
+        // 2nd request - Should succeed
+        let res2 = env.run(req.clone()).await.unwrap();
+        assert_eq!(res2.exit_code, 0);
+
+        // 3rd request - Should fail (timed out simulation)
+        let res3 = env.run(req.clone()).await.unwrap();
+        assert!(res3.timed_out);
+        assert_eq!(res3.exit_code, -1);
+    }
+}

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -13,10 +13,14 @@ use crate::error::EnvError;
 
 #[cfg(feature = "docker")]
 pub mod docker;
+#[cfg(feature = "chaos")]
+pub mod chaos;
 pub mod local;
 
 #[cfg(feature = "docker")]
 pub use docker::DockerEnvironment;
+#[cfg(feature = "chaos")]
+pub use chaos::ChaosEnvironment;
 pub use local::LocalEnvironment;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -11,16 +11,16 @@ use std::time::Duration;
 
 use crate::error::EnvError;
 
-#[cfg(feature = "docker")]
-pub mod docker;
 #[cfg(feature = "chaos")]
 pub mod chaos;
+#[cfg(feature = "docker")]
+pub mod docker;
 pub mod local;
 
-#[cfg(feature = "docker")]
-pub use docker::DockerEnvironment;
 #[cfg(feature = "chaos")]
 pub use chaos::ChaosEnvironment;
+#[cfg(feature = "docker")]
+pub use docker::DockerEnvironment;
 pub use local::LocalEnvironment;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
💡 **The Spark:** Agents currently assume their environments are perfectly reliable. But real-world systems fail. We need a way to test if agents gracefully recover or spin out of control.
🚀 **The Feature:** Implemented `ChaosEnvironment`, a decorator that wraps any `Environment` (local or docker) and injects failures (like simulated timeouts) at deterministic intervals based on an internal counter.
🔮 **The Potential:** "Chaos Engineering" for LLMs! This could be a game changer for robust test suites and evaluating agents against flakiness without needing a complex proxy.
⚠️ **Risk:** Low. Completely additive. All code is isolated behind the `chaos` feature flag and lives in `src/env/chaos.rs`.

---
*PR created automatically by Jules for task [18201667434152752259](https://jules.google.com/task/18201667434152752259) started by @madmax983*