### PR TITLE
🌟 Nova: Trajectory Markdown Exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ tokio = { version = "1", features = ["full", "test-util"] }
 default = []
 docker = []
 live-anthropic = []
+markdown-export = []
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -1,0 +1,72 @@
+use super::Trajectory;
+
+pub trait TrajectoryExporter {
+    fn export(trajectory: &Trajectory) -> String;
+}
+
+pub struct MarkdownExporter;
+
+use std::fmt::Write;
+
+impl TrajectoryExporter for MarkdownExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let mut md = String::new();
+
+        md.push_str("# Trajectory Export\n\n");
+
+        if let Some(task) = &trajectory.info.task {
+            let _ = write!(md, "**Task:** {task}\n\n");
+        }
+
+        if let Some(outcome) = &trajectory.info.outcome {
+            let _ = write!(md, "**Outcome:** {outcome}\n\n");
+        }
+
+        md.push_str("## Messages\n\n");
+
+        for msg in &trajectory.messages {
+            let role_title = match msg.role.as_str() {
+                "system" => "System",
+                "user" => "User",
+                "assistant" => "Assistant",
+                "tool" => "Tool",
+                other => other,
+            };
+
+            let _ = write!(md, "### {role_title}\n\n{}\n\n", msg.content);
+        }
+
+        md
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Message;
+    use crate::trajectory::outcome;
+
+    #[test]
+    fn test_markdown_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::assistant("Hello user"));
+
+        let md = MarkdownExporter::export(&t);
+
+        assert!(md.contains("# Trajectory Export"));
+        assert!(md.contains("**Task:** Add a feature"));
+        assert!(md.contains("**Outcome:** submitted"));
+        assert!(md.contains("## Messages"));
+        assert!(md.contains("### System"));
+        assert!(md.contains("System prompt"));
+        assert!(md.contains("### User"));
+        assert!(md.contains("Hello agent"));
+        assert!(md.contains("### Assistant"));
+        assert!(md.contains("Hello user"));
+    }
+}

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -15,6 +15,9 @@ pub const FORMAT_VERSION: &str = "mini-swe-agent-1.1";
 /// Coarse run outcome. Exactly one of three values, suitable for computing
 /// pass@1-style metrics from trajectory files alone:
 /// `"submitted"` | `"step_limit_reached"` | `"error"`.
+#[cfg(feature = "markdown-export")]
+pub mod export;
+
 pub mod outcome {
     pub const SUBMITTED: &str = "submitted";
     pub const STEP_LIMIT_REACHED: &str = "step_limit_reached";


### PR DESCRIPTION
💡 **The Spark:** "I noticed we serialize trajectories to JSON perfectly, but they aren't easily readable by humans in standard dev workflows or markdown environments." 
🚀 **The Feature:** "Implemented `TrajectoryExporter` trait and `MarkdownExporter` struct to seamlessly convert agent runs into readable Markdown documents." 
🔮 **The Potential:** "Could be used for generating readable automated PR descriptions, generating docs for failed tasks, or uploading agent interactions straight to a documentation site." 
⚠️ **Risk:** "Low. Strictly additive and isolated in `src/trajectory/export.rs` under the new `markdown-export` feature flag."

---
*PR created automatically by Jules for task [4597830864547627660](https://jules.google.com/task/4597830864547627660) started by @madmax983*