### PR TITLE
Add semantic inspect diff and script execution coverage

### DIFF
--- a/docs/spec-inspect.md
+++ b/docs/spec-inspect.md
@@ -98,7 +98,7 @@ same filtered field-diff semantics.
 
 The text header summarizes `instance_id`, both paths, baseline/candidate
 failure categories, attempts, cost, token counts, total steps, and the first
-divergent step. `--format json` emits:
+divergent step with its role. `--format json` emits:
 
 ```json
 {
@@ -106,7 +106,8 @@ divergent step. `--format json` emits:
   "header": {
     "baseline_failure_category": "none",
     "candidate_failure_category": "step_limit",
-    "first_divergent_step_index": 3
+    "first_divergent_step_index": 3,
+    "first_divergent_step_role": "assistant"
   },
   "steps": [
     {

--- a/docs/spec-inspect.md
+++ b/docs/spec-inspect.md
@@ -12,6 +12,12 @@ rust-swe-agent bench inspect --sweep <dir> --instance <instance_id> --full
 rust-swe-agent bench inspect --sweep <dir> --instance <instance_id> --format json
 rust-swe-agent bench inspect --sweep <dir> --filter resolved=false
 rust-swe-agent bench inspect --sweep <dir> --filter failure_category=step_limit
+rust-swe-agent bench inspect --diff <baseline.traj.json> <candidate.traj.json>
+rust-swe-agent bench inspect --diff <baseline.traj.json> <candidate.traj.json> --format json
+rust-swe-agent bench inspect --diff <baseline.traj.json> <candidate.traj.json> --format unified
+rust-swe-agent bench inspect --diff <baseline.traj.json> <candidate.traj.json> --show-noise
+rust-swe-agent bench compare --baseline <dir> --candidate <dir> --inspect-diff <instance_id>
+rust-swe-agent bench compare --baseline <dir> --candidate <dir> --emit-diff-script <out.sh>
 ```
 
 ### Inputs
@@ -21,8 +27,14 @@ rust-swe-agent bench inspect --sweep <dir> --filter failure_category=step_limit
 * `--filter`: summary-table mode (`resolved=true|false` or `failure_category=<snake_case>`).
 * `--format`: `text` (default) or `json`.
 * `--full`: disable stdout/stderr truncation in transcript mode.
+* `--diff`: compare two trajectory JSON files for the same `instance_id`.
+* `--show-noise`: in diff mode, include whitespace-only and timestamp-only differences.
+* `--inspect-diff`: compare sugar that resolves `<instance_id>.traj.json` inside both sweep directories.
+* `--emit-diff-script`: writes one `bench inspect --diff` invocation per regressed instance.
 
 Exactly one of `--instance` or `--filter` is required.
+Diff mode is separate and cannot be combined with `--sweep`, `--instance`, or
+`--filter`.
 
 ## Transcript behavior
 
@@ -49,6 +61,73 @@ Truncation defaults:
 * Truncate when stdout/stderr exceeds **40 lines** or **2 KiB**.
 * Marker: `… [N more lines, full output at trajectory.json#/steps/N]`.
 * `--full` disables truncation.
+
+## Diff behavior
+
+`bench inspect --diff` is read-only. Both trajectories must resolve to the
+same `instance_id`. The ID is read from `info.instance_id` when present and
+otherwise derived from the trajectory filename (`<id>.traj.json`) or nested
+directory (`<id>/trajectory.json`). A mismatch exits non-zero with a clear
+error.
+
+The diff aligns by an explicit `(role, logical_step_index)` key, not by raw
+message position. A normal action turn groups the pending `system`/`user`
+prompt, assistant message, and following tool result into one `assistant`
+step. Orphan prompt/tool records are retained under `prompt`/`tool` roles so
+length mismatches show as `baseline_only` or `candidate_only` tails instead of
+silently shifting later steps. Matching steps are collapsed as:
+
+```text
+[step 0 - identical] role=assistant
+```
+
+Divergent steps expand field-by-field in side-by-side columns. When terminal
+color is forced with `CLICOLOR_FORCE=1` and `NO_COLOR` is unset, changed field
+labels are highlighted with ANSI color. The compared fields are:
+
+* `prompt.content`
+* `assistant.content`
+* `bash.command`
+* `tool.exit_code`
+* `tool.stdout`
+* `tool.stderr`
+
+Whitespace-only and timestamp-only differences are suppressed by default.
+`--show-noise` re-enables them.
+
+The text header summarizes `instance_id`, both paths, baseline/candidate
+failure categories, attempts, cost, token counts, total steps, and the first
+divergent step. `--format json` emits:
+
+```json
+{
+  "instance_id": "<id>",
+  "header": {
+    "baseline_failure_category": "none",
+    "candidate_failure_category": "step_limit",
+    "first_divergent_step_index": 3
+  },
+  "steps": [
+    {
+      "index": 3,
+      "role": "assistant",
+      "status": "diverge",
+      "baseline": {},
+      "candidate": {},
+      "diff_fields": ["assistant.content", "tool.stdout"]
+    }
+  ]
+}
+```
+
+`--format unified` emits a line-oriented unified diff over canonical step text
+for pager workflows, including classic `---`/`+++` headers, `@@ -a,b +c,d @@`
+hunk ranges, unchanged context lines, and `-`/`+` changed lines.
+
+`bench compare --inspect-diff <instance_id>` resolves the two trajectory files
+inside the baseline and candidate sweep directories and renders the same diff.
+`bench compare --emit-diff-script <out.sh>` writes a shell script containing
+one diff command for each regressed instance; it does not run the script.
 
 ## Worked examples
 

--- a/docs/spec-inspect.md
+++ b/docs/spec-inspect.md
@@ -73,9 +73,9 @@ error.
 The diff aligns by an explicit `(role, logical_step_index)` key, not by raw
 message position. A normal action turn groups the pending `system`/`user`
 prompt, assistant message, and following tool result into one `assistant`
-step. Orphan prompt/tool records are retained under `prompt`/`tool` roles so
-length mismatches show as `baseline_only` or `candidate_only` tails instead of
-silently shifting later steps. Matching steps are collapsed as:
+step. Step indices are role-local: orphan `prompt`/`tool` records are retained
+under their own roles, but they do not consume assistant turn indices, so later
+assistant turns still align. Matching steps are collapsed as:
 
 ```text
 [step 0 - identical] role=assistant

--- a/docs/spec-inspect.md
+++ b/docs/spec-inspect.md
@@ -93,7 +93,8 @@ labels are highlighted with ANSI color. The compared fields are:
 * `tool.stderr`
 
 Whitespace-only and timestamp-only differences are suppressed by default.
-`--show-noise` re-enables them.
+`--show-noise` re-enables them. Text, JSON, and unified formats all use the
+same filtered field-diff semantics.
 
 The text header summarizes `instance_id`, both paths, baseline/candidate
 failure categories, attempts, cost, token counts, total steps, and the first

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -112,7 +112,8 @@ pub struct CompareCmd {
     pub candidate: PathBuf,
 
     /// Output format: `text` (default, terminal-friendly) or `json`
-    /// (machine-readable diff document).
+    /// (machine-readable report). `unified` is accepted with
+    /// `--inspect-diff`.
     #[arg(long, default_value = "text")]
     pub format: String,
 
@@ -130,6 +131,21 @@ pub struct CompareCmd {
     /// Threshold in percentage points used to highlight large breakdown deltas.
     #[arg(long = "breakdown-min-delta-pp", default_value_t = 5.0)]
     pub breakdown_min_delta_pp: f64,
+
+    /// Render `bench inspect --diff` for this instance id by locating both
+    /// trajectory files inside the baseline and candidate sweep directories.
+    #[arg(long)]
+    pub inspect_diff: Option<String>,
+
+    /// Write a shell script with one `bench inspect --diff` command per
+    /// regressed instance. The script is not executed automatically.
+    #[arg(long)]
+    pub emit_diff_script: Option<PathBuf>,
+
+    /// Include whitespace-only and timestamp-only trajectory differences in
+    /// inspect-diff output.
+    #[arg(long, default_value_t = false)]
+    pub show_noise: bool,
 }
 
 #[derive(Debug, Args)]
@@ -278,7 +294,7 @@ pub struct EvaluateCmd {
 pub struct InspectCmd {
     /// Completed sweep directory produced by `bench swebench`.
     #[arg(long)]
-    pub sweep: PathBuf,
+    pub sweep: Option<PathBuf>,
 
     /// One specific instance id to render as a human-readable transcript.
     #[arg(long)]
@@ -288,7 +304,15 @@ pub struct InspectCmd {
     #[arg(long)]
     pub filter: Option<String>,
 
-    /// Output format: `text` (default) or `json`.
+    /// Diff two trajectory JSON files for the same instance.
+    #[arg(long, value_names = ["BASELINE", "CANDIDATE"], num_args = 2)]
+    pub diff: Vec<PathBuf>,
+
+    /// Include whitespace-only and timestamp-only differences in diff mode.
+    #[arg(long, default_value_t = false)]
+    pub show_noise: bool,
+
+    /// Output format: `text` (default), `json`, or `unified` in diff mode.
     #[arg(long, default_value = "text")]
     pub format: String,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -253,19 +253,29 @@ async fn bench_doctor(mut s: args::SwebenchCmd) -> Result<(), Error> {
 }
 
 fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
-    let format = match c.format.as_str() {
-        "text" => crate::run::compare::CompareFormat::Text,
-        "json" => crate::run::compare::CompareFormat::Json,
-        other => {
-            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text` or `json`)"
-            ))));
-        }
-    };
+    if c.inspect_diff.is_some() && c.emit_diff_script.is_some() {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(
+            "compare: pass only one of --inspect-diff or --emit-diff-script".into(),
+        )));
+    }
+
+    if let Some(instance_id) = c.inspect_diff {
+        let format = parse_trajectory_diff_format(&c.format)?;
+        let report = crate::run::trajectory_diff::diff_sweep_instance(
+            &c.baseline,
+            &c.candidate,
+            &instance_id,
+            c.show_noise,
+        )?;
+        print_trajectory_diff(&report, format)?;
+        return Ok(());
+    }
+
+    let format = parse_compare_format(&c.format)?;
     let breakdown = parse_breakdown_selection(&c.breakdown, false)?;
     let report = crate::run::compare::compute(&crate::run::compare::CompareArgs {
-        baseline: c.baseline,
-        candidate: c.candidate,
+        baseline: c.baseline.clone(),
+        candidate: c.candidate.clone(),
         format,
         max_regressions: c.max_regressions,
         breakdown,
@@ -277,6 +287,9 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
             println!("{}", report.to_json_pretty()?);
         }
     }
+    if let Some(path) = c.emit_diff_script {
+        crate::run::compare::write_diff_script(&report, &path)?;
+    }
     if let Some(max) = c.max_regressions {
         if report.regression_count() > max {
             tracing::error!(
@@ -285,6 +298,47 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
                 "compare: regression count exceeds --max-regressions threshold"
             );
             std::process::exit(1);
+        }
+    }
+    Ok(())
+}
+
+fn parse_compare_format(raw: &str) -> Result<crate::run::compare::CompareFormat, Error> {
+    match raw {
+        "text" => Ok(crate::run::compare::CompareFormat::Text),
+        "json" => Ok(crate::run::compare::CompareFormat::Json),
+        other => Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "unknown --format `{other}` (expected `text` or `json`)"
+        )))),
+    }
+}
+
+fn parse_trajectory_diff_format(
+    raw: &str,
+) -> Result<crate::run::trajectory_diff::TrajectoryDiffFormat, Error> {
+    match raw {
+        "text" => Ok(crate::run::trajectory_diff::TrajectoryDiffFormat::Text),
+        "json" => Ok(crate::run::trajectory_diff::TrajectoryDiffFormat::Json),
+        "unified" => Ok(crate::run::trajectory_diff::TrajectoryDiffFormat::Unified),
+        other => Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "unknown --format `{other}` (expected `text`, `json`, or `unified`)"
+        )))),
+    }
+}
+
+fn print_trajectory_diff(
+    report: &crate::run::trajectory_diff::TrajectoryDiffReport,
+    format: crate::run::trajectory_diff::TrajectoryDiffFormat,
+) -> Result<(), Error> {
+    match format {
+        crate::run::trajectory_diff::TrajectoryDiffFormat::Text => {
+            print!("{}", crate::run::trajectory_diff::render_text(report));
+        }
+        crate::run::trajectory_diff::TrajectoryDiffFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(report)?);
+        }
+        crate::run::trajectory_diff::TrajectoryDiffFormat::Unified => {
+            print!("{}", crate::run::trajectory_diff::render_unified(report));
         }
     }
     Ok(())
@@ -378,6 +432,29 @@ fn parse_breakdown_selection(
 }
 
 fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
+    if !i.diff.is_empty() {
+        if i.instance.is_some() || i.filter.is_some() || i.sweep.is_some() {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(
+                "inspect: --diff cannot be combined with --sweep, --instance, or --filter".into(),
+            )));
+        }
+        if i.diff.len() != 2 {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(
+                "inspect: --diff expects exactly two trajectory paths".into(),
+            )));
+        }
+        let format = parse_trajectory_diff_format(&i.format)?;
+        let report = crate::run::trajectory_diff::diff_paths(
+            &crate::run::trajectory_diff::TrajectoryDiffArgs {
+                baseline: i.diff[0].clone(),
+                candidate: i.diff[1].clone(),
+                show_noise: i.show_noise,
+            },
+        )?;
+        print_trajectory_diff(&report, format)?;
+        return Ok(());
+    }
+
     let format = match i.format.as_str() {
         "text" => crate::run::inspect::InspectFormat::Text,
         "json" => crate::run::inspect::InspectFormat::Json,
@@ -387,8 +464,13 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
             ))));
         }
     };
+    let sweep = i.sweep.ok_or_else(|| {
+        Error::Config(crate::error::ConfigError::Invalid(
+            "inspect: --sweep is required unless --diff is used".into(),
+        ))
+    })?;
     let out = crate::run::inspect::run(&crate::run::inspect::InspectArgs {
-        sweep: i.sweep,
+        sweep,
         instance: i.instance,
         filter: i.filter,
         full: i.full,

--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -137,7 +137,12 @@ mod tests {
     #[tokio::test]
     async fn env_var_passthrough() {
         let env = LocalEnvironment::new();
-        let mut req = RunRequest::new("echo $RSA_TEST_VAR");
+        let command = if cfg!(windows) {
+            "echo %RSA_TEST_VAR%"
+        } else {
+            "echo $RSA_TEST_VAR"
+        };
+        let mut req = RunRequest::new(command);
         req.env.insert("RSA_TEST_VAR".into(), "from_test".into());
         let r = env.run(req).await.unwrap();
         assert_eq!(r.stdout.trim(), "from_test");
@@ -146,7 +151,12 @@ mod tests {
     #[tokio::test]
     async fn timeout_flags_timed_out() {
         let env = LocalEnvironment::new();
-        let req = RunRequest::new("sleep 5").with_timeout(Duration::from_millis(100));
+        let command = if cfg!(windows) {
+            "powershell -NoProfile -Command Start-Sleep -Seconds 5"
+        } else {
+            "sleep 5"
+        };
+        let req = RunRequest::new(command).with_timeout(Duration::from_millis(100));
         let r = env.run(req).await.unwrap();
         assert!(r.timed_out);
     }

--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -47,7 +47,7 @@ impl Environment for LocalEnvironment {
     async fn run(&self, req: RunRequest) -> Result<RunResult, EnvError> {
         let mut cmd = if cfg!(windows) {
             let mut c = Command::new(&self.shell);
-            c.arg("/C").arg(&req.command);
+            c.raw_arg("/C").raw_arg(&req.command);
             c
         } else {
             let mut c = Command::new(&self.shell);

--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -45,15 +45,7 @@ fn default_shell() -> String {
 #[async_trait]
 impl Environment for LocalEnvironment {
     async fn run(&self, req: RunRequest) -> Result<RunResult, EnvError> {
-        let mut cmd = if cfg!(windows) {
-            let mut c = Command::new(&self.shell);
-            c.raw_arg("/C").raw_arg(&req.command);
-            c
-        } else {
-            let mut c = Command::new(&self.shell);
-            c.arg("-c").arg(&req.command);
-            c
-        };
+        let mut cmd = shell_command(&self.shell, &req.command);
 
         if let Some(cwd) = req.cwd.as_ref() {
             cmd.current_dir(cwd);
@@ -110,6 +102,20 @@ impl Environment for LocalEnvironment {
             }),
         }
     }
+}
+
+#[cfg(windows)]
+fn shell_command(shell: &str, command: &str) -> Command {
+    let mut cmd = Command::new(shell);
+    cmd.raw_arg("/C").raw_arg(command);
+    cmd
+}
+
+#[cfg(not(windows))]
+fn shell_command(shell: &str, command: &str) -> Command {
+    let mut cmd = Command::new(shell);
+    cmd.arg("-c").arg(command);
+    cmd
 }
 
 #[cfg(test)]

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -482,6 +482,49 @@ pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
     Ok(report)
 }
 
+pub fn write_diff_script(report: &CompareReport, out_path: &Path) -> Result<(), Error> {
+    let exe = std::env::current_exe().ok().map_or_else(
+        || "rust-swe-agent".into(),
+        |path| path.display().to_string(),
+    );
+    let mut script = String::new();
+    script.push_str("#!/usr/bin/env sh\n");
+    script.push_str("set -eu\n\n");
+    for regression in &report.regressions {
+        let baseline = crate::run::trajectory_diff::resolve_trajectory_path(
+            &report.baseline_dir,
+            &regression.instance_id,
+        )
+        .ok_or_else(|| {
+            Error::Trajectory(format!(
+                "compare: baseline trajectory not found for `{}` in {}",
+                regression.instance_id,
+                report.baseline_dir.display()
+            ))
+        })?;
+        let candidate = crate::run::trajectory_diff::resolve_trajectory_path(
+            &report.candidate_dir,
+            &regression.instance_id,
+        )
+        .ok_or_else(|| {
+            Error::Trajectory(format!(
+                "compare: candidate trajectory not found for `{}` in {}",
+                regression.instance_id,
+                report.candidate_dir.display()
+            ))
+        })?;
+        let _ = writeln!(
+            script,
+            "{} bench inspect --diff {} {}",
+            sh_quote(&exe),
+            sh_quote_path(&baseline),
+            sh_quote_path(&candidate)
+        );
+    }
+    std::fs::write(out_path, script)?;
+    Ok(())
+}
+
 /// Pure diff over two already-loaded id->result maps. Split out so tests
 /// can drive it without touching the filesystem.
 #[must_use]
@@ -610,6 +653,23 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
         breakdown_delta: Vec::new(),
         regressions,
     }
+}
+
+fn sh_quote_path(path: &Path) -> String {
+    sh_quote(&path.display().to_string())
+}
+
+fn sh_quote(value: &str) -> String {
+    let mut quoted = String::from("'");
+    for ch in value.chars() {
+        if ch == '\'' {
+            quoted.push_str("'\\''");
+        } else {
+            quoted.push(ch);
+        }
+    }
+    quoted.push('\'');
+    quoted
 }
 
 fn classify(

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -193,7 +193,8 @@ async fn capture_patch(env: &dyn Environment, spec: &PatchCaptureSpec) -> Result
     // where `cmd /C` receives the command string as one argv and can pass
     // embedded quotes through to child programs.
     let base = validate_git_rev(spec.base_commit.as_deref().unwrap_or("HEAD"))?;
-    let cmd = format!("git diff --no-color --binary --unified=3 {base} -- .");
+    let base_arg = quote_git_rev_for_shell(base);
+    let cmd = format!("git diff --no-color --binary --unified=3 --end-of-options {base_arg} -- .");
     let mut req = RunRequest::new(cmd).with_timeout(Duration::from_secs(60));
     req.cwd = Some(spec.workdir.clone());
     let result = env
@@ -215,14 +216,41 @@ async fn capture_patch(env: &dyn Environment, spec: &PatchCaptureSpec) -> Result
 
 fn validate_git_rev(rev: &str) -> Result<&str, String> {
     let valid = !rev.is_empty()
-        && rev.bytes().all(|b| {
-            b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-' | b'/' | b'~' | b'^')
-        });
+        && rev
+            .chars()
+            .all(|ch| !ch.is_control() && !matches!(ch, '"' | '%') && !ch.is_whitespace());
     if valid {
         Ok(rev)
     } else {
         Err(format!("invalid git revision for diff base: {rev:?}"))
     }
+}
+
+fn quote_git_rev_for_shell(rev: &str) -> String {
+    if cfg!(windows) {
+        quote_git_rev_for_cmd(rev)
+    } else {
+        quote_git_rev_for_sh(rev)
+    }
+}
+
+fn quote_git_rev_for_cmd(rev: &str) -> String {
+    let mut out = String::with_capacity(rev.len());
+    for ch in rev.chars() {
+        match ch {
+            '^' => out.push_str("^^"),
+            '&' | '|' | '<' | '>' | '(' | ')' => {
+                out.push('^');
+                out.push(ch);
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+fn quote_git_rev_for_sh(rev: &str) -> String {
+    format!("'{}'", rev.replace('\'', "'\\''"))
 }
 
 fn build_model(
@@ -288,7 +316,11 @@ pub fn slugify(task: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
+
     use super::*;
+    use std::path::Path;
+    use std::process::Command;
 
     #[test]
     fn slugify_basic() {
@@ -301,7 +333,80 @@ mod tests {
     fn validate_git_rev_rejects_shell_metacharacters() {
         assert_eq!(validate_git_rev("HEAD"), Ok("HEAD"));
         assert_eq!(validate_git_rev("abc123"), Ok("abc123"));
+        assert_eq!(validate_git_rev("HEAD@{1}"), Ok("HEAD@{1}"));
+        assert_eq!(validate_git_rev("v1.2^{commit}"), Ok("v1.2^{commit}"));
         assert!(validate_git_rev("HEAD && rm -rf /").is_err());
         assert!(validate_git_rev("").is_err());
+    }
+
+    #[tokio::test]
+    async fn capture_patch_accepts_reflog_revision_base() {
+        let work = tempfile::tempdir().unwrap();
+        let repo = work.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_repo(&repo);
+        std::fs::write(repo.join("hello.txt"), "before\n").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "base"]);
+        std::fs::write(repo.join("hello.txt"), "committed\n").unwrap();
+        git(&repo, &["commit", "-am", "advance"]);
+        std::fs::write(repo.join("hello.txt"), "after\n").unwrap();
+
+        let spec = PatchCaptureSpec {
+            base_commit: Some("HEAD@{1}".into()),
+            workdir: repo.clone(),
+            patch_path: work.path().join("out.patch"),
+        };
+
+        let diff = capture_patch(&LocalEnvironment::new(), &spec)
+            .await
+            .unwrap();
+        assert!(diff.contains("-before"), "{diff}");
+        assert!(diff.contains("+after"), "{diff}");
+    }
+
+    #[tokio::test]
+    async fn capture_patch_accepts_peeled_tag_revision_base() {
+        let work = tempfile::tempdir().unwrap();
+        let repo = work.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_repo(&repo);
+        std::fs::write(repo.join("hello.txt"), "before\n").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "base"]);
+        git(&repo, &["tag", "-a", "v1.2", "-m", "v1.2"]);
+        std::fs::write(repo.join("hello.txt"), "after\n").unwrap();
+
+        let spec = PatchCaptureSpec {
+            base_commit: Some("v1.2^{commit}".into()),
+            workdir: repo.clone(),
+            patch_path: work.path().join("out.patch"),
+        };
+
+        let diff = capture_patch(&LocalEnvironment::new(), &spec)
+            .await
+            .unwrap();
+        assert!(diff.contains("-before"), "{diff}");
+        assert!(diff.contains("+after"), "{diff}");
+    }
+
+    fn init_repo(dir: &Path) {
+        git(dir, &["init"]);
+        git(dir, &["config", "user.email", "test@example.invalid"]);
+        git(dir, &["config", "user.name", "Test User"]);
+    }
+
+    fn git(dir: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
     }
 }

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -218,7 +218,7 @@ fn validate_git_rev(rev: &str) -> Result<&str, String> {
     let valid = !rev.is_empty()
         && rev
             .chars()
-            .all(|ch| !ch.is_control() && !matches!(ch, '"' | '%') && !ch.is_whitespace());
+            .all(|ch| !ch.is_control() && !ch.is_whitespace());
     if valid {
         Ok(rev)
     } else {
@@ -239,7 +239,7 @@ fn quote_git_rev_for_cmd(rev: &str) -> String {
     for ch in rev.chars() {
         match ch {
             '^' => out.push_str("^^"),
-            '&' | '|' | '<' | '>' | '(' | ')' => {
+            '&' | '|' | '<' | '>' | '(' | ')' | '%' | '"' => {
                 out.push('^');
                 out.push(ch);
             }
@@ -335,6 +335,14 @@ mod tests {
         assert_eq!(validate_git_rev("abc123"), Ok("abc123"));
         assert_eq!(validate_git_rev("HEAD@{1}"), Ok("HEAD@{1}"));
         assert_eq!(validate_git_rev("v1.2^{commit}"), Ok("v1.2^{commit}"));
+        assert_eq!(
+            validate_git_rev("refs/heads/feat%test"),
+            Ok("refs/heads/feat%test")
+        );
+        assert_eq!(
+            validate_git_rev("refs/heads/feat\"test"),
+            Ok("refs/heads/feat\"test")
+        );
         assert!(validate_git_rev("HEAD && rm -rf /").is_err());
         assert!(validate_git_rev("").is_err());
     }
@@ -390,23 +398,99 @@ mod tests {
         assert!(diff.contains("+after"), "{diff}");
     }
 
+    #[tokio::test]
+    async fn capture_patch_accepts_percent_ref_base() {
+        let work = tempfile::tempdir().unwrap();
+        let repo = work.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_repo(&repo);
+        std::fs::write(repo.join("hello.txt"), "before\n").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "base"]);
+        git(&repo, &["branch", "feat%test"]);
+        std::fs::write(repo.join("hello.txt"), "after\n").unwrap();
+
+        let spec = PatchCaptureSpec {
+            base_commit: Some("refs/heads/feat%test".into()),
+            workdir: repo.clone(),
+            patch_path: work.path().join("out.patch"),
+        };
+
+        let diff = capture_patch(&LocalEnvironment::new(), &spec)
+            .await
+            .unwrap();
+        assert!(diff.contains("-before"), "{diff}");
+        assert!(diff.contains("+after"), "{diff}");
+    }
+
+    #[tokio::test]
+    async fn capture_patch_accepts_quoted_ref_base() {
+        let work = tempfile::tempdir().unwrap();
+        let repo = work.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_repo(&repo);
+        std::fs::write(repo.join("hello.txt"), "before\n").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "base"]);
+        write_packed_ref(&repo, "refs/heads/feat\"test");
+        std::fs::write(repo.join("hello.txt"), "after\n").unwrap();
+
+        let spec = PatchCaptureSpec {
+            base_commit: Some("refs/heads/feat\"test".into()),
+            workdir: repo.clone(),
+            patch_path: work.path().join("out.patch"),
+        };
+
+        let diff = capture_patch(&LocalEnvironment::new(), &spec)
+            .await
+            .unwrap();
+        assert!(diff.contains("-before"), "{diff}");
+        assert!(diff.contains("+after"), "{diff}");
+    }
+
     fn init_repo(dir: &Path) {
         git(dir, &["init"]);
         git(dir, &["config", "user.email", "test@example.invalid"]);
         git(dir, &["config", "user.name", "Test User"]);
     }
 
+    fn write_packed_ref(dir: &Path, ref_name: &str) {
+        let hash = git_stdout(dir, &["rev-parse", "HEAD"]);
+        std::fs::write(
+            dir.join(".git").join("packed-refs"),
+            format!("{} {}\n", hash.trim(), ref_name),
+        )
+        .unwrap();
+        let resolved = git_stdout(dir, &["rev-parse", ref_name]);
+        assert_eq!(resolved.trim(), hash.trim());
+    }
+
     fn git(dir: &Path, args: &[&str]) {
-        let out = Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .unwrap();
+        let out = git_raw(dir, args);
         assert!(
             out.status.success(),
             "git {args:?} failed\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&out.stdout),
             String::from_utf8_lossy(&out.stderr)
         );
+    }
+
+    fn git_stdout(dir: &Path, args: &[&str]) -> String {
+        let out = git_raw(dir, args);
+        assert!(
+            out.status.success(),
+            "git {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8(out.stdout).unwrap()
+    }
+
+    fn git_raw(dir: &Path, args: &[&str]) -> std::process::Output {
+        Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap()
     }
 }

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -18,6 +18,8 @@ use crate::model::{DeterministicModel, Model, ModelUsage};
 use crate::stream::{BroadcastSink, SseServer, StreamSink};
 use crate::trajectory::FailureCategory;
 
+const PATCH_BASE_ENV: &str = "RUST_SWE_AGENT_PATCH_BASE";
+
 /// How a runner should snapshot the agent's working tree as a unified diff
 /// after submission. Optional on `MiniArgs` because patch capture only
 /// makes sense for benchmark sweeps; the standalone `bench mini` CLI run
@@ -189,14 +191,14 @@ fn classify_error(err: &Error) -> FailureCategory {
 /// We use `--no-color`, `--binary`, and `--unified=3` to match the format
 /// the SWE-bench evaluator (`sb-cli`) consumes and `git apply` accepts.
 async fn capture_patch(env: &dyn Environment, spec: &PatchCaptureSpec) -> Result<String, String> {
-    // `cwd` keeps paths out of the shell command. That matters on Windows,
-    // where `cmd /C` receives the command string as one argv and can pass
-    // embedded quotes through to child programs.
+    // Keep paths in `cwd` and the base revision in the environment so valid
+    // revspec punctuation does not become shell syntax.
     let base = validate_git_rev(spec.base_commit.as_deref().unwrap_or("HEAD"))?;
-    let base_arg = quote_git_rev_for_shell(base);
+    let base_arg = patch_base_shell_arg(base);
     let cmd = format!("git diff --no-color --binary --unified=3 --end-of-options {base_arg} -- .");
     let mut req = RunRequest::new(cmd).with_timeout(Duration::from_secs(60));
     req.cwd = Some(spec.workdir.clone());
+    req.env.insert(PATCH_BASE_ENV.into(), base.to_owned());
     let result = env
         .run(req)
         .await
@@ -215,10 +217,7 @@ async fn capture_patch(env: &dyn Environment, spec: &PatchCaptureSpec) -> Result
 }
 
 fn validate_git_rev(rev: &str) -> Result<&str, String> {
-    let valid = !rev.is_empty()
-        && rev
-            .chars()
-            .all(|ch| !ch.is_control() && !ch.is_whitespace());
+    let valid = !rev.is_empty() && rev.chars().all(|ch| !ch.is_control());
     if valid {
         Ok(rev)
     } else {
@@ -226,31 +225,39 @@ fn validate_git_rev(rev: &str) -> Result<&str, String> {
     }
 }
 
-fn quote_git_rev_for_shell(rev: &str) -> String {
+fn patch_base_shell_arg(rev: &str) -> String {
     if cfg!(windows) {
-        quote_git_rev_for_cmd(rev)
+        if rev.contains('"') {
+            quote_git_rev_for_cmd(rev)
+        } else {
+            format!("\"%{PATCH_BASE_ENV}%\"")
+        }
     } else {
-        quote_git_rev_for_sh(rev)
+        format!("\"${PATCH_BASE_ENV}\"")
     }
 }
 
 fn quote_git_rev_for_cmd(rev: &str) -> String {
-    let mut out = String::with_capacity(rev.len());
+    let needs_quotes = rev.chars().any(char::is_whitespace);
+    let mut out = String::with_capacity(rev.len() + usize::from(needs_quotes) * 2);
+    if needs_quotes {
+        out.push('"');
+    }
     for ch in rev.chars() {
-        match ch {
-            '^' => out.push_str("^^"),
-            '&' | '|' | '<' | '>' | '(' | ')' | '%' | '"' => {
+        match (needs_quotes, ch) {
+            (_, '"') => out.push_str("\\\""),
+            (false, '^') => out.push_str("^^"),
+            (false, '&' | '|' | '<' | '>' | '(' | ')' | '%') => {
                 out.push('^');
                 out.push(ch);
             }
             _ => out.push(ch),
         }
     }
+    if needs_quotes {
+        out.push('"');
+    }
     out
-}
-
-fn quote_git_rev_for_sh(rev: &str) -> String {
-    format!("'{}'", rev.replace('\'', "'\\''"))
 }
 
 fn build_model(
@@ -330,7 +337,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_git_rev_rejects_shell_metacharacters() {
+    fn validate_git_rev_accepts_revspec_chars_and_rejects_empty_or_control() {
         assert_eq!(validate_git_rev("HEAD"), Ok("HEAD"));
         assert_eq!(validate_git_rev("abc123"), Ok("abc123"));
         assert_eq!(validate_git_rev("HEAD@{1}"), Ok("HEAD@{1}"));
@@ -343,7 +350,12 @@ mod tests {
             validate_git_rev("refs/heads/feat\"test"),
             Ok("refs/heads/feat\"test")
         );
-        assert!(validate_git_rev("HEAD && rm -rf /").is_err());
+        assert_eq!(validate_git_rev("HEAD^{/foo bar}"), Ok("HEAD^{/foo bar}"));
+        assert_eq!(
+            validate_git_rev("HEAD^{/foo && bar}"),
+            Ok("HEAD^{/foo && bar}")
+        );
+        assert!(validate_git_rev("HEAD\nmain").is_err());
         assert!(validate_git_rev("").is_err());
     }
 
@@ -446,6 +458,51 @@ mod tests {
             .unwrap();
         assert!(diff.contains("-before"), "{diff}");
         assert!(diff.contains("+after"), "{diff}");
+    }
+
+    #[tokio::test]
+    async fn capture_patch_accepts_commit_message_search_revision_with_space() {
+        let work = tempfile::tempdir().unwrap();
+        let repo = work.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_repo(&repo);
+        std::fs::write(repo.join("hello.txt"), "before\n").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "foo bar base"]);
+        std::fs::write(repo.join("hello.txt"), "after\n").unwrap();
+
+        let spec = PatchCaptureSpec {
+            base_commit: Some("HEAD^{/foo bar}".into()),
+            workdir: repo.clone(),
+            patch_path: work.path().join("out.patch"),
+        };
+
+        let diff = capture_patch(&LocalEnvironment::new(), &spec)
+            .await
+            .unwrap();
+        assert!(diff.contains("-before"), "{diff}");
+        assert!(diff.contains("+after"), "{diff}");
+    }
+
+    #[tokio::test]
+    async fn capture_patch_quotes_shell_metacharacters_in_revision_base() {
+        let work = tempfile::tempdir().unwrap();
+        let repo = work.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_repo(&repo);
+        std::fs::write(repo.join("hello.txt"), "before\n").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "base"]);
+
+        let spec = PatchCaptureSpec {
+            base_commit: Some("HEAD && echo injected > injected.txt".into()),
+            workdir: repo.clone(),
+            patch_path: work.path().join("out.patch"),
+        };
+
+        let result = capture_patch(&LocalEnvironment::new(), &spec).await;
+        assert!(result.is_err(), "{result:?}");
+        assert!(!repo.join("injected.txt").exists());
     }
 
     fn init_repo(dir: &Path) {

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -189,19 +189,13 @@ fn classify_error(err: &Error) -> FailureCategory {
 /// We use `--no-color`, `--binary`, and `--unified=3` to match the format
 /// the SWE-bench evaluator (`sb-cli`) consumes and `git apply` accepts.
 async fn capture_patch(env: &dyn Environment, spec: &PatchCaptureSpec) -> Result<String, String> {
-    // `git -C <workdir>` keeps us independent of the env's idea of cwd
-    // (the local env inherits the process cwd, the docker env uses `-w`).
-    // The `--` ensures the trailing argument is a pathspec rather than a
-    // ref, which matters when the workdir is empty or unborn.
-    let base = spec.base_commit.as_deref().unwrap_or("HEAD");
-    // Quote `base` to defuse hostile dataset values; SWE-bench commits are
-    // hex SHAs but a malformed instance shouldn't be able to inject shell.
-    let cmd = format!(
-        "git -C {workdir} diff --no-color --binary --unified=3 {base} -- .",
-        workdir = shell_quote(&spec.workdir.to_string_lossy()),
-        base = shell_quote(base),
-    );
-    let req = RunRequest::new(cmd).with_timeout(Duration::from_secs(60));
+    // `cwd` keeps paths out of the shell command. That matters on Windows,
+    // where `cmd /C` receives the command string as one argv and can pass
+    // embedded quotes through to child programs.
+    let base = validate_git_rev(spec.base_commit.as_deref().unwrap_or("HEAD"))?;
+    let cmd = format!("git diff --no-color --binary --unified=3 {base} -- .");
+    let mut req = RunRequest::new(cmd).with_timeout(Duration::from_secs(60));
+    req.cwd = Some(spec.workdir.clone());
     let result = env
         .run(req)
         .await
@@ -219,21 +213,16 @@ async fn capture_patch(env: &dyn Environment, spec: &PatchCaptureSpec) -> Result
     Ok(result.stdout)
 }
 
-/// Single-quote-escape a string for safe inclusion in a `bash -c` argv.
-/// Closes the quote, emits an escaped literal `'`, reopens — the standard
-/// POSIX shell idiom.
-fn shell_quote(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 2);
-    out.push('\'');
-    for c in s.chars() {
-        if c == '\'' {
-            out.push_str("'\\''");
-        } else {
-            out.push(c);
-        }
+fn validate_git_rev(rev: &str) -> Result<&str, String> {
+    let valid = !rev.is_empty()
+        && rev.bytes().all(|b| {
+            b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-' | b'/' | b'~' | b'^')
+        });
+    if valid {
+        Ok(rev)
+    } else {
+        Err(format!("invalid git revision for diff base: {rev:?}"))
     }
-    out.push('\'');
-    out
 }
 
 fn build_model(
@@ -309,11 +298,10 @@ mod tests {
     }
 
     #[test]
-    fn shell_quote_escapes_single_quotes() {
-        assert_eq!(shell_quote("a"), "'a'");
-        assert_eq!(shell_quote("a b"), "'a b'");
-        assert_eq!(shell_quote("a'b"), "'a'\\''b'");
-        // Already-quoted-looking strings round-trip safely.
-        assert_eq!(shell_quote("$(rm -rf /)"), "'$(rm -rf /)'");
+    fn validate_git_rev_rejects_shell_metacharacters() {
+        assert_eq!(validate_git_rev("HEAD"), Ok("HEAD"));
+        assert_eq!(validate_git_rev("abc123"), Ok("abc123"));
+        assert!(validate_git_rev("HEAD && rm -rf /").is_err());
+        assert!(validate_git_rev("").is_err());
     }
 }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -8,3 +8,4 @@ pub mod inspect;
 pub mod mini;
 pub mod replay;
 pub mod swebench;
+pub mod trajectory_diff;

--- a/src/run/trajectory_diff.rs
+++ b/src/run/trajectory_diff.rs
@@ -11,6 +11,15 @@ use crate::env::RunResult;
 use crate::error::Error;
 use crate::trajectory::{FailureCategory, MessageRecord, Trajectory};
 
+const DIFF_FIELD_ORDER: [&str; 6] = [
+    "prompt.content",
+    "assistant.content",
+    "bash.command",
+    "tool.exit_code",
+    "tool.stdout",
+    "tool.stderr",
+];
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrajectoryDiffFormat {
     Text,
@@ -453,7 +462,6 @@ fn semantic_steps(trajectory: &Trajectory) -> Vec<KeyedSemanticStep> {
     let mut message_index = 0usize;
     let mut assistant_index = 0usize;
     let mut tool_index = 0usize;
-    let prompt_index = 0usize;
     while message_index < trajectory.messages.len() {
         let message = &trajectory.messages[message_index];
         if let Some(run_result) = run_result(message) {
@@ -507,7 +515,7 @@ fn semantic_steps(trajectory: &Trajectory) -> Vec<KeyedSemanticStep> {
     if let Some(prompt) = take_prompt(&mut pending_prompt) {
         push_keyed_step(
             &mut steps,
-            prompt_index,
+            assistant_index,
             "prompt",
             SemanticStep {
                 prompt: Some(prompt),
@@ -580,14 +588,7 @@ fn parse_bash_fence(content: &str) -> Option<String> {
 
 fn diff_fields(left: &SemanticStep, right: &SemanticStep, show_noise: bool) -> Vec<String> {
     let mut fields = Vec::new();
-    for field in [
-        "prompt.content",
-        "assistant.content",
-        "bash.command",
-        "tool.exit_code",
-        "tool.stdout",
-        "tool.stderr",
-    ] {
+    for field in DIFF_FIELD_ORDER {
         if !field_equal(left, right, field, show_noise) {
             fields.push(field.to_owned());
         }
@@ -846,21 +847,55 @@ fn canonical_side_lines(report: &TrajectoryDiffReport, baseline: bool) -> Vec<St
             step.candidate.as_ref()
         };
         lines.push(format!("step {} role={}", step.index, step.role));
-        if let Some(side) = side {
-            for field in present_fields(side) {
-                let value = if field == "tool.exit_code" {
-                    side.exit_code
-                        .map_or_else(|| "<missing>".into(), |code| code.to_string())
-                } else {
-                    side.field_value(field).unwrap_or("<missing>").to_owned()
-                };
-                push_canonical_field_lines(&mut lines, field, &value);
-            }
-        } else {
+        if side.is_none() {
             lines.push("<missing>".into());
+            continue;
+        }
+        for field in canonical_fields(step) {
+            let Some(value) = canonical_field_value(step, field, baseline) else {
+                continue;
+            };
+            push_canonical_field_lines(&mut lines, field, &value);
         }
     }
     lines
+}
+
+fn canonical_fields(step: &TrajectoryDiffStep) -> Vec<&'static str> {
+    let mut fields = Vec::new();
+    for field in DIFF_FIELD_ORDER {
+        let present = step
+            .baseline
+            .as_ref()
+            .is_some_and(|side| side.field_display_value(field).is_some())
+            || step
+                .candidate
+                .as_ref()
+                .is_some_and(|side| side.field_display_value(field).is_some());
+        if present {
+            fields.push(field);
+        }
+    }
+    fields
+}
+
+fn canonical_field_value(step: &TrajectoryDiffStep, field: &str, baseline: bool) -> Option<String> {
+    let is_diff_field = step.diff_fields.iter().any(|name| name == field);
+    let source = if is_diff_field {
+        if baseline {
+            step.baseline.as_ref()
+        } else {
+            step.candidate.as_ref()
+        }
+    } else {
+        step.baseline.as_ref().or(step.candidate.as_ref())
+    }?;
+
+    Some(
+        source
+            .field_display_value(field)
+            .map_or_else(|| "<missing>".into(), Cow::into_owned),
+    )
 }
 
 fn push_canonical_field_lines(lines: &mut Vec<String>, field: &str, value: &str) {

--- a/src/run/trajectory_diff.rs
+++ b/src/run/trajectory_diff.rs
@@ -1,0 +1,1069 @@
+//! Pairwise semantic diffs for mini-swe-agent trajectory files.
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::env::RunResult;
+use crate::error::Error;
+use crate::trajectory::{FailureCategory, MessageRecord, Trajectory};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrajectoryDiffFormat {
+    Text,
+    Json,
+    Unified,
+}
+
+#[derive(Debug, Clone)]
+pub struct TrajectoryDiffArgs {
+    pub baseline: PathBuf,
+    pub candidate: PathBuf,
+    pub show_noise: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TrajectoryDiffReport {
+    pub instance_id: String,
+    pub header: TrajectoryDiffHeader,
+    pub steps: Vec<TrajectoryDiffStep>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TrajectoryDiffHeader {
+    pub baseline_path: PathBuf,
+    pub candidate_path: PathBuf,
+    pub baseline_failure_category: String,
+    pub candidate_failure_category: String,
+    pub baseline_attempts: u64,
+    pub candidate_attempts: u64,
+    pub baseline_cost_usd: Option<f64>,
+    pub candidate_cost_usd: Option<f64>,
+    pub baseline_prompt_tokens: Option<u64>,
+    pub candidate_prompt_tokens: Option<u64>,
+    pub baseline_completion_tokens: Option<u64>,
+    pub candidate_completion_tokens: Option<u64>,
+    pub baseline_total_steps: usize,
+    pub candidate_total_steps: usize,
+    pub first_divergent_step_index: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrajectoryDiffStatus {
+    #[serde(rename = "match")]
+    Match,
+    Diverge,
+    BaselineOnly,
+    CandidateOnly,
+}
+
+impl TrajectoryDiffStatus {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Match => "identical",
+            Self::Diverge => "diverge",
+            Self::BaselineOnly => "baseline_only",
+            Self::CandidateOnly => "candidate_only",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct SemanticStep {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assistant_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stdout: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stderr: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TrajectoryDiffStep {
+    pub index: usize,
+    pub role: String,
+    pub status: TrajectoryDiffStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline: Option<SemanticStep>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub candidate: Option<SemanticStep>,
+    pub diff_fields: Vec<String>,
+}
+
+struct NamedTrajectory {
+    path: PathBuf,
+    instance_id: String,
+    trajectory: Trajectory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct StepKey {
+    index: usize,
+    role: String,
+}
+
+#[derive(Debug, Clone)]
+struct KeyedSemanticStep {
+    key: StepKey,
+    step: SemanticStep,
+}
+
+pub fn diff_paths(args: &TrajectoryDiffArgs) -> Result<TrajectoryDiffReport, Error> {
+    let baseline = load_named_trajectory(&args.baseline)?;
+    let candidate = load_named_trajectory(&args.candidate)?;
+    if baseline.instance_id != candidate.instance_id {
+        return Err(Error::Trajectory(format!(
+            "inspect diff: instance_id mismatch: baseline `{}` candidate `{}`",
+            baseline.instance_id, candidate.instance_id
+        )));
+    }
+    Ok(diff_trajectories(&baseline, &candidate, args.show_noise))
+}
+
+pub fn diff_sweep_instance(
+    baseline_sweep: &Path,
+    candidate_sweep: &Path,
+    instance_id: &str,
+    show_noise: bool,
+) -> Result<TrajectoryDiffReport, Error> {
+    let baseline = resolve_trajectory_path(baseline_sweep, instance_id).ok_or_else(|| {
+        Error::Trajectory(format!(
+            "inspect diff: baseline trajectory not found for `{instance_id}` in {}",
+            baseline_sweep.display()
+        ))
+    })?;
+    let candidate = resolve_trajectory_path(candidate_sweep, instance_id).ok_or_else(|| {
+        Error::Trajectory(format!(
+            "inspect diff: candidate trajectory not found for `{instance_id}` in {}",
+            candidate_sweep.display()
+        ))
+    })?;
+    diff_paths(&TrajectoryDiffArgs {
+        baseline,
+        candidate,
+        show_noise,
+    })
+}
+
+pub fn resolve_trajectory_path(sweep: &Path, instance_id: &str) -> Option<PathBuf> {
+    let nested = sweep.join(instance_id).join("trajectory.json");
+    if nested.exists() {
+        return Some(nested);
+    }
+    let flat = sweep.join(format!("{instance_id}.traj.json"));
+    flat.exists().then_some(flat)
+}
+
+pub fn render_text(report: &TrajectoryDiffReport) -> String {
+    let mut s = String::new();
+    let width = terminal_width();
+    let column_width = width.saturating_sub(5).saturating_div(2).max(30);
+    let color = color_enabled();
+    s.push_str("\n=== bench inspect diff ===\n");
+    let _ = writeln!(s, "instance_id: {}", report.instance_id);
+    let _ = writeln!(s, "baseline:    {}", report.header.baseline_path.display());
+    let _ = writeln!(s, "candidate:   {}", report.header.candidate_path.display());
+    let _ = writeln!(
+        s,
+        "failure_category: {} -> {}",
+        report.header.baseline_failure_category, report.header.candidate_failure_category
+    );
+    let _ = writeln!(
+        s,
+        "attempts: {} -> {}",
+        report.header.baseline_attempts, report.header.candidate_attempts
+    );
+    let _ = writeln!(
+        s,
+        "cost_usd: {} -> {}",
+        format_cost(report.header.baseline_cost_usd),
+        format_cost(report.header.candidate_cost_usd)
+    );
+    let _ = writeln!(
+        s,
+        "tokens: prompt={} completion={} -> prompt={} completion={}",
+        format_u64(report.header.baseline_prompt_tokens),
+        format_u64(report.header.baseline_completion_tokens),
+        format_u64(report.header.candidate_prompt_tokens),
+        format_u64(report.header.candidate_completion_tokens)
+    );
+    let _ = writeln!(
+        s,
+        "steps: {} -> {}",
+        report.header.baseline_total_steps, report.header.candidate_total_steps
+    );
+    let _ = writeln!(
+        s,
+        "first_divergent_step: {}",
+        report
+            .header
+            .first_divergent_step_index
+            .map_or_else(|| "none".into(), |v| v.to_string())
+    );
+
+    for step in &report.steps {
+        let _ = writeln!(
+            s,
+            "\n[step {} - {}] role={}",
+            step.index,
+            step.status.label(),
+            step.role
+        );
+        if step.status == TrajectoryDiffStatus::Match {
+            continue;
+        }
+        if !step.diff_fields.is_empty() {
+            let _ = writeln!(s, "fields: {}", step.diff_fields.join(", "));
+        }
+        for field in &step.diff_fields {
+            let baseline_value = step
+                .baseline
+                .as_ref()
+                .and_then(|side| side.field_display_value(field));
+            let candidate_value = step
+                .candidate
+                .as_ref()
+                .and_then(|side| side.field_display_value(field));
+            write_field_side_by_side(
+                &mut s,
+                field,
+                baseline_value.as_deref(),
+                candidate_value.as_deref(),
+                column_width,
+                color,
+            );
+        }
+        if step.diff_fields.is_empty() {
+            write_side_summary(&mut s, step.baseline.as_ref(), step.candidate.as_ref());
+        }
+    }
+    s
+}
+
+pub fn render_unified(report: &TrajectoryDiffReport) -> String {
+    let baseline = canonical_side_lines(report, true);
+    let candidate = canonical_side_lines(report, false);
+    let mut s = String::new();
+    let _ = writeln!(s, "--- baseline");
+    let _ = writeln!(s, "+++ candidate");
+    if baseline == candidate {
+        return s;
+    }
+    let _ = writeln!(
+        s,
+        "@@ -{} +{} @@",
+        unified_range(baseline.len()),
+        unified_range(candidate.len())
+    );
+    for (prefix, line) in line_diff(&baseline, &candidate) {
+        let _ = writeln!(s, "{prefix}{line}");
+    }
+    s
+}
+
+fn diff_trajectories(
+    baseline: &NamedTrajectory,
+    candidate: &NamedTrajectory,
+    show_noise: bool,
+) -> TrajectoryDiffReport {
+    let baseline_steps = semantic_steps(&baseline.trajectory);
+    let candidate_steps = semantic_steps(&candidate.trajectory);
+    let baseline_by_key: BTreeMap<StepKey, SemanticStep> = baseline_steps
+        .iter()
+        .map(|item| (item.key.clone(), item.step.clone()))
+        .collect();
+    let candidate_by_key: BTreeMap<StepKey, SemanticStep> = candidate_steps
+        .iter()
+        .map(|item| (item.key.clone(), item.step.clone()))
+        .collect();
+    let keys: BTreeSet<StepKey> = baseline_by_key
+        .keys()
+        .chain(candidate_by_key.keys())
+        .cloned()
+        .collect();
+    let mut steps = Vec::with_capacity(keys.len());
+
+    for key in keys {
+        let b = baseline_by_key.get(&key).cloned();
+        let c = candidate_by_key.get(&key).cloned();
+        let (status, diff_fields) = match (&b, &c) {
+            (Some(left), Some(right)) => {
+                let fields = diff_fields(left, right, show_noise);
+                if fields.is_empty() {
+                    (TrajectoryDiffStatus::Match, fields)
+                } else {
+                    (TrajectoryDiffStatus::Diverge, fields)
+                }
+            }
+            (Some(left), None) => (
+                TrajectoryDiffStatus::BaselineOnly,
+                present_fields(left)
+                    .into_iter()
+                    .map(str::to_owned)
+                    .collect(),
+            ),
+            (None, Some(right)) => (
+                TrajectoryDiffStatus::CandidateOnly,
+                present_fields(right)
+                    .into_iter()
+                    .map(str::to_owned)
+                    .collect(),
+            ),
+            (None, None) => (TrajectoryDiffStatus::Match, Vec::new()),
+        };
+        steps.push(TrajectoryDiffStep {
+            index: key.index,
+            role: key.role,
+            status,
+            baseline: b,
+            candidate: c,
+            diff_fields,
+        });
+    }
+
+    let first_divergent_step_index = steps
+        .iter()
+        .find(|step| step.status != TrajectoryDiffStatus::Match)
+        .map(|step| step.index);
+
+    TrajectoryDiffReport {
+        instance_id: baseline.instance_id.clone(),
+        header: build_header(
+            baseline,
+            candidate,
+            baseline_steps.len(),
+            candidate_steps.len(),
+            first_divergent_step_index,
+        ),
+        steps,
+    }
+}
+
+fn build_header(
+    baseline: &NamedTrajectory,
+    candidate: &NamedTrajectory,
+    baseline_step_count: usize,
+    candidate_step_count: usize,
+    first_divergent_step_index: Option<usize>,
+) -> TrajectoryDiffHeader {
+    TrajectoryDiffHeader {
+        baseline_path: baseline.path.clone(),
+        candidate_path: candidate.path.clone(),
+        baseline_failure_category: failure_label_opt(baseline.trajectory.info.failure_category)
+            .into(),
+        candidate_failure_category: failure_label_opt(candidate.trajectory.info.failure_category)
+            .into(),
+        baseline_attempts: attempts(&baseline.trajectory),
+        candidate_attempts: attempts(&candidate.trajectory),
+        baseline_cost_usd: baseline.trajectory.info.total_cost_usd,
+        candidate_cost_usd: candidate.trajectory.info.total_cost_usd,
+        baseline_prompt_tokens: baseline
+            .trajectory
+            .info
+            .token_usage
+            .as_ref()
+            .map(|usage| usage.prompt_tokens),
+        candidate_prompt_tokens: candidate
+            .trajectory
+            .info
+            .token_usage
+            .as_ref()
+            .map(|usage| usage.prompt_tokens),
+        baseline_completion_tokens: baseline
+            .trajectory
+            .info
+            .token_usage
+            .as_ref()
+            .map(|usage| usage.completion_tokens),
+        candidate_completion_tokens: candidate
+            .trajectory
+            .info
+            .token_usage
+            .as_ref()
+            .map(|usage| usage.completion_tokens),
+        baseline_total_steps: baseline
+            .trajectory
+            .info
+            .steps
+            .map_or(baseline_step_count, usize_from_u32),
+        candidate_total_steps: candidate
+            .trajectory
+            .info
+            .steps
+            .map_or(candidate_step_count, usize_from_u32),
+        first_divergent_step_index,
+    }
+}
+
+fn load_named_trajectory(path: &Path) -> Result<NamedTrajectory, Error> {
+    let text = std::fs::read_to_string(path)?;
+    let trajectory: Trajectory = serde_json::from_str(&text)?;
+    let instance_id = explicit_instance_id(&trajectory)
+        .or_else(|| derive_instance_id(path))
+        .ok_or_else(|| {
+            Error::Trajectory(format!(
+                "inspect diff: unable to infer instance_id from {}",
+                path.display()
+            ))
+        })?;
+    Ok(NamedTrajectory {
+        path: path.to_path_buf(),
+        instance_id,
+        trajectory,
+    })
+}
+
+fn explicit_instance_id(trajectory: &Trajectory) -> Option<String> {
+    trajectory
+        .info
+        .other
+        .get("instance_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+}
+
+fn derive_instance_id(path: &Path) -> Option<String> {
+    let file_name = path.file_name()?.to_str()?;
+    if file_name == "trajectory.json" {
+        return path
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(std::ffi::OsStr::to_str)
+            .map(str::to_owned);
+    }
+    file_name
+        .strip_suffix(".traj.json")
+        .map(str::to_owned)
+        .or_else(|| path.file_stem()?.to_str().map(str::to_owned))
+}
+
+fn semantic_steps(trajectory: &Trajectory) -> Vec<KeyedSemanticStep> {
+    let mut steps = Vec::new();
+    let mut pending_prompt = Vec::new();
+    let mut message_index = 0usize;
+    let mut step_index = 0usize;
+    while message_index < trajectory.messages.len() {
+        let message = &trajectory.messages[message_index];
+        if let Some(run_result) = run_result(message) {
+            push_keyed_step(
+                &mut steps,
+                step_index,
+                "tool",
+                SemanticStep {
+                    prompt: take_prompt(&mut pending_prompt),
+                    assistant_content: None,
+                    bash: None,
+                    exit_code: Some(run_result.exit_code),
+                    stdout: Some(run_result.stdout),
+                    stderr: Some(run_result.stderr),
+                },
+            );
+            step_index += 1;
+            message_index += 1;
+            continue;
+        }
+
+        if message.role == "system" || message.role == "user" {
+            pending_prompt.push(format!("{}: {}", message.role, message.content));
+            message_index += 1;
+            continue;
+        }
+
+        if message.role == "assistant" {
+            let mut step = SemanticStep {
+                prompt: take_prompt(&mut pending_prompt),
+                assistant_content: Some(message.content.clone()),
+                bash: infer_bash_from_assistant(message),
+                exit_code: None,
+                stdout: None,
+                stderr: None,
+            };
+            if let Some(next) = trajectory.messages.get(message_index + 1) {
+                if let Some(run_result) = run_result(next) {
+                    step.exit_code = Some(run_result.exit_code);
+                    step.stdout = Some(run_result.stdout);
+                    step.stderr = Some(run_result.stderr);
+                    message_index += 1;
+                }
+            }
+            push_keyed_step(&mut steps, step_index, "assistant", step);
+            step_index += 1;
+        }
+        message_index += 1;
+    }
+
+    if let Some(prompt) = take_prompt(&mut pending_prompt) {
+        push_keyed_step(
+            &mut steps,
+            step_index,
+            "prompt",
+            SemanticStep {
+                prompt: Some(prompt),
+                assistant_content: None,
+                bash: None,
+                exit_code: None,
+                stdout: None,
+                stderr: None,
+            },
+        );
+    }
+    steps
+}
+
+fn take_prompt(prompt_parts: &mut Vec<String>) -> Option<String> {
+    (!prompt_parts.is_empty()).then(|| std::mem::take(prompt_parts).join("\n"))
+}
+
+fn push_keyed_step(
+    steps: &mut Vec<KeyedSemanticStep>,
+    index: usize,
+    role: &str,
+    step: SemanticStep,
+) {
+    steps.push(KeyedSemanticStep {
+        key: StepKey {
+            index,
+            role: role.to_owned(),
+        },
+        step,
+    });
+}
+
+fn run_result(message: &MessageRecord) -> Option<RunResult> {
+    if message.role != "user" && message.role != "tool" {
+        return None;
+    }
+    message
+        .extra
+        .other
+        .get("run_result")
+        .and_then(|value| serde_json::from_value::<RunResult>(value.clone()).ok())
+}
+
+fn infer_bash_from_assistant(message: &MessageRecord) -> Option<String> {
+    message
+        .extra
+        .actions
+        .as_ref()
+        .and_then(|actions| {
+            actions
+                .iter()
+                .find(|action| action.as_str() != "__SUBMIT__")
+        })
+        .cloned()
+        .or_else(|| parse_bash_fence(&message.content))
+}
+
+fn parse_bash_fence(content: &str) -> Option<String> {
+    let start = content.find("```bash")?;
+    let after_lang = content[start..]
+        .find('\n')
+        .map(|offset| start + offset + 1)?;
+    let end = content[after_lang..]
+        .find("```")
+        .map(|offset| after_lang + offset)?;
+    let command = content[after_lang..end].trim();
+    (!command.is_empty()).then(|| command.to_owned())
+}
+
+fn diff_fields(left: &SemanticStep, right: &SemanticStep, show_noise: bool) -> Vec<String> {
+    let mut fields = Vec::new();
+    for field in [
+        "prompt.content",
+        "assistant.content",
+        "bash.command",
+        "tool.exit_code",
+        "tool.stdout",
+        "tool.stderr",
+    ] {
+        if !field_equal(left, right, field, show_noise) {
+            fields.push(field.to_owned());
+        }
+    }
+    fields
+}
+
+fn field_equal(left: &SemanticStep, right: &SemanticStep, field: &str, show_noise: bool) -> bool {
+    match field {
+        "tool.exit_code" => left.exit_code == right.exit_code,
+        _ => option_text_equal(
+            left.field_value(field),
+            right.field_value(field),
+            show_noise,
+        ),
+    }
+}
+
+fn option_text_equal(left: Option<&str>, right: Option<&str>, show_noise: bool) -> bool {
+    match (left, right) {
+        (Some(a), Some(b)) if show_noise => a == b,
+        (Some(a), Some(b)) => canonical_noise(a) == canonical_noise(b),
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+fn present_fields(step: &SemanticStep) -> Vec<&'static str> {
+    let mut fields = Vec::new();
+    if step.prompt.is_some() {
+        fields.push("prompt.content");
+    }
+    if step.assistant_content.is_some() {
+        fields.push("assistant.content");
+    }
+    if step.bash.is_some() {
+        fields.push("bash.command");
+    }
+    if step.exit_code.is_some() {
+        fields.push("tool.exit_code");
+    }
+    if step.stdout.is_some() {
+        fields.push("tool.stdout");
+    }
+    if step.stderr.is_some() {
+        fields.push("tool.stderr");
+    }
+    fields
+}
+
+impl SemanticStep {
+    fn field_value(&self, field: &str) -> Option<&str> {
+        match field {
+            "prompt.content" => self.prompt.as_deref(),
+            "assistant.content" => self.assistant_content.as_deref(),
+            "bash.command" => self.bash.as_deref(),
+            "tool.stdout" => self.stdout.as_deref(),
+            "tool.stderr" => self.stderr.as_deref(),
+            _ => None,
+        }
+    }
+
+    fn field_display_value(&self, field: &str) -> Option<Cow<'_, str>> {
+        if field == "tool.exit_code" {
+            return self.exit_code.map(|code| Cow::Owned(code.to_string()));
+        }
+        self.field_value(field).map(Cow::Borrowed)
+    }
+}
+
+fn canonical_noise(text: &str) -> String {
+    collapse_whitespace(&replace_timestamps(text))
+}
+
+fn collapse_whitespace(text: &str) -> String {
+    let mut out = String::new();
+    let mut previous_space = false;
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            if !previous_space {
+                out.push(' ');
+                previous_space = true;
+            }
+        } else {
+            out.push(ch);
+            previous_space = false;
+        }
+    }
+    out.trim().to_owned()
+}
+
+fn replace_timestamps(text: &str) -> String {
+    let mut out = String::new();
+    let mut index = 0usize;
+    while index < text.len() {
+        if let Some(end) = timestamp_end(text, index) {
+            out.push_str("<timestamp>");
+            index = end;
+            continue;
+        }
+        let Some(ch) = text[index..].chars().next() else {
+            break;
+        };
+        out.push(ch);
+        index += ch.len_utf8();
+    }
+    out
+}
+
+fn timestamp_end(text: &str, start: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
+    if start + 10 > bytes.len() || !looks_like_date(bytes, start) {
+        return None;
+    }
+    let mut end = start + 10;
+    if end < bytes.len() && (bytes[end] == b'T' || bytes[end] == b' ') {
+        let time_start = end + 1;
+        if time_start + 8 <= bytes.len() && looks_like_time(bytes, time_start) {
+            end = time_start + 8;
+            while end < bytes.len() && is_timestamp_tail(bytes[end]) {
+                end += 1;
+            }
+        }
+    }
+    Some(end)
+}
+
+fn looks_like_date(bytes: &[u8], start: usize) -> bool {
+    is_digit(bytes[start])
+        && is_digit(bytes[start + 1])
+        && is_digit(bytes[start + 2])
+        && is_digit(bytes[start + 3])
+        && bytes[start + 4] == b'-'
+        && is_digit(bytes[start + 5])
+        && is_digit(bytes[start + 6])
+        && bytes[start + 7] == b'-'
+        && is_digit(bytes[start + 8])
+        && is_digit(bytes[start + 9])
+}
+
+fn looks_like_time(bytes: &[u8], start: usize) -> bool {
+    is_digit(bytes[start])
+        && is_digit(bytes[start + 1])
+        && bytes[start + 2] == b':'
+        && is_digit(bytes[start + 3])
+        && is_digit(bytes[start + 4])
+        && bytes[start + 5] == b':'
+        && is_digit(bytes[start + 6])
+        && is_digit(bytes[start + 7])
+}
+
+fn is_timestamp_tail(byte: u8) -> bool {
+    byte.is_ascii_digit() || matches!(byte, b'.' | b'Z' | b'z' | b'+' | b'-' | b':')
+}
+
+fn is_digit(byte: u8) -> bool {
+    byte.is_ascii_digit()
+}
+
+fn write_field_side_by_side(
+    s: &mut String,
+    field: &str,
+    baseline: Option<&str>,
+    candidate: Option<&str>,
+    column_width: usize,
+    color: bool,
+) {
+    if color {
+        let _ = writeln!(s, "\x1b[1;31m!= {field}\x1b[0m");
+    } else {
+        let _ = writeln!(s, "!= {field}");
+    }
+    let baseline_lines = lines_or_missing(baseline);
+    let candidate_lines = lines_or_missing(candidate);
+    let max_len = baseline_lines.len().max(candidate_lines.len());
+    for index in 0..max_len {
+        let left = baseline_lines.get(index).map_or("", String::as_str);
+        let right = candidate_lines.get(index).map_or("", String::as_str);
+        let _ = writeln!(
+            s,
+            "{:<width$} | {}",
+            truncate_for_column(left, column_width),
+            truncate_for_column(right, column_width),
+            width = column_width
+        );
+    }
+}
+
+fn color_enabled() -> bool {
+    if std::env::var_os("NO_COLOR").is_some() {
+        return false;
+    }
+    std::env::var("CLICOLOR_FORCE").is_ok_and(|value| !value.is_empty() && value != "0")
+}
+
+fn lines_or_missing(value: Option<&str>) -> Vec<String> {
+    match value {
+        Some("") => vec![String::new()],
+        Some(text) => text.lines().map(str::to_owned).collect(),
+        None => vec!["<missing>".into()],
+    }
+}
+
+fn truncate_for_column(text: &str, width: usize) -> String {
+    let mut out = String::new();
+    for ch in text.chars() {
+        if out.chars().count() >= width {
+            out.push('~');
+            return out;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn write_side_summary(
+    s: &mut String,
+    baseline: Option<&SemanticStep>,
+    candidate: Option<&SemanticStep>,
+) {
+    if let Some(step) = baseline {
+        let _ = writeln!(s, "baseline:  {}", compact_step_summary(step));
+    }
+    if let Some(step) = candidate {
+        let _ = writeln!(s, "candidate: {}", compact_step_summary(step));
+    }
+}
+
+fn compact_step_summary(step: &SemanticStep) -> String {
+    step.bash
+        .as_deref()
+        .or(step.assistant_content.as_deref())
+        .or(step.prompt.as_deref())
+        .unwrap_or("<empty>")
+        .lines()
+        .next()
+        .unwrap_or("<empty>")
+        .to_owned()
+}
+
+fn canonical_side_lines(report: &TrajectoryDiffReport, baseline: bool) -> Vec<String> {
+    let mut lines = Vec::new();
+    lines.push(format!("instance_id: {}", report.instance_id));
+    lines.push(format!(
+        "failure_category: {}",
+        if baseline {
+            &report.header.baseline_failure_category
+        } else {
+            &report.header.candidate_failure_category
+        }
+    ));
+    for step in &report.steps {
+        let side = if baseline {
+            step.baseline.as_ref()
+        } else {
+            step.candidate.as_ref()
+        };
+        lines.push(format!("step {} role={}", step.index, step.role));
+        if let Some(side) = side {
+            for field in present_fields(side) {
+                let value = if field == "tool.exit_code" {
+                    side.exit_code
+                        .map_or_else(|| "<missing>".into(), |code| code.to_string())
+                } else {
+                    side.field_value(field).unwrap_or("<missing>").to_owned()
+                };
+                push_canonical_field_lines(&mut lines, field, &value);
+            }
+        } else {
+            lines.push("<missing>".into());
+        }
+    }
+    lines
+}
+
+fn push_canonical_field_lines(lines: &mut Vec<String>, field: &str, value: &str) {
+    let mut parts = value.split('\n').collect::<Vec<_>>();
+    if parts.last().is_some_and(|part| part.is_empty()) {
+        parts.pop();
+    }
+    if parts.is_empty() {
+        lines.push(format!("{field}: "));
+        return;
+    }
+    for part in parts {
+        lines.push(format!("{field}: {part}"));
+    }
+}
+
+fn unified_range(line_count: usize) -> String {
+    match line_count {
+        0 => "0,0".into(),
+        1 => "1".into(),
+        n => format!("1,{n}"),
+    }
+}
+
+fn line_diff(baseline: &[String], candidate: &[String]) -> Vec<(char, String)> {
+    let rows = baseline.len();
+    let cols = candidate.len();
+    let mut lcs = vec![vec![0usize; cols + 1]; rows + 1];
+    for i in (0..rows).rev() {
+        for j in (0..cols).rev() {
+            lcs[i][j] = if baseline[i] == candidate[j] {
+                lcs[i + 1][j + 1] + 1
+            } else {
+                lcs[i + 1][j].max(lcs[i][j + 1])
+            };
+        }
+    }
+
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    let mut j = 0usize;
+    while i < rows || j < cols {
+        if baseline
+            .get(i)
+            .is_some_and(|line| candidate.get(j) == Some(line))
+        {
+            out.push((' ', baseline[i].clone()));
+            i += 1;
+            j += 1;
+        } else if i < rows && (j == cols || lcs[i + 1][j] >= lcs[i][j + 1]) {
+            out.push(('-', baseline[i].clone()));
+            i += 1;
+        } else if j < cols {
+            out.push(('+', candidate[j].clone()));
+            j += 1;
+        }
+    }
+    out
+}
+
+fn terminal_width() -> usize {
+    if let Ok(columns) = std::env::var("COLUMNS") {
+        if let Ok(parsed) = columns.parse::<usize>() {
+            if parsed >= 40 {
+                return parsed;
+            }
+        }
+    }
+    std::process::Command::new("stty")
+        .arg("size")
+        .output()
+        .ok()
+        .and_then(|output| {
+            output
+                .status
+                .success()
+                .then_some(output.stdout)
+                .and_then(|bytes| {
+                    let text = String::from_utf8(bytes).ok()?;
+                    text.split_whitespace().nth(1)?.parse::<usize>().ok()
+                })
+        })
+        .filter(|width| *width >= 40)
+        .unwrap_or(160)
+}
+
+fn attempts(trajectory: &Trajectory) -> u64 {
+    trajectory
+        .info
+        .other
+        .get("attempts")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(1)
+}
+
+fn failure_label_opt(category: Option<FailureCategory>) -> &'static str {
+    category.map_or("none", failure_label)
+}
+
+fn failure_label(category: FailureCategory) -> &'static str {
+    match category {
+        FailureCategory::EnvSetup => "env_setup",
+        FailureCategory::ModelApi => "model_api",
+        FailureCategory::ModelParse => "model_parse",
+        FailureCategory::StepLimit => "step_limit",
+        FailureCategory::CostLimit => "cost_limit",
+        FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::Unknown => "unknown",
+    }
+}
+
+fn format_cost(value: Option<f64>) -> String {
+    value.map_or_else(|| "?".into(), |cost| format!("{cost:.6}"))
+}
+
+fn format_u64(value: Option<u64>) -> String {
+    value.map_or_else(|| "?".into(), |v| v.to_string())
+}
+
+fn usize_from_u32(value: u32) -> usize {
+    usize::try_from(value).unwrap_or(usize::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use std::time::{Duration, Instant};
+
+    use crate::model::Message;
+    use crate::trajectory::{TokenUsage, Trajectory, outcome};
+
+    use super::{TrajectoryDiffArgs, diff_paths, render_text};
+
+    #[test]
+    fn diffing_and_rendering_eighty_step_trajectories_stays_under_500ms() {
+        let dir = tempfile::tempdir().unwrap();
+        let baseline = dir.path().join("baseline.traj.json");
+        let candidate = dir.path().join("candidate.traj.json");
+        write_perf_trajectory(&baseline, "perf", 80, None);
+        write_perf_trajectory(&candidate, "perf", 80, Some(79));
+
+        let start = Instant::now();
+        let report = diff_paths(&TrajectoryDiffArgs {
+            baseline,
+            candidate,
+            show_noise: false,
+        })
+        .unwrap();
+        let rendered = render_text(&report);
+        let elapsed = start.elapsed();
+
+        assert!(rendered.contains("first_divergent_step: 79"));
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "80-step semantic diff + render took {elapsed:?}, expected <500ms"
+        );
+    }
+
+    fn write_perf_trajectory(
+        path: &std::path::Path,
+        instance_id: &str,
+        steps: usize,
+        divergent_step: Option<usize>,
+    ) {
+        let mut t = Trajectory::new();
+        t.info
+            .other
+            .insert("instance_id".into(), serde_json::json!(instance_id));
+        t.info.outcome = Some(outcome::SUBMITTED.into());
+        t.info.total_cost_usd = Some(0.10);
+        t.info.token_usage = Some(TokenUsage {
+            prompt_tokens: 100,
+            completion_tokens: 20,
+        });
+        t.info.steps = Some(u32::try_from(steps).unwrap_or(u32::MAX));
+
+        for index in 0..steps {
+            let command = if divergent_step == Some(index) {
+                format!("echo changed-{index}")
+            } else {
+                format!("echo step-{index}")
+            };
+            let mut asst = Message::assistant(format!("```bash\n{command}\n```"));
+            asst.extra.actions = Some(vec![command]);
+            t.record_message(&asst);
+
+            let stdout = if divergent_step == Some(index) {
+                format!("changed-{index}\n")
+            } else {
+                format!("step-{index}\n")
+            };
+            let mut obs = Message::user("tool result");
+            obs.extra.other.insert(
+                "run_result".into(),
+                serde_json::json!({
+                    "stdout": stdout,
+                    "stderr": "",
+                    "exit_code": 0,
+                    "timed_out": false
+                }),
+            );
+            t.record_message(&obs);
+        }
+
+        std::fs::write(path, serde_json::to_string_pretty(&t).unwrap()).unwrap();
+    }
+}

--- a/src/run/trajectory_diff.rs
+++ b/src/run/trajectory_diff.rs
@@ -451,13 +451,15 @@ fn semantic_steps(trajectory: &Trajectory) -> Vec<KeyedSemanticStep> {
     let mut steps = Vec::new();
     let mut pending_prompt = Vec::new();
     let mut message_index = 0usize;
-    let mut step_index = 0usize;
+    let mut assistant_index = 0usize;
+    let mut tool_index = 0usize;
+    let prompt_index = 0usize;
     while message_index < trajectory.messages.len() {
         let message = &trajectory.messages[message_index];
         if let Some(run_result) = run_result(message) {
             push_keyed_step(
                 &mut steps,
-                step_index,
+                tool_index,
                 "tool",
                 SemanticStep {
                     prompt: take_prompt(&mut pending_prompt),
@@ -468,7 +470,7 @@ fn semantic_steps(trajectory: &Trajectory) -> Vec<KeyedSemanticStep> {
                     stderr: Some(run_result.stderr),
                 },
             );
-            step_index += 1;
+            tool_index += 1;
             message_index += 1;
             continue;
         }
@@ -496,8 +498,8 @@ fn semantic_steps(trajectory: &Trajectory) -> Vec<KeyedSemanticStep> {
                     message_index += 1;
                 }
             }
-            push_keyed_step(&mut steps, step_index, "assistant", step);
-            step_index += 1;
+            push_keyed_step(&mut steps, assistant_index, "assistant", step);
+            assistant_index += 1;
         }
         message_index += 1;
     }
@@ -505,7 +507,7 @@ fn semantic_steps(trajectory: &Trajectory) -> Vec<KeyedSemanticStep> {
     if let Some(prompt) = take_prompt(&mut pending_prompt) {
         push_keyed_step(
             &mut steps,
-            step_index,
+            prompt_index,
             "prompt",
             SemanticStep {
                 prompt: Some(prompt),

--- a/src/run/trajectory_diff.rs
+++ b/src/run/trajectory_diff.rs
@@ -58,6 +58,7 @@ pub struct TrajectoryDiffHeader {
     pub baseline_total_steps: usize,
     pub candidate_total_steps: usize,
     pub first_divergent_step_index: Option<usize>,
+    pub first_divergent_step_role: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -214,10 +215,7 @@ pub fn render_text(report: &TrajectoryDiffReport) -> String {
     let _ = writeln!(
         s,
         "first_divergent_step: {}",
-        report
-            .header
-            .first_divergent_step_index
-            .map_or_else(|| "none".into(), |v| v.to_string())
+        first_divergent_step_label(&report.header)
     );
 
     for step in &report.steps {
@@ -340,10 +338,11 @@ fn diff_trajectories(
         });
     }
 
-    let first_divergent_step_index = steps
+    let first_divergent_step = steps
         .iter()
-        .find(|step| step.status != TrajectoryDiffStatus::Match)
-        .map(|step| step.index);
+        .find(|step| step.status != TrajectoryDiffStatus::Match);
+    let first_divergent_step_index = first_divergent_step.map(|step| step.index);
+    let first_divergent_step_role = first_divergent_step.map(|step| step.role.clone());
 
     TrajectoryDiffReport {
         instance_id: baseline.instance_id.clone(),
@@ -353,6 +352,7 @@ fn diff_trajectories(
             baseline_steps.len(),
             candidate_steps.len(),
             first_divergent_step_index,
+            first_divergent_step_role,
         ),
         steps,
     }
@@ -364,6 +364,7 @@ fn build_header(
     baseline_step_count: usize,
     candidate_step_count: usize,
     first_divergent_step_index: Option<usize>,
+    first_divergent_step_role: Option<String>,
 ) -> TrajectoryDiffHeader {
     TrajectoryDiffHeader {
         baseline_path: baseline.path.clone(),
@@ -411,6 +412,18 @@ fn build_header(
             .steps
             .map_or(candidate_step_count, usize_from_u32),
         first_divergent_step_index,
+        first_divergent_step_role,
+    }
+}
+
+fn first_divergent_step_label(header: &TrajectoryDiffHeader) -> String {
+    match (
+        header.first_divergent_step_index,
+        header.first_divergent_step_role.as_deref(),
+    ) {
+        (Some(index), Some(role)) => format!("{index} role={role}"),
+        (Some(index), None) => index.to_string(),
+        _ => "none".into(),
     }
 }
 

--- a/src/stream/sse.rs
+++ b/src/stream/sse.rs
@@ -330,7 +330,20 @@ mod tests {
             .unwrap();
         let addr = server.local_addr();
         server.shutdown().await;
-        // Port should be reusable.
-        let _again = TcpListener::bind(addr).await.unwrap();
+        // Windows can report AddrInUse briefly after close; poll the
+        // condition instead of turning socket cleanup timing into a race.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            match TcpListener::bind(addr).await {
+                Ok(_again) => break,
+                Err(e)
+                    if e.kind() == std::io::ErrorKind::AddrInUse
+                        && tokio::time::Instant::now() < deadline =>
+                {
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                }
+                Err(e) => panic!("failed to rebind {addr}: {e}"),
+            }
+        }
     }
 }

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::process::Command;
 
 use rust_swe_agent::run::swebench::{InstanceResult, SweepResults};
-use rust_swe_agent::trajectory::{FailureCategory, outcome};
+use rust_swe_agent::trajectory::{FailureCategory, TokenUsage, Trajectory, outcome};
 
 fn binary_path() -> std::path::PathBuf {
     // CARGO_BIN_EXE_<name> is set by cargo when running integration tests.
@@ -102,6 +102,54 @@ fn write_results(dir: &Path, instances: Vec<InstanceResult>) {
     .unwrap();
 }
 
+fn write_diff_traj(
+    dir: &Path,
+    instance_id: &str,
+    failure_category: Option<FailureCategory>,
+    assistant: &str,
+    command: &str,
+    stdout: &str,
+) {
+    let mut t = Trajectory::new();
+    t.info
+        .other
+        .insert("instance_id".into(), serde_json::json!(instance_id));
+    t.info.outcome = Some(if failure_category.is_some() {
+        outcome::ERROR.into()
+    } else {
+        outcome::SUBMITTED.into()
+    });
+    t.info.failure_category = failure_category;
+    t.info.total_cost_usd = Some(0.10);
+    t.info.token_usage = Some(TokenUsage {
+        prompt_tokens: 10,
+        completion_tokens: 5,
+    });
+    t.info.steps = Some(1);
+
+    let mut asst = rust_swe_agent::model::Message::assistant(assistant);
+    asst.extra.actions = Some(vec![command.into()]);
+    t.record_message(&asst);
+
+    let mut obs = rust_swe_agent::model::Message::user("tool result");
+    obs.extra.other.insert(
+        "run_result".into(),
+        serde_json::json!({
+            "stdout": stdout,
+            "stderr": "",
+            "exit_code": 0,
+            "timed_out": false
+        }),
+    );
+    t.record_message(&obs);
+
+    std::fs::write(
+        dir.join(format!("{instance_id}.traj.json")),
+        serde_json::to_string_pretty(&t).unwrap(),
+    )
+    .unwrap();
+}
+
 #[test]
 fn help_lists_compare_subcommand() {
     let out = Command::new(binary_path())
@@ -125,12 +173,177 @@ fn help_lists_compare_subcommand() {
         .unwrap();
     assert!(out.status.success());
     let stdout = String::from_utf8_lossy(&out.stdout);
-    for flag in ["--baseline", "--candidate", "--format", "--max-regressions"] {
+    for flag in [
+        "--baseline",
+        "--candidate",
+        "--format",
+        "--max-regressions",
+        "--inspect-diff",
+        "--emit-diff-script",
+    ] {
         assert!(
             stdout.contains(flag),
             "expected `{flag}` in compare --help, got:\n{stdout}"
         );
     }
+}
+
+#[test]
+fn compare_inspect_diff_sugar_renders_one_instance_diff() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    write_results(baseline_dir.path(), vec![submitted("a")]);
+    write_results(
+        candidate_dir.path(),
+        vec![errored("a", FailureCategory::StepLimit)],
+    );
+    write_diff_traj(
+        baseline_dir.path(),
+        "a",
+        None,
+        "```bash\npytest -q\n```",
+        "pytest -q",
+        "1 failed\n",
+    );
+    write_diff_traj(
+        candidate_dir.path(),
+        "a",
+        Some(FailureCategory::StepLimit),
+        "```bash\npytest tests\n```",
+        "pytest tests",
+        "2 failed\n",
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--inspect-diff",
+            "a",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("=== bench inspect diff ==="), "{stdout}");
+    assert!(stdout.contains("instance_id: a"), "{stdout}");
+    assert!(stdout.contains("[step 0 - diverge]"), "{stdout}");
+    assert!(stdout.contains("pytest tests"), "{stdout}");
+}
+
+#[test]
+fn compare_emit_diff_script_executes_generated_script_for_all_regressions() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    let script = tempfile::NamedTempFile::new().unwrap();
+    let script_path = script.path().to_path_buf();
+    write_results(
+        baseline_dir.path(),
+        vec![
+            submitted("regressed-one"),
+            submitted("regressed-two"),
+            submitted("stable"),
+        ],
+    );
+    write_results(
+        candidate_dir.path(),
+        vec![
+            errored("regressed-one", FailureCategory::StepLimit),
+            errored("regressed-two", FailureCategory::ModelParse),
+            submitted("stable"),
+        ],
+    );
+    write_diff_traj(
+        baseline_dir.path(),
+        "regressed-one",
+        None,
+        "```bash\npytest -q\n```",
+        "pytest -q",
+        "1 failed\n",
+    );
+    write_diff_traj(
+        candidate_dir.path(),
+        "regressed-one",
+        Some(FailureCategory::StepLimit),
+        "```bash\npytest tests\n```",
+        "pytest tests",
+        "2 failed\n",
+    );
+    write_diff_traj(
+        baseline_dir.path(),
+        "regressed-two",
+        None,
+        "```bash\ncargo test\n```",
+        "cargo test",
+        "ok\n",
+    );
+    write_diff_traj(
+        candidate_dir.path(),
+        "regressed-two",
+        Some(FailureCategory::ModelParse),
+        "```bash\ncargo test --all\n```",
+        "cargo test --all",
+        "parse error\n",
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--emit-diff-script",
+            script_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let script_text = std::fs::read_to_string(&script_path).unwrap();
+    assert!(
+        script_text.contains("bench inspect --diff"),
+        "{script_text}"
+    );
+    assert!(
+        script_text.contains("regressed-one.traj.json"),
+        "{script_text}"
+    );
+    assert!(
+        script_text.contains("regressed-two.traj.json"),
+        "{script_text}"
+    );
+    assert!(!script_text.contains("stable.traj.json"), "{script_text}");
+
+    let out = Command::new("sh").arg(&script_path).output().unwrap();
+    assert!(
+        out.status.success(),
+        "generated script should exit zero; stdout:\n{}\nstderr:\n{}\nscript:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+        script_text
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(stdout.matches("=== bench inspect diff ===").count(), 2);
+    assert!(stdout.contains("instance_id: regressed-one"), "{stdout}");
+    assert!(stdout.contains("instance_id: regressed-two"), "{stdout}");
+    assert!(
+        !stdout.contains("instance_id: stable"),
+        "script should only inspect regressions:\n{stdout}"
+    );
 }
 
 #[test]

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -201,6 +201,30 @@ fn write_orphan_tool_alignment_traj(path: &Path, instance_id: &str, include_orph
     std::fs::write(path, serde_json::to_string_pretty(&t).unwrap()).unwrap();
 }
 
+fn write_trailing_prompt_traj(path: &Path, instance_id: &str, include_trailing_prompt: bool) {
+    let mut t = Trajectory::new();
+    t.info
+        .other
+        .insert("instance_id".into(), serde_json::json!(instance_id));
+    t.info.outcome = Some(outcome::SUBMITTED.into());
+    t.info.total_cost_usd = Some(0.10);
+    t.info.token_usage = Some(TokenUsage {
+        prompt_tokens: 100,
+        completion_tokens: 20,
+    });
+    t.info.steps = Some(2);
+
+    record_assistant_tool_step(&mut t, "```bash\necho one\n```", "echo one", "one\n");
+    record_assistant_tool_step(&mut t, "```bash\necho two\n```", "echo two", "two\n");
+    if include_trailing_prompt {
+        t.record_message(&rust_swe_agent::model::Message::user(
+            "continue with next check",
+        ));
+    }
+
+    std::fs::write(path, serde_json::to_string_pretty(&t).unwrap()).unwrap();
+}
+
 fn record_assistant_tool_step(
     trajectory: &mut Trajectory,
     assistant: &str,
@@ -531,6 +555,45 @@ fn diff_orphan_tool_record_does_not_shift_later_assistant_indices() {
 }
 
 #[test]
+fn diff_trailing_prompt_tail_uses_next_logical_step_index() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("baseline.traj.json");
+    let candidate = dir.path().join("candidate.traj.json");
+    write_trailing_prompt_traj(&baseline, "abc", false);
+    write_trailing_prompt_traj(&candidate, "abc", true);
+
+    let out = Command::new(binary_path())
+        .arg("bench")
+        .arg("inspect")
+        .arg("--diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["header"]["first_divergent_step_index"], 2, "{v:#}");
+    let prompt_tail = v["steps"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|step| step["role"] == "prompt")
+        .unwrap_or_else(|| panic!("missing prompt tail in {v:#}"));
+    assert_eq!(prompt_tail["index"], 2);
+    assert_eq!(prompt_tail["status"], "candidate_only");
+    assert_eq!(
+        prompt_tail["candidate"]["prompt"],
+        "user: continue with next check"
+    );
+}
+
+#[test]
 fn diff_instance_id_mismatch_fails_fast() {
     let dir = tempfile::tempdir().unwrap();
     let baseline = dir.path().join("baseline.traj.json");
@@ -708,6 +771,53 @@ fn diff_suppresses_timestamp_noise_by_default() {
     assert!(out.status.success());
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("[step 0 - identical]"), "{stdout}");
+}
+
+#[test]
+fn diff_unified_format_suppresses_noise_by_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("baseline.traj.json");
+    let candidate = dir.path().join("candidate.traj.json");
+    write_diff_traj(
+        &baseline,
+        "abc",
+        None,
+        0.10,
+        &[(
+            "hello world",
+            "cat log",
+            "finished_at=2026-04-27T12:00:00Z\n",
+            "",
+            0,
+        )],
+    );
+    write_diff_traj(
+        &candidate,
+        "abc",
+        None,
+        0.10,
+        &[(
+            "hello   world",
+            "cat log",
+            "finished_at=2026-04-27T12:00:01Z\n",
+            "",
+            0,
+        )],
+    );
+
+    let out = Command::new(binary_path())
+        .arg("bench")
+        .arg("inspect")
+        .arg("--diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .arg("--format")
+        .arg("unified")
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(stdout, "--- baseline\n+++ candidate\n", "{stdout}");
 }
 
 #[test]

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -5,7 +5,7 @@
 use std::path::Path;
 use std::process::Command;
 
-use rust_swe_agent::trajectory::{FailureCategory, Trajectory, outcome};
+use rust_swe_agent::trajectory::{FailureCategory, TokenUsage, Trajectory, outcome};
 
 fn binary_path() -> std::path::PathBuf {
     std::env::var("CARGO_BIN_EXE_rust-swe-agent").map_or_else(
@@ -91,6 +91,94 @@ fn write_traj_with_stderr(dir: &Path, instance_id: &str, stderr: &str) {
     .unwrap();
 }
 
+fn write_diff_traj(
+    path: &Path,
+    instance_id: &str,
+    failure_category: Option<FailureCategory>,
+    cost_usd: f64,
+    steps: &[(&str, &str, &str, &str, i32)],
+) {
+    let mut t = Trajectory::new();
+    t.info
+        .other
+        .insert("instance_id".into(), serde_json::json!(instance_id));
+    t.info.outcome = Some(if failure_category.is_some() {
+        outcome::ERROR.into()
+    } else {
+        outcome::SUBMITTED.into()
+    });
+    t.info.failure_category = failure_category;
+    t.info.total_cost_usd = Some(cost_usd);
+    t.info.token_usage = Some(TokenUsage {
+        prompt_tokens: 100,
+        completion_tokens: 20,
+    });
+    t.info.steps = Some(u32::try_from(steps.len()).unwrap_or(u32::MAX));
+
+    for (assistant, command, stdout, stderr, exit_code) in steps {
+        let mut asst = rust_swe_agent::model::Message::assistant(*assistant);
+        asst.extra.actions = Some(vec![(*command).into()]);
+        t.record_message(&asst);
+
+        let mut obs = rust_swe_agent::model::Message::user("tool result");
+        obs.extra.other.insert(
+            "run_result".into(),
+            serde_json::json!({
+                "stdout": stdout,
+                "stderr": stderr,
+                "exit_code": exit_code,
+                "timed_out": false
+            }),
+        );
+        t.record_message(&obs);
+    }
+
+    std::fs::write(path, serde_json::to_string_pretty(&t).unwrap()).unwrap();
+}
+
+fn write_prompted_diff_traj(
+    path: &Path,
+    instance_id: &str,
+    system_prompt: &str,
+    user_prompt: &str,
+    assistant: &str,
+    command: &str,
+    stdout: &str,
+) {
+    let mut t = Trajectory::new();
+    t.info
+        .other
+        .insert("instance_id".into(), serde_json::json!(instance_id));
+    t.info.outcome = Some(outcome::SUBMITTED.into());
+    t.info.total_cost_usd = Some(0.10);
+    t.info.token_usage = Some(TokenUsage {
+        prompt_tokens: 100,
+        completion_tokens: 20,
+    });
+    t.info.steps = Some(1);
+
+    t.record_message(&rust_swe_agent::model::Message::system(system_prompt));
+    t.record_message(&rust_swe_agent::model::Message::user(user_prompt));
+
+    let mut asst = rust_swe_agent::model::Message::assistant(assistant);
+    asst.extra.actions = Some(vec![command.into()]);
+    t.record_message(&asst);
+
+    let mut obs = rust_swe_agent::model::Message::user("tool result");
+    obs.extra.other.insert(
+        "run_result".into(),
+        serde_json::json!({
+            "stdout": stdout,
+            "stderr": "",
+            "exit_code": 0,
+            "timed_out": false
+        }),
+    );
+    t.record_message(&obs);
+
+    std::fs::write(path, serde_json::to_string_pretty(&t).unwrap()).unwrap();
+}
+
 #[test]
 fn help_lists_inspect_subcommand_and_flags() {
     let out = Command::new(binary_path())
@@ -107,9 +195,509 @@ fn help_lists_inspect_subcommand_and_flags() {
         .unwrap();
     assert!(out.status.success());
     let stdout = String::from_utf8_lossy(&out.stdout);
-    for flag in ["--sweep", "--instance", "--filter", "--format", "--full"] {
+    for flag in [
+        "--sweep",
+        "--instance",
+        "--filter",
+        "--format",
+        "--full",
+        "--diff",
+        "--show-noise",
+    ] {
         assert!(stdout.contains(flag), "missing {flag} in:\n{stdout}");
     }
+}
+
+#[test]
+fn diff_identical_trajectories_collapse_to_all_match_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("baseline.traj.json");
+    let candidate = dir.path().join("candidate.traj.json");
+    write_diff_traj(
+        &baseline,
+        "abc",
+        None,
+        0.10,
+        &[("```bash\necho hi\n```", "echo hi", "hi\n", "", 0)],
+    );
+    write_diff_traj(
+        &candidate,
+        "abc",
+        None,
+        0.10,
+        &[("```bash\necho hi\n```", "echo hi", "hi\n", "", 0)],
+    );
+
+    let out = Command::new(binary_path())
+        .arg("bench")
+        .arg("inspect")
+        .arg("--diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("=== bench inspect diff ==="), "{stdout}");
+    assert!(stdout.contains("instance_id: abc"), "{stdout}");
+    assert!(stdout.contains("[step 0 - identical]"), "{stdout}");
+    assert!(!stdout.contains("assistant.content"), "{stdout}");
+}
+
+#[test]
+fn diff_single_step_divergence_expands_only_that_step() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("baseline.traj.json");
+    let candidate = dir.path().join("candidate.traj.json");
+    write_diff_traj(
+        &baseline,
+        "abc",
+        None,
+        0.10,
+        &[
+            ("```bash\necho same\n```", "echo same", "same\n", "", 0),
+            ("```bash\npytest -q\n```", "pytest -q", "1 failed\n", "", 1),
+        ],
+    );
+    write_diff_traj(
+        &candidate,
+        "abc",
+        Some(FailureCategory::StepLimit),
+        0.20,
+        &[
+            ("```bash\necho same\n```", "echo same", "same\n", "", 0),
+            (
+                "```bash\npytest tests\n```",
+                "pytest tests",
+                "2 failed\n",
+                "",
+                1,
+            ),
+        ],
+    );
+
+    let out = Command::new(binary_path())
+        .arg("bench")
+        .arg("inspect")
+        .arg("--diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("first_divergent_step: 1"), "{stdout}");
+    assert!(stdout.contains("[step 0 - identical]"), "{stdout}");
+    assert!(stdout.contains("[step 1 - diverge]"), "{stdout}");
+    assert!(stdout.contains("assistant.content"), "{stdout}");
+    assert!(stdout.contains("bash.command"), "{stdout}");
+    assert!(stdout.contains("tool.stdout"), "{stdout}");
+}
+
+#[test]
+fn diff_length_mismatch_renders_unmatched_tail() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("baseline.traj.json");
+    let candidate = dir.path().join("candidate.traj.json");
+    write_diff_traj(
+        &baseline,
+        "abc",
+        None,
+        0.10,
+        &[("```bash\necho one\n```", "echo one", "one\n", "", 0)],
+    );
+    write_diff_traj(
+        &candidate,
+        "abc",
+        None,
+        0.12,
+        &[
+            ("```bash\necho one\n```", "echo one", "one\n", "", 0),
+            ("```bash\necho two\n```", "echo two", "two\n", "", 0),
+        ],
+    );
+
+    let out = Command::new(binary_path())
+        .arg("bench")
+        .arg("inspect")
+        .arg("--diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["steps"][0]["status"], "match");
+    assert_eq!(v["steps"][1]["status"], "candidate_only");
+    assert_eq!(v["steps"][1]["candidate"]["bash"], "echo two");
+}
+
+#[test]
+fn diff_length_mismatch_renders_baseline_only_tail() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("baseline.traj.json");
+    let candidate = dir.path().join("candidate.traj.json");
+    write_diff_traj(
+        &baseline,
+        "abc",
+        None,
+        0.12,
+        &[
+            ("```bash\necho one\n```", "echo one", "one\n", "", 0),
+            ("```bash\necho old\n```", "echo old", "old\n", "", 0),
+        ],
+    );
+    write_diff_traj(
+        &candidate,
+        "abc",
+        None,
+        0.10,
+        &[("```bash\necho one\n```", "echo one", "one\n", "", 0)],
+    );
+
+    let out = Command::new(binary_path())
+        .arg("bench")
+        .arg("inspect")
+        .arg("--diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["steps"][1]["index"], 1);
+    assert_eq!(v["steps"][1]["role"], "assistant");
+    assert_eq!(v["steps"][1]["status"], "baseline_only");
+    assert_eq!(v["steps"][1]["baseline"]["bash"], "echo old");
+    assert!(v["steps"][1]["candidate"].is_null());
+}
+
+#[test]
+fn diff_groups_initial_prompt_assistant_and_tool_result_as_one_role_keyed_step() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("baseline.traj.json");
+    let candidate = dir.path().join("candidate.traj.json");
+    write_prompted_diff_traj(
+        &baseline,
+        "abc",
+        "You are a careful agent.",
+        "Fix issue #29.",
+        "```bash\npytest -q\n```",
+        "pytest -q",
+        "1 failed\n",
+    );
+    write_prompted_diff_traj(
+        &candidate,
+        "abc",
+        "You are a careful agent.",
+        "Fix issue #29.",
+        "```bash\npytest -q\n```",
+        "pytest -q",
+        "1 failed\n",
+    );
+
+    let out = Command::new(binary_path())
+        .arg("bench")
+        .arg("inspect")
+        .arg("--diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let steps = v["steps"].as_array().unwrap();
+    assert_eq!(
+        steps.len(),
+        1,
+        "system+user prompt, assistant, and tool result should form one semantic step: {v:#}"
+    );
+    assert_eq!(steps[0]["index"], 0);
+    assert_eq!(steps[0]["role"], "assistant");
+    assert_eq!(steps[0]["status"], "match");
+    assert_eq!(
+        steps[0]["baseline"]["prompt"],
+        "system: You are a careful agent.\nuser: Fix issue #29."
+    );
+    assert_eq!(steps[0]["baseline"]["bash"], "pytest -q");
+    assert_eq!(steps[0]["baseline"]["stdout"], "1 failed\n");
+}
+
+#[test]
+fn diff_instance_id_mismatch_fails_fast() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("baseline.traj.json");
+    let candidate = dir.path().join("candidate.traj.json");
+    write_diff_traj(
+        &baseline,
+        "abc",
+        None,
+        0.10,
+        &[("```bash\necho hi\n```", "echo hi", "hi\n", "", 0)],
+    );
+    write_diff_traj(
+        &candidate,
+        "xyz",
+        None,
+        0.10,
+        &[("```bash\necho hi\n```", "echo hi", "hi\n", "", 0)],
+    );
+
+    let out = Command::new(binary_path())
+        .arg("bench")
+        .arg("inspect")
+        .arg("--diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("instance_id mismatch"), "{stderr}");
+    assert!(stderr.contains("abc"), "{stderr}");
+    assert!(stderr.contains("xyz"), "{stderr}");
+}
+
+#[test]
+fn diff_json_output_schema_is_stable() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("baseline.traj.json");
+    let candidate = dir.path().join("candidate.traj.json");
+    write_diff_traj(
+        &baseline,
+        "abc",
+        None,
+        0.10,
+        &[("```bash\npytest -q\n```", "pytest -q", "1 failed\n", "", 1)],
+    );
+    write_diff_traj(
+        &candidate,
+        "abc",
+        Some(FailureCategory::StepLimit),
+        0.20,
+        &[(
+            "```bash\npytest tests\n```",
+            "pytest tests",
+            "2 failed\n",
+            "",
+            1,
+        )],
+    );
+
+    let out = Command::new(binary_path())
+        .arg("bench")
+        .arg("inspect")
+        .arg("--diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["instance_id"], "abc");
+    assert_eq!(v["header"]["baseline_failure_category"], "none");
+    assert_eq!(v["header"]["candidate_failure_category"], "step_limit");
+    assert_eq!(v["header"]["baseline_total_steps"], 1);
+    assert_eq!(v["header"]["candidate_total_steps"], 1);
+    assert_eq!(v["header"]["first_divergent_step_index"], 0);
+    assert_eq!(v["steps"][0]["index"], 0);
+    assert_eq!(v["steps"][0]["role"], "assistant");
+    assert_eq!(v["steps"][0]["status"], "diverge");
+    assert_eq!(
+        v["steps"][0]["diff_fields"],
+        serde_json::json!(["assistant.content", "bash.command", "tool.stdout"])
+    );
+}
+
+#[test]
+fn diff_suppresses_whitespace_noise_unless_requested() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("baseline.traj.json");
+    let candidate = dir.path().join("candidate.traj.json");
+    write_diff_traj(
+        &baseline,
+        "abc",
+        None,
+        0.10,
+        &[("hello world", "echo hi", "done\n", "", 0)],
+    );
+    write_diff_traj(
+        &candidate,
+        "abc",
+        None,
+        0.10,
+        &[("hello   world", "echo hi", "done\n", "", 0)],
+    );
+
+    let out = Command::new(binary_path())
+        .arg("bench")
+        .arg("inspect")
+        .arg("--diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[step 0 - identical]"), "{stdout}");
+
+    let out = Command::new(binary_path())
+        .arg("bench")
+        .arg("inspect")
+        .arg("--diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .arg("--show-noise")
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[step 0 - diverge]"), "{stdout}");
+    assert!(stdout.contains("assistant.content"), "{stdout}");
+}
+
+#[test]
+fn diff_suppresses_timestamp_noise_by_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("baseline.traj.json");
+    let candidate = dir.path().join("candidate.traj.json");
+    write_diff_traj(
+        &baseline,
+        "abc",
+        None,
+        0.10,
+        &[(
+            "```bash\ncat log\n```",
+            "cat log",
+            "finished_at=2026-04-27T12:00:00Z\n",
+            "",
+            0,
+        )],
+    );
+    write_diff_traj(
+        &candidate,
+        "abc",
+        None,
+        0.10,
+        &[(
+            "```bash\ncat log\n```",
+            "cat log",
+            "finished_at=2026-04-27T12:00:01Z\n",
+            "",
+            0,
+        )],
+    );
+
+    let out = Command::new(binary_path())
+        .arg("bench")
+        .arg("inspect")
+        .arg("--diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("[step 0 - identical]"), "{stdout}");
+}
+
+#[test]
+fn diff_unified_format_renders_canonical_unified_diff() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("baseline.traj.json");
+    let candidate = dir.path().join("candidate.traj.json");
+    write_diff_traj(
+        &baseline,
+        "abc",
+        None,
+        0.10,
+        &[("```bash\npytest -q\n```", "pytest -q", "1 failed\n", "", 1)],
+    );
+    write_diff_traj(
+        &candidate,
+        "abc",
+        Some(FailureCategory::StepLimit),
+        0.20,
+        &[(
+            "```bash\npytest tests\n```",
+            "pytest tests",
+            "2 failed\n",
+            "",
+            1,
+        )],
+    );
+
+    let out = Command::new(binary_path())
+        .arg("bench")
+        .arg("inspect")
+        .arg("--diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .arg("--format")
+        .arg("unified")
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.starts_with("--- baseline\n+++ candidate\n"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("@@ -1,"), "{stdout}");
+    assert!(stdout.contains(" instance_id: abc"), "{stdout}");
+    assert!(stdout.contains("-bash.command: pytest -q"), "{stdout}");
+    assert!(stdout.contains("+bash.command: pytest tests"), "{stdout}");
+    assert!(!stdout.contains("@@ trajectory abc @@"), "{stdout}");
+}
+
+#[test]
+fn diff_text_highlights_changed_fields_when_color_is_forced() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("baseline.traj.json");
+    let candidate = dir.path().join("candidate.traj.json");
+    write_diff_traj(
+        &baseline,
+        "abc",
+        None,
+        0.10,
+        &[("hello world", "echo hi", "done\n", "", 0)],
+    );
+    write_diff_traj(
+        &candidate,
+        "abc",
+        None,
+        0.10,
+        &[("goodbye world", "echo hi", "done\n", "", 0)],
+    );
+
+    let out = Command::new(binary_path())
+        .env("CLICOLOR_FORCE", "1")
+        .env_remove("NO_COLOR")
+        .arg("bench")
+        .arg("inspect")
+        .arg("--diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("\u{1b}[1;31m!= assistant.content\u{1b}[0m"),
+        "expected ANSI highlighting for changed field labels:\n{stdout}"
+    );
 }
 
 #[test]

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -529,6 +529,8 @@ fn diff_orphan_tool_record_does_not_shift_later_assistant_indices() {
         String::from_utf8_lossy(&out.stderr)
     );
     let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["header"]["first_divergent_step_index"], 0, "{v:#}");
+    assert_eq!(v["header"]["first_divergent_step_role"], "tool", "{v:#}");
     let steps = v["steps"].as_array().unwrap();
     let assistant_one = steps
         .iter()
@@ -579,6 +581,7 @@ fn diff_trailing_prompt_tail_uses_next_logical_step_index() {
     );
     let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
     assert_eq!(v["header"]["first_divergent_step_index"], 2, "{v:#}");
+    assert_eq!(v["header"]["first_divergent_step_role"], "prompt", "{v:#}");
     let prompt_tail = v["steps"]
         .as_array()
         .unwrap()
@@ -672,6 +675,7 @@ fn diff_json_output_schema_is_stable() {
     assert_eq!(v["header"]["baseline_total_steps"], 1);
     assert_eq!(v["header"]["candidate_total_steps"], 1);
     assert_eq!(v["header"]["first_divergent_step_index"], 0);
+    assert_eq!(v["header"]["first_divergent_step_role"], "assistant");
     assert_eq!(v["steps"][0]["index"], 0);
     assert_eq!(v["steps"][0]["role"], "assistant");
     assert_eq!(v["steps"][0]["status"], "diverge");

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -179,6 +179,54 @@ fn write_prompted_diff_traj(
     std::fs::write(path, serde_json::to_string_pretty(&t).unwrap()).unwrap();
 }
 
+fn write_orphan_tool_alignment_traj(path: &Path, instance_id: &str, include_orphan_tool: bool) {
+    let mut t = Trajectory::new();
+    t.info
+        .other
+        .insert("instance_id".into(), serde_json::json!(instance_id));
+    t.info.outcome = Some(outcome::SUBMITTED.into());
+    t.info.total_cost_usd = Some(0.10);
+    t.info.token_usage = Some(TokenUsage {
+        prompt_tokens: 100,
+        completion_tokens: 20,
+    });
+    t.info.steps = Some(2);
+
+    record_assistant_tool_step(&mut t, "```bash\necho one\n```", "echo one", "one\n");
+    if include_orphan_tool {
+        record_tool_result(&mut t, "orphan\n");
+    }
+    record_assistant_tool_step(&mut t, "```bash\necho two\n```", "echo two", "two\n");
+
+    std::fs::write(path, serde_json::to_string_pretty(&t).unwrap()).unwrap();
+}
+
+fn record_assistant_tool_step(
+    trajectory: &mut Trajectory,
+    assistant: &str,
+    command: &str,
+    stdout: &str,
+) {
+    let mut asst = rust_swe_agent::model::Message::assistant(assistant);
+    asst.extra.actions = Some(vec![command.into()]);
+    trajectory.record_message(&asst);
+    record_tool_result(trajectory, stdout);
+}
+
+fn record_tool_result(trajectory: &mut Trajectory, stdout: &str) {
+    let mut obs = rust_swe_agent::model::Message::user("tool result");
+    obs.extra.other.insert(
+        "run_result".into(),
+        serde_json::json!({
+            "stdout": stdout,
+            "stderr": "",
+            "exit_code": 0,
+            "timed_out": false
+        }),
+    );
+    trajectory.record_message(&obs);
+}
+
 #[test]
 fn help_lists_inspect_subcommand_and_flags() {
     let out = Command::new(binary_path())
@@ -431,6 +479,55 @@ fn diff_groups_initial_prompt_assistant_and_tool_result_as_one_role_keyed_step()
     );
     assert_eq!(steps[0]["baseline"]["bash"], "pytest -q");
     assert_eq!(steps[0]["baseline"]["stdout"], "1 failed\n");
+}
+
+#[test]
+fn diff_orphan_tool_record_does_not_shift_later_assistant_indices() {
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = dir.path().join("baseline.traj.json");
+    let candidate = dir.path().join("candidate.traj.json");
+    write_orphan_tool_alignment_traj(&baseline, "abc", true);
+    write_orphan_tool_alignment_traj(&candidate, "abc", false);
+
+    let out = Command::new(binary_path())
+        .arg("bench")
+        .arg("inspect")
+        .arg("--diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let steps = v["steps"].as_array().unwrap();
+    let assistant_one = steps
+        .iter()
+        .find(|step| step["role"] == "assistant" && step["index"] == 1)
+        .unwrap_or_else(|| panic!("missing assistant index 1 in {v:#}"));
+    assert_eq!(assistant_one["status"], "match", "{v:#}");
+    assert_eq!(assistant_one["baseline"]["bash"], "echo two");
+    assert_eq!(assistant_one["candidate"]["bash"], "echo two");
+    assert!(
+        steps.iter().any(|step| {
+            step["role"] == "tool"
+                && step["status"] == "baseline_only"
+                && step["baseline"]["stdout"] == "orphan\n"
+        }),
+        "orphan tool should be isolated as a tool-only diff: {v:#}"
+    );
+    assert!(
+        !steps.iter().any(|step| {
+            step["role"] == "assistant"
+                && (step["status"] == "baseline_only" || step["status"] == "candidate_only")
+        }),
+        "orphan tool must not turn matching assistant turns into tails: {v:#}"
+    );
 }
 
 #[test]

--- a/tests/swebench_budget.rs
+++ b/tests/swebench_budget.rs
@@ -302,7 +302,7 @@ async fn sweep_without_limit_runs_all_tasks() {
 
     assert_eq!(results.total, 3);
     assert_eq!(results.budget_halted, 0);
-    assert_eq!(results.submitted, 3);
+    assert_eq!(results.submitted, 3, "results: {results:?}");
     assert!(results.cost_limit_usd.is_none());
 }
 
@@ -741,5 +741,5 @@ async fn stale_results_json_is_not_trusted_over_newer_trajectory() {
     .unwrap();
 
     assert_eq!(results.budget_halted, 0);
-    assert_eq!(results.submitted, 1);
+    assert_eq!(results.submitted, 1, "results: {results:?}");
 }


### PR DESCRIPTION
## Summary
- Add semantic `bench inspect --diff` support with role/index-keyed step alignment
- Render grouped prompt/assistant/tool turns, field-level text diffs, and real unified hunks
- Extend `bench compare` to emit executable diff scripts and cover regression tails
- Update inspect docs and add coverage for performance, highlighting, and script execution

## Testing
- Unit and integration tests added for diff grouping, baseline-only tails, unified output, ANSI highlighting, and script execution
- Full `cargo test` passed