### PR TITLE
Add bench forecast and forecast-first gating

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -86,6 +86,8 @@ pub struct ReplayCmd {
 pub enum BenchCmd {
     /// Run a SWE-bench sweep over a local JSONL dataset.
     Swebench(SwebenchCmd),
+    /// Forecast sweep cost from a reproducible calibration slice.
+    Forecast(SwebenchCmd),
     /// Validate sweep inputs without launching tasks.
     Doctor(SwebenchCmd),
     /// Diff two completed sweep runs by instance id; surfaces regressions
@@ -148,13 +150,13 @@ pub struct CompareCmd {
     pub show_noise: bool,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct SwebenchCmd {
     #[arg(long)]
     pub dataset_path: PathBuf,
 
-    #[arg(long)]
+    #[arg(long, alias = "output-dir")]
     pub output: PathBuf,
 
     #[arg(long, default_value_t = 4)]
@@ -168,6 +170,14 @@ pub struct SwebenchCmd {
 
     #[arg(long)]
     pub config: Option<PathBuf>,
+
+    /// Environment: `local` or `docker`.
+    #[arg(long)]
+    pub env: Option<String>,
+
+    /// Docker image, if `--env docker`.
+    #[arg(long)]
+    pub docker_image: Option<String>,
 
     /// Skip tasks whose output trajectory file already exists on disk and
     /// parses as valid JSON. Lets an interrupted sweep resume without
@@ -249,6 +259,31 @@ pub struct SwebenchCmd {
     /// Max total seconds for all preflight checks.
     #[arg(long, default_value_t = 60)]
     pub preflight_total_timeout_s: u64,
+
+    /// Run a calibration forecast before the real sweep and launch only
+    /// when the forecast clears `--sweep-cost-limit-usd` or `--yes` is set.
+    #[arg(long, default_value_t = false)]
+    pub forecast_first: bool,
+
+    /// Proceed after `--forecast-first` even without a clear cost-cap pass.
+    #[arg(long, default_value_t = false)]
+    pub yes: bool,
+
+    /// Instance count for `bench forecast` calibration.
+    #[arg(long, default_value_t = 5)]
+    pub calibration_n: usize,
+
+    /// Forecast target instance count. Defaults to full post-filter dataset.
+    #[arg(long)]
+    pub target_n: Option<usize>,
+
+    /// Confidence level percentage for forecast intervals.
+    #[arg(long, default_value_t = 80.0)]
+    pub confidence: f64,
+
+    /// Exit non-zero when the forecast projects the sweep will exceed cap.
+    #[arg(long, default_value_t = false)]
+    pub fail_over_cap: bool,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -163,17 +163,24 @@ async fn replay_cmd(r: args::ReplayCmd) -> Result<(), Error> {
 async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
     let mut sweep_cmd = s;
     if sweep_cmd.forecast_first {
-        let report = run_forecast_from_cmd(sweep_cmd.clone()).await?;
-        print_forecast_report(&report, &sweep_cmd.format)?;
-        crate::run::forecast::validate_fail_over_cap(&report, sweep_cmd.fail_over_cap)?;
-        if !crate::run::forecast::forecast_gate_allows_sweep(
-            &report,
-            crate::run::forecast::ForecastGate { yes: sweep_cmd.yes },
-        )? {
-            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "forecast-first blocked sweep: {} (pass --yes to proceed anyway)",
-                report.threshold.message
-            ))));
+        match run_forecast_from_cmd(sweep_cmd.clone()).await? {
+            crate::run::forecast::ForecastOutcome::Report(report) => {
+                print_forecast_report(&report, &sweep_cmd.format)?;
+                crate::run::forecast::validate_fail_over_cap(&report, sweep_cmd.fail_over_cap)?;
+                if !crate::run::forecast::forecast_gate_allows_sweep(
+                    &report,
+                    crate::run::forecast::ForecastGate { yes: sweep_cmd.yes },
+                )? {
+                    return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                        "forecast-first blocked sweep: {} (pass --yes to proceed anyway)",
+                        report.threshold.message
+                    ))));
+                }
+            }
+            crate::run::forecast::ForecastOutcome::DryRun(results) => {
+                print_dry_run_summary(&results, &sweep_cmd.format);
+                return Ok(());
+            }
         }
         if sweep_cmd.sample.is_none() {
             sweep_cmd.seed = None;
@@ -221,14 +228,21 @@ async fn bench_doctor(mut s: args::SwebenchCmd) -> Result<(), Error> {
 async fn bench_forecast(s: args::SwebenchCmd) -> Result<(), Error> {
     let output_format = s.format.clone();
     let fail_over_cap = s.fail_over_cap;
-    let report = run_forecast_from_cmd(s).await?;
-    print_forecast_report(&report, &output_format)?;
-    crate::run::forecast::validate_fail_over_cap(&report, fail_over_cap)
+    match run_forecast_from_cmd(s).await? {
+        crate::run::forecast::ForecastOutcome::Report(report) => {
+            print_forecast_report(&report, &output_format)?;
+            crate::run::forecast::validate_fail_over_cap(&report, fail_over_cap)
+        }
+        crate::run::forecast::ForecastOutcome::DryRun(results) => {
+            print_dry_run_summary(&results, &output_format);
+            Ok(())
+        }
+    }
 }
 
 async fn run_forecast_from_cmd(
     mut s: args::SwebenchCmd,
-) -> Result<crate::run::forecast::ForecastReport, Error> {
+) -> Result<crate::run::forecast::ForecastOutcome, Error> {
     let calibration_n = s.calibration_n;
     let seed = s.seed.unwrap_or(42);
     let target_n = s.target_n;
@@ -246,6 +260,12 @@ async fn run_forecast_from_cmd(
         confidence_pct,
     })
     .await
+}
+
+fn print_dry_run_summary(results: &crate::run::swebench::SweepResults, output_format: &str) {
+    if output_format != "json" {
+        print!("{}", results.summary_table());
+    }
 }
 
 fn print_forecast_report(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -227,12 +227,15 @@ async fn bench_forecast(s: args::SwebenchCmd) -> Result<(), Error> {
 }
 
 async fn run_forecast_from_cmd(
-    s: args::SwebenchCmd,
+    mut s: args::SwebenchCmd,
 ) -> Result<crate::run::forecast::ForecastReport, Error> {
     let calibration_n = s.calibration_n;
     let seed = s.seed.unwrap_or(42);
     let target_n = s.target_n;
     let confidence_pct = s.confidence;
+    if s.sample.is_none() {
+        s.seed = None;
+    }
     let cfg = swebench_config_from_cmd(&s)?;
     let sweep = swebench_args_from_cmd(s, cfg, "forecast");
     crate::run::forecast::run(crate::run::forecast::ForecastArgs {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -51,6 +51,9 @@ pub async fn run() -> Result<(), Error> {
             cmd: args::BenchCmd::Swebench(s),
         } => bench_swebench(s).await,
         Command::Bench {
+            cmd: args::BenchCmd::Forecast(s),
+        } => bench_forecast(s).await,
+        Command::Bench {
             cmd: args::BenchCmd::Doctor(s),
         } => bench_doctor(s).await,
         Command::Bench {
@@ -72,7 +75,10 @@ pub async fn run() -> Result<(), Error> {
 fn init_logging(level: &str) {
     let filter = tracing_subscriber::EnvFilter::try_new(level)
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
-    let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .try_init();
 }
 
 async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
@@ -155,14 +161,139 @@ async fn replay_cmd(r: args::ReplayCmd) -> Result<(), Error> {
 }
 
 async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
+    let mut sweep_cmd = s;
+    if sweep_cmd.forecast_first {
+        let report = run_forecast_from_cmd(sweep_cmd.clone()).await?;
+        print_forecast_report(&report, &sweep_cmd.format)?;
+        crate::run::forecast::validate_fail_over_cap(&report, sweep_cmd.fail_over_cap)?;
+        if !crate::run::forecast::forecast_gate_allows_sweep(
+            &report,
+            crate::run::forecast::ForecastGate { yes: sweep_cmd.yes },
+        )? {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "forecast-first blocked sweep: {} (pass --yes to proceed anyway)",
+                report.threshold.message
+            ))));
+        }
+        if sweep_cmd.sample.is_none() {
+            sweep_cmd.seed = None;
+        }
+    }
+
+    let cfg = swebench_config_from_cmd(&sweep_cmd)?;
+    let preflight_mode = if sweep_cmd.dry_run {
+        "dry_run"
+    } else {
+        "sweep"
+    };
+    let results =
+        crate::run::swebench::run(swebench_args_from_cmd(sweep_cmd, cfg, preflight_mode)).await?;
+
+    tracing::info!(
+        total = results.total,
+        submitted = results.submitted,
+        skipped = results.skipped,
+        errored = results.errored,
+        budget_halted = results.budget_halted,
+        retries = results.retries,
+        retried_instances = results.retried_instances,
+        prompt_tokens = results.total_prompt_tokens,
+        completion_tokens = results.total_completion_tokens,
+        estimated_cost_usd = results.estimated_cost_usd,
+        cost_limit_usd = ?results.cost_limit_usd,
+        "sweep complete"
+    );
+    print!("{}", results.summary_table());
+    Ok(())
+}
+
+async fn bench_doctor(mut s: args::SwebenchCmd) -> Result<(), Error> {
+    s.dry_run = true;
+    let output_format = s.format.clone();
+    let cfg = swebench_config_from_cmd(&s)?;
+    let results = crate::run::swebench::run(swebench_args_from_cmd(s, cfg, "doctor")).await?;
+    if output_format != "json" {
+        print!("{}", results.summary_table());
+    }
+    Ok(())
+}
+
+async fn bench_forecast(s: args::SwebenchCmd) -> Result<(), Error> {
+    let output_format = s.format.clone();
+    let fail_over_cap = s.fail_over_cap;
+    let report = run_forecast_from_cmd(s).await?;
+    print_forecast_report(&report, &output_format)?;
+    crate::run::forecast::validate_fail_over_cap(&report, fail_over_cap)
+}
+
+async fn run_forecast_from_cmd(
+    s: args::SwebenchCmd,
+) -> Result<crate::run::forecast::ForecastReport, Error> {
+    let calibration_n = s.calibration_n;
+    let seed = s.seed.unwrap_or(42);
+    let target_n = s.target_n;
+    let confidence_pct = s.confidence;
+    let cfg = swebench_config_from_cmd(&s)?;
+    let sweep = swebench_args_from_cmd(s, cfg, "forecast");
+    crate::run::forecast::run(crate::run::forecast::ForecastArgs {
+        sweep,
+        calibration_n,
+        seed,
+        target_n,
+        confidence_pct,
+    })
+    .await
+}
+
+fn print_forecast_report(
+    report: &crate::run::forecast::ForecastReport,
+    output_format: &str,
+) -> Result<(), Error> {
+    match output_format {
+        "text" => {
+            print!("{}", crate::run::forecast::render_text(report));
+            Ok(())
+        }
+        "json" => {
+            println!("{}", crate::run::forecast::to_json(report)?);
+            Ok(())
+        }
+        other => Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "unknown --format `{other}` (expected `text` or `json`)"
+        )))),
+    }
+}
+
+fn swebench_config_from_cmd(s: &args::SwebenchCmd) -> Result<Config, Error> {
     let mut cfg = match &s.config {
         Some(p) => Config::load(p)?,
         None => Config::defaults()?,
     };
     cfg.root.model.name.clone_from(&s.model);
     cfg.root.agent.step_limit = s.step_limit;
+    if let Some(kind) = &s.env {
+        cfg.root.environment.kind = match kind.as_str() {
+            "local" => crate::config::EnvKind::Local,
+            "docker" => crate::config::EnvKind::Docker,
+            other => {
+                return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "unknown --env `{other}` (expected `local` or `docker`)"
+                ))));
+            }
+        };
+    }
+    if let Some(img) = s.docker_image.clone() {
+        cfg.root.environment.docker_image = Some(img);
+    }
+    Ok(cfg)
+}
 
-    let results = crate::run::swebench::run(crate::run::swebench::SwebenchArgs {
+fn swebench_args_from_cmd(
+    s: args::SwebenchCmd,
+    cfg: Config,
+    preflight_mode: &str,
+) -> crate::run::swebench::SwebenchArgs {
+    crate::run::swebench::SwebenchArgs {
         dataset_path: s.dataset_path,
         output_dir: s.output,
         parallel: s.parallel,
@@ -187,69 +318,8 @@ async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
         skip_model_probe: s.skip_model_probe,
         preflight_check_timeout_s: s.preflight_check_timeout_s,
         preflight_total_timeout_s: s.preflight_total_timeout_s,
-        preflight_mode: if s.dry_run { "dry_run" } else { "sweep" }.into(),
-    })
-    .await?;
-
-    tracing::info!(
-        total = results.total,
-        submitted = results.submitted,
-        skipped = results.skipped,
-        errored = results.errored,
-        budget_halted = results.budget_halted,
-        retries = results.retries,
-        retried_instances = results.retried_instances,
-        prompt_tokens = results.total_prompt_tokens,
-        completion_tokens = results.total_completion_tokens,
-        estimated_cost_usd = results.estimated_cost_usd,
-        cost_limit_usd = ?results.cost_limit_usd,
-        "sweep complete"
-    );
-    print!("{}", results.summary_table());
-    Ok(())
-}
-
-async fn bench_doctor(mut s: args::SwebenchCmd) -> Result<(), Error> {
-    s.dry_run = true;
-    let output_format = s.format.clone();
-    let mut cfg = match &s.config {
-        Some(p) => Config::load(p)?,
-        None => Config::defaults()?,
-    };
-    cfg.root.model.name.clone_from(&s.model);
-    cfg.root.agent.step_limit = s.step_limit;
-    let results = crate::run::swebench::run(crate::run::swebench::SwebenchArgs {
-        dataset_path: s.dataset_path,
-        output_dir: s.output,
-        parallel: s.parallel,
-        config: cfg,
-        resume: s.resume,
-        cost_limit_usd: s.sweep_cost_limit_usd,
-        instance_ids: s.instance_ids,
-        limit: s.limit,
-        sample: s.sample,
-        seed: s.seed,
-        max_retries: s.max_retries,
-        retry_on: s.retry_on,
-        retry_backoff_base_ms: s.retry_backoff_base_ms,
-        retry_backoff_cap_s: s.retry_backoff_cap_s,
-        retry_on_resume: s.retry_on_resume,
-        deterministic_responses: None,
-        deterministic_usage_per_call: None,
-        config_overlay_paths: s.config.into_iter().collect(),
-        dry_run: true,
-        skip_preflight: s.skip_preflight,
-        preflight_format: s.format,
-        skip_model_probe: s.skip_model_probe,
-        preflight_check_timeout_s: s.preflight_check_timeout_s,
-        preflight_total_timeout_s: s.preflight_total_timeout_s,
-        preflight_mode: "doctor".into(),
-    })
-    .await?;
-    if output_format != "json" {
-        print!("{}", results.summary_table());
+        preflight_mode: preflight_mode.into(),
     }
-    Ok(())
 }
 
 fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -1173,6 +1173,7 @@ mod tests {
         assert!(report.manifest_deltas.is_empty());
         // sanity: direct helper detects prompt hash-only changes
         let baseline = ProvenanceManifest {
+            purpose: None,
             harness: crate::run::swebench::HarnessManifest {
                 name: "x".into(),
                 version: "1".into(),
@@ -1424,6 +1425,7 @@ mod tests {
             retried_instances: 0,
             filter_spec: crate::run::swebench::FilterSpec::default(),
             manifest: Some(ProvenanceManifest {
+                purpose: None,
                 harness: crate::run::swebench::HarnessManifest {
                     name: "h".into(),
                     version: "v".into(),
@@ -1553,6 +1555,7 @@ mod tests {
             retried_instances: 0,
             filter_spec: crate::run::swebench::FilterSpec::default(),
             manifest: Some(ProvenanceManifest {
+                purpose: None,
                 harness: crate::run::swebench::HarnessManifest {
                     name: "h".into(),
                     version: "v".into(),
@@ -1636,6 +1639,7 @@ mod tests {
             retried_instances: 0,
             filter_spec: crate::run::swebench::FilterSpec::default(),
             manifest: Some(ProvenanceManifest {
+                purpose: None,
                 harness: crate::run::swebench::HarnessManifest {
                     name: "h".into(),
                     version: "v".into(),

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
-use crate::run::compare::load_run;
+use crate::run::compare::load_sweep;
 use crate::run::swebench::{self, InstanceResult};
 use crate::trajectory::{FailureCategory, outcome};
 
@@ -102,7 +102,13 @@ pub fn evaluation_path(sweep_dir: &Path) -> PathBuf {
 }
 
 pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
-    let results = load_run(&args.sweep_dir)?;
+    let loaded = load_sweep(&args.sweep_dir)?;
+    if loaded.manifest.as_ref().and_then(|m| m.purpose.as_deref()) == Some("forecast") {
+        return Err(Error::Trajectory(
+            "bench evaluate: refusing to evaluate forecast calibration output".into(),
+        ));
+    }
+    let results = loaded.instances;
     let mut eval = match args.backend {
         EvaluateBackend::None => build_none_eval(&results),
         EvaluateBackend::SbCli => run_sb_cli(args, &results)?,

--- a/src/run/forecast.rs
+++ b/src/run/forecast.rs
@@ -1,0 +1,658 @@
+//! `bench forecast`: run a small calibration sweep and extrapolate cost.
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{ConfigError, Error};
+use crate::run::swebench::{self, InstanceResult, SweepResults};
+use crate::trajectory::{Trajectory, outcome};
+
+/// Inputs for a forecast run.
+pub struct ForecastArgs {
+    /// Base sweep arguments. Forecast overrides output, sample, seed, and
+    /// calibration cost-limit handling before delegating to the sweep runner.
+    pub sweep: swebench::SwebenchArgs,
+    /// Number of instances to run in the calibration slice.
+    pub calibration_n: usize,
+    /// Deterministic sampler seed for calibration selection.
+    pub seed: u64,
+    /// Optional extrapolation target. Defaults to full post-filter dataset.
+    pub target_n: Option<usize>,
+    /// Confidence level percentage for interval estimates.
+    pub confidence_pct: f64,
+}
+
+/// Stable, serializable forecast report emitted by `bench forecast`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForecastReport {
+    /// What calibration slice was measured.
+    pub calibration: CalibrationSummary,
+    /// Per-instance p10/median/p90 summaries for observed calibration data.
+    pub per_instance: PerInstanceSummary,
+    /// Extrapolated totals for the requested target size.
+    pub forecast: ForecastTotals,
+    /// Directional submit/resolution-rate signal from the calibration slice.
+    pub resolution_rate: ResolutionRateSignal,
+    /// Optional sweep-cost cap interpretation.
+    pub threshold: ThresholdCheck,
+}
+
+/// Metadata about the calibration slice used for the forecast.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CalibrationSummary {
+    /// Number of calibration instances actually measured.
+    pub n: usize,
+    /// Seed used to select the calibration slice.
+    pub seed: u64,
+    /// Directory where calibration sweep artifacts were written.
+    pub output_dir: String,
+    /// Calibration instance ids in result order.
+    pub instance_ids: Vec<String>,
+}
+
+/// Per-instance observed distributions from the calibration slice.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerInstanceSummary {
+    /// Input/prompt token distribution.
+    pub input_tokens: QuantileSummary,
+    /// Output/completion token distribution.
+    pub output_tokens: QuantileSummary,
+    /// Recorded or estimated USD cost distribution.
+    pub usd_cost: QuantileSummary,
+    /// Agent step count distribution.
+    pub step_count: QuantileSummary,
+    /// Per-instance wall-clock runtime distribution in seconds.
+    pub wall_clock_seconds: QuantileSummary,
+}
+
+/// Three quantiles used for compact terminal and JSON summaries.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct QuantileSummary {
+    /// 10th percentile.
+    pub p10: f64,
+    /// 50th percentile.
+    pub median: f64,
+    /// 90th percentile.
+    pub p90: f64,
+}
+
+/// Extrapolated aggregate estimates for a target sweep size.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForecastTotals {
+    /// Number of instances being forecast.
+    pub target_n: usize,
+    /// Parallel worker count used for wall-clock extrapolation.
+    pub parallel: usize,
+    /// Confidence level percentage used for intervals.
+    pub confidence_pct: f64,
+    /// Total USD cost estimate.
+    pub total_cost_usd: IntervalEstimate,
+    /// Total input token estimate.
+    pub total_input_tokens: IntervalEstimate,
+    /// Total output token estimate.
+    pub total_output_tokens: IntervalEstimate,
+    /// Total elapsed wall-clock estimate at the requested parallelism.
+    pub wall_clock_seconds: IntervalEstimate,
+}
+
+/// Point estimate with a lower/upper confidence interval.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct IntervalEstimate {
+    /// Mean-based point estimate.
+    pub point: f64,
+    /// Lower interval bound.
+    pub lower: f64,
+    /// Upper interval bound.
+    pub upper: f64,
+}
+
+impl IntervalEstimate {
+    /// Interval width (`upper - lower`).
+    pub fn width(self) -> f64 {
+        self.upper - self.lower
+    }
+}
+
+/// Directional submit/resolution-rate estimate from calibration outcomes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolutionRateSignal {
+    /// Number of calibration instances that submitted.
+    pub resolved: usize,
+    /// Number of calibration instances measured.
+    pub total: usize,
+    /// `resolved / total` as a fraction.
+    pub point: f64,
+    /// Human-facing small-n caveat.
+    pub disclaimer: String,
+}
+
+/// Interpretation of a forecast against an optional sweep cost cap.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThresholdCheck {
+    /// Configured sweep cap, when present.
+    pub limit_usd: Option<f64>,
+    /// Machine-readable threshold result.
+    pub status: ThresholdStatus,
+    /// Human-readable threshold explanation.
+    pub message: String,
+}
+
+/// Cost-cap status for the forecast interval.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThresholdStatus {
+    /// No cap was configured.
+    NotConfigured,
+    /// The interval upper bound is below or equal to the cap.
+    Under,
+    /// The interval lower bound is above the cap.
+    Exceeds,
+    /// The interval crosses the cap.
+    TooTight,
+}
+
+/// Operator override controls for `bench swebench --forecast-first`.
+#[derive(Debug, Clone, Copy)]
+pub struct ForecastGate {
+    /// Allow the real sweep even if the forecast does not clearly pass.
+    pub yes: bool,
+}
+
+/// Run a forecast calibration through the normal sweep runner, isolated under
+/// `<output>/forecast`, then extrapolate from the recorded calibration usage.
+pub async fn run(args: ForecastArgs) -> Result<ForecastReport, Error> {
+    validate_args(args.calibration_n, args.confidence_pct)?;
+    let original_output = args.sweep.output_dir.clone();
+    let calibration_dir = original_output.join("forecast");
+    let target_n = match args.target_n {
+        Some(n) => {
+            validate_positive("target-n", n)?;
+            n
+        }
+        None => target_count(&args.sweep)?,
+    };
+    let limit = args.sweep.cost_limit_usd;
+    let parallel = args.sweep.parallel.max(1);
+
+    let mut sweep = args.sweep;
+    sweep.output_dir = calibration_dir.clone();
+    sweep.resume = false;
+    sweep.sample = Some(args.calibration_n);
+    sweep.seed = Some(args.seed);
+    sweep.cost_limit_usd = None;
+    sweep.preflight_format = "silent".into();
+    sweep.preflight_mode = "forecast".into();
+
+    let mut results = swebench::run(sweep).await?;
+    results
+        .instances
+        .sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
+    mark_forecast_manifest(&mut results, &calibration_dir)?;
+    let mut report = forecast_from_results(
+        &results,
+        args.seed,
+        target_n,
+        parallel,
+        args.confidence_pct,
+        limit,
+    )?;
+    report.calibration.output_dir = calibration_dir.display().to_string();
+    Ok(report)
+}
+
+/// Build a forecast report from an already-completed calibration sweep.
+pub fn forecast_from_results(
+    results: &SweepResults,
+    seed: u64,
+    target_n: usize,
+    parallel: usize,
+    confidence_pct: f64,
+    cost_limit_usd: Option<f64>,
+) -> Result<ForecastReport, Error> {
+    validate_args(results.instances.len().max(1), confidence_pct)?;
+    validate_positive("target-n", target_n)?;
+    validate_positive("parallel", parallel)?;
+    let mut instances = results.instances.clone();
+    instances.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
+    if instances.is_empty() {
+        return Err(Error::Config(ConfigError::Invalid(
+            "forecast calibration produced zero instances".into(),
+        )));
+    }
+
+    let input_tokens = values(&instances, |r| r.prompt_tokens.map_or(0.0, as_f64_u64));
+    let output_tokens = values(&instances, |r| r.completion_tokens.map_or(0.0, as_f64_u64));
+    let usd_cost = values(&instances, instance_cost_usd);
+    let step_count = values(&instances, |r| r.steps.map_or(0.0, f64::from));
+    let wall_clock_seconds = values(&instances, |r| r.duration_secs.unwrap_or(0.0));
+    let resolved = instances
+        .iter()
+        .filter(|r| r.outcome.as_deref() == Some(outcome::SUBMITTED))
+        .count();
+
+    Ok(ForecastReport {
+        calibration: CalibrationSummary {
+            n: instances.len(),
+            seed,
+            output_dir: String::new(),
+            instance_ids: instances.iter().map(|r| r.instance_id.clone()).collect(),
+        },
+        per_instance: PerInstanceSummary {
+            input_tokens: quantiles(&input_tokens),
+            output_tokens: quantiles(&output_tokens),
+            usd_cost: quantiles(&usd_cost),
+            step_count: quantiles(&step_count),
+            wall_clock_seconds: quantiles(&wall_clock_seconds),
+        },
+        forecast: ForecastTotals {
+            target_n,
+            parallel,
+            confidence_pct,
+            total_cost_usd: total_interval(&usd_cost, target_n, 1.0, confidence_pct),
+            total_input_tokens: total_interval(&input_tokens, target_n, 1.0, confidence_pct),
+            total_output_tokens: total_interval(&output_tokens, target_n, 1.0, confidence_pct),
+            wall_clock_seconds: total_interval(
+                &wall_clock_seconds,
+                target_n,
+                1.0 / as_f64_usize(parallel),
+                confidence_pct,
+            ),
+        },
+        resolution_rate: ResolutionRateSignal {
+            resolved,
+            total: instances.len(),
+            point: as_f64_usize(resolved) / as_f64_usize(instances.len()),
+            disclaimer: format!("n={}, treat as directional only", instances.len()),
+        },
+        threshold: threshold_check(
+            cost_limit_usd,
+            total_interval(&usd_cost, target_n, 1.0, confidence_pct),
+        ),
+    })
+}
+
+/// Enforce `--fail-over-cap` for a completed forecast report.
+pub fn validate_fail_over_cap(report: &ForecastReport, fail_over_cap: bool) -> Result<(), Error> {
+    if fail_over_cap && report.threshold.status == ThresholdStatus::Exceeds {
+        return Err(Error::Config(ConfigError::Invalid(format!(
+            "forecast projects sweep cost will exceed cap: {}",
+            report.threshold.message
+        ))));
+    }
+    Ok(())
+}
+
+/// Decide whether `--forecast-first` should launch the real sweep.
+pub fn forecast_gate_allows_sweep(
+    report: &ForecastReport,
+    gate: ForecastGate,
+) -> Result<bool, Error> {
+    if gate.yes {
+        return Ok(true);
+    }
+    Ok(report.threshold.status == ThresholdStatus::Under)
+}
+
+/// Serialize a forecast report as stable pretty JSON.
+pub fn to_json(report: &ForecastReport) -> Result<String, Error> {
+    serde_json::to_string_pretty(report).map_err(Error::from)
+}
+
+/// Render a terminal-friendly forecast report.
+pub fn render_text(report: &ForecastReport) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "\n=== SWE-bench forecast ===");
+    let _ = writeln!(
+        out,
+        "Calibration:       n={} seed={}",
+        report.calibration.n, report.calibration.seed
+    );
+    let _ = writeln!(
+        out,
+        "Target:            {} instance(s) at parallel {}",
+        report.forecast.target_n, report.forecast.parallel
+    );
+    let _ = writeln!(
+        out,
+        "Confidence:        {:.1}%",
+        report.forecast.confidence_pct
+    );
+    out.push_str("Per-instance p10 / median / p90:\n");
+    write_quantile_line(&mut out, "Input tokens", report.per_instance.input_tokens);
+    write_quantile_line(&mut out, "Output tokens", report.per_instance.output_tokens);
+    write_quantile_line(&mut out, "USD cost", report.per_instance.usd_cost);
+    write_quantile_line(&mut out, "Steps", report.per_instance.step_count);
+    write_quantile_line(
+        &mut out,
+        "Wall-clock sec",
+        report.per_instance.wall_clock_seconds,
+    );
+    out.push_str("Forecast totals:\n");
+    write_interval_line(
+        &mut out,
+        "Total USD",
+        report.forecast.total_cost_usd,
+        report.forecast.confidence_pct,
+        "$",
+    );
+    write_interval_line(
+        &mut out,
+        "Input tokens",
+        report.forecast.total_input_tokens,
+        report.forecast.confidence_pct,
+        "",
+    );
+    write_interval_line(
+        &mut out,
+        "Output tokens",
+        report.forecast.total_output_tokens,
+        report.forecast.confidence_pct,
+        "",
+    );
+    write_interval_line(
+        &mut out,
+        "Wall-clock sec",
+        report.forecast.wall_clock_seconds,
+        report.forecast.confidence_pct,
+        "",
+    );
+    let _ = writeln!(
+        out,
+        "Resolution signal: {:.2}% ({}/{}) - {}",
+        report.resolution_rate.point * 100.0,
+        report.resolution_rate.resolved,
+        report.resolution_rate.total,
+        report.resolution_rate.disclaimer
+    );
+    let _ = writeln!(out, "Threshold:         {}", report.threshold.message);
+    out
+}
+
+fn target_count(args: &swebench::SwebenchArgs) -> Result<usize, Error> {
+    let instances = swebench::load_dataset(&args.dataset_path)?;
+    let (filtered, _) = swebench::apply_subset(
+        instances,
+        args.instance_ids.as_deref(),
+        args.limit,
+        None,
+        None,
+    )?;
+    Ok(filtered.len())
+}
+
+fn mark_forecast_manifest(results: &mut SweepResults, calibration_dir: &Path) -> Result<(), Error> {
+    if let Some(manifest) = &mut results.manifest {
+        manifest.purpose = Some("forecast".into());
+    }
+    mark_trajectory_purpose(results, calibration_dir)?;
+    let path = calibration_dir.join("results.json");
+    std::fs::write(path, serde_json::to_string_pretty(results)?)?;
+    Ok(())
+}
+
+fn mark_trajectory_purpose(results: &SweepResults, calibration_dir: &Path) -> Result<(), Error> {
+    for result in &results.instances {
+        let path = swebench::trajectory_path_for(calibration_dir, &result.instance_id);
+        if !path.exists() {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path)?;
+        let mut trajectory: Trajectory = serde_json::from_str(&text)?;
+        trajectory.info.other.insert(
+            "purpose".into(),
+            serde_json::Value::String("forecast".into()),
+        );
+        trajectory.save_pretty(&path)?;
+    }
+    Ok(())
+}
+
+fn validate_args(calibration_n: usize, confidence_pct: f64) -> Result<(), Error> {
+    validate_positive("calibration-n", calibration_n)?;
+    if !(0.0..100.0).contains(&confidence_pct) {
+        return Err(Error::Config(ConfigError::Invalid(
+            "--confidence must be greater than 0 and less than 100".into(),
+        )));
+    }
+    Ok(())
+}
+
+fn validate_positive(name: &str, n: usize) -> Result<(), Error> {
+    if n == 0 {
+        return Err(Error::Config(ConfigError::Invalid(format!(
+            "--{name} must be greater than 0"
+        ))));
+    }
+    Ok(())
+}
+
+fn values(instances: &[InstanceResult], f: impl Fn(&InstanceResult) -> f64) -> Vec<f64> {
+    instances.iter().map(f).collect()
+}
+
+fn instance_cost_usd(r: &InstanceResult) -> f64 {
+    r.cost_usd.unwrap_or_else(|| {
+        swebench::estimate_cost_usd(
+            r.prompt_tokens.unwrap_or(0),
+            r.completion_tokens.unwrap_or(0),
+        )
+    })
+}
+
+fn quantiles(values: &[f64]) -> QuantileSummary {
+    QuantileSummary {
+        p10: quantile(values, 0.10),
+        median: quantile(values, 0.50),
+        p90: quantile(values, 0.90),
+    }
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn quantile(values: &[f64], q: f64) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    if sorted.len() == 1 {
+        return sorted[0];
+    }
+    let span = as_f64_usize(sorted.len() - 1);
+    let pos = q.clamp(0.0, 1.0) * span;
+    let lo = pos.floor() as usize;
+    let hi = pos.ceil() as usize;
+    if lo == hi {
+        sorted[lo]
+    } else {
+        let weight = pos - as_f64_usize(lo);
+        sorted[lo].mul_add(1.0 - weight, sorted[hi] * weight)
+    }
+}
+
+fn total_interval(
+    values: &[f64],
+    target_n: usize,
+    scale: f64,
+    confidence_pct: f64,
+) -> IntervalEstimate {
+    let target = as_f64_usize(target_n);
+    let mean = mean(values);
+    let point = mean * target * scale;
+    if values.len() < 2 {
+        return IntervalEstimate {
+            point,
+            lower: point,
+            upper: point,
+        };
+    }
+
+    let mut bootstrap = bootstrap_totals(values, target, scale);
+    bootstrap.sort_by(f64::total_cmp);
+    let alpha = (1.0 - confidence_pct / 100.0) / 2.0;
+    let lower = quantile_sorted(&bootstrap, alpha).max(0.0);
+    let upper = quantile_sorted(&bootstrap, 1.0 - alpha).max(lower);
+    IntervalEstimate {
+        point,
+        lower,
+        upper,
+    }
+}
+
+fn bootstrap_totals(values: &[f64], target: f64, scale: f64) -> Vec<f64> {
+    let mut rng = ForecastRng::new(0x05EE_DF0E_CA57_u64);
+    let mut estimates = Vec::with_capacity(2000);
+    for _ in 0..2000 {
+        let mut sum = 0.0;
+        for _ in values {
+            let idx = rng.next_usize() % values.len();
+            sum += values[idx];
+        }
+        estimates.push((sum / as_f64_usize(values.len())) * target * scale);
+    }
+    estimates
+}
+
+fn quantile_sorted(sorted: &[f64], q: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    if sorted.len() == 1 {
+        return sorted[0];
+    }
+    let span = as_f64_usize(sorted.len() - 1);
+    let pos = q.clamp(0.0, 1.0) * span;
+    let lo = floor_to_usize(pos);
+    let hi = ceil_to_usize(pos);
+    if lo == hi {
+        sorted[lo]
+    } else {
+        let weight = pos - as_f64_usize(lo);
+        sorted[lo].mul_add(1.0 - weight, sorted[hi] * weight)
+    }
+}
+
+fn mean(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        0.0
+    } else {
+        values.iter().sum::<f64>() / as_f64_usize(values.len())
+    }
+}
+
+fn threshold_check(limit_usd: Option<f64>, cost: IntervalEstimate) -> ThresholdCheck {
+    let Some(limit) = limit_usd else {
+        return ThresholdCheck {
+            limit_usd: None,
+            status: ThresholdStatus::NotConfigured,
+            message: "no sweep cost limit configured".into(),
+        };
+    };
+    if cost.upper <= limit {
+        ThresholdCheck {
+            limit_usd: Some(limit),
+            status: ThresholdStatus::Under,
+            message: format!(
+                "projects under cap: upper ${:.4} <= limit ${limit:.4}",
+                cost.upper
+            ),
+        }
+    } else if cost.lower > limit {
+        ThresholdCheck {
+            limit_usd: Some(limit),
+            status: ThresholdStatus::Exceeds,
+            message: format!(
+                "projects over cap: lower ${:.4} > limit ${limit:.4}",
+                cost.lower
+            ),
+        }
+    } else {
+        ThresholdCheck {
+            limit_usd: Some(limit),
+            status: ThresholdStatus::TooTight,
+            message: format!(
+                "too tight to call: interval ${:.4}-${:.4} crosses limit ${limit:.4}",
+                cost.lower, cost.upper
+            ),
+        }
+    }
+}
+
+fn write_quantile_line(out: &mut String, label: &str, q: QuantileSummary) {
+    let _ = writeln!(
+        out,
+        "  {label:<15} {:>10.4} / {:>10.4} / {:>10.4}",
+        q.p10, q.median, q.p90
+    );
+}
+
+fn write_interval_line(
+    out: &mut String,
+    label: &str,
+    interval: IntervalEstimate,
+    confidence_pct: f64,
+    prefix: &str,
+) {
+    let _ = writeln!(
+        out,
+        "  {label:<15} {prefix}{:.4} ({:.1}% CI {prefix}{:.4}-{prefix}{:.4})",
+        interval.point, confidence_pct, interval.lower, interval.upper
+    );
+}
+
+fn as_f64_u64(value: u64) -> f64 {
+    #[allow(clippy::cast_precision_loss)]
+    {
+        value as f64
+    }
+}
+
+fn as_f64_usize(value: usize) -> f64 {
+    #[allow(clippy::cast_precision_loss)]
+    {
+        value as f64
+    }
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn floor_to_usize(value: f64) -> usize {
+    value.floor() as usize
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn ceil_to_usize(value: f64) -> usize {
+    value.ceil() as usize
+}
+
+#[derive(Clone, Copy)]
+struct ForecastRng {
+    state: u64,
+}
+
+impl ForecastRng {
+    fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.state = x;
+        x
+    }
+
+    fn next_usize(&mut self) -> usize {
+        #[cfg(target_pointer_width = "64")]
+        {
+            usize::from_le_bytes(self.next_u64().to_le_bytes())
+        }
+        #[cfg(target_pointer_width = "32")]
+        {
+            let bytes = self.next_u64().to_le_bytes();
+            usize::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+        }
+    }
+}

--- a/src/run/forecast.rs
+++ b/src/run/forecast.rs
@@ -24,6 +24,15 @@ pub struct ForecastArgs {
     pub confidence_pct: f64,
 }
 
+/// Result of running forecast setup.
+#[derive(Debug, Clone)]
+pub enum ForecastOutcome {
+    /// A measured calibration sweep produced a forecast report.
+    Report(Box<ForecastReport>),
+    /// Dry-run stopped after preflight without writing forecast artifacts.
+    DryRun(Box<SweepResults>),
+}
+
 /// Stable, serializable forecast report emitted by `bench forecast`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ForecastReport {
@@ -162,8 +171,9 @@ pub struct ForecastGate {
 
 /// Run a forecast calibration through the normal sweep runner, isolated under
 /// `<output>/forecast`, then extrapolate from the recorded calibration usage.
-pub async fn run(args: ForecastArgs) -> Result<ForecastReport, Error> {
+pub async fn run(args: ForecastArgs) -> Result<ForecastOutcome, Error> {
     validate_args(args.calibration_n, args.confidence_pct)?;
+    let dry_run = args.sweep.dry_run;
     let original_output = args.sweep.output_dir.clone();
     let calibration_dir = original_output.join("forecast");
     let target_n = match args.target_n {
@@ -186,10 +196,15 @@ pub async fn run(args: ForecastArgs) -> Result<ForecastReport, Error> {
     sweep.sample = None;
     sweep.seed = None;
     sweep.cost_limit_usd = None;
-    sweep.preflight_format = "silent".into();
+    if !dry_run {
+        sweep.preflight_format = "silent".into();
+    }
     sweep.preflight_mode = "forecast".into();
 
     let mut results = swebench::run(sweep).await?;
+    if dry_run {
+        return Ok(ForecastOutcome::DryRun(Box::new(results)));
+    }
     results
         .instances
         .sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
@@ -203,7 +218,7 @@ pub async fn run(args: ForecastArgs) -> Result<ForecastReport, Error> {
         limit,
     )?;
     report.calibration.output_dir = calibration_dir.display().to_string();
-    Ok(report)
+    Ok(ForecastOutcome::Report(Box::new(report)))
 }
 
 /// Build a forecast report from an already-completed calibration sweep.

--- a/src/run/forecast.rs
+++ b/src/run/forecast.rs
@@ -376,8 +376,8 @@ fn target_count(args: &swebench::SwebenchArgs) -> Result<usize, Error> {
         instances,
         args.instance_ids.as_deref(),
         args.limit,
-        None,
-        None,
+        args.sample,
+        args.seed,
     )?;
     Ok(filtered.len())
 }

--- a/src/run/forecast.rs
+++ b/src/run/forecast.rs
@@ -11,7 +11,7 @@ use crate::trajectory::{Trajectory, outcome};
 
 /// Inputs for a forecast run.
 pub struct ForecastArgs {
-    /// Base sweep arguments. Forecast overrides output, sample, seed, and
+    /// Base sweep arguments. Forecast overrides output, subset selection, and
     /// calibration cost-limit handling before delegating to the sweep runner.
     pub sweep: swebench::SwebenchArgs,
     /// Number of instances to run in the calibration slice.
@@ -175,12 +175,16 @@ pub async fn run(args: ForecastArgs) -> Result<ForecastReport, Error> {
     };
     let limit = args.sweep.cost_limit_usd;
     let parallel = args.sweep.parallel.max(1);
+    let calibration_instance_ids =
+        calibration_instance_ids(&args.sweep, args.calibration_n, args.seed)?;
 
     let mut sweep = args.sweep;
     sweep.output_dir = calibration_dir.clone();
     sweep.resume = false;
-    sweep.sample = Some(args.calibration_n);
-    sweep.seed = Some(args.seed);
+    sweep.instance_ids = Some(calibration_instance_ids.join(","));
+    sweep.limit = None;
+    sweep.sample = None;
+    sweep.seed = None;
     sweep.cost_limit_usd = None;
     sweep.preflight_format = "silent".into();
     sweep.preflight_mode = "forecast".into();
@@ -371,6 +375,26 @@ pub fn render_text(report: &ForecastReport) -> String {
 }
 
 fn target_count(args: &swebench::SwebenchArgs) -> Result<usize, Error> {
+    Ok(planned_instances(args)?.len())
+}
+
+fn calibration_instance_ids(
+    args: &swebench::SwebenchArgs,
+    calibration_n: usize,
+    seed: u64,
+) -> Result<Vec<String>, Error> {
+    let planned = planned_instances(args)?;
+    let (calibration, _) =
+        swebench::apply_subset(planned, None, None, Some(calibration_n), Some(seed))?;
+    Ok(calibration
+        .into_iter()
+        .map(|inst| inst.instance_id)
+        .collect())
+}
+
+fn planned_instances(
+    args: &swebench::SwebenchArgs,
+) -> Result<Vec<swebench::SweBenchInstance>, Error> {
     let instances = swebench::load_dataset(&args.dataset_path)?;
     let (filtered, _) = swebench::apply_subset(
         instances,
@@ -379,7 +403,7 @@ fn target_count(args: &swebench::SwebenchArgs) -> Result<usize, Error> {
         args.sample,
         args.seed,
     )?;
-    Ok(filtered.len())
+    Ok(filtered)
 }
 
 fn mark_forecast_manifest(results: &mut SweepResults, calibration_dir: &Path) -> Result<(), Error> {

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod compare;
 pub mod evaluate;
+pub mod forecast;
 pub mod hello_world;
 pub mod inspect;
 pub mod mini;

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -168,6 +168,8 @@ pub struct FilterSpec {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProvenanceManifest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<String>,
     pub harness: HarnessManifest,
     pub dataset: DatasetManifest,
     pub prompt_template: PromptTemplateManifest,
@@ -886,13 +888,13 @@ async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
     ensure_total_deadline(deadline)?;
     match args.config.root.environment.kind {
         crate::config::EnvKind::Local => {
-            for bin in ["bash", "git", "patch"] {
+            for bin in local_preflight_tools() {
                 ensure_total_deadline(deadline)?;
                 let ok = timed_sync(
                     "env.local_tools",
                     args.preflight_check_timeout_s,
                     deadline,
-                    move || Command::new("which").arg(bin).output(),
+                    move || local_tool_probe(bin).output(),
                 )
                 .await?
                 .status
@@ -1017,8 +1019,35 @@ fn render_preflight_report(
 }
 
 fn print_preflight_report(checks: &[CheckResult], format: &str, mode: &str) -> Result<(), Error> {
+    if format == "silent" {
+        return Ok(());
+    }
     print!("{}", render_preflight_report(checks, format, mode)?);
     Ok(())
+}
+
+#[cfg(windows)]
+fn local_preflight_tools() -> &'static [&'static str] {
+    &["cmd.exe", "git"]
+}
+
+#[cfg(not(windows))]
+fn local_preflight_tools() -> &'static [&'static str] {
+    &["bash", "git", "patch"]
+}
+
+#[cfg(windows)]
+fn local_tool_probe(bin: &str) -> Command {
+    let mut cmd = Command::new("where.exe");
+    cmd.arg(bin);
+    cmd
+}
+
+#[cfg(not(windows))]
+fn local_tool_probe(bin: &str) -> Command {
+    let mut cmd = Command::new("which");
+    cmd.arg(bin);
+    cmd
 }
 
 async fn timed_sync<T, E, F>(
@@ -1069,6 +1098,7 @@ fn build_manifest(
     redact_json_secrets(&mut config_raw);
     let resolved = serde_yaml::to_string(&config_raw).unwrap_or_else(|_| "--- {}\n".to_owned());
     ProvenanceManifest {
+        purpose: None,
         harness: resolve_harness_manifest(),
         dataset: DatasetManifest {
             path: args.dataset_path.display().to_string(),
@@ -1808,7 +1838,7 @@ fn load_fresh_trajectory_info(
     read_trajectory_info(path)
 }
 
-fn apply_subset(
+pub(crate) fn apply_subset(
     mut instances: Vec<SweBenchInstance>,
     instance_ids_arg: Option<&str>,
     limit: Option<usize>,

--- a/tests/bench_forecast.rs
+++ b/tests/bench_forecast.rs
@@ -1,0 +1,537 @@
+//! `bench forecast`: calibration-driven sweep cost forecasts.
+
+#![allow(clippy::unwrap_used, clippy::too_many_lines)]
+
+use std::fmt::Write as _;
+use std::path::Path;
+use std::process::Command;
+
+use rust_swe_agent::run::evaluate::{BreakdownSelection, EvaluateArgs, EvaluateBackend};
+use rust_swe_agent::run::forecast::{
+    ForecastArgs, ForecastGate, ThresholdStatus, forecast_from_results, forecast_gate_allows_sweep,
+    run, validate_fail_over_cap,
+};
+use rust_swe_agent::run::swebench::{InstanceResult, SwebenchArgs, SweepResults};
+use rust_swe_agent::trajectory::{FailureCategory, outcome};
+use rust_swe_agent::{Config, ModelUsage};
+
+fn binary_path() -> std::path::PathBuf {
+    std::env::var("CARGO_BIN_EXE_rust-swe-agent").map_or_else(
+        |_| {
+            let mut p = std::env::current_exe().unwrap();
+            p.pop();
+            p.pop();
+            p.push("rust-swe-agent");
+            p
+        },
+        std::path::PathBuf::from,
+    )
+}
+
+fn write_dataset(path: &Path, instance_ids: &[&str]) {
+    let mut s = String::new();
+    for id in instance_ids {
+        let _ = writeln!(
+            s,
+            "{{\"instance_id\":\"{id}\",\"problem_statement\":\"noop\"}}"
+        );
+    }
+    std::fs::write(path, s).unwrap();
+}
+
+fn write_step_limit_zero_config(path: &Path) {
+    std::fs::write(path, "agent:\n  step_limit: 0\n").unwrap();
+}
+
+fn init_repo(dir: &Path) {
+    fn git(dir: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    git(dir, &["init", "-q", "-b", "main"]);
+    git(dir, &["config", "user.email", "test@test"]);
+    git(dir, &["config", "user.name", "test"]);
+    git(dir, &["config", "commit.gpgSign", "false"]);
+    git(dir, &["config", "tag.gpgSign", "false"]);
+    git(dir, &["commit", "-q", "--allow-empty", "-m", "base"]);
+}
+
+fn config_with_workdir(dir: &Path) -> Config {
+    let yaml = format!("environment:\n  workdir: {}\n", dir.display());
+    Config::from_yaml_str(&yaml).unwrap()
+}
+
+fn submit_response() -> String {
+    "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".to_owned()
+}
+
+fn instance(
+    id: &str,
+    input_tokens: u64,
+    output_tokens: u64,
+    cost_usd: f64,
+    steps: u32,
+    duration_secs: f64,
+    submitted: bool,
+) -> InstanceResult {
+    InstanceResult {
+        instance_id: id.into(),
+        exit_reason: if submitted { "submitted" } else { "error" }.into(),
+        outcome: Some(if submitted {
+            outcome::SUBMITTED.into()
+        } else {
+            outcome::ERROR.into()
+        }),
+        failure_category: (!submitted).then_some(FailureCategory::Unknown),
+        steps: Some(steps),
+        cost_usd: Some(cost_usd),
+        prompt_tokens: Some(input_tokens),
+        completion_tokens: Some(output_tokens),
+        duration_secs: Some(duration_secs),
+        error: None,
+        patch_present: submitted,
+        non_empty_patch: false,
+        attempts: 1,
+        retry_reasons: Vec::new(),
+    }
+}
+
+fn fixture_results() -> SweepResults {
+    let instances = vec![
+        instance("a", 100, 10, 0.01, 1, 2.0, true),
+        instance("b", 200, 20, 0.02, 2, 4.0, false),
+        instance("c", 300, 30, 0.03, 3, 6.0, true),
+    ];
+    SweepResults {
+        total: instances.len(),
+        submitted: 2,
+        skipped: 0,
+        errored: 1,
+        failures_by_category: Default::default(),
+        budget_halted: 0,
+        with_patch: 0,
+        total_prompt_tokens: 600,
+        total_completion_tokens: 60,
+        estimated_cost_usd: 0.06,
+        retries: 0,
+        retried_instances: 0,
+        filter_spec: Default::default(),
+        manifest: None,
+        cost_limit_usd: None,
+        instances,
+    }
+}
+
+#[test]
+fn target_n_extrapolation_math_is_correct_against_fixture() {
+    let report = forecast_from_results(&fixture_results(), 42, 6, 2, 80.0, None).unwrap();
+
+    assert_eq!(report.calibration.n, 3);
+    assert_eq!(report.calibration.seed, 42);
+    assert_eq!(report.forecast.target_n, 6);
+    assert_eq!(report.forecast.parallel, 2);
+
+    assert!((report.forecast.total_input_tokens.point - 1200.0).abs() < 1e-9);
+    assert!((report.forecast.total_output_tokens.point - 120.0).abs() < 1e-9);
+    assert!((report.forecast.total_cost_usd.point - 0.12).abs() < 1e-9);
+    assert!((report.forecast.wall_clock_seconds.point - 12.0).abs() < 1e-9);
+
+    assert!((report.per_instance.input_tokens.median - 200.0).abs() < 1e-9);
+    assert!((report.per_instance.output_tokens.median - 20.0).abs() < 1e-9);
+    assert!((report.per_instance.usd_cost.median - 0.02).abs() < 1e-9);
+    assert_eq!(report.resolution_rate.resolved, 2);
+    assert_eq!(report.resolution_rate.total, 3);
+}
+
+#[test]
+fn confidence_interval_widens_monotonically_as_confidence_increases() {
+    let report_80 = forecast_from_results(&fixture_results(), 42, 6, 2, 80.0, None).unwrap();
+    let report_95 = forecast_from_results(&fixture_results(), 42, 6, 2, 95.0, None).unwrap();
+
+    assert!(
+        report_95.forecast.total_cost_usd.width() > report_80.forecast.total_cost_usd.width(),
+        "95% interval should be wider than 80%"
+    );
+}
+
+#[test]
+fn forecast_json_is_byte_deterministic_for_same_calibration_slice() {
+    let mut reversed = fixture_results();
+    reversed.instances.reverse();
+
+    let expected = rust_swe_agent::run::forecast::to_json(
+        &forecast_from_results(&fixture_results(), 42, 6, 2, 80.0, None).unwrap(),
+    )
+    .unwrap();
+    let actual = rust_swe_agent::run::forecast::to_json(
+        &forecast_from_results(&reversed, 42, 6, 2, 80.0, None).unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn fail_over_cap_errors_only_when_forecast_exceeds_cap() {
+    let under = forecast_from_results(&fixture_results(), 42, 6, 2, 80.0, Some(0.50)).unwrap();
+    assert_eq!(under.threshold.status, ThresholdStatus::Under);
+    validate_fail_over_cap(&under, true).unwrap();
+
+    let over = forecast_from_results(&fixture_results(), 42, 6, 2, 80.0, Some(0.01)).unwrap();
+    assert_eq!(over.threshold.status, ThresholdStatus::Exceeds);
+    assert!(validate_fail_over_cap(&over, true).is_err());
+    validate_fail_over_cap(&over, false).unwrap();
+}
+
+#[test]
+fn forecast_first_gate_requires_clear_cap_or_yes() {
+    let clear = forecast_from_results(&fixture_results(), 42, 6, 2, 80.0, Some(1.0)).unwrap();
+    assert!(forecast_gate_allows_sweep(&clear, ForecastGate { yes: false }).unwrap());
+
+    let tripped = forecast_from_results(&fixture_results(), 42, 6, 2, 80.0, Some(0.01)).unwrap();
+    assert!(!forecast_gate_allows_sweep(&tripped, ForecastGate { yes: false }).unwrap());
+    assert!(forecast_gate_allows_sweep(&tripped, ForecastGate { yes: true }).unwrap());
+
+    let no_cap = forecast_from_results(&fixture_results(), 42, 6, 2, 80.0, None).unwrap();
+    assert!(!forecast_gate_allows_sweep(&no_cap, ForecastGate { yes: false }).unwrap());
+    assert!(forecast_gate_allows_sweep(&no_cap, ForecastGate { yes: true }).unwrap());
+}
+
+#[test]
+fn cli_exposes_forecast_command_and_forecast_first_flag() {
+    let bin = binary_path();
+
+    let bench_help = Command::new(&bin)
+        .args(["bench", "--help"])
+        .output()
+        .unwrap();
+    assert!(bench_help.status.success());
+    let bench_stdout = String::from_utf8(bench_help.stdout).unwrap();
+    assert!(
+        bench_stdout.contains("forecast"),
+        "expected `forecast` in bench help, got:\n{bench_stdout}"
+    );
+
+    let forecast_help = Command::new(&bin)
+        .args(["bench", "forecast", "--help"])
+        .output()
+        .unwrap();
+    assert!(forecast_help.status.success());
+    let forecast_stdout = String::from_utf8(forecast_help.stdout).unwrap();
+    for flag in [
+        "--calibration-n",
+        "--target-n",
+        "--confidence",
+        "--fail-over-cap",
+    ] {
+        assert!(
+            forecast_stdout.contains(flag),
+            "expected {flag} in forecast help, got:\n{forecast_stdout}"
+        );
+    }
+
+    let swebench_help = Command::new(&bin)
+        .args(["bench", "swebench", "--help"])
+        .output()
+        .unwrap();
+    assert!(swebench_help.status.success());
+    let swebench_stdout = String::from_utf8(swebench_help.stdout).unwrap();
+    assert!(
+        swebench_stdout.contains("--forecast-first"),
+        "expected --forecast-first in swebench help, got:\n{swebench_stdout}"
+    );
+    assert!(
+        swebench_stdout.contains("--yes"),
+        "expected --yes in swebench help, got:\n{swebench_stdout}"
+    );
+}
+
+#[test]
+fn cli_forecast_json_stdout_is_one_forecast_document() {
+    let work = tempfile::tempdir().unwrap();
+    let dataset = work.path().join("dataset.jsonl");
+    let config = work.path().join("config.yaml");
+    let output = work.path().join("runs");
+    write_dataset(&dataset, &["a", "b"]);
+    write_step_limit_zero_config(&config);
+
+    let run = Command::new(binary_path())
+        .args([
+            "bench",
+            "forecast",
+            "--dataset-path",
+            dataset.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--config",
+            config.to_str().unwrap(),
+            "--calibration-n",
+            "1",
+            "--seed",
+            "7",
+            "--target-n",
+            "2",
+            "--step-limit",
+            "0",
+            "--format",
+            "json",
+            "--skip-model-probe",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        run.status.success(),
+        "forecast failed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8(run.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|err| panic!("{err}: {stdout}"));
+    assert_eq!(
+        parsed
+            .pointer("/calibration/seed")
+            .and_then(serde_json::Value::as_u64),
+        Some(7)
+    );
+    assert!(
+        parsed.get("checks").is_none(),
+        "stdout should contain only the forecast document, got: {stdout}"
+    );
+}
+
+#[test]
+fn cli_fail_over_cap_returns_nonzero_when_forecast_exceeds_cap() {
+    let work = tempfile::tempdir().unwrap();
+    let dataset = work.path().join("dataset.jsonl");
+    let config = work.path().join("config.yaml");
+    let output = work.path().join("runs");
+    write_dataset(&dataset, &["a"]);
+    write_step_limit_zero_config(&config);
+
+    let run = Command::new(binary_path())
+        .args([
+            "bench",
+            "forecast",
+            "--dataset-path",
+            dataset.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--config",
+            config.to_str().unwrap(),
+            "--calibration-n",
+            "1",
+            "--seed",
+            "7",
+            "--target-n",
+            "1",
+            "--step-limit",
+            "0",
+            "--sweep-cost-limit-usd=-0.01",
+            "--fail-over-cap",
+            "--skip-model-probe",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!run.status.success(), "forecast unexpectedly passed");
+    assert!(
+        String::from_utf8_lossy(&run.stderr).contains("exceed cap"),
+        "stderr should mention cap exceedance: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+}
+
+#[test]
+fn cli_forecast_first_blocks_or_launches_real_sweep() {
+    let work = tempfile::tempdir().unwrap();
+    let dataset = work.path().join("dataset.jsonl");
+    let config = work.path().join("config.yaml");
+    write_dataset(&dataset, &["a", "b"]);
+    write_step_limit_zero_config(&config);
+
+    let blocked_output = work.path().join("blocked");
+    let blocked = Command::new(binary_path())
+        .args([
+            "bench",
+            "swebench",
+            "--dataset-path",
+            dataset.to_str().unwrap(),
+            "--output",
+            blocked_output.to_str().unwrap(),
+            "--config",
+            config.to_str().unwrap(),
+            "--forecast-first",
+            "--calibration-n",
+            "1",
+            "--seed",
+            "7",
+            "--step-limit",
+            "0",
+            "--sweep-cost-limit-usd=-0.01",
+            "--skip-model-probe",
+        ])
+        .output()
+        .unwrap();
+    assert!(!blocked.status.success(), "forecast-first should block");
+    assert!(blocked_output.join("forecast/results.json").exists());
+    assert!(
+        !blocked_output.join("results.json").exists(),
+        "blocked real sweep must not write parent results.json"
+    );
+
+    let clear_output = work.path().join("clear");
+    let clear = Command::new(binary_path())
+        .args([
+            "bench",
+            "swebench",
+            "--dataset-path",
+            dataset.to_str().unwrap(),
+            "--output",
+            clear_output.to_str().unwrap(),
+            "--config",
+            config.to_str().unwrap(),
+            "--forecast-first",
+            "--calibration-n",
+            "1",
+            "--seed",
+            "7",
+            "--step-limit",
+            "0",
+            "--sweep-cost-limit-usd",
+            "1.0",
+            "--skip-model-probe",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        clear.status.success(),
+        "forecast-first clear case failed: {}",
+        String::from_utf8_lossy(&clear.stderr)
+    );
+    assert!(clear_output.join("forecast/results.json").exists());
+    assert!(
+        clear_output.join("results.json").exists(),
+        "clear forecast should launch real sweep"
+    );
+}
+
+#[tokio::test]
+async fn calibration_writes_only_inside_forecast_subdirectory_and_marks_manifest() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let dataset = work.path().join("dataset.jsonl");
+    write_dataset(&dataset, &["a", "b", "c"]);
+    let output = work.path().join("runs");
+
+    let usage = ModelUsage {
+        input_tokens: 100,
+        output_tokens: 10,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+        cost_usd: Some(0.001),
+    };
+    let report = run(ForecastArgs {
+        sweep: SwebenchArgs {
+            dataset_path: dataset,
+            output_dir: output.clone(),
+            parallel: 1,
+            config: config_with_workdir(&repo),
+            resume: false,
+            cost_limit_usd: Some(0.50),
+            instance_ids: None,
+            limit: None,
+            sample: None,
+            seed: None,
+            max_retries: 0,
+            retry_on: None,
+            retry_backoff_base_ms: 0,
+            retry_backoff_cap_s: 0,
+            retry_on_resume: false,
+            deterministic_responses: Some(vec![submit_response()]),
+            deterministic_usage_per_call: Some(usage),
+            config_overlay_paths: Vec::new(),
+            dry_run: false,
+            skip_preflight: true,
+            preflight_format: "text".into(),
+            skip_model_probe: true,
+            preflight_check_timeout_s: 10,
+            preflight_total_timeout_s: 60,
+            preflight_mode: "test".into(),
+        },
+        calibration_n: 2,
+        seed: 7,
+        target_n: Some(4),
+        confidence_pct: 80.0,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(report.calibration.n, 2);
+    assert_eq!(report.forecast.target_n, 4);
+    assert!(output.join("forecast").join("results.json").exists());
+    assert!(
+        !output.join("results.json").exists(),
+        "forecast must not write the parent sweep results.json"
+    );
+
+    let forecast_results: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(output.join("forecast/results.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        forecast_results
+            .pointer("/manifest/purpose")
+            .and_then(serde_json::Value::as_str),
+        Some("forecast")
+    );
+    for id in &report.calibration.instance_ids {
+        let traj: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(output.join("forecast").join(format!("{id}.traj.json")))
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            traj.pointer("/info/purpose")
+                .and_then(serde_json::Value::as_str),
+            Some("forecast")
+        );
+    }
+
+    let eval_err = rust_swe_agent::run::evaluate::run(&EvaluateArgs {
+        sweep_dir: output.join("forecast"),
+        dataset_path: None,
+        backend: EvaluateBackend::None,
+        timeout_per_instance_secs: 1,
+        parallel: 1,
+        sb_subset: "swe-bench-m".into(),
+        sb_split: "dev".into(),
+        run_id: None,
+        breakdown: BreakdownSelection::none(),
+    })
+    .unwrap_err();
+    assert!(
+        eval_err.to_string().contains("forecast calibration"),
+        "evaluate should refuse forecast output, got: {eval_err}"
+    );
+
+    assert!(
+        output
+            .join("forecast")
+            .read_dir()
+            .unwrap()
+            .all(|entry| entry.unwrap().path().starts_with(output.join("forecast")))
+    );
+}

--- a/tests/bench_forecast.rs
+++ b/tests/bench_forecast.rs
@@ -535,3 +535,114 @@ async fn calibration_writes_only_inside_forecast_subdirectory_and_marks_manifest
             .all(|entry| entry.unwrap().path().starts_with(output.join("forecast")))
     );
 }
+
+#[tokio::test]
+async fn default_target_n_honors_planned_sample_and_seed() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let dataset = work.path().join("dataset.jsonl");
+    write_dataset(&dataset, &["a", "b", "c", "d", "e"]);
+    let output = work.path().join("runs");
+    let mut cfg = config_with_workdir(&repo);
+    cfg.root.agent.step_limit = 0;
+
+    let report = run(ForecastArgs {
+        sweep: SwebenchArgs {
+            dataset_path: dataset,
+            output_dir: output,
+            parallel: 1,
+            config: cfg,
+            resume: false,
+            cost_limit_usd: None,
+            instance_ids: None,
+            limit: None,
+            sample: Some(2),
+            seed: Some(99),
+            max_retries: 0,
+            retry_on: None,
+            retry_backoff_base_ms: 0,
+            retry_backoff_cap_s: 0,
+            retry_on_resume: false,
+            deterministic_responses: None,
+            deterministic_usage_per_call: None,
+            config_overlay_paths: Vec::new(),
+            dry_run: false,
+            skip_preflight: true,
+            preflight_format: "text".into(),
+            skip_model_probe: true,
+            preflight_check_timeout_s: 10,
+            preflight_total_timeout_s: 60,
+            preflight_mode: "test".into(),
+        },
+        calibration_n: 1,
+        seed: 7,
+        target_n: None,
+        confidence_pct: 80.0,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(report.forecast.target_n, 2);
+}
+
+#[tokio::test]
+async fn missing_planned_sample_seed_fails_before_calibration_writes() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let dataset = work.path().join("dataset.jsonl");
+    write_dataset(&dataset, &["a", "b", "c"]);
+    let output = work.path().join("runs");
+    let mut cfg = config_with_workdir(&repo);
+    cfg.root.agent.step_limit = 0;
+
+    let err = run(ForecastArgs {
+        sweep: SwebenchArgs {
+            dataset_path: dataset,
+            output_dir: output.clone(),
+            parallel: 1,
+            config: cfg,
+            resume: false,
+            cost_limit_usd: None,
+            instance_ids: None,
+            limit: None,
+            sample: Some(2),
+            seed: None,
+            max_retries: 0,
+            retry_on: None,
+            retry_backoff_base_ms: 0,
+            retry_backoff_cap_s: 0,
+            retry_on_resume: false,
+            deterministic_responses: None,
+            deterministic_usage_per_call: None,
+            config_overlay_paths: Vec::new(),
+            dry_run: false,
+            skip_preflight: true,
+            preflight_format: "text".into(),
+            skip_model_probe: true,
+            preflight_check_timeout_s: 10,
+            preflight_total_timeout_s: 60,
+            preflight_mode: "test".into(),
+        },
+        calibration_n: 1,
+        seed: 7,
+        target_n: None,
+        confidence_pct: 80.0,
+    })
+    .await
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("`--sample` requires `--seed`"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        !output.join("forecast/results.json").exists(),
+        "forecast must fail validation before spending calibration budget"
+    );
+}

--- a/tests/bench_forecast.rs
+++ b/tests/bench_forecast.rs
@@ -8,8 +8,8 @@ use std::process::Command;
 
 use rust_swe_agent::run::evaluate::{BreakdownSelection, EvaluateArgs, EvaluateBackend};
 use rust_swe_agent::run::forecast::{
-    ForecastArgs, ForecastGate, ThresholdStatus, forecast_from_results, forecast_gate_allows_sweep,
-    run, validate_fail_over_cap,
+    ForecastArgs, ForecastGate, ForecastOutcome, ForecastReport, ThresholdStatus,
+    forecast_from_results, forecast_gate_allows_sweep, run, validate_fail_over_cap,
 };
 use rust_swe_agent::run::swebench::{InstanceResult, SwebenchArgs, SweepResults};
 use rust_swe_agent::trajectory::{FailureCategory, outcome};
@@ -128,6 +128,13 @@ fn fixture_results() -> SweepResults {
         manifest: None,
         cost_limit_usd: None,
         instances,
+    }
+}
+
+fn expect_forecast_report(outcome: ForecastOutcome) -> ForecastReport {
+    match outcome {
+        ForecastOutcome::Report(report) => *report,
+        ForecastOutcome::DryRun(_) => panic!("expected measured forecast report, got dry-run"),
     }
 }
 
@@ -310,6 +317,109 @@ fn cli_forecast_json_stdout_is_one_forecast_document() {
 }
 
 #[test]
+fn cli_forecast_dry_run_returns_preflight_without_artifacts() {
+    let work = tempfile::tempdir().unwrap();
+    let dataset = work.path().join("dataset.jsonl");
+    let config = work.path().join("config.yaml");
+    let output = work.path().join("runs");
+    write_dataset(&dataset, &["a"]);
+    write_step_limit_zero_config(&config);
+
+    let run = Command::new(binary_path())
+        .args([
+            "bench",
+            "forecast",
+            "--dataset-path",
+            dataset.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--config",
+            config.to_str().unwrap(),
+            "--calibration-n",
+            "1",
+            "--seed",
+            "7",
+            "--target-n",
+            "1",
+            "--dry-run",
+            "--step-limit",
+            "0",
+            "--skip-model-probe",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        run.status.success(),
+        "forecast dry-run failed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&run.stdout).contains("preflight checks passed"),
+        "dry-run should report preflight success, got: {}",
+        String::from_utf8_lossy(&run.stdout)
+    );
+    assert!(
+        !output.join("forecast/results.json").exists(),
+        "dry-run must not write forecast results"
+    );
+}
+
+#[test]
+fn cli_forecast_first_dry_run_returns_preflight_without_artifacts() {
+    let work = tempfile::tempdir().unwrap();
+    let dataset = work.path().join("dataset.jsonl");
+    let config = work.path().join("config.yaml");
+    let output = work.path().join("runs");
+    write_dataset(&dataset, &["a"]);
+    write_step_limit_zero_config(&config);
+
+    let run = Command::new(binary_path())
+        .args([
+            "bench",
+            "swebench",
+            "--dataset-path",
+            dataset.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--config",
+            config.to_str().unwrap(),
+            "--forecast-first",
+            "--calibration-n",
+            "1",
+            "--seed",
+            "7",
+            "--target-n",
+            "1",
+            "--dry-run",
+            "--step-limit",
+            "0",
+            "--skip-model-probe",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        run.status.success(),
+        "forecast-first dry-run failed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&run.stdout).contains("preflight checks passed"),
+        "dry-run should report preflight success, got: {}",
+        String::from_utf8_lossy(&run.stdout)
+    );
+    assert!(
+        !output.join("forecast/results.json").exists(),
+        "dry-run must not write forecast results"
+    );
+    assert!(
+        !output.join("results.json").exists(),
+        "dry-run must not launch or write the real sweep"
+    );
+}
+
+#[test]
 fn cli_fail_over_cap_returns_nonzero_when_forecast_exceeds_cap() {
     let work = tempfile::tempdir().unwrap();
     let dataset = work.path().join("dataset.jsonl");
@@ -443,7 +553,7 @@ async fn calibration_writes_only_inside_forecast_subdirectory_and_marks_manifest
         cache_creation_tokens: 0,
         cost_usd: Some(0.001),
     };
-    let report = run(ForecastArgs {
+    let outcome = run(ForecastArgs {
         sweep: SwebenchArgs {
             dataset_path: dataset,
             output_dir: output.clone(),
@@ -478,6 +588,7 @@ async fn calibration_writes_only_inside_forecast_subdirectory_and_marks_manifest
     })
     .await
     .unwrap();
+    let report = expect_forecast_report(outcome);
 
     assert_eq!(report.calibration.n, 2);
     assert_eq!(report.forecast.target_n, 4);
@@ -549,7 +660,7 @@ async fn default_target_n_honors_planned_sample_and_seed() {
     let mut cfg = config_with_workdir(&repo);
     cfg.root.agent.step_limit = 0;
 
-    let report = run(ForecastArgs {
+    let outcome = run(ForecastArgs {
         sweep: SwebenchArgs {
             dataset_path: dataset,
             output_dir: output,
@@ -584,6 +695,7 @@ async fn default_target_n_honors_planned_sample_and_seed() {
     })
     .await
     .unwrap();
+    let report = expect_forecast_report(outcome);
 
     assert_eq!(report.forecast.target_n, 2);
 }
@@ -601,7 +713,7 @@ async fn calibration_sampling_stays_within_planned_limit() {
     let mut cfg = config_with_workdir(&repo);
     cfg.root.agent.step_limit = 0;
 
-    let report = run(ForecastArgs {
+    let outcome = run(ForecastArgs {
         sweep: SwebenchArgs {
             dataset_path: dataset,
             output_dir: output,
@@ -636,6 +748,7 @@ async fn calibration_sampling_stays_within_planned_limit() {
     })
     .await
     .unwrap();
+    let report = expect_forecast_report(outcome);
 
     assert_eq!(report.forecast.target_n, 1);
     assert_eq!(report.calibration.instance_ids, ["a"]);

--- a/tests/bench_forecast.rs
+++ b/tests/bench_forecast.rs
@@ -589,6 +589,59 @@ async fn default_target_n_honors_planned_sample_and_seed() {
 }
 
 #[tokio::test]
+async fn calibration_sampling_stays_within_planned_limit() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let dataset = work.path().join("dataset.jsonl");
+    write_dataset(&dataset, &["a", "b", "c", "d", "e"]);
+    let output = work.path().join("runs");
+    let mut cfg = config_with_workdir(&repo);
+    cfg.root.agent.step_limit = 0;
+
+    let report = run(ForecastArgs {
+        sweep: SwebenchArgs {
+            dataset_path: dataset,
+            output_dir: output,
+            parallel: 1,
+            config: cfg,
+            resume: false,
+            cost_limit_usd: None,
+            instance_ids: None,
+            limit: Some(1),
+            sample: None,
+            seed: None,
+            max_retries: 0,
+            retry_on: None,
+            retry_backoff_base_ms: 0,
+            retry_backoff_cap_s: 0,
+            retry_on_resume: false,
+            deterministic_responses: None,
+            deterministic_usage_per_call: None,
+            config_overlay_paths: Vec::new(),
+            dry_run: false,
+            skip_preflight: true,
+            preflight_format: "text".into(),
+            skip_model_probe: true,
+            preflight_check_timeout_s: 10,
+            preflight_total_timeout_s: 60,
+            preflight_mode: "test".into(),
+        },
+        calibration_n: 1,
+        seed: 7,
+        target_n: None,
+        confidence_pct: 80.0,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(report.forecast.target_n, 1);
+    assert_eq!(report.calibration.instance_ids, ["a"]);
+}
+
+#[tokio::test]
 async fn missing_planned_sample_seed_fails_before_calibration_writes() {
     let work = tempfile::tempdir().unwrap();
     let repo = work.path().join("repo");


### PR DESCRIPTION
## Summary
- Add `bench forecast` with calibration sampling, extrapolated cost reporting, and cap checks
- Add `bench swebench --forecast-first` plus `--yes`, `--calibration-n`, `--target-n`, `--confidence`, and `--fail-over-cap`
- Keep forecast artifacts isolated under `output/forecast/` and mark them with forecast provenance so evaluation refuses them
- Make CLI forecast JSON clean on stdout and route logs to stderr
- Add deterministic forecast and CLI integration tests for JSON output, exit codes, gating, and provenance

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`