### PR TITLE
[codex] Add cost attribution reporting for evaluate and compare

### DIFF
--- a/docs/spec-evaluation.md
+++ b/docs/spec-evaluation.md
@@ -34,6 +34,7 @@ rust-swe-agent bench evaluate \
   [--sb-split dev] \
   [--run-id <custom_run_id>] \
   [--backend sb-cli|none] \
+  [--cost-attribution on|off] \
   [--timeout-per-instance 600] \
   [--parallel 4]
 ```
@@ -59,6 +60,15 @@ rust-swe-agent bench evaluate \
       "eval_exit_reason": "resolved|unresolved|patch_apply_failed|eval_error|skipped_no_patch",
       "eval_log_path": "optional/path/or/url"
     }
+  ],
+  "cost_attribution": [
+    {
+      "bucket": "resolved|env_setup|model_api|model_parse|step_limit|cost_limit|wallclock_timeout|agent_internal|unknown|uncategorized|TOTAL",
+      "n": 12,
+      "total_usd": 4.321,
+      "mean_usd": 0.3601,
+      "share_pct": 37.42
+    }
   ]
 }
 ```
@@ -75,6 +85,12 @@ Rows missing from backend output are synthesized as:
 - `resolved_rate`: equivalent to `pass@1` for one-run sweeps.
 - `pass@1`: fraction of instances whose first run resolved.
 - `pass@k`: fraction of instances with at least one resolved run.
+- `cost_attribution` (default `on`): a deterministic table that attributes
+  per-trajectory `cost_usd` into terminal buckets. Resolved rows always land
+  in `resolved` even if a legacy `failure_category` is also present. Rows with
+  no `failure_category` and not resolved land in `uncategorized`. Missing
+  `cost_usd` contributes `n` but is summed as `$0.00`; the CLI prints a
+  warning line so operators know spend is understated.
 
 When a sweep has only one run per instance, `resolved_rate`, `pass@1`, and
 `pass@k` are the same value.
@@ -111,6 +127,9 @@ This affects:
 - resolved-rate difference (`resolved_delta_rate`)
 - `resolved_delta_ci95`, a 95% Wilson/Newcombe confidence interval
 - `within_noise`, true when the confidence interval crosses zero
+- optional cost-attribution deltas (`--cost-attribution on|off`), which compare
+  baseline and candidate bucket spend with fields
+  `n_baseline,total_usd_baseline,n_candidate,total_usd_candidate,delta_usd,share_pp_delta`
 
 So a sweep with high submission-rate but zero resolved instances is treated as
 fully regressed against a baseline that resolved everything.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -15,6 +15,12 @@ pub enum StratifyModeArg {
     Balanced,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum OnOffArg {
+    On,
+    Off,
+}
+
 #[derive(Debug, Args)]
 pub struct MiniCmd {
     /// The task prompt.
@@ -151,6 +157,14 @@ pub struct CompareCmd {
     /// Threshold in percentage points used to highlight large breakdown deltas.
     #[arg(long = "breakdown-min-delta-pp", default_value_t = 5.0)]
     pub breakdown_min_delta_pp: f64,
+
+    /// Attribute sweep USD cost to terminal buckets in the compare report.
+    #[arg(long, value_enum, default_value_t = OnOffArg::On)]
+    pub cost_attribution: OnOffArg,
+
+    /// Highlight cost-attribution deltas whose absolute USD change meets this threshold.
+    #[arg(long = "cost-attribution-min-delta-usd", default_value_t = 1.0)]
+    pub cost_attribution_min_delta_usd: f64,
 
     /// Render `bench inspect --diff` for this instance id by locating both
     /// trajectory files inside the baseline and candidate sweep directories.
@@ -358,6 +372,10 @@ pub struct EvaluateCmd {
     /// Optional metric breakdown axes (`repo,failure_category`) or `none`.
     #[arg(long, default_value = "repo,failure_category")]
     pub breakdown: String,
+
+    /// Attribute sweep USD cost to terminal buckets in the evaluation report.
+    #[arg(long, value_enum, default_value_t = OnOffArg::On)]
+    pub cost_attribution: OnOffArg,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -397,6 +397,8 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
         max_regressions: c.max_regressions,
         breakdown,
         min_delta_pp: c.breakdown_min_delta_pp / 100.0,
+        cost_attribution: matches!(c.cost_attribution, args::OnOffArg::On),
+        cost_attribution_min_delta_usd: c.cost_attribution_min_delta_usd,
     })?;
     match format {
         crate::run::compare::CompareFormat::Text => print!("{}", report.human_table()),
@@ -504,6 +506,7 @@ fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
         sb_split: e.sb_split,
         run_id: e.run_id,
         breakdown,
+        cost_attribution: matches!(e.cost_attribution, args::OnOffArg::On),
     };
     let eval = crate::run::evaluate::run(&args)?;
     let sweep_results = crate::run::compare::load_run(&e.sweep)?;
@@ -526,6 +529,19 @@ fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
         print!(
             "{}",
             crate::run::evaluate::render_breakdown_table(&eval.breakdown)
+        );
+    }
+    if !eval.cost_attribution.is_empty() {
+        let missing_cost_count =
+            crate::run::evaluate::cost_missing_count_for_run_slots(&e.sweep, &sweep_results)?;
+        if missing_cost_count > 0 {
+            println!(
+                "warning: cost attribution missing usd_cost for {missing_cost_count} trajectories; treating as $0.00"
+            );
+        }
+        print!(
+            "{}",
+            crate::run::evaluate::render_cost_attribution_table(&eval.cost_attribution)
         );
     }
     Ok(())

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -659,13 +659,16 @@ pub(crate) fn load_run_slots<S: std::hash::BuildHasher>(
             result: result.clone(),
         }));
     } else {
-        slots.extend(fallback.iter().filter_map(|(instance_id, result)| {
-            (!seen_ids.contains(instance_id)).then(|| LoadedRunSlot {
-                instance_id: instance_id.clone(),
-                run_index: 1,
-                result: result.clone(),
-            })
-        }));
+        slots.extend(
+            fallback
+                .iter()
+                .filter(|(instance_id, _)| !seen_ids.contains(*instance_id))
+                .map(|(instance_id, result)| LoadedRunSlot {
+                    instance_id: instance_id.clone(),
+                    run_index: 1,
+                    result: result.clone(),
+                }),
+        );
     }
     slots.sort_by(|a, b| {
         a.instance_id
@@ -1630,6 +1633,13 @@ mod tests {
     #![allow(clippy::unwrap_used)]
     use super::*;
 
+    fn assert_f64_eq(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() < 1e-9,
+            "expected {expected}, got {actual}"
+        );
+    }
+
     fn submitted(id: &str) -> InstanceResult {
         InstanceResult {
             instance_id: id.into(),
@@ -2242,29 +2252,29 @@ mod tests {
 
         let step_limit = rows.iter().find(|row| row.bucket == "step_limit").unwrap();
         assert_eq!(step_limit.n_baseline, 1);
-        assert_eq!(step_limit.total_usd_baseline, 0.2);
+        assert_f64_eq(step_limit.total_usd_baseline, 0.2);
         assert_eq!(step_limit.n_candidate, 1);
-        assert_eq!(step_limit.total_usd_candidate, 0.2);
-        assert_eq!(step_limit.delta_usd, 0.0);
-        assert_eq!(step_limit.share_pp_delta, -16.67);
+        assert_f64_eq(step_limit.total_usd_candidate, 0.2);
+        assert_f64_eq(step_limit.delta_usd, 0.0);
+        assert_f64_eq(step_limit.share_pp_delta, -16.67);
         assert!(!step_limit.exceeds_threshold);
 
         let resolved = rows.iter().find(|row| row.bucket == "resolved").unwrap();
         assert_eq!(resolved.n_baseline, 1);
-        assert_eq!(resolved.total_usd_baseline, 0.1);
+        assert_f64_eq(resolved.total_usd_baseline, 0.1);
         assert_eq!(resolved.n_candidate, 0);
-        assert_eq!(resolved.total_usd_candidate, 0.0);
-        assert_eq!(resolved.delta_usd, -0.1);
-        assert_eq!(resolved.share_pp_delta, -33.33);
+        assert_f64_eq(resolved.total_usd_candidate, 0.0);
+        assert_f64_eq(resolved.delta_usd, -0.1);
+        assert_f64_eq(resolved.share_pp_delta, -33.33);
         assert!(!resolved.exceeds_threshold);
 
         let model_api = rows.iter().find(|row| row.bucket == "model_api").unwrap();
         assert_eq!(model_api.n_baseline, 0);
-        assert_eq!(model_api.total_usd_baseline, 0.0);
+        assert_f64_eq(model_api.total_usd_baseline, 0.0);
         assert_eq!(model_api.n_candidate, 1);
-        assert_eq!(model_api.total_usd_candidate, 0.2);
-        assert_eq!(model_api.delta_usd, 0.2);
-        assert_eq!(model_api.share_pp_delta, 50.0);
+        assert_f64_eq(model_api.total_usd_candidate, 0.2);
+        assert_f64_eq(model_api.delta_usd, 0.2);
+        assert_f64_eq(model_api.share_pp_delta, 50.0);
         assert!(!model_api.exceeds_threshold);
     }
 

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -532,7 +532,8 @@ fn scan_trajectory_run_slots(
     dir: &Path,
     min_mtime: Option<SystemTime>,
 ) -> Result<Vec<LoadedRunSlot>, Error> {
-    let mut scanned = Vec::new();
+    let mut instance_dirs: Vec<(String, std::path::PathBuf)> = Vec::new();
+    let mut root_trajectories: Vec<(String, std::path::PathBuf)> = Vec::new();
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
@@ -544,7 +545,7 @@ fn scan_trajectory_run_slots(
             else {
                 continue;
             };
-            scan_nested_run_trajectories(&path, &instance_id, min_mtime, &mut scanned)?;
+            instance_dirs.push((instance_id, path));
             continue;
         }
         if !path_passes_mtime(&path, min_mtime) {
@@ -556,15 +557,25 @@ fn scan_trajectory_run_slots(
         let Some(id) = name_str.strip_suffix(".traj.json") else {
             continue;
         };
-        if let Some(result) = instance_result_from_trajectory(id, &path)? {
+        root_trajectories.push((id.to_owned(), path));
+    }
+    instance_dirs.sort_by(|a, b| a.0.cmp(&b.0));
+    root_trajectories.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut scanned = Vec::new();
+    for (instance_id, path) in instance_dirs {
+        scan_nested_run_trajectories(&path, &instance_id, min_mtime, &mut scanned)?;
+    }
+    for (id, path) in root_trajectories {
+        if let Some(result) = instance_result_from_trajectory(&id, &path)? {
             scanned.push(LoadedRunSlot {
-                instance_id: id.to_owned(),
+                instance_id: id,
                 run_index: 1,
                 result,
             });
         }
     }
-    Ok(scanned)
+    Ok(dedupe_run_slots(scanned))
 }
 
 fn scan_nested_run_trajectories(
@@ -573,6 +584,7 @@ fn scan_nested_run_trajectories(
     min_mtime: Option<SystemTime>,
     out: &mut Vec<LoadedRunSlot>,
 ) -> Result<(), Error> {
+    let mut run_trajectories: Vec<(u32, std::path::PathBuf)> = Vec::new();
     for entry in std::fs::read_dir(instance_dir)? {
         let entry = entry?;
         let path = entry.path();
@@ -589,6 +601,10 @@ fn scan_nested_run_trajectories(
         else {
             continue;
         };
+        run_trajectories.push((run_index, path));
+    }
+    run_trajectories.sort_by_key(|(run_index, _)| *run_index);
+    for (run_index, path) in run_trajectories {
         if let Some(result) = instance_result_from_trajectory(instance_id, &path)? {
             out.push(LoadedRunSlot {
                 instance_id: instance_id.to_owned(),
@@ -598,6 +614,18 @@ fn scan_nested_run_trajectories(
         }
     }
     Ok(())
+}
+
+fn dedupe_run_slots(scanned: Vec<LoadedRunSlot>) -> Vec<LoadedRunSlot> {
+    let mut seen = BTreeSet::new();
+    let mut deduped = Vec::with_capacity(scanned.len());
+    for slot in scanned {
+        let key = (slot.instance_id.clone(), slot.run_index);
+        if seen.insert(key) {
+            deduped.push(slot);
+        }
+    }
+    deduped
 }
 
 fn path_passes_mtime(path: &Path, min_mtime: Option<SystemTime>) -> bool {

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -651,6 +651,8 @@ pub(crate) fn load_run_slots<S: std::hash::BuildHasher>(
     fallback: &HashMap<String, InstanceResult, S>,
 ) -> Result<Vec<LoadedRunSlot>, Error> {
     let mut slots = scan_trajectory_run_slots(dir, None)?;
+    let active_ids: BTreeSet<&str> = fallback.keys().map(String::as_str).collect();
+    slots.retain(|slot| active_ids.contains(slot.instance_id.as_str()));
     let seen_ids: BTreeSet<String> = slots.iter().map(|slot| slot.instance_id.clone()).collect();
     if slots.is_empty() {
         slots.extend(fallback.iter().map(|(instance_id, result)| LoadedRunSlot {

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -17,7 +17,10 @@ use std::time::SystemTime;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
-use crate::run::evaluate::{BreakdownAxis, EvaluationResults, pct};
+use crate::run::evaluate::{
+    BreakdownAxis, CostAttributionBucket, EvaluationResults, cost_attribution_bucket_label, pct,
+    round_dp,
+};
 use crate::run::swebench::{
     FilterSpec, InstanceResult, ProvenanceManifest, SweepResults, effective_runs, resolved_count,
 };
@@ -40,6 +43,8 @@ pub struct CompareArgs {
     pub max_regressions: Option<usize>,
     pub breakdown: crate::run::evaluate::BreakdownSelection,
     pub min_delta_pp: f64,
+    pub cost_attribution: bool,
+    pub cost_attribution_min_delta_usd: f64,
 }
 
 /// Per-task transition between baseline and candidate. `pass` prefers
@@ -127,6 +132,10 @@ pub struct CompareReport {
     pub subset_warnings: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub breakdown_delta: Vec<BreakdownDeltaRow>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cost_attribution_delta: Vec<CostAttributionDeltaRow>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cost_attribution_warnings: Vec<String>,
     /// Tasks that passed in the baseline but failed in the candidate.
     /// This is the high-signal artifact for CI gating; sorted by
     /// `instance_id` for stable output.
@@ -156,6 +165,18 @@ pub struct BreakdownDeltaRow {
     pub candidate_n: usize,
     pub candidate_resolved_rate: f64,
     pub delta_resolved_rate: f64,
+    pub exceeds_threshold: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CostAttributionDeltaRow {
+    pub bucket: String,
+    pub n_baseline: usize,
+    pub total_usd_baseline: f64,
+    pub n_candidate: usize,
+    pub total_usd_candidate: f64,
+    pub delta_usd: f64,
+    pub share_pp_delta: f64,
     pub exceeds_threshold: bool,
 }
 
@@ -232,7 +253,21 @@ impl CompareReport {
             &self.failure_category_candidate,
             &self.failure_category_delta,
         );
-        write_subset_warnings(&mut s, &self.subset_warnings);
+        write_cost_attribution_delta_section(
+            &mut s,
+            &self.cost_attribution_warnings,
+            &self.cost_attribution_delta,
+        );
+        let subset_warnings = if self.cost_attribution_delta.is_empty() {
+            self.subset_warnings.clone()
+        } else {
+            self.subset_warnings
+                .iter()
+                .filter(|warning| !warning.contains("dataset subset differs"))
+                .cloned()
+                .collect()
+        };
+        write_subset_warnings(&mut s, &subset_warnings);
         write_breakdown_delta_section(&mut s, &self.breakdown_delta);
         write_regressions(&mut s, &self.regressions);
         s
@@ -331,6 +366,34 @@ fn write_breakdown_delta_section(s: &mut String, rows: &[BreakdownDeltaRow]) {
     }
 }
 
+fn write_cost_attribution_delta_section(
+    s: &mut String,
+    warnings: &[String],
+    rows: &[CostAttributionDeltaRow],
+) {
+    if rows.is_empty() {
+        return;
+    }
+    s.push_str("\nCost attribution delta:\n");
+    for warning in warnings {
+        let _ = writeln!(s, "  ! {warning}");
+    }
+    for row in rows {
+        let _ = writeln!(
+            s,
+            "  {} bucket={}  n: {} -> {}  total_usd: ${:.4} -> ${:.4}  delta_usd={:+.4}  share_pp_delta={:+.2}",
+            if row.exceeds_threshold { "*" } else { "-" },
+            row.bucket,
+            row.n_baseline,
+            row.n_candidate,
+            row.total_usd_baseline,
+            row.total_usd_candidate,
+            row.delta_usd,
+            row.share_pp_delta
+        );
+    }
+}
+
 fn write_regressions(s: &mut String, regressions: &[TaskTransition]) {
     if regressions.is_empty() {
         s.push_str("\nRegressions:        none\n");
@@ -365,6 +428,13 @@ pub struct LoadedSweep {
     pub instances: HashMap<String, InstanceResult>,
     pub manifest: Option<ProvenanceManifest>,
     pub filter_spec: Option<FilterSpec>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LoadedRunSlot {
+    pub instance_id: String,
+    pub run_index: u32,
+    pub result: InstanceResult,
 }
 
 pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
@@ -453,7 +523,16 @@ fn scan_trajectory_instances(
     dir: &Path,
     min_mtime: Option<SystemTime>,
 ) -> Result<HashMap<String, InstanceResult>, Error> {
-    let mut scanned: Vec<(String, u32, InstanceResult)> = Vec::new();
+    Ok(aggregate_scanned_results(scan_trajectory_run_slots(
+        dir, min_mtime,
+    )?))
+}
+
+fn scan_trajectory_run_slots(
+    dir: &Path,
+    min_mtime: Option<SystemTime>,
+) -> Result<Vec<LoadedRunSlot>, Error> {
+    let mut scanned = Vec::new();
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
@@ -478,17 +557,21 @@ fn scan_trajectory_instances(
             continue;
         };
         if let Some(result) = instance_result_from_trajectory(id, &path)? {
-            scanned.push((id.to_owned(), 1, result));
+            scanned.push(LoadedRunSlot {
+                instance_id: id.to_owned(),
+                run_index: 1,
+                result,
+            });
         }
     }
-    Ok(aggregate_scanned_results(scanned))
+    Ok(scanned)
 }
 
 fn scan_nested_run_trajectories(
     instance_dir: &Path,
     instance_id: &str,
     min_mtime: Option<SystemTime>,
-    out: &mut Vec<(String, u32, InstanceResult)>,
+    out: &mut Vec<LoadedRunSlot>,
 ) -> Result<(), Error> {
     for entry in std::fs::read_dir(instance_dir)? {
         let entry = entry?;
@@ -507,7 +590,11 @@ fn scan_nested_run_trajectories(
             continue;
         };
         if let Some(result) = instance_result_from_trajectory(instance_id, &path)? {
-            out.push((instance_id.to_owned(), run_index, result));
+            out.push(LoadedRunSlot {
+                instance_id: instance_id.to_owned(),
+                run_index,
+                result,
+            });
         }
     }
     Ok(())
@@ -559,12 +646,42 @@ fn instance_result_from_trajectory(
     }))
 }
 
-fn aggregate_scanned_results(
-    scanned: Vec<(String, u32, InstanceResult)>,
-) -> HashMap<String, InstanceResult> {
+pub(crate) fn load_run_slots<S: std::hash::BuildHasher>(
+    dir: &Path,
+    fallback: &HashMap<String, InstanceResult, S>,
+) -> Result<Vec<LoadedRunSlot>, Error> {
+    let mut slots = scan_trajectory_run_slots(dir, None)?;
+    let seen_ids: BTreeSet<String> = slots.iter().map(|slot| slot.instance_id.clone()).collect();
+    if slots.is_empty() {
+        slots.extend(fallback.iter().map(|(instance_id, result)| LoadedRunSlot {
+            instance_id: instance_id.clone(),
+            run_index: 1,
+            result: result.clone(),
+        }));
+    } else {
+        slots.extend(fallback.iter().filter_map(|(instance_id, result)| {
+            (!seen_ids.contains(instance_id)).then(|| LoadedRunSlot {
+                instance_id: instance_id.clone(),
+                run_index: 1,
+                result: result.clone(),
+            })
+        }));
+    }
+    slots.sort_by(|a, b| {
+        a.instance_id
+            .cmp(&b.instance_id)
+            .then_with(|| a.run_index.cmp(&b.run_index))
+    });
+    Ok(slots)
+}
+
+fn aggregate_scanned_results(scanned: Vec<LoadedRunSlot>) -> HashMap<String, InstanceResult> {
     let mut grouped: BTreeMap<String, Vec<(u32, InstanceResult)>> = BTreeMap::new();
-    for (id, run_index, result) in scanned {
-        grouped.entry(id).or_default().push((run_index, result));
+    for slot in scanned {
+        grouped
+            .entry(slot.instance_id)
+            .or_default()
+            .push((slot.run_index, slot.result));
     }
     let mut out = HashMap::new();
     for (id, mut rows) in grouped {
@@ -618,15 +735,17 @@ fn optional_sum(values: impl Iterator<Item = f64>) -> Option<f64> {
 pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
     let baseline = load_sweep(&args.baseline)?;
     let candidate = load_sweep(&args.candidate)?;
-    let baseline_eval = load_resolved_overrides(&args.baseline)?;
-    let candidate_eval = load_resolved_overrides(&args.candidate)?;
+    let baseline_eval = load_evaluation_results(&args.baseline)?;
+    let candidate_eval = load_evaluation_results(&args.candidate)?;
+    let baseline_resolved_override = baseline_eval.as_ref().map(resolved_overrides_from_eval);
+    let candidate_resolved_override = candidate_eval.as_ref().map(resolved_overrides_from_eval);
     let mut report = diff_with_overrides(
         &args.baseline,
         &args.candidate,
         &baseline.instances,
         &candidate.instances,
-        baseline_eval.as_ref(),
-        candidate_eval.as_ref(),
+        baseline_resolved_override.as_ref(),
+        candidate_resolved_override.as_ref(),
         manifest_delta_lines(baseline.manifest.as_ref(), candidate.manifest.as_ref()),
     );
     report.subset_warnings = subset_warnings(
@@ -636,11 +755,47 @@ pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
     report.breakdown_delta = build_breakdown_delta(
         &baseline.instances,
         &candidate.instances,
-        baseline_eval.as_ref(),
-        candidate_eval.as_ref(),
+        baseline_resolved_override.as_ref(),
+        candidate_resolved_override.as_ref(),
         &args.breakdown.axes,
         args.min_delta_pp,
     );
+    if args.cost_attribution {
+        let baseline_cost_rows = baseline_eval
+            .as_ref()
+            .and_then(non_empty_cost_attribution_rows);
+        let candidate_cost_rows = candidate_eval
+            .as_ref()
+            .and_then(non_empty_cost_attribution_rows);
+        let baseline_fallback_rows = baseline_cost_rows.is_none().then(|| {
+            build_cost_attribution_rows_from_results(
+                &baseline.instances,
+                baseline_resolved_override.as_ref(),
+            )
+        });
+        let candidate_fallback_rows = candidate_cost_rows.is_none().then(|| {
+            build_cost_attribution_rows_from_results(
+                &candidate.instances,
+                candidate_resolved_override.as_ref(),
+            )
+        });
+        let baseline_rows = if let Some(rows) = baseline_cost_rows {
+            rows
+        } else {
+            baseline_fallback_rows.as_deref().unwrap_or(&[])
+        };
+        let candidate_rows = if let Some(rows) = candidate_cost_rows {
+            rows
+        } else {
+            candidate_fallback_rows.as_deref().unwrap_or(&[])
+        };
+        report.cost_attribution_delta = build_cost_attribution_delta_from_rows(
+            baseline_rows,
+            candidate_rows,
+            args.cost_attribution_min_delta_usd,
+        );
+        report.cost_attribution_warnings = build_cost_attribution_warnings(&report.subset_warnings);
+    }
     Ok(report)
 }
 
@@ -773,6 +928,8 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
         manifest_deltas,
         subset_warnings: Vec::new(),
         breakdown_delta: Vec::new(),
+        cost_attribution_delta: Vec::new(),
+        cost_attribution_warnings: Vec::new(),
         regressions: transition_summary.regressions,
     }
 }
@@ -1063,30 +1220,29 @@ fn wilson_ci(successes: u64, total: u64) -> ConfidenceInterval {
     }
 }
 
-fn load_resolved_overrides(
-    dir: &Path,
-) -> Result<Option<HashMap<String, ResolutionOverride>>, Error> {
+fn load_evaluation_results(dir: &Path) -> Result<Option<EvaluationResults>, Error> {
     let path = crate::run::evaluate::evaluation_path(dir);
     if !path.exists() {
         return Ok(None);
     }
     let text = std::fs::read_to_string(path)?;
-    let eval: EvaluationResults = serde_json::from_str(&text)?;
-    Ok(Some(
-        eval.instances
-            .into_iter()
-            .map(|row| {
-                (
-                    row.instance_id,
-                    ResolutionOverride {
-                        resolved: row.resolved,
-                        runs: row.runs,
-                        resolved_count: row.resolved_count,
-                    },
-                )
-            })
-            .collect(),
-    ))
+    Ok(Some(serde_json::from_str(&text)?))
+}
+
+fn resolved_overrides_from_eval(eval: &EvaluationResults) -> HashMap<String, ResolutionOverride> {
+    eval.instances
+        .iter()
+        .map(|row| {
+            (
+                row.instance_id.clone(),
+                ResolutionOverride {
+                    resolved: row.resolved,
+                    runs: row.runs,
+                    resolved_count: row.resolved_count,
+                },
+            )
+        })
+        .collect()
 }
 
 fn manifest_delta_lines(
@@ -1272,6 +1428,17 @@ fn build_breakdown_delta<S: std::hash::BuildHasher>(
     out
 }
 
+fn build_cost_attribution_warnings(subset_warnings: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(warning) = subset_warnings
+        .iter()
+        .find(|warning| warning.contains("dataset subset differs"))
+    {
+        out.push(format!("totals are not directly comparable: {warning}"));
+    }
+    out
+}
+
 fn breakdown_map<S: std::hash::BuildHasher>(
     items: &HashMap<String, InstanceResult, S>,
     resolved_override: Option<&HashMap<String, ResolutionOverride>>,
@@ -1299,6 +1466,163 @@ fn breakdown_map<S: std::hash::BuildHasher>(
         }
     }
     out
+}
+
+fn cost_attribution_map<S: std::hash::BuildHasher>(
+    items: &HashMap<String, InstanceResult, S>,
+    resolved_override: Option<&HashMap<String, ResolutionOverride>>,
+) -> HashMap<String, (usize, f64)> {
+    let mut out = HashMap::new();
+    for (id, row) in items {
+        let resolved = stats_for(id, row, resolved_override).resolved_count > 0;
+        let key = cost_attribution_bucket_label(resolved, row.failure_category).to_owned();
+        let entry = out.entry(key).or_insert((0, 0.0));
+        entry.0 += 1;
+        entry.1 += row.cost_usd.unwrap_or(0.0);
+    }
+    out
+}
+
+fn non_empty_cost_attribution_rows(eval: &EvaluationResults) -> Option<&[CostAttributionBucket]> {
+    (!eval.cost_attribution.is_empty()).then_some(eval.cost_attribution.as_slice())
+}
+
+fn build_cost_attribution_rows_from_results<S: std::hash::BuildHasher>(
+    items: &HashMap<String, InstanceResult, S>,
+    resolved_override: Option<&HashMap<String, ResolutionOverride>>,
+) -> Vec<CostAttributionBucket> {
+    let map = cost_attribution_map(items, resolved_override);
+    let total_usd: f64 = map.values().map(|(_, total)| *total).sum();
+    let total_n: usize = map.values().map(|(n, _)| *n).sum();
+
+    let mut rows: Vec<CostAttributionBucket> = map
+        .into_iter()
+        .map(|(bucket, (n, total))| CostAttributionBucket {
+            bucket,
+            n,
+            total_usd: round_dp(total, 4),
+            mean_usd: if n == 0 {
+                0.0
+            } else {
+                #[allow(clippy::cast_precision_loss)]
+                {
+                    round_dp(total / n as f64, 4)
+                }
+            },
+            share_pct: if total_usd == 0.0 {
+                0.0
+            } else {
+                round_dp(total * 100.0 / total_usd, 2)
+            },
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        b.total_usd
+            .partial_cmp(&a.total_usd)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.bucket.cmp(&b.bucket))
+    });
+    rows.push(CostAttributionBucket {
+        bucket: crate::run::evaluate::COST_ATTRIBUTION_TOTAL_BUCKET.to_owned(),
+        n: total_n,
+        total_usd: round_dp(total_usd, 4),
+        mean_usd: if total_n == 0 {
+            0.0
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            {
+                round_dp(total_usd / total_n as f64, 4)
+            }
+        },
+        share_pct: if total_n == 0 { 0.0 } else { 100.0 },
+    });
+    rows
+}
+
+fn build_cost_attribution_delta_from_rows(
+    baseline_rows: &[CostAttributionBucket],
+    candidate_rows: &[CostAttributionBucket],
+    min_delta_usd: f64,
+) -> Vec<CostAttributionDeltaRow> {
+    let (baseline_map, baseline_total) = cost_attribution_rows_to_map(baseline_rows);
+    let (candidate_map, candidate_total) = cost_attribution_rows_to_map(candidate_rows);
+
+    let mut keys: BTreeSet<String> = BTreeSet::new();
+    keys.extend(baseline_map.keys().cloned());
+    keys.extend(candidate_map.keys().cloned());
+
+    let mut out = Vec::new();
+    for key in keys {
+        let (n_baseline, total_usd_baseline_raw) =
+            baseline_map.get(&key).copied().unwrap_or((0, 0.0));
+        let (n_candidate, total_usd_candidate_raw) =
+            candidate_map.get(&key).copied().unwrap_or((0, 0.0));
+        if n_baseline == 0
+            && n_candidate == 0
+            && total_usd_baseline_raw == 0.0
+            && total_usd_candidate_raw == 0.0
+        {
+            continue;
+        }
+        let share_baseline = if baseline_total == 0.0 {
+            0.0
+        } else {
+            total_usd_baseline_raw * 100.0 / baseline_total
+        };
+        let share_candidate = if candidate_total == 0.0 {
+            0.0
+        } else {
+            total_usd_candidate_raw * 100.0 / candidate_total
+        };
+        let delta_usd_raw = total_usd_candidate_raw - total_usd_baseline_raw;
+        out.push(CostAttributionDeltaRow {
+            bucket: key,
+            n_baseline,
+            total_usd_baseline: round_dp(total_usd_baseline_raw, 4),
+            n_candidate,
+            total_usd_candidate: round_dp(total_usd_candidate_raw, 4),
+            delta_usd: round_dp(delta_usd_raw, 4),
+            share_pp_delta: round_dp(share_candidate - share_baseline, 2),
+            exceeds_threshold: delta_usd_raw.abs() >= min_delta_usd,
+        });
+    }
+    out.sort_by(|a, b| {
+        b.delta_usd
+            .abs()
+            .partial_cmp(&a.delta_usd.abs())
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.bucket.cmp(&b.bucket))
+    });
+    out
+}
+
+fn cost_attribution_rows_to_map(
+    rows: &[CostAttributionBucket],
+) -> (HashMap<String, (usize, f64)>, f64) {
+    let mut map = HashMap::new();
+    let mut total_usd = None;
+    for row in rows {
+        if row.bucket == crate::run::evaluate::COST_ATTRIBUTION_TOTAL_BUCKET {
+            total_usd = Some(row.total_usd);
+            continue;
+        }
+        map.insert(row.bucket.clone(), (row.n, row.total_usd));
+    }
+    let total_usd = total_usd.unwrap_or_else(|| map.values().map(|(_, total)| *total).sum());
+    (map, total_usd)
+}
+
+#[cfg(test)]
+fn build_cost_attribution_delta<S: std::hash::BuildHasher>(
+    baseline: &HashMap<String, InstanceResult, S>,
+    candidate: &HashMap<String, InstanceResult, S>,
+    baseline_override: Option<&HashMap<String, ResolutionOverride>>,
+    candidate_override: Option<&HashMap<String, ResolutionOverride>>,
+    min_delta_usd: f64,
+) -> Vec<CostAttributionDeltaRow> {
+    let baseline_rows = build_cost_attribution_rows_from_results(baseline, baseline_override);
+    let candidate_rows = build_cost_attribution_rows_from_results(candidate, candidate_override);
+    build_cost_attribution_delta_from_rows(&baseline_rows, &candidate_rows, min_delta_usd)
 }
 
 #[cfg(test)]
@@ -1550,6 +1874,8 @@ mod tests {
             max_regressions: None,
             breakdown: crate::run::evaluate::BreakdownSelection::none(),
             min_delta_pp: 0.0,
+            cost_attribution: true,
+            cost_attribution_min_delta_usd: 1.0,
         })
         .unwrap();
         assert_eq!(r.regressions.len(), 1);
@@ -1810,6 +2136,7 @@ mod tests {
                 eval_log_path: None,
             }],
             breakdown: Vec::new(),
+            cost_attribution: Vec::new(),
         };
         let candidate_eval = crate::run::evaluate::EvaluationResults {
             instances: vec![crate::run::evaluate::InstanceEvaluation {
@@ -1824,6 +2151,7 @@ mod tests {
                 eval_log_path: None,
             }],
             breakdown: Vec::new(),
+            cost_attribution: Vec::new(),
         };
 
         std::fs::write(
@@ -1844,6 +2172,8 @@ mod tests {
             max_regressions: None,
             breakdown: crate::run::evaluate::BreakdownSelection::none(),
             min_delta_pp: 0.0,
+            cost_attribution: true,
+            cost_attribution_min_delta_usd: 1.0,
         })
         .unwrap();
         assert_eq!(r.baseline_resolved, 1);
@@ -1871,6 +2201,7 @@ mod tests {
                 eval_log_path: None,
             }],
             breakdown: Vec::new(),
+            cost_attribution: Vec::new(),
         };
         std::fs::write(
             crate::run::evaluate::evaluation_path(dir_c.path()),
@@ -1885,11 +2216,56 @@ mod tests {
             max_regressions: None,
             breakdown: crate::run::evaluate::BreakdownSelection::none(),
             min_delta_pp: 0.0,
+            cost_attribution: true,
+            cost_attribution_min_delta_usd: 1.0,
         })
         .unwrap();
         assert_eq!(r.baseline_resolved, 10);
         assert_eq!(r.candidate_runs, 10);
         assert_eq!(r.candidate_resolved, 1);
+    }
+
+    #[test]
+    fn cost_attribution_delta_computes_usd_and_share_point_changes() {
+        let baseline = map_of([
+            submitted("resolved"),
+            errored("step", FailureCategory::StepLimit),
+        ]);
+        let candidate = map_of([
+            errored("resolved", FailureCategory::StepLimit),
+            errored("api", FailureCategory::ModelApi),
+        ]);
+
+        let rows = build_cost_attribution_delta(&baseline, &candidate, None, None, 1.0);
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].bucket, "model_api");
+
+        let step_limit = rows.iter().find(|row| row.bucket == "step_limit").unwrap();
+        assert_eq!(step_limit.n_baseline, 1);
+        assert_eq!(step_limit.total_usd_baseline, 0.2);
+        assert_eq!(step_limit.n_candidate, 1);
+        assert_eq!(step_limit.total_usd_candidate, 0.2);
+        assert_eq!(step_limit.delta_usd, 0.0);
+        assert_eq!(step_limit.share_pp_delta, -16.67);
+        assert!(!step_limit.exceeds_threshold);
+
+        let resolved = rows.iter().find(|row| row.bucket == "resolved").unwrap();
+        assert_eq!(resolved.n_baseline, 1);
+        assert_eq!(resolved.total_usd_baseline, 0.1);
+        assert_eq!(resolved.n_candidate, 0);
+        assert_eq!(resolved.total_usd_candidate, 0.0);
+        assert_eq!(resolved.delta_usd, -0.1);
+        assert_eq!(resolved.share_pp_delta, -33.33);
+        assert!(!resolved.exceeds_threshold);
+
+        let model_api = rows.iter().find(|row| row.bucket == "model_api").unwrap();
+        assert_eq!(model_api.n_baseline, 0);
+        assert_eq!(model_api.total_usd_baseline, 0.0);
+        assert_eq!(model_api.n_candidate, 1);
+        assert_eq!(model_api.total_usd_candidate, 0.2);
+        assert_eq!(model_api.delta_usd, 0.2);
+        assert_eq!(model_api.share_pp_delta, 50.0);
+        assert!(!model_api.exceeds_threshold);
     }
 
     #[test]

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -800,18 +800,22 @@ pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
         let candidate_cost_rows = candidate_eval
             .as_ref()
             .and_then(non_empty_cost_attribution_rows);
-        let baseline_fallback_rows = baseline_cost_rows.is_none().then(|| {
-            build_cost_attribution_rows_from_results(
+        let baseline_fallback_rows = if baseline_cost_rows.is_none() {
+            Some(build_cost_attribution_rows_from_run_slots(&load_run_slots(
+                &args.baseline,
                 &baseline.instances,
-                baseline_resolved_override.as_ref(),
-            )
-        });
-        let candidate_fallback_rows = candidate_cost_rows.is_none().then(|| {
-            build_cost_attribution_rows_from_results(
+            )?))
+        } else {
+            None
+        };
+        let candidate_fallback_rows = if candidate_cost_rows.is_none() {
+            Some(build_cost_attribution_rows_from_run_slots(&load_run_slots(
+                &args.candidate,
                 &candidate.instances,
-                candidate_resolved_override.as_ref(),
-            )
-        });
+            )?))
+        } else {
+            None
+        };
         let baseline_rows = if let Some(rows) = baseline_cost_rows {
             rows
         } else {
@@ -1501,6 +1505,7 @@ fn breakdown_map<S: std::hash::BuildHasher>(
     out
 }
 
+#[cfg(test)]
 fn cost_attribution_map<S: std::hash::BuildHasher>(
     items: &HashMap<String, InstanceResult, S>,
     resolved_override: Option<&HashMap<String, ResolutionOverride>>,
@@ -1520,11 +1525,35 @@ fn non_empty_cost_attribution_rows(eval: &EvaluationResults) -> Option<&[CostAtt
     (!eval.cost_attribution.is_empty()).then_some(eval.cost_attribution.as_slice())
 }
 
+fn cost_attribution_map_from_run_slots(slots: &[LoadedRunSlot]) -> HashMap<String, (usize, f64)> {
+    let mut out = HashMap::new();
+    for slot in slots {
+        let resolved = slot.result.resolved_count > 0;
+        let key = cost_attribution_bucket_label(resolved, slot.result.failure_category).to_owned();
+        let entry = out.entry(key).or_insert((0, 0.0));
+        entry.0 += 1;
+        entry.1 += slot.result.cost_usd.unwrap_or(0.0);
+    }
+    out
+}
+
+fn build_cost_attribution_rows_from_run_slots(
+    slots: &[LoadedRunSlot],
+) -> Vec<CostAttributionBucket> {
+    build_cost_attribution_rows_from_map(cost_attribution_map_from_run_slots(slots))
+}
+
+#[cfg(test)]
 fn build_cost_attribution_rows_from_results<S: std::hash::BuildHasher>(
     items: &HashMap<String, InstanceResult, S>,
     resolved_override: Option<&HashMap<String, ResolutionOverride>>,
 ) -> Vec<CostAttributionBucket> {
-    let map = cost_attribution_map(items, resolved_override);
+    build_cost_attribution_rows_from_map(cost_attribution_map(items, resolved_override))
+}
+
+fn build_cost_attribution_rows_from_map(
+    map: HashMap<String, (usize, f64)>,
+) -> Vec<CostAttributionBucket> {
     let total_usd: f64 = map.values().map(|(_, total)| *total).sum();
     let total_n: usize = map.values().map(|(n, _)| *n).sum();
 

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -886,12 +886,11 @@ fn build_cost_attribution_report(
     for sample in samples {
         total_n += 1;
         let bucket = cost_attribution_bucket_label(sample.resolved, sample.failure_category);
-        let usd_cost = match sample.cost_usd {
-            Some(cost) => cost,
-            None => {
-                missing_cost_count += 1;
-                0.0
-            }
+        let usd_cost = if let Some(cost) = sample.cost_usd {
+            cost
+        } else {
+            missing_cost_count += 1;
+            0.0
         };
         total_usd += usd_cost;
         let entry = buckets.entry(bucket.to_owned()).or_insert((0, 0.0));
@@ -982,6 +981,13 @@ mod tests {
 
     use super::*;
     use crate::trajectory::FailureCategory;
+
+    fn assert_f64_eq(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() < 1e-9,
+            "expected {expected}, got {actual}"
+        );
+    }
 
     fn submitted(id: &str) -> InstanceResult {
         InstanceResult {
@@ -1207,28 +1213,28 @@ mod tests {
 
         let resolved_row = rows.get("resolved").copied().unwrap();
         assert_eq!(resolved_row.n, 1);
-        assert_eq!(resolved_row.total_usd, 0.0);
-        assert_eq!(resolved_row.mean_usd, 0.0);
-        assert_eq!(resolved_row.share_pct, 0.0);
+        assert_f64_eq(resolved_row.total_usd, 0.0);
+        assert_f64_eq(resolved_row.mean_usd, 0.0);
+        assert_f64_eq(resolved_row.share_pct, 0.0);
 
         let uncategorized_row = rows.get("uncategorized").copied().unwrap();
         assert_eq!(uncategorized_row.n, 1);
-        assert_eq!(uncategorized_row.total_usd, 1.0);
-        assert_eq!(uncategorized_row.mean_usd, 1.0);
-        assert_eq!(uncategorized_row.share_pct, 25.0);
+        assert_f64_eq(uncategorized_row.total_usd, 1.0);
+        assert_f64_eq(uncategorized_row.mean_usd, 1.0);
+        assert_f64_eq(uncategorized_row.share_pct, 25.0);
 
         let model_api_row = rows.get("model_api").copied().unwrap();
         assert_eq!(model_api_row.n, 1);
-        assert_eq!(model_api_row.total_usd, 3.0);
-        assert_eq!(model_api_row.mean_usd, 3.0);
-        assert_eq!(model_api_row.share_pct, 75.0);
+        assert_f64_eq(model_api_row.total_usd, 3.0);
+        assert_f64_eq(model_api_row.mean_usd, 3.0);
+        assert_f64_eq(model_api_row.share_pct, 75.0);
 
         let total_row = report.rows.last().unwrap();
         assert_eq!(total_row.bucket, "TOTAL");
         assert_eq!(total_row.n, 3);
-        assert_eq!(total_row.total_usd, 4.0);
-        assert_eq!(total_row.mean_usd, 1.3333);
-        assert_eq!(total_row.share_pct, 100.0);
+        assert_f64_eq(total_row.total_usd, 4.0);
+        assert_f64_eq(total_row.mean_usd, 1.3333);
+        assert_f64_eq(total_row.share_pct, 100.0);
     }
 
     #[test]

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -8,9 +8,23 @@ use std::process::Command;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
-use crate::run::compare::load_sweep;
+use crate::run::compare::{load_run_slots, load_sweep};
 use crate::run::swebench::{self, InstanceResult, effective_runs};
 use crate::trajectory::{FailureCategory, outcome};
+
+pub const COST_ATTRIBUTION_RESOLVED_BUCKET: &str = "resolved";
+pub const COST_ATTRIBUTION_UNCATEGORIZED_BUCKET: &str = "uncategorized";
+pub const COST_ATTRIBUTION_TOTAL_BUCKET: &str = "TOTAL";
+pub const ALL_FAILURE_CATEGORIES: [FailureCategory; 8] = [
+    FailureCategory::EnvSetup,
+    FailureCategory::ModelApi,
+    FailureCategory::ModelParse,
+    FailureCategory::StepLimit,
+    FailureCategory::CostLimit,
+    FailureCategory::WallclockTimeout,
+    FailureCategory::AgentInternal,
+    FailureCategory::Unknown,
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EvaluateBackend {
@@ -29,6 +43,7 @@ pub struct EvaluateArgs {
     pub sb_split: String,
     pub run_id: Option<String>,
     pub breakdown: BreakdownSelection,
+    pub cost_attribution: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -101,6 +116,8 @@ pub struct EvaluationResults {
     pub instances: Vec<InstanceEvaluation>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub breakdown: Vec<BreakdownBucket>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cost_attribution: Vec<CostAttributionBucket>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -121,6 +138,58 @@ pub struct BreakdownBucket {
     pub resolved_rate: f64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CostAttributionBucket {
+    pub bucket: String,
+    pub n: usize,
+    pub total_usd: f64,
+    pub mean_usd: f64,
+    pub share_pct: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct CostAttributionReport {
+    rows: Vec<CostAttributionBucket>,
+    missing_cost_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RunSlotKey {
+    instance_id: String,
+    run_index: u32,
+}
+
+impl RunSlotKey {
+    fn new(instance_id: &str, run_index: u32) -> Self {
+        Self {
+            instance_id: instance_id.to_owned(),
+            run_index,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct EvaluateRunOutput {
+    eval: EvaluationResults,
+    resolved_by_run: HashMap<RunSlotKey, bool>,
+}
+
+impl EvaluateRunOutput {
+    fn without_run_resolution(eval: EvaluationResults) -> Self {
+        Self {
+            eval,
+            resolved_by_run: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CostAttributionSample {
+    resolved: bool,
+    failure_category: Option<FailureCategory>,
+    cost_usd: Option<f64>,
+}
+
 #[must_use]
 pub fn evaluation_path(sweep_dir: &Path) -> PathBuf {
     sweep_dir.join("evaluation.json")
@@ -134,11 +203,19 @@ pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
         ));
     }
     let results = loaded.instances;
-    let mut eval = match args.backend {
-        EvaluateBackend::None => build_none_eval(&results),
+    let run_output = match args.backend {
+        EvaluateBackend::None => {
+            EvaluateRunOutput::without_run_resolution(build_none_eval(&results))
+        }
         EvaluateBackend::SbCli => run_sb_cli(args, &results)?,
     };
+    let mut eval = run_output.eval;
     eval.breakdown = build_breakdown(&eval.instances, &results, &args.breakdown);
+    if args.cost_attribution {
+        let run_slots = load_run_slots(&args.sweep_dir, &results)?;
+        eval.cost_attribution =
+            build_cost_attribution_from_run_slots(&run_slots, &run_output.resolved_by_run).rows;
+    }
     std::fs::write(
         evaluation_path(&args.sweep_dir),
         serde_json::to_string_pretty(&eval)?,
@@ -194,6 +271,7 @@ fn build_none_eval(results: &HashMap<String, InstanceResult>) -> EvaluationResul
     EvaluationResults {
         instances,
         breakdown: Vec::new(),
+        cost_attribution: Vec::new(),
     }
 }
 
@@ -219,7 +297,7 @@ fn none_eval_for_result(id: &str, r: &InstanceResult) -> InstanceEvaluation {
 fn run_sb_cli(
     args: &EvaluateArgs,
     results: &HashMap<String, InstanceResult>,
-) -> Result<EvaluationResults, Error> {
+) -> Result<EvaluateRunOutput, Error> {
     let preds = swebench::predictions_path(&args.sweep_dir);
     if !preds.exists() {
         return Err(Error::Trajectory(format!(
@@ -233,6 +311,7 @@ fn run_sb_cli(
     let run_id = args.run_id.clone().unwrap_or_else(generated_run_id);
 
     let max_runs = results.values().map(effective_runs).max().unwrap_or(1);
+    let mut resolved_by_run = HashMap::new();
     if max_runs > 1 {
         let mut reports = BTreeMap::new();
         for run_index in 1..=max_runs {
@@ -243,13 +322,29 @@ fn run_sb_cli(
             }
             let run_report_id = format!("{run_id}-run-{run_index}");
             let parsed = submit_sb_cli_predictions(args, &run_preds, &report_dir, &run_report_id)?;
+            resolved_by_run.extend(
+                parsed.iter().map(|(instance_id, row)| {
+                    (RunSlotKey::new(instance_id, run_index), row.resolved)
+                }),
+            );
             reports.insert(run_index, parsed);
         }
-        return Ok(merge_rerun_reports_with_results(results, &reports));
+        return Ok(EvaluateRunOutput {
+            eval: merge_rerun_reports_with_results(results, &reports),
+            resolved_by_run,
+        });
     }
 
     let parsed = submit_sb_cli_predictions(args, &preds, &report_dir, &run_id)?;
-    Ok(merge_with_results(results, &parsed))
+    resolved_by_run.extend(
+        parsed
+            .iter()
+            .map(|(instance_id, row)| (RunSlotKey::new(instance_id, 1), row.resolved)),
+    );
+    Ok(EvaluateRunOutput {
+        eval: merge_with_results(results, &parsed),
+        resolved_by_run,
+    })
 }
 
 fn predictions_file_has_rows(path: &Path) -> Result<bool, Error> {
@@ -522,6 +617,7 @@ fn merge_with_results(
     EvaluationResults {
         instances,
         breakdown: Vec::new(),
+        cost_attribution: Vec::new(),
     }
 }
 
@@ -584,6 +680,7 @@ fn merge_rerun_reports_with_results(
     EvaluationResults {
         instances,
         breakdown: Vec::new(),
+        cost_attribution: Vec::new(),
     }
 }
 
@@ -693,6 +790,18 @@ pub fn failure_label(cat: FailureCategory) -> &'static str {
 }
 
 #[must_use]
+pub fn cost_attribution_bucket_label(
+    resolved: bool,
+    failure_category: Option<FailureCategory>,
+) -> &'static str {
+    if resolved {
+        COST_ATTRIBUTION_RESOLVED_BUCKET
+    } else {
+        failure_category.map_or(COST_ATTRIBUTION_UNCATEGORIZED_BUCKET, failure_label)
+    }
+}
+
+#[must_use]
 pub fn pct(numer: usize, denom: usize) -> f64 {
     if denom == 0 {
         return 0.0;
@@ -700,6 +809,140 @@ pub fn pct(numer: usize, denom: usize) -> f64 {
     #[allow(clippy::cast_precision_loss)]
     {
         numer as f64 / denom as f64
+    }
+}
+
+#[must_use]
+pub fn round_dp(value: f64, places: u32) -> f64 {
+    let factor = 10_f64.powf(f64::from(places));
+    (value * factor).round() / factor
+}
+
+#[must_use]
+pub fn cost_missing_count<S: std::hash::BuildHasher>(
+    results: &HashMap<String, InstanceResult, S>,
+) -> usize {
+    results
+        .values()
+        .filter(|row| row.cost_usd.is_none())
+        .count()
+}
+
+pub(crate) fn cost_missing_count_for_run_slots<S: std::hash::BuildHasher>(
+    sweep_dir: &Path,
+    results: &HashMap<String, InstanceResult, S>,
+) -> Result<usize, Error> {
+    Ok(load_run_slots(sweep_dir, results)?
+        .into_iter()
+        .filter(|slot| slot.result.cost_usd.is_none())
+        .count())
+}
+
+#[cfg(test)]
+fn build_cost_attribution<S: std::hash::BuildHasher>(
+    evals: &[InstanceEvaluation],
+    results: &HashMap<String, InstanceResult, S>,
+) -> CostAttributionReport {
+    build_cost_attribution_report(evals.iter().map(|row| {
+        let result = results.get(&row.instance_id);
+        CostAttributionSample {
+            resolved: row.resolved,
+            failure_category: result.and_then(|result| result.failure_category),
+            cost_usd: result.and_then(|result| result.cost_usd),
+        }
+    }))
+}
+
+fn build_cost_attribution_from_run_slots(
+    run_slots: &[crate::run::compare::LoadedRunSlot],
+    resolved_by_run: &HashMap<RunSlotKey, bool>,
+) -> CostAttributionReport {
+    build_cost_attribution_report(run_slots.iter().map(|slot| {
+        CostAttributionSample {
+            resolved: resolved_by_run
+                .get(&RunSlotKey::new(&slot.instance_id, slot.run_index))
+                .copied()
+                .unwrap_or(false),
+            failure_category: slot.result.failure_category,
+            cost_usd: slot.result.cost_usd,
+        }
+    }))
+}
+
+fn build_cost_attribution_report(
+    samples: impl IntoIterator<Item = CostAttributionSample>,
+) -> CostAttributionReport {
+    let mut buckets: BTreeMap<String, (usize, f64)> = BTreeMap::new();
+    for category in ALL_FAILURE_CATEGORIES {
+        buckets.insert(failure_label(category).to_owned(), (0, 0.0));
+    }
+    buckets.insert(COST_ATTRIBUTION_RESOLVED_BUCKET.to_owned(), (0, 0.0));
+    buckets.insert(COST_ATTRIBUTION_UNCATEGORIZED_BUCKET.to_owned(), (0, 0.0));
+
+    let mut total_n = 0usize;
+    let mut total_usd = 0.0;
+    let mut missing_cost_count = 0usize;
+
+    for sample in samples {
+        total_n += 1;
+        let bucket = cost_attribution_bucket_label(sample.resolved, sample.failure_category);
+        let usd_cost = match sample.cost_usd {
+            Some(cost) => cost,
+            None => {
+                missing_cost_count += 1;
+                0.0
+            }
+        };
+        total_usd += usd_cost;
+        let entry = buckets.entry(bucket.to_owned()).or_insert((0, 0.0));
+        entry.0 += 1;
+        entry.1 += usd_cost;
+    }
+
+    let mut rows: Vec<CostAttributionBucket> = buckets
+        .into_iter()
+        .map(|(bucket, (n, total))| CostAttributionBucket {
+            bucket,
+            n,
+            total_usd: round_dp(total, 4),
+            mean_usd: if n == 0 {
+                0.0
+            } else {
+                #[allow(clippy::cast_precision_loss)]
+                {
+                    round_dp(total / n as f64, 4)
+                }
+            },
+            share_pct: if total_usd == 0.0 {
+                0.0
+            } else {
+                round_dp(total * 100.0 / total_usd, 2)
+            },
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        b.total_usd
+            .partial_cmp(&a.total_usd)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.bucket.cmp(&b.bucket))
+    });
+    rows.push(CostAttributionBucket {
+        bucket: COST_ATTRIBUTION_TOTAL_BUCKET.to_owned(),
+        n: total_n,
+        total_usd: round_dp(total_usd, 4),
+        mean_usd: if total_n == 0 {
+            0.0
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            {
+                round_dp(total_usd / total_n as f64, 4)
+            }
+        },
+        share_pct: if total_n == 0 { 0.0 } else { 100.0 },
+    });
+    CostAttributionReport {
+        rows,
+        missing_cost_count,
     }
 }
 
@@ -715,6 +958,19 @@ pub fn render_breakdown_table(rows: &[BreakdownBucket]) -> String {
             out,
             "{axis},{},{},{},{:.4}",
             row.bucket_value, row.n, row.resolved, row.resolved_rate
+        );
+    }
+    out
+}
+
+#[must_use]
+pub fn render_cost_attribution_table(rows: &[CostAttributionBucket]) -> String {
+    let mut out = String::from("bucket,n,total_usd,mean_usd,share_pct\n");
+    for row in rows {
+        let _ = writeln!(
+            out,
+            "{},{},{:.4},{:.4},{:.2}",
+            row.bucket, row.n, row.total_usd, row.mean_usd, row.share_pct
         );
     }
     out
@@ -768,6 +1024,24 @@ mod tests {
             runs: 0,
             resolved_count: 0,
             pass_at_1: false,
+        }
+    }
+
+    fn eval_row(id: &str, resolved: bool) -> InstanceEvaluation {
+        InstanceEvaluation {
+            instance_id: id.into(),
+            resolved,
+            runs: 1,
+            resolved_count: u32::from(resolved),
+            pass_at_1: resolved,
+            tests_passed: vec![],
+            tests_failed: vec![],
+            eval_exit_reason: if resolved {
+                EvalExitReason::Resolved
+            } else {
+                EvalExitReason::Unresolved
+            },
+            eval_log_path: None,
         }
     }
 
@@ -895,5 +1169,100 @@ mod tests {
         );
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].bucket_value, "none");
+    }
+
+    #[test]
+    fn cost_attribution_tracks_missing_costs_and_resolved_precedence() {
+        let mut resolved = submitted("resolved");
+        resolved.failure_category = Some(FailureCategory::StepLimit);
+        resolved.cost_usd = None;
+
+        let mut uncategorized = errored("uncategorized");
+        uncategorized.failure_category = None;
+        uncategorized.cost_usd = Some(1.0);
+
+        let mut model_api = errored("model-api");
+        model_api.failure_category = Some(FailureCategory::ModelApi);
+        model_api.cost_usd = Some(3.0);
+
+        let evals = vec![
+            eval_row("resolved", true),
+            eval_row("uncategorized", false),
+            eval_row("model-api", false),
+        ];
+        let results = HashMap::from([
+            ("resolved".to_string(), resolved),
+            ("uncategorized".to_string(), uncategorized),
+            ("model-api".to_string(), model_api),
+        ]);
+
+        let report = build_cost_attribution(&evals, &results);
+        assert_eq!(report.missing_cost_count, 1);
+
+        let rows = report
+            .rows
+            .iter()
+            .map(|row| (row.bucket.as_str(), row))
+            .collect::<HashMap<_, _>>();
+
+        let resolved_row = rows.get("resolved").copied().unwrap();
+        assert_eq!(resolved_row.n, 1);
+        assert_eq!(resolved_row.total_usd, 0.0);
+        assert_eq!(resolved_row.mean_usd, 0.0);
+        assert_eq!(resolved_row.share_pct, 0.0);
+
+        let uncategorized_row = rows.get("uncategorized").copied().unwrap();
+        assert_eq!(uncategorized_row.n, 1);
+        assert_eq!(uncategorized_row.total_usd, 1.0);
+        assert_eq!(uncategorized_row.mean_usd, 1.0);
+        assert_eq!(uncategorized_row.share_pct, 25.0);
+
+        let model_api_row = rows.get("model_api").copied().unwrap();
+        assert_eq!(model_api_row.n, 1);
+        assert_eq!(model_api_row.total_usd, 3.0);
+        assert_eq!(model_api_row.mean_usd, 3.0);
+        assert_eq!(model_api_row.share_pct, 75.0);
+
+        let total_row = report.rows.last().unwrap();
+        assert_eq!(total_row.bucket, "TOTAL");
+        assert_eq!(total_row.n, 3);
+        assert_eq!(total_row.total_usd, 4.0);
+        assert_eq!(total_row.mean_usd, 1.3333);
+        assert_eq!(total_row.share_pct, 100.0);
+    }
+
+    #[test]
+    fn cost_attribution_rows_sort_by_total_usd_then_bucket() {
+        let mut env_setup = errored("env");
+        env_setup.failure_category = Some(FailureCategory::EnvSetup);
+        env_setup.cost_usd = Some(2.0);
+
+        let mut model_api = errored("api");
+        model_api.failure_category = Some(FailureCategory::ModelApi);
+        model_api.cost_usd = Some(2.0);
+
+        let mut uncategorized = errored("uncategorized");
+        uncategorized.failure_category = None;
+        uncategorized.cost_usd = Some(5.0);
+
+        let evals = vec![
+            eval_row("env", false),
+            eval_row("api", false),
+            eval_row("uncategorized", false),
+        ];
+        let results = HashMap::from([
+            ("env".to_string(), env_setup),
+            ("api".to_string(), model_api),
+            ("uncategorized".to_string(), uncategorized),
+        ]);
+
+        let report = build_cost_attribution(&evals, &results);
+        let top_buckets: Vec<&str> = report
+            .rows
+            .iter()
+            .take(3)
+            .map(|row| row.bucket.as_str())
+            .collect();
+        assert_eq!(top_buckets, vec!["uncategorized", "env_setup", "model_api"]);
     }
 }

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -1435,6 +1435,102 @@ fn compare_cost_attribution_prefers_evaluation_json_table_over_aggregate_rows() 
 }
 
 #[test]
+fn compare_cost_attribution_falls_back_to_run_slots_when_evaluation_json_is_missing() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+
+    let mut baseline = errored("task-a", FailureCategory::StepLimit);
+    baseline.runs = 2;
+    baseline.cost_usd = Some(0.30);
+    write_results(baseline_dir.path(), vec![baseline]);
+    write_run_traj(
+        baseline_dir.path(),
+        "task-a",
+        1,
+        Some(FailureCategory::StepLimit),
+        Some(0.10),
+    );
+    write_run_traj(
+        baseline_dir.path(),
+        "task-a",
+        2,
+        Some(FailureCategory::ModelApi),
+        Some(0.20),
+    );
+
+    let mut candidate = errored("task-a", FailureCategory::AgentInternal);
+    candidate.runs = 2;
+    candidate.cost_usd = Some(0.30);
+    write_results(candidate_dir.path(), vec![candidate]);
+    write_run_traj(
+        candidate_dir.path(),
+        "task-a",
+        1,
+        Some(FailureCategory::AgentInternal),
+        Some(0.25),
+    );
+    write_run_traj(
+        candidate_dir.path(),
+        "task-a",
+        2,
+        Some(FailureCategory::ModelApi),
+        Some(0.05),
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let rows = v["cost_attribution_delta"].as_array().unwrap();
+    assert!(
+        rows.iter().any(|row| {
+            row["bucket"] == "step_limit"
+                && row["n_baseline"] == 1
+                && row["total_usd_baseline"] == 0.1
+                && row["n_candidate"] == 0
+                && row["total_usd_candidate"] == 0.0
+        }),
+        "{rows:?}"
+    );
+    assert!(
+        rows.iter().any(|row| {
+            row["bucket"] == "model_api"
+                && row["n_baseline"] == 1
+                && row["total_usd_baseline"] == 0.2
+                && row["n_candidate"] == 1
+                && row["total_usd_candidate"] == 0.05
+        }),
+        "{rows:?}"
+    );
+    assert!(
+        rows.iter().any(|row| {
+            row["bucket"] == "agent_internal"
+                && row["n_baseline"] == 0
+                && row["total_usd_baseline"] == 0.0
+                && row["n_candidate"] == 1
+                && row["total_usd_candidate"] == 0.25
+        }),
+        "{rows:?}"
+    );
+    assert!(rows.iter().all(|row| row["bucket"] != "TOTAL"), "{rows:?}");
+}
+
+#[test]
 fn compare_breakdown_json_includes_all_buckets_and_threshold_flag() {
     let baseline_dir = tempfile::tempdir().unwrap();
     let candidate_dir = tempfile::tempdir().unwrap();

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -257,6 +257,36 @@ fn write_run_traj(
     std::fs::write(traj_path, serde_json::to_string_pretty(&t).unwrap()).unwrap();
 }
 
+fn write_root_traj(
+    dir: &Path,
+    instance_id: &str,
+    failure_category: Option<FailureCategory>,
+    cost_usd: Option<f64>,
+) {
+    let mut t = Trajectory::new();
+    t.info
+        .other
+        .insert("instance_id".into(), serde_json::json!(instance_id));
+    t.info.outcome = Some(if failure_category.is_some() {
+        outcome::ERROR.into()
+    } else {
+        outcome::SUBMITTED.into()
+    });
+    t.info.failure_category = failure_category;
+    t.info.total_cost_usd = cost_usd;
+    t.info.token_usage = Some(TokenUsage {
+        prompt_tokens: 10,
+        completion_tokens: 5,
+    });
+    t.info.steps = Some(1);
+
+    std::fs::write(
+        dir.join(format!("{instance_id}.traj.json")),
+        serde_json::to_string_pretty(&t).unwrap(),
+    )
+    .unwrap();
+}
+
 fn write_evaluation_json(dir: &Path, value: &serde_json::Value) {
     std::fs::write(
         dir.join("evaluation.json"),
@@ -1176,6 +1206,63 @@ fn evaluate_cost_attribution_ignores_stale_trajectories_outside_current_sweep() 
         rows.iter()
             .any(|row| { row["bucket"] == "TOTAL" && row["n"] == 1 && row["total_usd"] == 0.1 })
     );
+}
+
+#[test]
+fn evaluate_cost_attribution_dedupes_legacy_root_and_nested_run_slots() {
+    let sweep_dir = tempfile::tempdir().unwrap();
+    write_results(
+        sweep_dir.path(),
+        vec![errored("task-a", FailureCategory::StepLimit)],
+    );
+    write_root_traj(
+        sweep_dir.path(),
+        "task-a",
+        Some(FailureCategory::ModelApi),
+        Some(0.30),
+    );
+    write_run_traj(
+        sweep_dir.path(),
+        "task-a",
+        1,
+        Some(FailureCategory::StepLimit),
+        Some(0.10),
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "evaluate",
+            "--sweep",
+            sweep_dir.path().to_str().unwrap(),
+            "--backend",
+            "none",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("step_limit,1,0.1000,0.1000,100.00"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("TOTAL,1,0.1000,0.1000,100.00"), "{stdout}");
+    assert!(!stdout.contains("model_api,1,0.3000"), "{stdout}");
+
+    let eval_path = sweep_dir.path().join("evaluation.json");
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(eval_path).unwrap()).unwrap();
+    let rows = v["cost_attribution"].as_array().unwrap();
+    assert!(rows.iter().any(|row| {
+        row["bucket"] == "step_limit" && row["n"] == 1 && row["total_usd"] == 0.1
+    }));
+    assert!(rows.iter().any(|row| {
+        row["bucket"] == "TOTAL" && row["n"] == 1 && row["total_usd"] == 0.1
+    }));
 }
 
 #[test]

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -1113,6 +1113,72 @@ fn evaluate_cost_attribution_uses_per_run_trajectories_for_reruns() {
 }
 
 #[test]
+fn evaluate_cost_attribution_ignores_stale_trajectories_outside_current_sweep() {
+    let sweep_dir = tempfile::tempdir().unwrap();
+    write_results(
+        sweep_dir.path(),
+        vec![errored("task-a", FailureCategory::StepLimit)],
+    );
+    write_run_traj(
+        sweep_dir.path(),
+        "task-a",
+        1,
+        Some(FailureCategory::StepLimit),
+        Some(0.10),
+    );
+    write_run_traj(
+        sweep_dir.path(),
+        "stale-task",
+        1,
+        Some(FailureCategory::ModelApi),
+        None,
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "evaluate",
+            "--sweep",
+            sweep_dir.path().to_str().unwrap(),
+            "--backend",
+            "none",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("step_limit,1,0.1000,0.1000,100.00"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("TOTAL,1,0.1000,0.1000,100.00"), "{stdout}");
+    assert!(!stdout.contains("model_api,1"), "{stdout}");
+    assert!(
+        !stdout.contains("warning: cost attribution missing usd_cost"),
+        "{stdout}"
+    );
+
+    let eval_path = sweep_dir.path().join("evaluation.json");
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(eval_path).unwrap()).unwrap();
+    let rows = v["cost_attribution"].as_array().unwrap();
+    assert!(
+        rows.iter().any(|row| {
+            row["bucket"] == "model_api" && row["n"] == 0 && row["total_usd"] == 0.0
+        }),
+        "{rows:?}"
+    );
+    assert!(
+        rows.iter()
+            .any(|row| { row["bucket"] == "TOTAL" && row["n"] == 1 && row["total_usd"] == 0.1 })
+    );
+}
+
+#[test]
 fn compare_cost_attribution_warns_when_dataset_subsets_differ() {
     let baseline_dir = tempfile::tempdir().unwrap();
     let candidate_dir = tempfile::tempdir().unwrap();

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -89,6 +89,18 @@ fn rerun_result(id: &str, runs: u32, resolved_count: u32) -> InstanceResult {
 }
 
 fn write_results(dir: &Path, instances: Vec<InstanceResult>) {
+    write_results_with_filter_spec(
+        dir,
+        instances,
+        rust_swe_agent::run::swebench::FilterSpec::default(),
+    );
+}
+
+fn write_results_with_filter_spec(
+    dir: &Path,
+    instances: Vec<InstanceResult>,
+    filter_spec: rust_swe_agent::run::swebench::FilterSpec,
+) {
     let sweep = SweepResults {
         total: instances.len(),
         submitted: instances
@@ -115,7 +127,7 @@ fn write_results(dir: &Path, instances: Vec<InstanceResult>) {
             f64::from(u32::try_from(passed).unwrap())
                 / f64::from(u32::try_from(instances.len()).unwrap())
         },
-        filter_spec: rust_swe_agent::run::swebench::FilterSpec::default(),
+        filter_spec,
         manifest: None,
         cost_limit_usd: None,
         instances,
@@ -215,6 +227,44 @@ fn write_diff_traj(
     .unwrap();
 }
 
+fn write_run_traj(
+    dir: &Path,
+    instance_id: &str,
+    run_index: u32,
+    failure_category: Option<FailureCategory>,
+    cost_usd: Option<f64>,
+) {
+    let mut t = Trajectory::new();
+    t.info
+        .other
+        .insert("instance_id".into(), serde_json::json!(instance_id));
+    t.info.outcome = Some(if failure_category.is_some() {
+        outcome::ERROR.into()
+    } else {
+        outcome::SUBMITTED.into()
+    });
+    t.info.failure_category = failure_category;
+    t.info.total_cost_usd = cost_usd;
+    t.info.token_usage = Some(TokenUsage {
+        prompt_tokens: 10,
+        completion_tokens: 5,
+    });
+    t.info.steps = Some(1);
+
+    let traj_path =
+        rust_swe_agent::run::swebench::trajectory_path_for_run(dir, instance_id, run_index);
+    std::fs::create_dir_all(traj_path.parent().unwrap()).unwrap();
+    std::fs::write(traj_path, serde_json::to_string_pretty(&t).unwrap()).unwrap();
+}
+
+fn write_evaluation_json(dir: &Path, value: serde_json::Value) {
+    std::fs::write(
+        dir.join("evaluation.json"),
+        serde_json::to_string_pretty(&value).unwrap(),
+    )
+    .unwrap();
+}
+
 #[test]
 fn help_lists_compare_subcommand() {
     let out = Command::new(binary_path())
@@ -243,6 +293,7 @@ fn help_lists_compare_subcommand() {
         "--candidate",
         "--format",
         "--max-regressions",
+        "--cost-attribution",
         "--inspect-diff",
         "--emit-diff-script",
     ] {
@@ -516,6 +567,8 @@ fn compare_treats_wallclock_timeout_as_ordinary_failure_transition() {
             max_regressions: None,
             breakdown: rust_swe_agent::run::evaluate::BreakdownSelection::none(),
             min_delta_pp: 0.0,
+            cost_attribution: true,
+            cost_attribution_min_delta_usd: 1.0,
         })
         .unwrap();
     assert_eq!(
@@ -536,6 +589,8 @@ fn compare_treats_wallclock_timeout_as_ordinary_failure_transition() {
             max_regressions: None,
             breakdown: rust_swe_agent::run::evaluate::BreakdownSelection::none(),
             min_delta_pp: 0.0,
+            cost_attribution: true,
+            cost_attribution_min_delta_usd: 1.0,
         })
         .unwrap();
     assert_eq!(
@@ -910,12 +965,17 @@ fn evaluate_none_backend_writes_evaluation_json() {
     assert!(stdout.contains("resolved_rate: 0.0000"), "{stdout}");
     assert!(stdout.contains("pass@1: 0.0000"), "{stdout}");
     assert!(stdout.contains("pass@k: 0.0000"), "{stdout}");
+    assert!(
+        stdout.contains("bucket,n,total_usd,mean_usd,share_pct"),
+        "{stdout}"
+    );
 
     let eval_path = sweep_dir.path().join("evaluation.json");
     assert!(eval_path.exists());
     let v: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(eval_path).unwrap()).unwrap();
     assert_eq!(v["instances"].as_array().unwrap().len(), 2);
+    assert!(v["cost_attribution"].is_array(), "{v:?}");
 }
 
 #[test]
@@ -942,6 +1002,280 @@ fn evaluate_breakdown_none_is_headline_only() {
         !stdout.contains("axis,bucket,n,resolved,resolved_rate"),
         "{stdout}"
     );
+}
+
+#[test]
+fn evaluate_cost_attribution_off_matches_legacy_stdout() {
+    let sweep_dir = tempfile::tempdir().unwrap();
+    write_results(
+        sweep_dir.path(),
+        vec![submitted("a"), errored("b", FailureCategory::ModelApi)],
+    );
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "evaluate",
+            "--sweep",
+            sweep_dir.path().to_str().unwrap(),
+            "--backend",
+            "none",
+            "--cost-attribution",
+            "off",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let expected = "\
+resolved: 0\n\
+resolved_rate: 0.0000\n\
+pass@1: 0.0000\n\
+pass@k: 0.0000\n\
+axis,bucket,n,resolved,resolved_rate\n\
+repo,unknown,2,0,0.0000\n\
+failure_category,model_api,1,0,0.0000\n\
+failure_category,none,1,0,0.0000\n";
+    assert_eq!(stdout, expected);
+
+    let eval_path = sweep_dir.path().join("evaluation.json");
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(eval_path).unwrap()).unwrap();
+    assert!(v.get("cost_attribution").is_none(), "{v:?}");
+}
+
+#[test]
+fn evaluate_cost_attribution_uses_per_run_trajectories_for_reruns() {
+    let sweep_dir = tempfile::tempdir().unwrap();
+    let mut aggregate = errored("task-a", FailureCategory::StepLimit);
+    aggregate.runs = 2;
+    aggregate.cost_usd = Some(0.30);
+    write_results(sweep_dir.path(), vec![aggregate]);
+    write_run_traj(
+        sweep_dir.path(),
+        "task-a",
+        1,
+        Some(FailureCategory::StepLimit),
+        Some(0.10),
+    );
+    write_run_traj(
+        sweep_dir.path(),
+        "task-a",
+        2,
+        Some(FailureCategory::ModelApi),
+        Some(0.20),
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "evaluate",
+            "--sweep",
+            sweep_dir.path().to_str().unwrap(),
+            "--backend",
+            "none",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("step_limit,1,0.1000,0.1000,33.33"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("model_api,1,0.2000,0.2000,66.67"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("TOTAL,2,0.3000,0.1500,100.00"), "{stdout}");
+
+    let eval_path = sweep_dir.path().join("evaluation.json");
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(eval_path).unwrap()).unwrap();
+    let rows = v["cost_attribution"].as_array().unwrap();
+    assert!(
+        rows.iter().any(|row| {
+            row["bucket"] == "step_limit" && row["n"] == 1 && row["total_usd"] == 0.1
+        })
+    );
+    assert!(
+        rows.iter().any(|row| {
+            row["bucket"] == "model_api" && row["n"] == 1 && row["total_usd"] == 0.2
+        })
+    );
+}
+
+#[test]
+fn compare_cost_attribution_warns_when_dataset_subsets_differ() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    write_results_with_filter_spec(
+        baseline_dir.path(),
+        vec![submitted("a"), errored("b", FailureCategory::StepLimit)],
+        rust_swe_agent::run::swebench::FilterSpec {
+            original_count: 10,
+            selected_count: 2,
+            instance_ids: Some(vec!["a".into(), "b".into()]),
+            limit: None,
+            sample: None,
+            seed: None,
+            stratify_by: None,
+            stratify_mode: None,
+        },
+    );
+    write_results_with_filter_spec(
+        candidate_dir.path(),
+        vec![errored("a", FailureCategory::ModelApi), submitted("c")],
+        rust_swe_agent::run::swebench::FilterSpec {
+            original_count: 10,
+            selected_count: 2,
+            instance_ids: Some(vec!["a".into(), "c".into()]),
+            limit: None,
+            sample: None,
+            seed: None,
+            stratify_by: None,
+            stratify_mode: None,
+        },
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Cost attribution delta:"), "{stdout}");
+    assert!(
+        stdout.contains("totals are not directly comparable"),
+        "{stdout}"
+    );
+    assert_eq!(
+        stdout.matches("totals are not directly comparable").count(),
+        1,
+        "{stdout}"
+    );
+    assert_eq!(
+        stdout.matches("dataset subset differs").count(),
+        1,
+        "{stdout}"
+    );
+}
+
+#[test]
+fn compare_cost_attribution_prefers_evaluation_json_table_over_aggregate_rows() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+
+    let mut baseline = errored("task-a", FailureCategory::StepLimit);
+    baseline.runs = 2;
+    baseline.cost_usd = Some(0.30);
+    write_results(baseline_dir.path(), vec![baseline]);
+
+    let mut candidate = errored("task-a", FailureCategory::ModelApi);
+    candidate.runs = 2;
+    candidate.cost_usd = Some(0.30);
+    write_results(candidate_dir.path(), vec![candidate]);
+
+    write_evaluation_json(
+        baseline_dir.path(),
+        serde_json::json!({
+            "instances": [{
+                "instance_id": "task-a",
+                "resolved": false,
+                "runs": 2,
+                "resolved_count": 0,
+                "pass_at_1": false,
+                "tests_passed": [],
+                "tests_failed": [],
+                "eval_exit_reason": "unresolved"
+            }],
+            "cost_attribution": [
+                {"bucket": "model_api", "n": 1, "total_usd": 0.2, "mean_usd": 0.2, "share_pct": 66.67},
+                {"bucket": "step_limit", "n": 1, "total_usd": 0.1, "mean_usd": 0.1, "share_pct": 33.33},
+                {"bucket": "TOTAL", "n": 2, "total_usd": 0.3, "mean_usd": 0.15, "share_pct": 100.0}
+            ]
+        }),
+    );
+    write_evaluation_json(
+        candidate_dir.path(),
+        serde_json::json!({
+            "instances": [{
+                "instance_id": "task-a",
+                "resolved": false,
+                "runs": 2,
+                "resolved_count": 0,
+                "pass_at_1": false,
+                "tests_passed": [],
+                "tests_failed": [],
+                "eval_exit_reason": "unresolved"
+            }],
+            "cost_attribution": [
+                {"bucket": "agent_internal", "n": 1, "total_usd": 0.25, "mean_usd": 0.25, "share_pct": 83.33},
+                {"bucket": "model_api", "n": 1, "total_usd": 0.05, "mean_usd": 0.05, "share_pct": 16.67},
+                {"bucket": "TOTAL", "n": 2, "total_usd": 0.3, "mean_usd": 0.15, "share_pct": 100.0}
+            ]
+        }),
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let rows = v["cost_attribution_delta"].as_array().unwrap();
+    assert!(
+        rows.iter().any(|row| {
+            row["bucket"] == "step_limit"
+                && row["n_baseline"] == 1
+                && row["total_usd_baseline"] == 0.1
+                && row["n_candidate"] == 0
+                && row["total_usd_candidate"] == 0.0
+        }),
+        "{rows:?}"
+    );
+    assert!(
+        rows.iter().any(|row| {
+            row["bucket"] == "model_api"
+                && row["n_baseline"] == 1
+                && row["total_usd_baseline"] == 0.2
+                && row["n_candidate"] == 1
+                && row["total_usd_candidate"] == 0.05
+        }),
+        "{rows:?}"
+    );
+    assert!(rows.iter().all(|row| row["bucket"] != "TOTAL"), "{rows:?}");
 }
 
 #[test]

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -1257,12 +1257,15 @@ fn evaluate_cost_attribution_dedupes_legacy_root_and_nested_run_slots() {
     let v: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(eval_path).unwrap()).unwrap();
     let rows = v["cost_attribution"].as_array().unwrap();
-    assert!(rows.iter().any(|row| {
-        row["bucket"] == "step_limit" && row["n"] == 1 && row["total_usd"] == 0.1
-    }));
-    assert!(rows.iter().any(|row| {
-        row["bucket"] == "TOTAL" && row["n"] == 1 && row["total_usd"] == 0.1
-    }));
+    assert!(
+        rows.iter().any(|row| {
+            row["bucket"] == "step_limit" && row["n"] == 1 && row["total_usd"] == 0.1
+        })
+    );
+    assert!(
+        rows.iter()
+            .any(|row| { row["bucket"] == "TOTAL" && row["n"] == 1 && row["total_usd"] == 0.1 })
+    );
 }
 
 #[test]

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -257,10 +257,10 @@ fn write_run_traj(
     std::fs::write(traj_path, serde_json::to_string_pretty(&t).unwrap()).unwrap();
 }
 
-fn write_evaluation_json(dir: &Path, value: serde_json::Value) {
+fn write_evaluation_json(dir: &Path, value: &serde_json::Value) {
     std::fs::write(
         dir.join("evaluation.json"),
-        serde_json::to_string_pretty(&value).unwrap(),
+        serde_json::to_string_pretty(value).unwrap(),
     )
     .unwrap();
 }
@@ -1196,7 +1196,7 @@ fn compare_cost_attribution_prefers_evaluation_json_table_over_aggregate_rows() 
 
     write_evaluation_json(
         baseline_dir.path(),
-        serde_json::json!({
+        &serde_json::json!({
             "instances": [{
                 "instance_id": "task-a",
                 "resolved": false,
@@ -1216,7 +1216,7 @@ fn compare_cost_attribution_prefers_evaluation_json_table_over_aggregate_rows() 
     );
     write_evaluation_json(
         candidate_dir.path(),
-        serde_json::json!({
+        &serde_json::json!({
             "instances": [{
                 "instance_id": "task-a",
                 "resolved": false,

--- a/tests/bench_forecast.rs
+++ b/tests/bench_forecast.rs
@@ -646,6 +646,7 @@ async fn calibration_writes_only_inside_forecast_subdirectory_and_marks_manifest
         sb_split: "dev".into(),
         run_id: None,
         breakdown: BreakdownSelection::none(),
+        cost_attribution: true,
     })
     .unwrap_err();
     assert!(


### PR DESCRIPTION
## Summary

Implements issue #37 by adding cost attribution reporting to `bench evaluate` and `bench compare`, including the missing acceptance criteria around rerun attribution.

- add `--cost-attribution` controls for evaluation and compare output
- write structured `cost_attribution` tables into `evaluation.json`
- compare persisted attribution tables when available and report per-bucket USD/share deltas
- handle missing `usd_cost` as `$0.00` with warnings
- keep `resolved` higher priority than failure buckets

## Root cause

Rerun sweeps were previously attributed from aggregated instance rows in `results.json`. That collapsed multiple trajectories into one row, which lost per-run terminal failure categories and distorted `usd_cost` attribution. Compare output also recomputed attribution from aggregated rows and printed the dataset-subset comparability warning twice.

This change moves evaluation attribution to per-run trajectory slots, preserves per-run resolved state from `sb-cli`, prefers persisted `evaluation.json` attribution tables during compare, and deduplicates the subset warning in text output.

Closes #37.

## Validation

- `cargo fmt --all`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -W clippy::pedantic -W clippy::nursery`

## Impact

Operators can now trust cost attribution for rerun sweeps, compare reports stay aligned with persisted evaluation artifacts, and the CLI output is less misleading when subset composition differs.