### PR TITLE
swebench: add preflight checks, `doctor`/`dry-run` mode, and CLI options

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -86,6 +86,8 @@ pub struct ReplayCmd {
 pub enum BenchCmd {
     /// Run a SWE-bench sweep over a local JSONL dataset.
     Swebench(SwebenchCmd),
+    /// Validate sweep inputs without launching tasks.
+    Doctor(SwebenchCmd),
     /// Diff two completed sweep runs by instance id; surfaces regressions
     /// and (with `--max-regressions`) gates CI on prompt/harness changes.
     Compare(CompareCmd),
@@ -206,6 +208,30 @@ pub struct SwebenchCmd {
     /// `failure_category` is retryable instead of skipping them.
     #[arg(long, default_value_t = false)]
     pub retry_on_resume: bool,
+
+    /// Run preflight checks and exit without launching tasks.
+    #[arg(long, default_value_t = false)]
+    pub dry_run: bool,
+
+    /// Skip startup preflight checks before launching a sweep.
+    #[arg(long, default_value_t = false)]
+    pub skip_preflight: bool,
+
+    /// Doctor/dry-run output format.
+    #[arg(long, default_value = "text")]
+    pub format: String,
+
+    /// Skip model backend probe during preflight.
+    #[arg(long, default_value_t = false)]
+    pub skip_model_probe: bool,
+
+    /// Max seconds per preflight check.
+    #[arg(long, default_value_t = 10)]
+    pub preflight_check_timeout_s: u64,
+
+    /// Max total seconds for all preflight checks.
+    #[arg(long, default_value_t = 60)]
+    pub preflight_total_timeout_s: u64,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -133,6 +133,7 @@ pub struct CompareCmd {
 }
 
 #[derive(Debug, Args)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct SwebenchCmd {
     #[arg(long)]
     pub dataset_path: PathBuf,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -51,6 +51,9 @@ pub async fn run() -> Result<(), Error> {
             cmd: args::BenchCmd::Swebench(s),
         } => bench_swebench(s).await,
         Command::Bench {
+            cmd: args::BenchCmd::Doctor(s),
+        } => bench_doctor(s).await,
+        Command::Bench {
             cmd: args::BenchCmd::Compare(c),
         } => bench_compare(c),
         Command::Bench {
@@ -178,6 +181,13 @@ async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
         deterministic_responses: None,
         deterministic_usage_per_call: None,
         config_overlay_paths: s.config.into_iter().collect(),
+        dry_run: s.dry_run,
+        skip_preflight: s.skip_preflight,
+        preflight_format: s.format,
+        skip_model_probe: s.skip_model_probe,
+        preflight_check_timeout_s: s.preflight_check_timeout_s,
+        preflight_total_timeout_s: s.preflight_total_timeout_s,
+        preflight_mode: if s.dry_run { "dry_run" } else { "sweep" }.into(),
     })
     .await?;
 
@@ -195,6 +205,46 @@ async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
         cost_limit_usd = ?results.cost_limit_usd,
         "sweep complete"
     );
+    print!("{}", results.summary_table());
+    Ok(())
+}
+
+async fn bench_doctor(mut s: args::SwebenchCmd) -> Result<(), Error> {
+    s.dry_run = true;
+    let mut cfg = match &s.config {
+        Some(p) => Config::load(p)?,
+        None => Config::defaults()?,
+    };
+    cfg.root.model.name.clone_from(&s.model);
+    cfg.root.agent.step_limit = s.step_limit;
+    let results = crate::run::swebench::run(crate::run::swebench::SwebenchArgs {
+        dataset_path: s.dataset_path,
+        output_dir: s.output,
+        parallel: s.parallel,
+        config: cfg,
+        resume: s.resume,
+        cost_limit_usd: s.sweep_cost_limit_usd,
+        instance_ids: s.instance_ids,
+        limit: s.limit,
+        sample: s.sample,
+        seed: s.seed,
+        max_retries: s.max_retries,
+        retry_on: s.retry_on,
+        retry_backoff_base_ms: s.retry_backoff_base_ms,
+        retry_backoff_cap_s: s.retry_backoff_cap_s,
+        retry_on_resume: s.retry_on_resume,
+        deterministic_responses: None,
+        deterministic_usage_per_call: None,
+        config_overlay_paths: s.config.into_iter().collect(),
+        dry_run: true,
+        skip_preflight: s.skip_preflight,
+        preflight_format: s.format,
+        skip_model_probe: s.skip_model_probe,
+        preflight_check_timeout_s: s.preflight_check_timeout_s,
+        preflight_total_timeout_s: s.preflight_total_timeout_s,
+        preflight_mode: "doctor".into(),
+    })
+    .await?;
     print!("{}", results.summary_table());
     Ok(())
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -211,6 +211,7 @@ async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
 
 async fn bench_doctor(mut s: args::SwebenchCmd) -> Result<(), Error> {
     s.dry_run = true;
+    let output_format = s.format.clone();
     let mut cfg = match &s.config {
         Some(p) => Config::load(p)?,
         None => Config::defaults()?,
@@ -245,7 +246,9 @@ async fn bench_doctor(mut s: args::SwebenchCmd) -> Result<(), Error> {
         preflight_mode: "doctor".into(),
     })
     .await?;
-    print!("{}", results.summary_table());
+    if output_format != "json" {
+        print!("{}", results.summary_table());
+    }
     Ok(())
 }
 

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -83,7 +83,7 @@ impl DockerEnvironment {
     }
 }
 
-async fn preflight() -> Result<(), EnvError> {
+pub async fn preflight() -> Result<(), EnvError> {
     match Command::new("docker")
         .arg("version")
         .stdin(StdStdio::null())

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -321,6 +321,7 @@ impl SweepResults {
     }
 }
 
+#[allow(clippy::struct_excessive_bools)]
 pub struct SwebenchArgs {
     pub dataset_path: PathBuf,
     pub output_dir: PathBuf,
@@ -384,7 +385,6 @@ pub struct SwebenchArgs {
 enum CheckStatus {
     Ok,
     Warn,
-    Fail,
 }
 
 #[derive(Debug, Clone)]
@@ -831,6 +831,7 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     Ok(sweep)
 }
 
+#[allow(clippy::too_many_lines)]
 async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
     let deadline = Instant::now() + Duration::from_secs(args.preflight_total_timeout_s);
     let mut checks = Vec::new();
@@ -993,7 +994,6 @@ fn render_preflight_report(
                     status: match c.status {
                         CheckStatus::Ok => "ok",
                         CheckStatus::Warn => "warn",
-                        CheckStatus::Fail => "fail",
                     }
                     .into(),
                     name: c.name.into(),
@@ -1009,7 +1009,6 @@ fn render_preflight_report(
         let s = match c.status {
             CheckStatus::Ok => "ok",
             CheckStatus::Warn => "warn",
-            CheckStatus::Fail => "fail",
         };
         let _ = writeln!(out, "[{s}] {} — {}", c.name, c.message);
     }

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -910,12 +910,13 @@ async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
         crate::config::EnvKind::Docker => {
             #[cfg(feature = "docker")]
             {
-                tokio::time::timeout(
-                    Duration::from_secs(args.preflight_check_timeout_s),
-                    crate::env::docker::preflight(),
-                )
-                .await
-                .map_err(|_| Error::Trajectory("docker preflight timed out".into()))??;
+                ensure_total_deadline(deadline)?;
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                let per_check = Duration::from_secs(args.preflight_check_timeout_s);
+                let budget = remaining.min(per_check);
+                tokio::time::timeout(budget, crate::env::docker::preflight())
+                    .await
+                    .map_err(|_| Error::Trajectory("docker preflight timed out".into()))??;
                 checks.push(CheckResult {
                     status: CheckStatus::Ok,
                     name: "env.docker",

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -483,7 +483,9 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
         print_preflight_report(&report, &args.preflight_format, &args.preflight_mode)?;
     }
     if args.dry_run {
-        println!("preflight checks passed");
+        if args.preflight_format != "json" {
+            println!("preflight checks passed");
+        }
         return Ok(SweepResults {
             total: 0,
             submitted: 0,
@@ -866,16 +868,10 @@ async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
         name: "dataset.parse",
         message: format!("valid jsonl, selected {} instances", subset.len()),
     });
-    if let Some(parent) = args.output_dir.parent().filter(|p| !p.exists()) {
-        return Err(Error::Trajectory(format!(
-            "output parent does not exist: {}",
-            parent.display()
-        )));
-    }
     checks.push(CheckResult {
         status: CheckStatus::Ok,
         name: "output.parent",
-        message: "parent exists".into(),
+        message: "will be created if missing".into(),
     });
     if args.output_dir.join("results.json").exists() && !args.resume {
         checks.push(CheckResult {
@@ -910,17 +906,25 @@ async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
         }
         crate::config::EnvKind::Docker => {
             #[cfg(feature = "docker")]
-            tokio::time::timeout(
-                Duration::from_secs(args.preflight_check_timeout_s),
-                crate::env::docker::preflight(),
-            )
-            .await
-            .map_err(|_| Error::Trajectory("docker preflight timed out".into()))??;
-            checks.push(CheckResult {
-                status: CheckStatus::Ok,
-                name: "env.docker",
-                message: "docker daemon reachable".into(),
-            });
+            {
+                tokio::time::timeout(
+                    Duration::from_secs(args.preflight_check_timeout_s),
+                    crate::env::docker::preflight(),
+                )
+                .await
+                .map_err(|_| Error::Trajectory("docker preflight timed out".into()))??;
+                checks.push(CheckResult {
+                    status: CheckStatus::Ok,
+                    name: "env.docker",
+                    message: "docker daemon reachable".into(),
+                });
+            }
+            #[cfg(not(feature = "docker"))]
+            {
+                return Err(Error::Trajectory(
+                    "environment.kind=docker requires binary built with `docker` feature".into(),
+                ));
+            }
         }
     }
     if !args.skip_model_probe {

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -17,13 +17,14 @@ use std::process::Command;
 #[cfg(test)]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::SystemTime;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::config::Config;
 use crate::error::Error;
-use crate::model::ModelUsage;
+use crate::model::{Model, ModelUsage};
 use crate::trajectory::{FailureCategory, Trajectory, outcome};
 
 /// Sentinel `exit_reason` for tasks that never started because the
@@ -370,6 +371,40 @@ pub struct SwebenchArgs {
     pub deterministic_usage_per_call: Option<ModelUsage>,
     /// CLI-provided config overlay paths used to construct `config`.
     pub config_overlay_paths: Vec<PathBuf>,
+    pub dry_run: bool,
+    pub skip_preflight: bool,
+    pub preflight_format: String,
+    pub skip_model_probe: bool,
+    pub preflight_check_timeout_s: u64,
+    pub preflight_total_timeout_s: u64,
+    pub preflight_mode: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CheckStatus {
+    Ok,
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, Clone)]
+struct CheckResult {
+    status: CheckStatus,
+    name: &'static str,
+    message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct PreflightReport {
+    mode: String,
+    checks: Vec<CheckResultOut>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CheckResultOut {
+    status: String,
+    name: String,
+    message: String,
 }
 
 fn default_attempts() -> u32 {
@@ -443,6 +478,31 @@ fn parse_dataset_lines(text: &str) -> Result<Vec<SweBenchInstance>, Error> {
 // without yielding reusable pieces.
 #[allow(clippy::too_many_lines)]
 pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
+    if !args.skip_preflight {
+        let report = run_preflight(&args).await?;
+        print_preflight_report(&report, &args.preflight_format, &args.preflight_mode)?;
+    }
+    if args.dry_run {
+        println!("preflight checks passed");
+        return Ok(SweepResults {
+            total: 0,
+            submitted: 0,
+            skipped: 0,
+            errored: 0,
+            failures_by_category: BTreeMap::new(),
+            budget_halted: 0,
+            with_patch: 0,
+            total_prompt_tokens: 0,
+            total_completion_tokens: 0,
+            estimated_cost_usd: 0.0,
+            retries: 0,
+            retried_instances: 0,
+            filter_spec: FilterSpec::default(),
+            manifest: None,
+            cost_limit_usd: args.cost_limit_usd,
+            instances: Vec::new(),
+        });
+    }
     std::fs::create_dir_all(&args.output_dir)?;
     let started_at_utc = chrono::Utc::now().to_rfc3339();
     let prior_results = if args.resume {
@@ -765,6 +825,226 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     std::fs::write(&summary_path, serde_json::to_string_pretty(&sweep)?)?;
 
     Ok(sweep)
+}
+
+async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
+    let deadline = Instant::now() + Duration::from_secs(args.preflight_total_timeout_s);
+    let mut checks = Vec::new();
+    let dataset_path = args.dataset_path.clone();
+    let dataset_bytes = timed_sync(
+        "dataset.read",
+        args.preflight_check_timeout_s,
+        deadline,
+        move || std::fs::read(&dataset_path),
+    )
+    .await?;
+    checks.push(CheckResult {
+        status: CheckStatus::Ok,
+        name: "dataset.read",
+        message: format!("readable: {}", args.dataset_path.display()),
+    });
+    let instances = timed_sync(
+        "dataset.parse",
+        args.preflight_check_timeout_s,
+        deadline,
+        move || load_dataset_from_bytes(&dataset_bytes),
+    )
+    .await?;
+    let instance_ids = args.instance_ids.clone();
+    let limit = args.limit;
+    let sample = args.sample;
+    let seed = args.seed;
+    let (subset, _) = timed_sync(
+        "dataset.subset",
+        args.preflight_check_timeout_s,
+        deadline,
+        move || apply_subset(instances, instance_ids.as_deref(), limit, sample, seed),
+    )
+    .await?;
+    checks.push(CheckResult {
+        status: CheckStatus::Ok,
+        name: "dataset.parse",
+        message: format!("valid jsonl, selected {} instances", subset.len()),
+    });
+    if let Some(parent) = args.output_dir.parent().filter(|p| !p.exists()) {
+        return Err(Error::Trajectory(format!(
+            "output parent does not exist: {}",
+            parent.display()
+        )));
+    }
+    checks.push(CheckResult {
+        status: CheckStatus::Ok,
+        name: "output.parent",
+        message: "parent exists".into(),
+    });
+    if args.output_dir.join("results.json").exists() && !args.resume {
+        checks.push(CheckResult {
+            status: CheckStatus::Warn,
+            name: "output.results_json",
+            message: "results.json exists and --resume is false".into(),
+        });
+    }
+    ensure_total_deadline(deadline)?;
+    match args.config.root.environment.kind {
+        crate::config::EnvKind::Local => {
+            for bin in ["bash", "git", "patch"] {
+                ensure_total_deadline(deadline)?;
+                let ok = timed_sync(
+                    "env.local_tools",
+                    args.preflight_check_timeout_s,
+                    deadline,
+                    move || Command::new("which").arg(bin).output(),
+                )
+                .await?
+                .status
+                .success();
+                if !ok {
+                    return Err(Error::Trajectory(format!("required binary missing: {bin}")));
+                }
+            }
+            checks.push(CheckResult {
+                status: CheckStatus::Ok,
+                name: "env.local_tools",
+                message: "bash/git/patch are on PATH".into(),
+            });
+        }
+        crate::config::EnvKind::Docker => {
+            #[cfg(feature = "docker")]
+            tokio::time::timeout(
+                Duration::from_secs(args.preflight_check_timeout_s),
+                crate::env::docker::preflight(),
+            )
+            .await
+            .map_err(|_| Error::Trajectory("docker preflight timed out".into()))??;
+            checks.push(CheckResult {
+                status: CheckStatus::Ok,
+                name: "env.docker",
+                message: "docker daemon reachable".into(),
+            });
+        }
+    }
+    if !args.skip_model_probe {
+        ensure_total_deadline(deadline)?;
+        let backend = crate::model::LitellmBackend::new(args.config.root.model.name.clone());
+        let msgs = vec![crate::model::Message::user("Reply with exactly: ok")];
+        let opts = crate::model::QueryOpts {
+            max_tokens: Some(1),
+            ..crate::model::QueryOpts::default()
+        };
+        let _ = tokio::time::timeout(
+            Duration::from_secs(args.preflight_check_timeout_s),
+            backend.query(&msgs, &opts),
+        )
+        .await
+        .map_err(|_| Error::Trajectory("model probe timed out".into()))?
+        .map_err(|e| Error::Trajectory(format!("model probe failed: {e}")))?;
+        checks.push(CheckResult {
+            status: CheckStatus::Ok,
+            name: "model.probe",
+            message: "litellm 1-token probe succeeded".into(),
+        });
+    }
+    let renderer = crate::template::Renderer::new();
+    let fixture =
+        serde_json::json!({"task":"demo","instance_id":"x","repo":"r","base_commit":"abc"});
+    let _ = renderer.render_str(&args.config.root.prompts.system, &fixture)?;
+    let _ = renderer.render_str(&args.config.root.prompts.instance, &fixture)?;
+    checks.push(CheckResult {
+        status: CheckStatus::Ok,
+        name: "prompt.templates",
+        message: "system/instance templates parse + render".into(),
+    });
+    ensure_total_deadline(deadline)?;
+    if let Some(obj) = args.config.raw.as_object() {
+        let known: std::collections::HashSet<&str> =
+            ["agent", "model", "environment", "prompts", "extends"]
+                .into_iter()
+                .collect();
+        for k in obj.keys() {
+            if !known.contains(k.as_str()) {
+                checks.push(CheckResult {
+                    status: CheckStatus::Warn,
+                    name: "config.unknown_top_level",
+                    message: format!("unknown top-level key: {k}"),
+                });
+            }
+        }
+    }
+    Ok(checks)
+}
+
+fn render_preflight_report(
+    checks: &[CheckResult],
+    format: &str,
+    mode: &str,
+) -> Result<String, Error> {
+    if format == "json" {
+        let payload = PreflightReport {
+            mode: mode.into(),
+            checks: checks
+                .iter()
+                .map(|c| CheckResultOut {
+                    status: match c.status {
+                        CheckStatus::Ok => "ok",
+                        CheckStatus::Warn => "warn",
+                        CheckStatus::Fail => "fail",
+                    }
+                    .into(),
+                    name: c.name.into(),
+                    message: c.message.clone(),
+                })
+                .collect(),
+        };
+        return serde_json::to_string_pretty(&payload)
+            .map_err(|e| Error::Trajectory(format!("preflight json encode: {e}")));
+    }
+    let mut out = String::new();
+    for c in checks {
+        let s = match c.status {
+            CheckStatus::Ok => "ok",
+            CheckStatus::Warn => "warn",
+            CheckStatus::Fail => "fail",
+        };
+        let _ = writeln!(out, "[{s}] {} — {}", c.name, c.message);
+    }
+    Ok(out)
+}
+
+fn print_preflight_report(checks: &[CheckResult], format: &str, mode: &str) -> Result<(), Error> {
+    print!("{}", render_preflight_report(checks, format, mode)?);
+    Ok(())
+}
+
+async fn timed_sync<T, E, F>(
+    name: &str,
+    timeout_s: u64,
+    deadline: Instant,
+    f: F,
+) -> Result<T, Error>
+where
+    T: Send + 'static,
+    E: Send + 'static + std::fmt::Display,
+    F: Send + 'static + FnOnce() -> Result<T, E>,
+{
+    ensure_total_deadline(deadline)?;
+    let rem = deadline.saturating_duration_since(Instant::now());
+    let per = Duration::from_secs(timeout_s);
+    let budget = rem.min(per);
+    let h = tokio::task::spawn_blocking(f);
+    let out = tokio::time::timeout(budget, h)
+        .await
+        .map_err(|_| Error::Trajectory(format!("{name}: timeout exceeded")))?
+        .map_err(|e| Error::Trajectory(format!("{name}: join error: {e}")))?
+        .map_err(|e| Error::Trajectory(format!("{name}: {e}")))?;
+    ensure_total_deadline(deadline)?;
+    Ok(out)
+}
+
+fn ensure_total_deadline(deadline: Instant) -> Result<(), Error> {
+    if Instant::now() > deadline {
+        return Err(Error::Trajectory("preflight total timeout exceeded".into()));
+    }
+    Ok(())
 }
 
 fn build_manifest(
@@ -1828,6 +2108,13 @@ mod tests {
             deterministic_responses: None,
             deterministic_usage_per_call: None,
             config_overlay_paths: Vec::new(),
+            dry_run: false,
+            skip_preflight: true,
+            preflight_format: "text".into(),
+            skip_model_probe: true,
+            preflight_check_timeout_s: 10,
+            preflight_total_timeout_s: 60,
+            preflight_mode: "test".into(),
         };
         let manifest = build_manifest(
             &args,
@@ -1862,6 +2149,13 @@ mod tests {
             deterministic_responses: None,
             deterministic_usage_per_call: None,
             config_overlay_paths: Vec::new(),
+            dry_run: false,
+            skip_preflight: true,
+            preflight_format: "text".into(),
+            skip_model_probe: true,
+            preflight_check_timeout_s: 10,
+            preflight_total_timeout_s: 60,
+            preflight_mode: "test".into(),
         };
         let manifest = build_manifest(
             &args,
@@ -1911,6 +2205,13 @@ prompts:
             deterministic_responses: None,
             deterministic_usage_per_call: None,
             config_overlay_paths: Vec::new(),
+            dry_run: false,
+            skip_preflight: true,
+            preflight_format: "text".into(),
+            skip_model_probe: true,
+            preflight_check_timeout_s: 10,
+            preflight_total_timeout_s: 60,
+            preflight_mode: "test".into(),
         };
         let filter = FilterSpec::default();
         let m_a = build_manifest(&args_a, "dataset", 1, &filter, "2026-01-01T00:00:00Z", None);
@@ -1984,6 +2285,13 @@ prompts:
             deterministic_responses: None,
             deterministic_usage_per_call: None,
             config_overlay_paths: Vec::new(),
+            dry_run: false,
+            skip_preflight: true,
+            preflight_format: "text".into(),
+            skip_model_probe: true,
+            preflight_check_timeout_s: 10,
+            preflight_total_timeout_s: 60,
+            preflight_mode: "test".into(),
         };
         PANIC_AFTER_INITIAL_MANIFEST_WRITE.store(true, Ordering::Relaxed);
         let panicked = std::panic::AssertUnwindSafe(run(args))
@@ -2198,5 +2506,41 @@ prompts:
             err.to_string().contains("produced zero instances"),
             "unexpected err: {err}"
         );
+    }
+
+    #[test]
+    fn doctor_and_dry_run_report_render_identical_for_same_checks() {
+        let checks = vec![
+            CheckResult {
+                status: CheckStatus::Ok,
+                name: "dataset.read",
+                message: "readable".into(),
+            },
+            CheckResult {
+                status: CheckStatus::Warn,
+                name: "config.unknown_top_level",
+                message: "unknown key".into(),
+            },
+        ];
+        let doctor = render_preflight_report(&checks, "text", "doctor").unwrap();
+        let dry = render_preflight_report(&checks, "text", "dry_run").unwrap();
+        assert_eq!(doctor, dry);
+    }
+
+    #[test]
+    fn preflight_json_schema_has_stable_top_level_fields() {
+        let checks = vec![CheckResult {
+            status: CheckStatus::Ok,
+            name: "dataset.read",
+            message: "readable".into(),
+        }];
+        let payload = render_preflight_report(&checks, "json", "doctor").unwrap();
+        let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert!(v.get("mode").is_some());
+        assert!(v.get("checks").is_some());
+        let c0 = &v["checks"][0];
+        assert!(c0.get("status").is_some());
+        assert!(c0.get("name").is_some());
+        assert!(c0.get("message").is_some());
     }
 }

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -483,8 +483,10 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
         print_preflight_report(&report, &args.preflight_format, &args.preflight_mode)?;
     }
     if args.dry_run {
-        if args.preflight_format != "json" {
+        if !args.skip_preflight && args.preflight_format != "json" {
             println!("preflight checks passed");
+        } else if args.skip_preflight && args.preflight_format != "json" {
+            println!("preflight skipped");
         }
         return Ok(SweepResults {
             total: 0,
@@ -935,13 +937,13 @@ async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
             max_tokens: Some(1),
             ..crate::model::QueryOpts::default()
         };
-        let _ = tokio::time::timeout(
-            Duration::from_secs(args.preflight_check_timeout_s),
-            backend.query(&msgs, &opts),
-        )
-        .await
-        .map_err(|_| Error::Trajectory("model probe timed out".into()))?
-        .map_err(|e| Error::Trajectory(format!("model probe failed: {e}")))?;
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let per_check = Duration::from_secs(args.preflight_check_timeout_s);
+        let budget = remaining.min(per_check);
+        let _ = tokio::time::timeout(budget, backend.query(&msgs, &opts))
+            .await
+            .map_err(|_| Error::Trajectory("model probe timed out".into()))?
+            .map_err(|e| Error::Trajectory(format!("model probe failed: {e}")))?;
         checks.push(CheckResult {
             status: CheckStatus::Ok,
             name: "model.probe",

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -2548,4 +2548,53 @@ prompts:
         assert!(c0.get("name").is_some());
         assert!(c0.get("message").is_some());
     }
+
+    #[tokio::test]
+    async fn timed_sync_succeeds_within_budget() {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let out = timed_sync("ok", 1, deadline, || -> Result<u32, std::io::Error> {
+            Ok(7)
+        })
+        .await
+        .unwrap();
+        assert_eq!(out, 7);
+    }
+
+    #[tokio::test]
+    async fn timed_sync_times_out() {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let err = timed_sync("slow", 0, deadline, || -> Result<(), std::io::Error> {
+            std::thread::sleep(Duration::from_millis(20));
+            Ok(())
+        })
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("timeout exceeded"));
+    }
+
+    #[test]
+    fn ensure_total_deadline_errors_when_expired() {
+        let deadline = Instant::now() - Duration::from_millis(1);
+        let err = ensure_total_deadline(deadline).unwrap_err();
+        assert!(err.to_string().contains("total timeout exceeded"));
+    }
+
+    #[test]
+    fn render_preflight_text_mode_is_line_oriented() {
+        let checks = vec![
+            CheckResult {
+                status: CheckStatus::Ok,
+                name: "a",
+                message: "x".into(),
+            },
+            CheckResult {
+                status: CheckStatus::Warn,
+                name: "b",
+                message: "y".into(),
+            },
+        ];
+        let out = render_preflight_report(&checks, "text", "doctor").unwrap();
+        assert!(out.contains("[ok] a"));
+        assert!(out.contains("[warn] b"));
+    }
 }

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -2574,7 +2574,9 @@ prompts:
 
     #[test]
     fn ensure_total_deadline_errors_when_expired() {
-        let deadline = Instant::now() - Duration::from_millis(1);
+        let deadline = Instant::now()
+            .checked_sub(Duration::from_millis(1))
+            .unwrap();
         let err = ensure_total_deadline(deadline).unwrap_err();
         assert!(err.to_string().contains("total timeout exceeded"));
     }

--- a/tests/swebench_budget.rs
+++ b/tests/swebench_budget.rs
@@ -125,6 +125,13 @@ async fn sweep_halts_when_cumulative_cost_reaches_limit() {
         deterministic_responses: Some(submit_only_responses_for(5)),
         deterministic_usage_per_call: Some(usage),
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -282,6 +289,13 @@ async fn sweep_without_limit_runs_all_tasks() {
         deterministic_responses: Some(submit_only_responses_for(3)),
         deterministic_usage_per_call: Some(usage),
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -365,6 +379,13 @@ async fn resume_skipped_costs_count_against_budget() {
         deterministic_responses: Some(submit_only_responses_for(2)),
         deterministic_usage_per_call: Some(usage),
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -481,6 +502,13 @@ async fn resume_uses_prior_results_token_totals_for_budget_accounting() {
         deterministic_responses: Some(submit_only_responses_for(1)),
         deterministic_usage_per_call: Some(usage),
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -585,6 +613,13 @@ async fn retry_on_resume_instances_are_precharged_before_rerun() {
         deterministic_responses: Some(submit_only_responses_for(1)),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -694,6 +729,13 @@ async fn stale_results_json_is_not_trusted_over_newer_trajectory() {
         deterministic_responses: Some(submit_only_responses_for(1)),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();

--- a/tests/swebench_failure_categories.rs
+++ b/tests/swebench_failure_categories.rs
@@ -109,6 +109,13 @@ async fn sweep_counts_failure_categories_and_preserves_legacy_unclassified() {
         deterministic_responses: None,
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();

--- a/tests/swebench_patch.rs
+++ b/tests/swebench_patch.rs
@@ -110,6 +110,13 @@ async fn sweep_emits_patch_artifact_for_modifying_agent() {
         deterministic_responses: Some(responses),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -194,6 +201,13 @@ async fn sweep_emits_empty_patch_when_agent_changes_nothing() {
         ]),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -262,6 +276,13 @@ async fn missing_workdir_marks_outcome_as_error() {
         ]),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();

--- a/tests/swebench_resume.rs
+++ b/tests/swebench_resume.rs
@@ -129,6 +129,13 @@ async fn resume_skips_valid_trajectory_and_reruns_invalid() {
         deterministic_responses: Some(submit_only_responses()),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -212,6 +219,13 @@ async fn resume_reruns_submitted_trajectory_with_missing_patch() {
         deterministic_responses: Some(submit_only_responses()),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -264,6 +278,13 @@ async fn without_resume_existing_trajectories_are_overwritten() {
         deterministic_responses: Some(submit_only_responses()),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -316,6 +337,13 @@ async fn malformed_results_json_does_not_block_new_non_resume_sweep() {
         deterministic_responses: Some(submit_only_responses()),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -397,6 +425,13 @@ async fn resume_uses_on_disk_patch_flags_even_if_prior_summary_is_false() {
         deterministic_responses: Some(submit_only_responses()),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();

--- a/tests/swebench_retry.rs
+++ b/tests/swebench_retry.rs
@@ -95,6 +95,13 @@ async fn instance_cost_prefers_recorded_trajectory_cost() {
         deterministic_responses: Some(vec![submit_response()]),
         deterministic_usage_per_call: Some(usage),
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -132,6 +139,13 @@ async fn retries_on_injected_transient_category_then_recovers() {
         deterministic_responses: Some(vec![malformed_action_response(), submit_response()]),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -176,6 +190,13 @@ async fn max_retries_zero_disables_retry() {
         deterministic_responses: Some(vec![malformed_action_response()]),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -224,6 +245,13 @@ async fn max_retries_cap_stops_without_infinite_loop_and_non_retryable_is_not_re
         ]),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -250,6 +278,13 @@ async fn max_retries_cap_stops_without_infinite_loop_and_non_retryable_is_not_re
         deterministic_responses: Some(vec![malformed_action_response()]),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -294,6 +329,13 @@ async fn cost_cap_can_trip_mid_retry_and_retry_on_resume_round_trip() {
         deterministic_responses: Some(vec![malformed_action_response(), submit_response()]),
         deterministic_usage_per_call: Some(usage),
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -342,6 +384,13 @@ async fn cost_cap_can_trip_mid_retry_and_retry_on_resume_round_trip() {
         deterministic_responses: Some(vec![submit_response()]),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();
@@ -366,6 +415,13 @@ async fn cost_cap_can_trip_mid_retry_and_retry_on_resume_round_trip() {
         deterministic_responses: Some(vec![submit_response()]),
         deterministic_usage_per_call: None,
         config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
     })
     .await
     .unwrap();


### PR DESCRIPTION
### Motivation

- Provide a lightweight preflight that validates dataset, config, environment, and model connectivity before launching a sweep. 
- Add a `doctor`/dry-run mode to check inputs and surface issues without submitting tasks. 
- Allow CI/interactive callers to control preflight behavior (format, timeouts, skip model probe) and surface machine-readable results.

### Description

- Added new CLI flags to `SwebenchCmd`: `--dry-run`, `--skip-preflight`, `--format`, `--skip-model-probe`, `--preflight-check-timeout-s`, and `--preflight-total-timeout-s`, and a `Doctor` subcommand that runs `SwebenchCmd` in diagnostic mode. 
- Implemented `run_preflight` in `run::swebench` that performs a sequence of checks (dataset read/parse/subset, output parent, `results.json` warning, local tools presence, docker daemon probe via `env::docker::preflight`, lightweight model probe via `LitellmBackend`, and prompt template rendering), collects `CheckResult`s, and renders output as text or JSON. 
- Added helpers `timed_sync` and `ensure_total_deadline` to enforce per-check and total preflight time budgets, and new types `CheckStatus`, `CheckResult`, `PreflightReport`, and `CheckResultOut` for structured reporting. 
- Exposed `env::docker::preflight` as `pub` so the docker probe can be reused during preflight. 
- Wired preflight and dry-run behavior into the existing sweep runner: when `--dry-run` the preflight runs and the sweep returns early with an empty `SweepResults`; when `--skip-preflight` preflight is bypassed. 
- Added `bench_doctor` CLI handler that forces `dry_run` and sets `preflight_mode = "doctor"`. 
- Updated many tests and `SwebenchArgs` usages to provide the new args and added unit tests for preflight report rendering and JSON schema stability.

### Testing

- Ran the full automated test suite with `cargo test`, including unit tests in `src/run/swebench.rs` and the integration tests under `tests/`, and all tests passed. 
- Exercised preflight code paths via new unit tests that validate text/json render parity and report top-level schema fields, and these tests passed. 
- Verified existing sweep behavior via the updated integration tests which set `skip_preflight=true` where appropriate, and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20b90c940832a88216aaf511847ef)