### PR TITLE
Add task wallclock timeout support

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -20,7 +20,7 @@ use crate::error::Error;
 use crate::model::{CacheHint, Message, MessageExtra, Model, QueryOpts, Role};
 use crate::stream::{NullSink, StreamEvent, StreamSink};
 use crate::template::Renderer;
-use crate::trajectory::{FailureCategory, TokenUsage, Trajectory, outcome};
+use crate::trajectory::{FailureCategory, TokenUsage, Trajectory, exit_reason, outcome};
 
 pub struct DefaultAgent {
     pub config: Config,
@@ -345,6 +345,24 @@ impl DefaultAgent {
             completion_tokens: self.completion_tokens,
         });
         self.trajectory.info.duration_secs = Some(self.started_at_instant.elapsed().as_secs_f64());
+    }
+
+    pub fn finalize_wallclock_timeout(&mut self, timeout: Duration) {
+        self.trajectory.info.exit_reason = Some(exit_reason::WALLCLOCK_TIMEOUT.into());
+        self.trajectory.info.failure_category = Some(FailureCategory::WallclockTimeout);
+        self.trajectory.info.steps = Some(self.steps);
+        self.trajectory.info.total_cost_usd = Some(self.total_cost_usd);
+        self.trajectory.info.ended_at = Some(chrono::Utc::now().to_rfc3339());
+        self.trajectory.info.other.insert(
+            "task_timeout_secs".into(),
+            serde_json::json!(timeout.as_secs()),
+        );
+        self.finalize_run_metadata(outcome::ERROR);
+        self.emit_run_ended(
+            exit_reason::WALLCLOCK_TIMEOUT,
+            Some(FailureCategory::WallclockTimeout),
+            None,
+        );
     }
 }
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -22,6 +22,11 @@ pub struct MiniCmd {
     #[arg(long, default_value_t = 50)]
     pub step_limit: u32,
 
+    /// Per-task wallclock timeout in seconds. Default: unset (no timeout).
+    /// Orthogonal to `--step-limit`; whichever fires first wins.
+    #[arg(long)]
+    pub task_timeout_secs: Option<u64>,
+
     /// Optional path to a TOML config (overlays defaults).
     #[arg(long)]
     pub config: Option<PathBuf>,
@@ -173,6 +178,11 @@ pub struct SwebenchCmd {
 
     #[arg(long, default_value_t = 50)]
     pub step_limit: u32,
+
+    /// Per-task wallclock timeout in seconds. Default: unset (no timeout).
+    /// Orthogonal to `--step-limit`; whichever fires first wins.
+    #[arg(long)]
+    pub task_timeout_secs: Option<u64>,
 
     #[arg(long)]
     pub config: Option<PathBuf>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -131,6 +131,7 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         trajectory_name,
         deterministic_responses: None,
         deterministic_usage_per_call: None,
+        task_timeout_secs: m.task_timeout_secs,
         stream_addr,
         patch_capture: None,
     };
@@ -330,6 +331,7 @@ fn swebench_args_from_cmd(
         reruns: s.reruns,
         resume: s.resume,
         cost_limit_usd: s.sweep_cost_limit_usd,
+        task_timeout_secs: s.task_timeout_secs,
         instance_ids: s.instance_ids,
         limit: s.limit,
         sample: s.sample,

--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -55,10 +55,10 @@ impl Environment for LocalEnvironment {
         }
         cmd.stdin(Stdio::null())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true);
+            .stderr(Stdio::piped());
 
         let mut child = cmd.spawn().map_err(EnvError::Io)?;
+        let mut process_guard = ProcessTreeGuard::new(child.id());
 
         // Take pipes so we can read them concurrently with `wait`.
         let mut stdout_pipe = child
@@ -79,6 +79,7 @@ impl Environment for LocalEnvironment {
             r1.map_err(EnvError::Io)?;
             r2.map_err(EnvError::Io)?;
             let status = child.wait().await.map_err(EnvError::Io)?;
+            process_guard.disarm();
             Ok::<_, EnvError>((
                 String::from_utf8_lossy(&stdout_buf).into_owned(),
                 String::from_utf8_lossy(&stderr_buf).into_owned(),
@@ -102,6 +103,59 @@ impl Environment for LocalEnvironment {
             }),
         }
     }
+}
+
+struct ProcessTreeGuard {
+    pid: Option<u32>,
+    armed: bool,
+}
+
+impl ProcessTreeGuard {
+    const fn new(pid: Option<u32>) -> Self {
+        Self { pid, armed: true }
+    }
+
+    const fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ProcessTreeGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        if let Some(pid) = self.pid {
+            kill_process_tree_sync(pid);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn kill_process_tree_sync(pid: u32) {
+    let _ = std::process::Command::new("taskkill")
+        .args(["/F", "/T", "/PID", &pid.to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+}
+
+#[cfg(not(windows))]
+fn kill_process_tree_sync(pid: u32) {
+    let pid_s = pid.to_string();
+    let _ = std::process::Command::new("pkill")
+        .args(["-TERM", "-P", &pid_s])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+    let _ = std::process::Command::new("kill")
+        .args(["-TERM", &pid_s])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
 }
 
 #[cfg(windows)]

--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -4,11 +4,19 @@
 
 use async_trait::async_trait;
 use std::process::Stdio;
+use std::time::Duration;
 use tokio::io::AsyncReadExt;
-use tokio::process::Command;
+use tokio::process::{Child, Command};
+use tokio::task::JoinHandle;
 
 use super::{Environment, RunRequest, RunResult};
 use crate::error::EnvError;
+
+#[cfg(not(windows))]
+const TERMINATE_GRACE: Duration = Duration::from_millis(250);
+const FORCE_KILL_WAIT: Duration = Duration::from_secs(2);
+#[cfg(not(windows))]
+const PROCESS_EXIT_POLL: Duration = Duration::from_millis(25);
 
 pub struct LocalEnvironment {
     shell: String,
@@ -46,6 +54,7 @@ fn default_shell() -> String {
 impl Environment for LocalEnvironment {
     async fn run(&self, req: RunRequest) -> Result<RunResult, EnvError> {
         let mut cmd = shell_command(&self.shell, &req.command);
+        isolate_process_tree(&mut cmd);
 
         if let Some(cwd) = req.cwd.as_ref() {
             cmd.current_dir(cwd);
@@ -69,40 +78,50 @@ impl Environment for LocalEnvironment {
             .stderr
             .take()
             .ok_or_else(|| EnvError::UnexpectedExit("stderr pipe missing".into()))?;
+        let stdout_task = tokio::spawn(async move { read_pipe_to_string(&mut stdout_pipe).await });
+        let stderr_task = tokio::spawn(async move { read_pipe_to_string(&mut stderr_pipe).await });
 
-        let wait_fut = async move {
-            let mut stdout_buf = Vec::new();
-            let mut stderr_buf = Vec::new();
-            let read_stdout = stdout_pipe.read_to_end(&mut stdout_buf);
-            let read_stderr = stderr_pipe.read_to_end(&mut stderr_buf);
-            let (r1, r2) = tokio::join!(read_stdout, read_stderr);
-            r1.map_err(EnvError::Io)?;
-            r2.map_err(EnvError::Io)?;
-            let status = child.wait().await.map_err(EnvError::Io)?;
+        if let Ok(status) = tokio::time::timeout(req.timeout, child.wait()).await {
+            let status = status.map_err(EnvError::Io)?;
             process_guard.disarm();
-            Ok::<_, EnvError>((
-                String::from_utf8_lossy(&stdout_buf).into_owned(),
-                String::from_utf8_lossy(&stderr_buf).into_owned(),
-                status.code().unwrap_or(-1),
-            ))
-        };
-
-        match tokio::time::timeout(req.timeout, wait_fut).await {
-            Ok(Ok((stdout, stderr, exit_code))) => Ok(RunResult {
+            let stdout = join_reader(stdout_task, "stdout").await?;
+            let stderr = join_reader(stderr_task, "stderr").await?;
+            return Ok(RunResult {
                 stdout,
                 stderr,
-                exit_code,
+                exit_code: status.code().unwrap_or(-1),
                 timed_out: false,
-            }),
-            Ok(Err(e)) => Err(e),
-            Err(_) => Ok(RunResult {
-                stdout: String::new(),
-                stderr: format!("timed out after {:?}", req.timeout),
-                exit_code: -1,
-                timed_out: true,
-            }),
+            });
         }
+
+        process_guard.terminate_and_wait(&mut child).await;
+        stdout_task.abort();
+        stderr_task.abort();
+        Ok(RunResult {
+            stdout: String::new(),
+            stderr: format!("timed out after {:?}", req.timeout),
+            exit_code: -1,
+            timed_out: true,
+        })
     }
+}
+
+async fn read_pipe_to_string<R>(pipe: &mut R) -> Result<String, EnvError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut buf = Vec::new();
+    pipe.read_to_end(&mut buf).await.map_err(EnvError::Io)?;
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+async fn join_reader(
+    handle: JoinHandle<Result<String, EnvError>>,
+    name: &str,
+) -> Result<String, EnvError> {
+    handle
+        .await
+        .map_err(|e| EnvError::UnexpectedExit(format!("{name} reader task failed: {e}")))?
 }
 
 struct ProcessTreeGuard {
@@ -118,6 +137,20 @@ impl ProcessTreeGuard {
     const fn disarm(&mut self) {
         self.armed = false;
     }
+
+    async fn terminate_and_wait(&mut self, child: &mut Child) {
+        let Some(pid) = self.pid else {
+            self.disarm();
+            return;
+        };
+        terminate_process_tree_async(pid).await;
+        if tokio::time::timeout(FORCE_KILL_WAIT, child.wait())
+            .await
+            .is_ok()
+        {
+            self.disarm();
+        }
+    }
 }
 
 impl Drop for ProcessTreeGuard {
@@ -126,37 +159,166 @@ impl Drop for ProcessTreeGuard {
             return;
         }
         if let Some(pid) = self.pid {
-            kill_process_tree_sync(pid);
+            terminate_process_tree_blocking(pid);
         }
     }
 }
 
 #[cfg(windows)]
-fn kill_process_tree_sync(pid: u32) {
+async fn terminate_process_tree_async(pid: u32) {
+    let _ = Command::new("taskkill")
+        .args(["/F", "/T", "/PID", &pid.to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await;
+}
+
+#[cfg(windows)]
+fn terminate_process_tree_blocking(pid: u32) {
     let _ = std::process::Command::new("taskkill")
         .args(["/F", "/T", "/PID", &pid.to_string()])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .spawn();
+        .status();
 }
 
-#[cfg(not(windows))]
-fn kill_process_tree_sync(pid: u32) {
+#[cfg(unix)]
+async fn terminate_process_tree_async(pid: u32) {
+    signal_process_group_async(pid, "TERM").await;
+    tokio::time::sleep(TERMINATE_GRACE).await;
+    if process_group_alive_async(pid).await {
+        signal_process_group_async(pid, "KILL").await;
+        wait_for_process_exit_async(pid).await;
+    }
+}
+
+#[cfg(unix)]
+fn terminate_process_tree_blocking(pid: u32) {
+    signal_process_group_blocking(pid, "TERM");
+    std::thread::sleep(TERMINATE_GRACE);
+    if process_group_alive_blocking(pid) {
+        signal_process_group_blocking(pid, "KILL");
+        wait_for_process_exit_blocking(pid);
+    }
+}
+
+#[cfg(all(not(windows), not(unix)))]
+async fn terminate_process_tree_async(pid: u32) {
     let pid_s = pid.to_string();
-    let _ = std::process::Command::new("pkill")
-        .args(["-TERM", "-P", &pid_s])
+    let _ = Command::new("kill")
+        .args(["-TERM", &pid_s])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .spawn();
+        .status()
+        .await;
+    tokio::time::sleep(TERMINATE_GRACE).await;
+    let _ = Command::new("kill")
+        .args(["-KILL", &pid_s])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await;
+}
+
+#[cfg(all(not(windows), not(unix)))]
+fn terminate_process_tree_blocking(pid: u32) {
+    let pid_s = pid.to_string();
     let _ = std::process::Command::new("kill")
         .args(["-TERM", &pid_s])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .spawn();
+        .status();
+    std::thread::sleep(TERMINATE_GRACE);
+    let _ = std::process::Command::new("kill")
+        .args(["-KILL", &pid_s])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
 }
+
+#[cfg(unix)]
+async fn wait_for_process_exit_async(pid: u32) {
+    let deadline = tokio::time::Instant::now() + FORCE_KILL_WAIT;
+    while tokio::time::Instant::now() < deadline {
+        if !process_group_alive_async(pid).await {
+            return;
+        }
+        tokio::time::sleep(PROCESS_EXIT_POLL).await;
+    }
+}
+
+#[cfg(unix)]
+fn wait_for_process_exit_blocking(pid: u32) {
+    let deadline = std::time::Instant::now() + FORCE_KILL_WAIT;
+    while std::time::Instant::now() < deadline {
+        if !process_group_alive_blocking(pid) {
+            return;
+        }
+        std::thread::sleep(PROCESS_EXIT_POLL);
+    }
+}
+
+#[cfg(unix)]
+async fn signal_process_group_async(pid: u32, signal: &str) {
+    let group = format!("-{pid}");
+    let _ = Command::new("kill")
+        .args([format!("-{signal}"), group])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await;
+}
+
+#[cfg(unix)]
+fn signal_process_group_blocking(pid: u32, signal: &str) {
+    let group = format!("-{pid}");
+    let _ = std::process::Command::new("kill")
+        .args([format!("-{signal}"), group])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+#[cfg(unix)]
+async fn process_group_alive_async(pid: u32) -> bool {
+    Command::new("kill")
+        .args(["-0", &format!("-{pid}")])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(unix)]
+fn process_group_alive_blocking(pid: u32) -> bool {
+    std::process::Command::new("kill")
+        .args(["-0", &format!("-{pid}")])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(unix)]
+fn isolate_process_tree(cmd: &mut Command) {
+    use std::os::unix::process::CommandExt;
+    cmd.as_std_mut().process_group(0);
+}
+
+#[cfg(not(unix))]
+fn isolate_process_tree(_cmd: &mut Command) {}
 
 #[cfg(windows)]
 fn shell_command(shell: &str, command: &str) -> Command {
@@ -222,6 +384,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn timeout_reclaims_stubborn_process_before_returning() {
+        let work = tempfile::tempdir().unwrap();
+        let pid_file = work.path().join("stubborn.pid");
+        let command = stubborn_process_command(&pid_file);
+
+        let env = LocalEnvironment::new();
+        let req = RunRequest::new(command).with_timeout(Duration::from_secs(1));
+        let r = env.run(req).await.unwrap();
+
+        assert!(r.timed_out);
+        let pid_text = std::fs::read_to_string(&pid_file).unwrap();
+        let pid = pid_text.trim().parse::<u32>().unwrap();
+        assert!(
+            !process_is_alive(pid),
+            "timed-out process {pid} was still alive after run returned"
+        );
+    }
+
+    #[tokio::test]
     async fn stderr_is_captured_separately() {
         let env = LocalEnvironment::new();
         let r = env
@@ -230,5 +411,44 @@ mod tests {
             .unwrap();
         assert_eq!(r.stdout.trim(), "out");
         assert_eq!(r.stderr.trim(), "err");
+    }
+
+    #[cfg(windows)]
+    fn stubborn_process_command(pid_file: &std::path::Path) -> String {
+        let path = pid_file.display().to_string().replace('\'', "''");
+        format!(
+            "powershell -NoProfile -Command \"$pidFile='{path}'; Set-Content -LiteralPath $pidFile -Value $PID; while ($true) {{ Start-Sleep -Milliseconds 200 }}\""
+        )
+    }
+
+    #[cfg(not(windows))]
+    fn stubborn_process_command(pid_file: &std::path::Path) -> String {
+        let path = sh_single_quote(&pid_file.display().to_string());
+        format!("trap '' TERM; printf '%s' $$ > {path}; while :; do sleep 1; done")
+    }
+
+    #[cfg(not(windows))]
+    fn sh_single_quote(s: &str) -> String {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+
+    fn process_is_alive(pid: u32) -> bool {
+        if cfg!(windows) {
+            std::process::Command::new("powershell")
+                .args([
+                    "-NoProfile",
+                    "-Command",
+                    &format!(
+                        "if (Get-Process -Id {pid} -ErrorAction SilentlyContinue) {{ exit 0 }} else {{ exit 1 }}"
+                    ),
+                ])
+                .status()
+                .is_ok_and(|status| status.success())
+        } else {
+            std::process::Command::new("kill")
+                .args(["-0", &pid.to_string()])
+                .status()
+                .is_ok_and(|status| status.success())
+        }
     }
 }

--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -144,10 +144,14 @@ impl ProcessTreeGuard {
             return;
         };
         terminate_process_tree_async(pid).await;
-        if tokio::time::timeout(FORCE_KILL_WAIT, child.wait())
+        let child_reaped = tokio::time::timeout(FORCE_KILL_WAIT, child.wait())
             .await
-            .is_ok()
-        {
+            .is_ok();
+        #[cfg(unix)]
+        if child_reaped {
+            wait_for_process_group_exit_async(pid).await;
+        }
+        if child_reaped {
             self.disarm();
         }
     }
@@ -189,20 +193,15 @@ fn terminate_process_tree_blocking(pid: u32) {
 async fn terminate_process_tree_async(pid: u32) {
     signal_process_group_async(pid, "TERM").await;
     tokio::time::sleep(TERMINATE_GRACE).await;
-    if process_group_alive_async(pid).await {
-        signal_process_group_async(pid, "KILL").await;
-        wait_for_process_exit_async(pid).await;
-    }
+    signal_process_group_async(pid, "KILL").await;
 }
 
 #[cfg(unix)]
 fn terminate_process_tree_blocking(pid: u32) {
     signal_process_group_blocking(pid, "TERM");
     std::thread::sleep(TERMINATE_GRACE);
-    if process_group_alive_blocking(pid) {
-        signal_process_group_blocking(pid, "KILL");
-        wait_for_process_exit_blocking(pid);
-    }
+    signal_process_group_blocking(pid, "KILL");
+    wait_for_process_group_exit_blocking(pid);
 }
 
 #[cfg(all(not(windows), not(unix)))]
@@ -244,7 +243,7 @@ fn terminate_process_tree_blocking(pid: u32) {
 }
 
 #[cfg(unix)]
-async fn wait_for_process_exit_async(pid: u32) {
+async fn wait_for_process_group_exit_async(pid: u32) {
     let deadline = tokio::time::Instant::now() + FORCE_KILL_WAIT;
     while tokio::time::Instant::now() < deadline {
         if !process_group_alive_async(pid).await {
@@ -255,7 +254,7 @@ async fn wait_for_process_exit_async(pid: u32) {
 }
 
 #[cfg(unix)]
-fn wait_for_process_exit_blocking(pid: u32) {
+fn wait_for_process_group_exit_blocking(pid: u32) {
     let deadline = std::time::Instant::now() + FORCE_KILL_WAIT;
     while std::time::Instant::now() < deadline {
         if !process_group_alive_blocking(pid) {
@@ -269,7 +268,7 @@ fn wait_for_process_exit_blocking(pid: u32) {
 async fn signal_process_group_async(pid: u32, signal: &str) {
     let group = format!("-{pid}");
     let _ = Command::new("kill")
-        .args([format!("-{signal}"), group])
+        .args([format!("-{signal}"), "--".to_owned(), group])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -281,7 +280,7 @@ async fn signal_process_group_async(pid: u32, signal: &str) {
 fn signal_process_group_blocking(pid: u32, signal: &str) {
     let group = format!("-{pid}");
     let _ = std::process::Command::new("kill")
-        .args([format!("-{signal}"), group])
+        .args([format!("-{signal}"), "--".to_owned(), group])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -291,7 +290,7 @@ fn signal_process_group_blocking(pid: u32, signal: &str) {
 #[cfg(unix)]
 async fn process_group_alive_async(pid: u32) -> bool {
     Command::new("kill")
-        .args(["-0", &format!("-{pid}")])
+        .args(["-0", "--", &format!("-{pid}")])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -303,7 +302,7 @@ async fn process_group_alive_async(pid: u32) -> bool {
 #[cfg(unix)]
 fn process_group_alive_blocking(pid: u32) -> bool {
     std::process::Command::new("kill")
-        .args(["-0", &format!("-{pid}")])
+        .args(["-0", "--", &format!("-{pid}")])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -442,11 +441,17 @@ mod tests {
                         "if (Get-Process -Id {pid} -ErrorAction SilentlyContinue) {{ exit 0 }} else {{ exit 1 }}"
                     ),
                 ])
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
                 .status()
                 .is_ok_and(|status| status.success())
         } else {
             std::process::Command::new("kill")
                 .args(["-0", &pid.to_string()])
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
                 .status()
                 .is_ok_and(|status| status.success())
         }

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -1195,6 +1195,7 @@ fn failure_label(cat: FailureCategory) -> &'static str {
         FailureCategory::ModelParse => "model_parse",
         FailureCategory::StepLimit => "step_limit",
         FailureCategory::CostLimit => "cost_limit",
+        FailureCategory::WallclockTimeout => "wallclock_timeout",
         FailureCategory::AgentInternal => "agent_internal",
         FailureCategory::Unknown => "unknown",
     }

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -686,6 +686,7 @@ pub fn failure_label(cat: FailureCategory) -> &'static str {
         FailureCategory::ModelParse => "model_parse",
         FailureCategory::StepLimit => "step_limit",
         FailureCategory::CostLimit => "cost_limit",
+        FailureCategory::WallclockTimeout => "wallclock_timeout",
         FailureCategory::AgentInternal => "agent_internal",
         FailureCategory::Unknown => "unknown",
     }

--- a/src/run/hello_world.rs
+++ b/src/run/hello_world.rs
@@ -20,6 +20,7 @@ pub async fn main(output_dir: PathBuf) -> Result<(), Error> {
             "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
         ]),
         deterministic_usage_per_call: None,
+        task_timeout_secs: None,
         stream_addr: None,
         patch_capture: None,
     };

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -543,6 +543,7 @@ fn failure_label(c: FailureCategory) -> &'static str {
         FailureCategory::ModelParse => "model_parse",
         FailureCategory::StepLimit => "step_limit",
         FailureCategory::CostLimit => "cost_limit",
+        FailureCategory::WallclockTimeout => "wallclock_timeout",
         FailureCategory::AgentInternal => "agent_internal",
         FailureCategory::Unknown => "unknown",
     }

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -50,6 +50,10 @@ pub struct MiniArgs {
     /// on every call. Only meaningful when `deterministic_responses` is
     /// `Some`. Lets tests drive cost/budget logic without a real API.
     pub deterministic_usage_per_call: Option<ModelUsage>,
+    /// Optional wallclock budget for the agent loop. When elapsed, any
+    /// in-flight environment command is dropped and the trajectory is
+    /// finalized as `wallclock_timeout`.
+    pub task_timeout_secs: Option<u64>,
     /// Optional SSE stream endpoint to bind. When `Some`, the runner
     /// starts a server before the agent runs and shuts it down after.
     pub stream_addr: Option<SocketAddr>,
@@ -103,21 +107,9 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     // Run the agent. On error, finalize the trajectory with
     // `outcome="error"` so the partial run is still a self-contained
     // record of what happened — then propagate.
-    let run_result = agent.run().await;
+    let run_result = run_agent_with_optional_timeout(&mut agent, args.task_timeout_secs).await;
     if let Err(e) = &run_result {
-        agent
-            .trajectory
-            .info
-            .exit_reason
-            .get_or_insert_with(|| "error".into());
-        agent.trajectory.info.failure_category = Some(classify_error(e));
-        agent
-            .trajectory
-            .info
-            .other
-            .entry("error_message".into())
-            .or_insert_with(|| serde_json::Value::String(e.to_string()));
-        agent.finalize_run_metadata(crate::trajectory::outcome::ERROR);
+        finalize_error_trajectory(&mut agent, e);
     }
 
     // Patch capture happens before the trajectory is saved so any
@@ -158,7 +150,15 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
 
     agent.trajectory.save_pretty(&traj_path)?;
 
-    let exit = run_result?;
+    let exit = match run_result {
+        Ok(exit) => exit,
+        Err(e) => {
+            if let Some(server) = server {
+                server.shutdown().await;
+            }
+            return Err(e);
+        }
+    };
 
     if let crate::agent::ExitReason::Submitted { final_output } = &exit {
         let out_path = args
@@ -173,6 +173,50 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         server.shutdown().await;
     }
     Ok(())
+}
+
+fn finalize_error_trajectory(agent: &mut DefaultAgent, err: &Error) {
+    agent
+        .trajectory
+        .info
+        .exit_reason
+        .get_or_insert_with(|| "error".into());
+    agent
+        .trajectory
+        .info
+        .failure_category
+        .get_or_insert_with(|| classify_error(err));
+    agent
+        .trajectory
+        .info
+        .other
+        .entry("error_message".into())
+        .or_insert_with(|| serde_json::Value::String(err.to_string()));
+    agent.finalize_run_metadata(crate::trajectory::outcome::ERROR);
+}
+
+async fn run_agent_with_optional_timeout(
+    agent: &mut DefaultAgent,
+    task_timeout_secs: Option<u64>,
+) -> Result<crate::agent::ExitReason, Error> {
+    let Some(secs) = task_timeout_secs else {
+        return agent.run().await;
+    };
+    let timeout = Duration::from_secs(secs);
+    if let Ok(result) = tokio::time::timeout(timeout, agent.run()).await {
+        return result;
+    }
+    let shutdown_error = agent.env.shutdown().await.err();
+    agent.finalize_wallclock_timeout(timeout);
+    if let Some(err) = shutdown_error {
+        agent.trajectory.info.other.insert(
+            "environment_shutdown_error".into(),
+            serde_json::Value::String(err.to_string()),
+        );
+    }
+    Err(Error::Trajectory(format!(
+        "task wallclock timeout after {secs}s"
+    )))
 }
 
 fn classify_error(err: &Error) -> FailureCategory {

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -25,7 +25,7 @@ use sha2::{Digest, Sha256};
 use crate::config::Config;
 use crate::error::Error;
 use crate::model::{Model, ModelUsage};
-use crate::trajectory::{FailureCategory, Trajectory, outcome};
+use crate::trajectory::{FailureCategory, Trajectory, exit_reason, outcome};
 
 /// Sentinel `exit_reason` for tasks that never started because the
 /// sweep-level USD budget was exhausted. Distinct from `error` and
@@ -394,6 +394,9 @@ pub struct SwebenchArgs {
     /// tasks contribute to the running total at their stored cost so a
     /// resumed sweep cannot blow past the limit.
     pub cost_limit_usd: Option<f64>,
+    /// Optional wallclock budget applied independently to each task's agent
+    /// loop. Orthogonal to step and cost limits; whichever fires first wins.
+    pub task_timeout_secs: Option<u64>,
     /// Dataset subset selector. Either comma-separated ids or
     /// `@path/to/file.txt` (one id per line).
     pub instance_ids: Option<String>,
@@ -830,24 +833,18 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     }
 
     let spawn_one = |run: SweepRun, set: &mut tokio::task::JoinSet<RunSlotResult>| {
-        let output_dir = args.output_dir.clone();
-        let cfg = args.config.clone();
-        let deterministic = args.deterministic_responses.clone();
-        let det_usage = args.deterministic_usage_per_call.clone();
-        let retry_policy = retry_policy.clone();
+        let params = RunOneParams {
+            output_dir: args.output_dir.clone(),
+            cfg: args.config.clone(),
+            deterministic_responses: args.deterministic_responses.clone(),
+            deterministic_usage_per_call: args.deterministic_usage_per_call.clone(),
+            retry_policy: retry_policy.clone(),
+            task_timeout_secs: args.task_timeout_secs,
+        };
         set.spawn(async move {
             RunSlotResult::new(
                 run.run_index,
-                run_one(
-                    run.inst,
-                    run.run_index,
-                    output_dir,
-                    cfg,
-                    deterministic,
-                    det_usage,
-                    retry_policy,
-                )
-                .await,
+                run_one(run.inst, run.run_index, params).await,
             )
         });
     };
@@ -2020,6 +2017,7 @@ fn parse_failure_category_label(s: &str) -> Result<FailureCategory, Error> {
         "model_parse" => Ok(FailureCategory::ModelParse),
         "step_limit" => Ok(FailureCategory::StepLimit),
         "cost_limit" => Ok(FailureCategory::CostLimit),
+        "wallclock_timeout" => Ok(FailureCategory::WallclockTimeout),
         "agent_internal" => Ok(FailureCategory::AgentInternal),
         "unknown" => Ok(FailureCategory::Unknown),
         _ => Err(Error::Config(crate::error::ConfigError::Invalid(format!(
@@ -2048,16 +2046,26 @@ fn deterministic_for_attempt(all: &[String], attempt: u32, retry_mode: bool) -> 
     all.last().cloned().into_iter().collect()
 }
 
-#[allow(clippy::too_many_lines)]
-async fn run_one(
-    inst: SweBenchInstance,
-    run_index: u32,
+#[derive(Clone)]
+struct RunOneParams {
     output_dir: PathBuf,
-    mut cfg: Config,
+    cfg: Config,
     deterministic_responses: Option<Vec<String>>,
     deterministic_usage_per_call: Option<ModelUsage>,
     retry_policy: RetryPolicy,
-) -> InstanceResult {
+    task_timeout_secs: Option<u64>,
+}
+
+#[allow(clippy::too_many_lines)]
+async fn run_one(inst: SweBenchInstance, run_index: u32, params: RunOneParams) -> InstanceResult {
+    let RunOneParams {
+        output_dir,
+        mut cfg,
+        deterministic_responses,
+        deterministic_usage_per_call,
+        retry_policy,
+        task_timeout_secs,
+    } = params;
     let id = inst.instance_id.clone();
     let task = inst.problem_statement.clone().unwrap_or_default();
     // A scripted model implies a local-only sweep — `image` from the dataset
@@ -2095,6 +2103,7 @@ async fn run_one(
             trajectory_name: trajectory_name.clone(),
             deterministic_responses: det_for_attempt,
             deterministic_usage_per_call: deterministic_usage_per_call.clone(),
+            task_timeout_secs,
             stream_addr: None,
             patch_capture: Some(crate::run::mini::PatchCaptureSpec {
                 base_commit: base_commit.clone(),
@@ -2137,6 +2146,7 @@ async fn run_one(
                 .or_else(|| match exit_reason.as_str() {
                     "step_limit" => Some(FailureCategory::StepLimit),
                     "cost_limit" => Some(FailureCategory::CostLimit),
+                    exit_reason::WALLCLOCK_TIMEOUT => Some(FailureCategory::WallclockTimeout),
                     _ => run_err
                         .as_ref()
                         .map(classify_error)
@@ -2199,7 +2209,11 @@ fn is_failed_instance(r: &InstanceResult) -> bool {
     r.outcome.as_deref() == Some(outcome::ERROR)
         || matches!(
             r.failure_category,
-            Some(FailureCategory::StepLimit | FailureCategory::CostLimit)
+            Some(
+                FailureCategory::StepLimit
+                    | FailureCategory::CostLimit
+                    | FailureCategory::WallclockTimeout
+            )
         )
 }
 
@@ -2210,6 +2224,7 @@ fn failure_category_label(cat: FailureCategory) -> &'static str {
         FailureCategory::ModelParse => "model_parse",
         FailureCategory::StepLimit => "step_limit",
         FailureCategory::CostLimit => "cost_limit",
+        FailureCategory::WallclockTimeout => "wallclock_timeout",
         FailureCategory::AgentInternal => "agent_internal",
         FailureCategory::Unknown => "unknown",
     }
@@ -2545,6 +2560,7 @@ mod tests {
             config: cfg,
             resume: false,
             cost_limit_usd: None,
+            task_timeout_secs: None,
             instance_ids: None,
             limit: None,
             sample: None,
@@ -2592,6 +2608,7 @@ mod tests {
             config: Config::defaults().unwrap(),
             resume: true,
             cost_limit_usd: None,
+            task_timeout_secs: None,
             instance_ids: None,
             limit: None,
             sample: None,
@@ -2649,6 +2666,7 @@ instance = "inst"
             config: cfg_a,
             resume: false,
             cost_limit_usd: None,
+            task_timeout_secs: None,
             instance_ids: None,
             limit: None,
             sample: None,
@@ -2730,6 +2748,7 @@ instance = "inst"
             config: Config::defaults().unwrap(),
             resume: false,
             cost_limit_usd: None,
+            task_timeout_secs: None,
             instance_ids: None,
             limit: None,
             sample: None,

--- a/src/run/tail.rs
+++ b/src/run/tail.rs
@@ -656,6 +656,7 @@ fn failure_label(category: FailureCategory) -> &'static str {
         FailureCategory::ModelParse => "model_parse",
         FailureCategory::StepLimit => "step_limit",
         FailureCategory::CostLimit => "cost_limit",
+        FailureCategory::WallclockTimeout => "wallclock_timeout",
         FailureCategory::AgentInternal => "agent_internal",
         FailureCategory::Unknown => "unknown",
     }

--- a/src/run/trajectory_diff.rs
+++ b/src/run/trajectory_diff.rs
@@ -1026,6 +1026,7 @@ fn failure_label(category: FailureCategory) -> &'static str {
         FailureCategory::ModelParse => "model_parse",
         FailureCategory::StepLimit => "step_limit",
         FailureCategory::CostLimit => "cost_limit",
+        FailureCategory::WallclockTimeout => "wallclock_timeout",
         FailureCategory::AgentInternal => "agent_internal",
         FailureCategory::Unknown => "unknown",
     }

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -24,6 +24,10 @@ pub mod outcome {
     pub const ERROR: &str = "error";
 }
 
+pub mod exit_reason {
+    pub const WALLCLOCK_TIMEOUT: &str = "wallclock_timeout";
+}
+
 /// Closed set of non-success terminal failure modes for sweeps.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
@@ -33,6 +37,7 @@ pub enum FailureCategory {
     ModelParse,
     StepLimit,
     CostLimit,
+    WallclockTimeout,
     AgentInternal,
     Unknown,
 }

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -127,6 +127,46 @@ fn write_results(dir: &Path, instances: Vec<InstanceResult>) {
     .unwrap();
 }
 
+fn write_wallclock_timeout_results_json(dir: &Path, id: &str) {
+    let payload = serde_json::json!({
+        "total": 1,
+        "submitted": 0,
+        "skipped": 0,
+        "errored": 1,
+        "failures_by_category": {"wallclock_timeout": 1},
+        "budget_halted": 0,
+        "with_patch": 0,
+        "total_prompt_tokens": 0,
+        "total_completion_tokens": 0,
+        "estimated_cost_usd": 0.0,
+        "retries": 0,
+        "retried_instances": 0,
+        "pass_at_k": 0.0,
+        "filter_spec": {},
+        "cost_limit_usd": null,
+        "instances": [{
+            "instance_id": id,
+            "exit_reason": "wallclock_timeout",
+            "outcome": "error",
+            "failure_category": "wallclock_timeout",
+            "steps": 1,
+            "duration_secs": 2.0,
+            "patch_present": false,
+            "non_empty_patch": false,
+            "attempts": 1,
+            "retry_reasons": [],
+            "runs": 1,
+            "resolved_count": 0,
+            "pass_at_1": false
+        }]
+    });
+    std::fs::write(
+        dir.join("results.json"),
+        serde_json::to_string_pretty(&payload).unwrap(),
+    )
+    .unwrap();
+}
+
 fn write_diff_traj(
     dir: &Path,
     instance_id: &str,
@@ -459,6 +499,56 @@ fn cli_json_output_is_machine_readable() {
     assert_eq!(v["regressions"][0]["kind"], "pass_fail");
     assert_eq!(v["resolved_delta"], -1);
     assert_eq!(v["transitions"]["pass_fail"], 1);
+}
+
+#[test]
+fn compare_treats_wallclock_timeout_as_ordinary_failure_transition() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+
+    write_wallclock_timeout_results_json(baseline_dir.path(), "slow");
+    write_results(candidate_dir.path(), vec![submitted("slow")]);
+    let report =
+        rust_swe_agent::run::compare::compute(&rust_swe_agent::run::compare::CompareArgs {
+            baseline: baseline_dir.path().to_path_buf(),
+            candidate: candidate_dir.path().to_path_buf(),
+            format: rust_swe_agent::run::compare::CompareFormat::Json,
+            max_regressions: None,
+            breakdown: rust_swe_agent::run::evaluate::BreakdownSelection::none(),
+            min_delta_pp: 0.0,
+        })
+        .unwrap();
+    assert_eq!(
+        report
+            .transitions
+            .get(&rust_swe_agent::run::compare::TransitionKind::FailPass),
+        Some(&1)
+    );
+    assert!(report.regressions.is_empty());
+
+    write_results(baseline_dir.path(), vec![submitted("slow")]);
+    write_wallclock_timeout_results_json(candidate_dir.path(), "slow");
+    let report =
+        rust_swe_agent::run::compare::compute(&rust_swe_agent::run::compare::CompareArgs {
+            baseline: baseline_dir.path().to_path_buf(),
+            candidate: candidate_dir.path().to_path_buf(),
+            format: rust_swe_agent::run::compare::CompareFormat::Json,
+            max_regressions: None,
+            breakdown: rust_swe_agent::run::evaluate::BreakdownSelection::none(),
+            min_delta_pp: 0.0,
+        })
+        .unwrap();
+    assert_eq!(
+        report
+            .transitions
+            .get(&rust_swe_agent::run::compare::TransitionKind::PassFail),
+        Some(&1)
+    );
+    assert_eq!(report.regressions.len(), 1);
+    assert_eq!(
+        report.regressions[0].candidate_exit_reason.as_deref(),
+        Some("wallclock_timeout")
+    );
 }
 
 #[test]

--- a/tests/bench_forecast.rs
+++ b/tests/bench_forecast.rs
@@ -68,7 +68,12 @@ fn init_repo(dir: &Path) {
 }
 
 fn config_with_workdir(dir: &Path) -> Config {
-    let toml = format!("[environment]\nworkdir = \"{}\"\n", dir.display());
+    let workdir = dir
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let toml = format!("[environment]\nworkdir = \"{workdir}\"\n");
     Config::from_toml_str(&toml).unwrap()
 }
 
@@ -568,6 +573,7 @@ async fn calibration_writes_only_inside_forecast_subdirectory_and_marks_manifest
             config: config_with_workdir(&repo),
             resume: false,
             cost_limit_usd: Some(0.50),
+            task_timeout_secs: None,
             instance_ids: None,
             limit: None,
             sample: None,
@@ -676,6 +682,7 @@ async fn default_target_n_honors_planned_sample_and_seed() {
             config: cfg,
             resume: false,
             cost_limit_usd: None,
+            task_timeout_secs: None,
             instance_ids: None,
             limit: None,
             sample: Some(2),
@@ -730,6 +737,7 @@ async fn calibration_sampling_stays_within_planned_limit() {
             config: cfg,
             resume: false,
             cost_limit_usd: None,
+            task_timeout_secs: None,
             instance_ids: None,
             limit: Some(1),
             sample: None,
@@ -785,6 +793,7 @@ async fn missing_planned_sample_seed_fails_before_calibration_writes() {
             config: cfg,
             resume: false,
             cost_limit_usd: None,
+            task_timeout_secs: None,
             instance_ids: None,
             limit: None,
             sample: Some(2),

--- a/tests/cli_task_timeout_help.rs
+++ b/tests/cli_task_timeout_help.rs
@@ -1,0 +1,31 @@
+#![allow(clippy::unwrap_used)]
+
+use clap::CommandFactory as _;
+use rust_swe_agent::cli::Cli;
+
+#[test]
+fn mini_help_documents_task_timeout_seconds_and_step_limit_interaction() {
+    let mut root = Cli::command();
+    let mini = root.find_subcommand_mut("mini").unwrap();
+    let help = mini.render_long_help().to_string();
+
+    assert!(help.contains("--task-timeout-secs"));
+    assert!(help.contains("seconds"));
+    assert!(help.contains("unset"));
+    assert!(help.contains("step-limit"));
+    assert!(help.contains("whichever fires first"));
+}
+
+#[test]
+fn swebench_help_documents_task_timeout_seconds_and_step_limit_interaction() {
+    let mut root = Cli::command();
+    let bench = root.find_subcommand_mut("bench").unwrap();
+    let swebench = bench.find_subcommand_mut("swebench").unwrap();
+    let help = swebench.render_long_help().to_string();
+
+    assert!(help.contains("--task-timeout-secs"));
+    assert!(help.contains("seconds"));
+    assert!(help.contains("unset"));
+    assert!(help.contains("step-limit"));
+    assert!(help.contains("whichever fires first"));
+}

--- a/tests/swebench_budget.rs
+++ b/tests/swebench_budget.rs
@@ -67,7 +67,12 @@ fn init_repo(dir: &Path) {
 }
 
 fn config_with_workdir(dir: &Path) -> Config {
-    let toml = format!("[environment]\nworkdir = \"{}\"\n", dir.display());
+    let workdir = dir
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let toml = format!("[environment]\nworkdir = \"{workdir}\"\n");
     Config::from_toml_str(&toml).unwrap()
 }
 
@@ -115,6 +120,7 @@ async fn sweep_halts_when_cumulative_cost_reaches_limit() {
         config: cfg,
         resume: false,
         cost_limit_usd: Some(limit),
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -280,6 +286,7 @@ async fn sweep_without_limit_runs_all_tasks() {
         config: cfg,
         resume: false,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -371,6 +378,7 @@ async fn resume_skipped_costs_count_against_budget() {
         config: cfg,
         resume: true,
         cost_limit_usd: Some(0.10),
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -499,6 +507,7 @@ async fn resume_uses_prior_results_token_totals_for_budget_accounting() {
         config: cfg,
         resume: true,
         cost_limit_usd: Some(0.10),
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -615,6 +624,7 @@ async fn retry_on_resume_instances_are_precharged_before_rerun() {
         config: cfg,
         resume: true,
         cost_limit_usd: Some(0.10),
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -736,6 +746,7 @@ async fn stale_results_json_is_not_trusted_over_newer_trajectory() {
         config: cfg,
         resume: true,
         cost_limit_usd: Some(0.10),
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,

--- a/tests/swebench_failure_categories.rs
+++ b/tests/swebench_failure_categories.rs
@@ -41,7 +41,16 @@ async fn sweep_counts_failure_categories_and_preserves_legacy_unclassified() {
     std::fs::create_dir_all(&output).unwrap();
 
     let ids = [
-        "ok", "env", "api", "parse", "step", "cost", "internal", "unknown", "legacy",
+        "ok",
+        "env",
+        "api",
+        "parse",
+        "step",
+        "cost",
+        "wallclock",
+        "internal",
+        "unknown",
+        "legacy",
     ];
     write_dataset(&dataset, &ids);
 
@@ -62,6 +71,7 @@ async fn sweep_counts_failure_categories_and_preserves_legacy_unclassified() {
         ("parse", FailureCategory::ModelParse),
         ("step", FailureCategory::StepLimit),
         ("cost", FailureCategory::CostLimit),
+        ("wallclock", FailureCategory::WallclockTimeout),
         ("internal", FailureCategory::AgentInternal),
         ("unknown", FailureCategory::Unknown),
     ] {
@@ -98,6 +108,7 @@ async fn sweep_counts_failure_categories_and_preserves_legacy_unclassified() {
         config: cfg,
         resume: true,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -144,6 +155,7 @@ async fn sweep_counts_failure_categories_and_preserves_legacy_unclassified() {
             "parse" => assert_eq!(r.failure_category, Some(FailureCategory::ModelParse)),
             "step" => assert_eq!(r.failure_category, Some(FailureCategory::StepLimit)),
             "cost" => assert_eq!(r.failure_category, Some(FailureCategory::CostLimit)),
+            "wallclock" => assert_eq!(r.failure_category, Some(FailureCategory::WallclockTimeout)),
             "internal" => assert_eq!(r.failure_category, Some(FailureCategory::AgentInternal)),
             "unknown" => assert_eq!(r.failure_category, Some(FailureCategory::Unknown)),
             other => panic!("unexpected id: {other}"),
@@ -157,6 +169,7 @@ async fn sweep_counts_failure_categories_and_preserves_legacy_unclassified() {
     assert!(table.contains("  - model_parse: 1"), "got: {table}");
     assert!(table.contains("  - step_limit: 1"), "got: {table}");
     assert!(table.contains("  - cost_limit: 1"), "got: {table}");
+    assert!(table.contains("  - wallclock_timeout: 1"), "got: {table}");
     assert!(table.contains("  - agent_internal: 1"), "got: {table}");
     assert!(table.contains("  - unknown: 1"), "got: {table}");
     assert!(

--- a/tests/swebench_patch.rs
+++ b/tests/swebench_patch.rs
@@ -66,6 +66,13 @@ fn write_dataset(path: &Path, instance_ids: &[&str], base_commit: &str) {
     std::fs::write(path, s).unwrap();
 }
 
+fn toml_escape_path(path: &Path) -> String {
+    path.display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
 #[tokio::test]
 async fn sweep_emits_patch_artifact_for_modifying_agent() {
     let work = tempfile::tempdir().unwrap();
@@ -90,7 +97,7 @@ async fn sweep_emits_patch_artifact_for_modifying_agent() {
 
     let toml = format!(
         "[environment]\nworkdir = \"{}\"\n\n[model]\nname = \"scripted-test-model\"\n",
-        repo.display()
+        toml_escape_path(&repo)
     );
     let cfg = Config::from_toml_str(&toml).unwrap();
     let results = run(SwebenchArgs {
@@ -101,6 +108,7 @@ async fn sweep_emits_patch_artifact_for_modifying_agent() {
         config: cfg,
         resume: false,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -180,7 +188,7 @@ async fn sweep_emits_empty_patch_when_agent_changes_nothing() {
 
     let toml = format!(
         "[environment]\nworkdir = \"{}\"\n\n[model]\nname = \"scripted-test-model\"\n",
-        repo.display()
+        toml_escape_path(&repo)
     );
     let cfg = Config::from_toml_str(&toml).unwrap();
     let results = run(SwebenchArgs {
@@ -191,6 +199,7 @@ async fn sweep_emits_empty_patch_when_agent_changes_nothing() {
         config: cfg,
         resume: false,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -256,7 +265,7 @@ async fn missing_workdir_marks_outcome_as_error() {
     // Workdir points at a path that doesn't exist; `git diff` will fail.
     let toml = format!(
         "[environment]\nworkdir = \"{}\"\n",
-        work.path().join("does-not-exist").display()
+        toml_escape_path(&work.path().join("does-not-exist"))
     );
     let cfg = Config::from_toml_str(&toml).unwrap();
     let results = run(SwebenchArgs {
@@ -267,6 +276,7 @@ async fn missing_workdir_marks_outcome_as_error() {
         config: cfg,
         resume: false,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,

--- a/tests/swebench_rerun.rs
+++ b/tests/swebench_rerun.rs
@@ -66,6 +66,7 @@ fn base_args(dataset: std::path::PathBuf, output: std::path::PathBuf, cfg: Confi
         resume: false,
         reruns: 3,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,

--- a/tests/swebench_resume.rs
+++ b/tests/swebench_resume.rs
@@ -81,7 +81,12 @@ fn init_repo(dir: &Path) {
 }
 
 fn config_with_workdir(dir: &Path) -> Config {
-    let toml = format!("[environment]\nworkdir = \"{}\"\n", dir.display());
+    let workdir = dir
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let toml = format!("[environment]\nworkdir = \"{workdir}\"\n");
     Config::from_toml_str(&toml).unwrap()
 }
 
@@ -120,6 +125,7 @@ async fn resume_skips_valid_trajectory_and_reruns_invalid() {
         config: cfg,
         resume: true,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -213,6 +219,7 @@ async fn resume_reruns_submitted_trajectory_with_missing_patch() {
         config: cfg,
         resume: true,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -275,6 +282,7 @@ async fn without_resume_existing_trajectories_are_overwritten() {
         config: cfg,
         resume: false,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -337,6 +345,7 @@ async fn malformed_results_json_does_not_block_new_non_resume_sweep() {
         config: cfg,
         resume: false,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -426,6 +435,7 @@ async fn resume_uses_on_disk_patch_flags_even_if_prior_summary_is_false() {
         config: cfg,
         resume: true,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,

--- a/tests/swebench_retry.rs
+++ b/tests/swebench_retry.rs
@@ -45,7 +45,12 @@ fn init_repo(dir: &Path) {
 }
 
 fn cfg(workdir: &Path) -> Config {
-    let toml = format!("[environment]\nworkdir = \"{}\"\n", workdir.display());
+    let workdir = workdir
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let toml = format!("[environment]\nworkdir = \"{workdir}\"\n");
     Config::from_toml_str(&toml).unwrap()
 }
 
@@ -84,6 +89,7 @@ async fn instance_cost_prefers_recorded_trajectory_cost() {
         config: cfg(&repo),
         resume: false,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -129,6 +135,7 @@ async fn retries_on_injected_transient_category_then_recovers() {
         config: cfg(&repo),
         resume: false,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -181,6 +188,7 @@ async fn max_retries_zero_disables_retry() {
         config: cfg(&repo),
         resume: false,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -234,6 +242,7 @@ async fn max_retries_cap_stops_without_infinite_loop_and_non_retryable_is_not_re
         config: cfg(&repo),
         resume: false,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: Some("a,b".into()),
         limit: None,
         sample: None,
@@ -271,6 +280,7 @@ async fn max_retries_cap_stops_without_infinite_loop_and_non_retryable_is_not_re
         config: cfg(&repo),
         resume: false,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: Some("b".into()),
         limit: None,
         sample: None,
@@ -323,6 +333,7 @@ async fn cost_cap_can_trip_mid_retry_and_retry_on_resume_round_trip() {
         config: cfg(&repo),
         resume: false,
         cost_limit_usd: Some(0.10),
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -379,6 +390,7 @@ async fn cost_cap_can_trip_mid_retry_and_retry_on_resume_round_trip() {
         config: cfg(&repo),
         resume: true,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,
@@ -411,6 +423,7 @@ async fn cost_cap_can_trip_mid_retry_and_retry_on_resume_round_trip() {
         config: cfg(&repo),
         resume: true,
         cost_limit_usd: None,
+        task_timeout_secs: None,
         instance_ids: None,
         limit: None,
         sample: None,

--- a/tests/swebench_wallclock_timeout.rs
+++ b/tests/swebench_wallclock_timeout.rs
@@ -21,7 +21,7 @@ fn long_running_response() -> String {
     let command = if cfg!(windows) {
         "for /L %i in (1,1,2147483647) do @rem"
     } else {
-        "sleep 30"
+        "trap '' TERM; while :; do sleep 1; done"
     };
     format!("```bash\n{command}\n```")
 }
@@ -71,9 +71,14 @@ async fn sweep_wallclock_timeout_finalizes_trajectory_and_reclaims_worker() {
     .unwrap();
     let elapsed = started.elapsed();
 
+    let max_elapsed = if cfg!(windows) {
+        Duration::from_secs(6)
+    } else {
+        Duration::from_secs(5)
+    };
     assert!(
-        elapsed < Duration::from_secs(5),
-        "worker should return within 3s of the 2s deadline; elapsed={elapsed:?}"
+        elapsed < max_elapsed,
+        "worker should return promptly after the 2s deadline; elapsed={elapsed:?}, max={max_elapsed:?}"
     );
     assert_eq!(results.total, 1);
     assert_eq!(results.submitted, 0);

--- a/tests/swebench_wallclock_timeout.rs
+++ b/tests/swebench_wallclock_timeout.rs
@@ -1,0 +1,114 @@
+#![allow(clippy::unwrap_used)]
+
+use std::fmt::Write as _;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use rust_swe_agent::Config;
+use rust_swe_agent::run::swebench::{SwebenchArgs, predictions_path, run, trajectory_path_for};
+use rust_swe_agent::trajectory::{FailureCategory, Trajectory, outcome};
+
+fn write_dataset(path: &Path) {
+    let mut s = String::new();
+    let _ = writeln!(
+        s,
+        "{{\"instance_id\":\"slow\",\"problem_statement\":\"sleep longer than the wallclock timeout\"}}"
+    );
+    std::fs::write(path, s).unwrap();
+}
+
+fn long_running_response() -> String {
+    let command = if cfg!(windows) {
+        "for /L %i in (1,1,2147483647) do @rem"
+    } else {
+        "sleep 30"
+    };
+    format!("```bash\n{command}\n```")
+}
+
+#[tokio::test]
+async fn sweep_wallclock_timeout_finalizes_trajectory_and_reclaims_worker() {
+    let work = tempfile::tempdir().unwrap();
+    let dataset = work.path().join("dataset.jsonl");
+    let output = work.path().join("runs");
+    write_dataset(&dataset);
+
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 10;
+    cfg.root.environment.timeout_secs = 60;
+
+    let started = Instant::now();
+    let results = run(SwebenchArgs {
+        dataset_path: dataset,
+        output_dir: output.clone(),
+        parallel: 1,
+        reruns: 1,
+        config: cfg,
+        resume: false,
+        cost_limit_usd: None,
+        task_timeout_secs: Some(2),
+        instance_ids: None,
+        limit: None,
+        sample: None,
+        seed: None,
+        max_retries: 0,
+        retry_on: None,
+        retry_backoff_base_ms: 0,
+        retry_backoff_cap_s: 0,
+        retry_on_resume: false,
+        deterministic_responses: Some(vec![long_running_response()]),
+        deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
+    })
+    .await
+    .unwrap();
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "worker should return within 3s of the 2s deadline; elapsed={elapsed:?}"
+    );
+    assert_eq!(results.total, 1);
+    assert_eq!(results.submitted, 0);
+    assert_eq!(results.errored, 1);
+    assert_eq!(
+        results
+            .failures_by_category
+            .get(&FailureCategory::WallclockTimeout),
+        Some(&1)
+    );
+    assert_eq!(results.instances.len(), 1);
+    let row = &results.instances[0];
+    assert_eq!(row.instance_id, "slow");
+    assert_eq!(row.exit_reason, "wallclock_timeout");
+    assert_eq!(row.outcome.as_deref(), Some(outcome::ERROR));
+    assert_eq!(
+        row.failure_category,
+        Some(FailureCategory::WallclockTimeout)
+    );
+    assert!(!row.patch_present);
+
+    let traj_text = std::fs::read_to_string(trajectory_path_for(&output, "slow")).unwrap();
+    let traj: Trajectory = serde_json::from_str(&traj_text).unwrap();
+    assert_eq!(traj.info.exit_reason.as_deref(), Some("wallclock_timeout"));
+    assert_eq!(traj.info.outcome.as_deref(), Some(outcome::ERROR));
+    assert_eq!(
+        traj.info.failure_category,
+        Some(FailureCategory::WallclockTimeout)
+    );
+    assert!(traj.info.duration_secs.is_some());
+    assert!(traj.info.ended_at.is_some());
+
+    let preds = std::fs::read_to_string(predictions_path(&output)).unwrap();
+    assert!(
+        preds.trim().is_empty(),
+        "wallclock timeouts must not emit predictions: {preds}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `--task-timeout-secs` to mini and swebench flows and thread it through runner config
- Finalize timed-out trajectories with a dedicated `wallclock_timeout` exit reason and failure category
- Ensure local process cleanup on timeout and recognize the new category across compare, inspect, tail, and trajectory diff outputs
- Extend tests to cover timeout classification, reporting, and sweep behavior

## Testing
- Added and updated unit/integration tests for timeout handling and failure-category reporting
- Not run (not requested)