### PR TITLE
⚡ Bolt: Reduce heap allocations in evaluation and aggregation hot paths

### DIFF
--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -493,7 +493,7 @@ fn merge_with_results(
     results: &HashMap<String, InstanceResult>,
     parsed: &HashMap<String, InstanceEvaluation>,
 ) -> EvaluationResults {
-    let mut instances: Vec<InstanceEvaluation> = Vec::new();
+    let mut instances: Vec<InstanceEvaluation> = Vec::with_capacity(results.len());
     for (id, r) in results {
         if let Some(row) = parsed.get(id) {
             let mut row = row.clone();
@@ -541,7 +541,7 @@ fn merge_rerun_reports_with_results(
     results: &HashMap<String, InstanceResult>,
     run_reports: &BTreeMap<u32, HashMap<String, InstanceEvaluation>>,
 ) -> EvaluationResults {
-    let mut instances = Vec::new();
+    let mut instances = Vec::with_capacity(results.len());
     for (id, result) in results {
         let runs = effective_runs(result);
         let mut resolved_count = 0u32;
@@ -611,7 +611,7 @@ fn build_breakdown(
     results: &HashMap<String, InstanceResult>,
     selection: &BreakdownSelection,
 ) -> Vec<BreakdownBucket> {
-    let mut out = Vec::new();
+    let mut out = Vec::with_capacity(selection.axes.len());
     for axis in &selection.axes {
         let mut buckets: BTreeMap<String, (usize, usize)> = BTreeMap::new();
         let mut unknown_repo = 0usize;

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -1618,10 +1618,10 @@ fn add_accounting_for_result(
 }
 
 fn aggregate_run_results(results: &[RunSlotResult], requested_runs: u32) -> Vec<InstanceResult> {
-    let mut grouped: BTreeMap<String, Vec<&RunSlotResult>> = BTreeMap::new();
+    let mut grouped: BTreeMap<&str, Vec<&RunSlotResult>> = BTreeMap::new();
     for r in results {
         grouped
-            .entry(r.result.instance_id.clone())
+            .entry(r.result.instance_id.as_str())
             .or_default()
             .push(r);
     }
@@ -1633,7 +1633,7 @@ fn aggregate_run_results(results: &[RunSlotResult], requested_runs: u32) -> Vec<
             continue;
         };
         let mut aggregate = first.clone();
-        aggregate.instance_id = instance_id;
+        instance_id.clone_into(&mut aggregate.instance_id);
         aggregate.exit_reason.clone_from(&first.exit_reason);
         aggregate.outcome.clone_from(&first.outcome);
         aggregate.failure_category = first.failure_category;


### PR DESCRIPTION
💡 **What:** 
- Swapped `Vec::new()` for `Vec::with_capacity(size)` in `merge_with_results`, `merge_rerun_reports_with_results`, and `build_breakdown` where the target collection size is known.
- Switched `BTreeMap<String, ...>` to `BTreeMap<&str, ...>` in `aggregate_run_results` and utilized `.clone_into()` to avoid intermediate memory allocations.

🎯 **Why:** 
- Vectors were dynamically allocating and shifting memory as they grew when iterating over maps of known sizes.
- Grouping logic was performing a `.clone()` on the `instance_id` for every result just to construct an intermediate Map key, causing high heap allocation pressure on the hot path.

📊 **Impact:** 
- Reduces dynamic heap reallocations (fewer sys calls for memory expansion).
- Prevents cloning short-lived string keys for each processed sweep result during result aggregation.

🔬 **Measurement:** 
- Run `cargo bench` or profile with large sweep evaluation sets. Performance is mathematically sound via zero-cost `&str` references and exact capacity definitions. All tests pass `cargo test` and `clippy`.

---
*PR created automatically by Jules for task [16336270593813182683](https://jules.google.com/task/16336270593813182683) started by @madmax983*