### PR TITLE
🛡️ Sentry: [test coverage improvement] Unit tests for forecast math

### DIFF
--- a/src/run/forecast.rs
+++ b/src/run/forecast.rs
@@ -695,3 +695,67 @@ impl ForecastRng {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::float_cmp)]
+    use super::*;
+
+    #[test]
+    fn test_quantile_empty_slice() {
+        assert_eq!(quantile(&[], 0.5), 0.0);
+        assert_eq!(quantile_sorted(&[], 0.5), 0.0);
+    }
+
+    #[test]
+    fn test_quantile_single_element() {
+        assert_eq!(quantile(&[42.0], 0.5), 42.0);
+        assert_eq!(quantile_sorted(&[42.0], 0.5), 42.0);
+    }
+
+    #[test]
+    fn test_quantile_clamp_bounds() {
+        let values = [10.0, 20.0, 30.0];
+        assert_eq!(quantile(&values, -1.0), 10.0);
+        assert_eq!(quantile(&values, 2.0), 30.0);
+        assert_eq!(quantile_sorted(&values, -1.0), 10.0);
+        assert_eq!(quantile_sorted(&values, 2.0), 30.0);
+    }
+
+    #[test]
+    fn test_mean() {
+        assert_eq!(mean(&[]), 0.0);
+        assert_eq!(mean(&[10.0, 20.0, 30.0]), 20.0);
+    }
+
+    #[test]
+    fn test_threshold_check() {
+        let cost = IntervalEstimate { point: 50.0, lower: 40.0, upper: 60.0 };
+
+        // NotConfigured
+        let check = threshold_check(None, cost);
+        assert_eq!(check.status, ThresholdStatus::NotConfigured);
+
+        // Under
+        let check = threshold_check(Some(100.0), cost);
+        assert_eq!(check.status, ThresholdStatus::Under);
+
+        // Exceeds
+        let check = threshold_check(Some(30.0), cost);
+        assert_eq!(check.status, ThresholdStatus::Exceeds);
+
+        // TooTight
+        let check = threshold_check(Some(50.0), cost);
+        assert_eq!(check.status, ThresholdStatus::TooTight);
+    }
+
+    #[test]
+    fn test_forecast_rng() {
+        let mut rng1 = ForecastRng::new(42);
+        let mut rng2 = ForecastRng::new(42);
+
+        assert_eq!(rng1.next_u64(), rng2.next_u64());
+        assert_eq!(rng1.next_usize(), rng2.next_usize());
+    }
+}

--- a/src/run/forecast.rs
+++ b/src/run/forecast.rs
@@ -731,7 +731,11 @@ mod tests {
 
     #[test]
     fn test_threshold_check() {
-        let cost = IntervalEstimate { point: 50.0, lower: 40.0, upper: 60.0 };
+        let cost = IntervalEstimate {
+            point: 50.0,
+            lower: 40.0,
+            upper: 60.0,
+        };
 
         // NotConfigured
         let check = threshold_check(None, cost);


### PR DESCRIPTION
🎯 Target: Math helper functions in `src/run/forecast.rs` (`quantile`, `quantile_sorted`, `mean`, `threshold_check`, `ForecastRng`).
💣 Risk: Math edge cases like empty slices, single element slices, or clamped bounds for quantiles could panic or return incorrect results. 
🧪 Strategy: Added unit tests using `#![allow(clippy::float_cmp)]` to verify empty slice fallbacks, clamp behaviors, array bounds, threshold enums and RNG consistency directly at the source.
🔬 Verification: Run `cargo test --lib run::forecast::tests`

---
*PR created automatically by Jules for task [421898454470906957](https://jules.google.com/task/421898454470906957) started by @madmax983*