### PR TITLE
🌟 Nova: HtmlExporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ docker = []
 chaos = []
 live-anthropic = []
 markdown-export = []
+html-export = []
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -4,10 +4,66 @@ pub trait TrajectoryExporter {
     fn export(trajectory: &Trajectory) -> String;
 }
 
+#[cfg(feature = "markdown-export")]
 pub struct MarkdownExporter;
 
+#[cfg(any(feature = "markdown-export", feature = "html-export"))]
 use std::fmt::Write;
 
+#[cfg(feature = "html-export")]
+pub struct HtmlExporter;
+
+#[cfg(feature = "html-export")]
+impl TrajectoryExporter for HtmlExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let mut html = String::new();
+
+        html.push_str("<!DOCTYPE html>\n");
+        html.push_str("<html>\n<head>\n<title>Trajectory Export</title>\n</head>\n<body>\n");
+        html.push_str("<h1>Trajectory Export</h1>\n\n");
+
+        if let Some(task) = &trajectory.info.task {
+            let _ = writeln!(html, "<p><strong>Task:</strong> {}</p>", html_escape(task));
+        }
+
+        if let Some(outcome) = &trajectory.info.outcome {
+            let _ = writeln!(
+                html,
+                "<p><strong>Outcome:</strong> {}</p>",
+                html_escape(outcome)
+            );
+        }
+
+        html.push_str("<h2>Messages</h2>\n\n");
+
+        for msg in &trajectory.messages {
+            let role_title = match msg.role.as_str() {
+                "system" => "System",
+                "user" => "User",
+                "assistant" => "Assistant",
+                "tool" => "Tool",
+                other => other,
+            };
+
+            let _ = writeln!(html, "<h3>{role_title}</h3>");
+            let _ = writeln!(html, "<pre>{}</pre>", html_escape(&msg.content));
+        }
+
+        html.push_str("</body>\n</html>");
+        html
+    }
+}
+
+#[cfg(feature = "html-export")]
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#x27;")
+}
+
+#[cfg(feature = "markdown-export")]
 impl TrajectoryExporter for MarkdownExporter {
     fn export(trajectory: &Trajectory) -> String {
         let mut md = String::new();
@@ -42,10 +98,14 @@ impl TrajectoryExporter for MarkdownExporter {
 
 #[cfg(test)]
 mod tests {
+    #[allow(unused_imports)]
     use super::*;
+    #[allow(unused_imports)]
     use crate::model::Message;
+    #[allow(unused_imports)]
     use crate::trajectory::outcome;
 
+    #[cfg(feature = "markdown-export")]
     #[test]
     fn test_markdown_export_format() {
         let mut t = Trajectory::new();
@@ -68,5 +128,33 @@ mod tests {
         assert!(md.contains("Hello agent"));
         assert!(md.contains("### Assistant"));
         assert!(md.contains("Hello user"));
+    }
+
+    #[cfg(feature = "html-export")]
+    #[test]
+    fn test_html_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::assistant("Hello user"));
+
+        let html = HtmlExporter::export(&t);
+
+        assert!(html.contains("<!DOCTYPE html>"));
+        assert!(html.contains("<html>"));
+        assert!(html.contains("<body>"));
+        assert!(html.contains("<h1>Trajectory Export</h1>"));
+        assert!(html.contains("<strong>Task:</strong> Add a feature"));
+        assert!(html.contains("<strong>Outcome:</strong> submitted"));
+        assert!(html.contains("<h2>Messages</h2>"));
+        assert!(html.contains("<h3>System</h3>"));
+        assert!(html.contains("<pre>System prompt</pre>"));
+        assert!(html.contains("<h3>User</h3>"));
+        assert!(html.contains("<pre>Hello agent</pre>"));
+        assert!(html.contains("<h3>Assistant</h3>"));
+        assert!(html.contains("<pre>Hello user</pre>"));
     }
 }

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -15,7 +15,7 @@ pub const FORMAT_VERSION: &str = "mini-swe-agent-1.1";
 /// Coarse run outcome. Exactly one of three values, suitable for computing
 /// pass@1-style metrics from trajectory files alone:
 /// `"submitted"` | `"step_limit_reached"` | `"error"`.
-#[cfg(feature = "markdown-export")]
+#[cfg(any(feature = "markdown-export", feature = "html-export"))]
 pub mod export;
 
 pub mod outcome {


### PR DESCRIPTION
💡 **The Spark:** "I noticed we export trajectories to Markdown, but a browser-native HTML format could be extremely useful for quick reviews."
🚀 **The Feature:** "Implemented `HtmlExporter` under a new `html-export` feature flag."
🔮 **The Potential:** "Could be used as a standalone visualizer or eventually expanded with CSS/JS for an interactive agent debug view."
⚠️ **Risk:** "Low. Isolated in `src/trajectory/export.rs` behind a feature flag and does not modify any core parsing or execution logic."

---
*PR created automatically by Jules for task [10058683330867042797](https://jules.google.com/task/10058683330867042797) started by @madmax983*