### PR TITLE
🌟 Nova: Fallback Model

### DIFF
--- a/src/model/fallback.rs
+++ b/src/model/fallback.rs
@@ -1,0 +1,78 @@
+use async_trait::async_trait;
+
+use crate::error::ModelError;
+use crate::model::{Message, Model, ModelResponse, QueryOpts};
+
+/// A model decorator that tries a primary model, and if it fails, falls back to a secondary model.
+pub struct FallbackModel {
+    primary: Box<dyn Model>,
+    secondary: Box<dyn Model>,
+}
+
+impl FallbackModel {
+    pub fn new(primary: Box<dyn Model>, secondary: Box<dyn Model>) -> Self {
+        Self { primary, secondary }
+    }
+}
+
+#[async_trait]
+impl Model for FallbackModel {
+    fn name(&self) -> &'static str {
+        "fallback"
+    }
+
+    fn supports_explicit_cache(&self) -> bool {
+        self.primary.supports_explicit_cache()
+    }
+
+    async fn query(
+        &self,
+        messages: &[Message],
+        opts: &QueryOpts,
+    ) -> Result<ModelResponse, ModelError> {
+        match self.primary.query(messages, opts).await {
+            Ok(res) => Ok(res),
+            Err(e) => {
+                tracing::warn!("primary model failed: {}, falling back to secondary", e);
+                self.secondary.query(messages, opts).await
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use crate::model::deterministic::DeterministicModel;
+
+    #[tokio::test]
+    async fn fallback_uses_primary_on_success() {
+        let primary = Box::new(DeterministicModel::new(vec!["primary_success".into()]));
+        let secondary = Box::new(DeterministicModel::new(vec!["secondary_success".into()]));
+        let model = FallbackModel::new(primary, secondary);
+
+        let res = model.query(&[], &QueryOpts::default()).await.unwrap();
+        assert_eq!(res.content, "primary_success");
+    }
+
+    #[tokio::test]
+    async fn fallback_uses_secondary_on_primary_failure() {
+        let primary = Box::new(DeterministicModel::new(vec![]));
+        let secondary = Box::new(DeterministicModel::new(vec!["secondary_success".into()]));
+        let model = FallbackModel::new(primary, secondary);
+
+        let res = model.query(&[], &QueryOpts::default()).await.unwrap();
+        assert_eq!(res.content, "secondary_success");
+    }
+
+    #[tokio::test]
+    async fn fallback_fails_if_both_fail() {
+        let primary = Box::new(DeterministicModel::new(vec![]));
+        let secondary = Box::new(DeterministicModel::new(vec![]));
+        let model = FallbackModel::new(primary, secondary);
+
+        let res = model.query(&[], &QueryOpts::default()).await;
+        assert!(res.is_err());
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -14,9 +14,11 @@ use std::collections::BTreeMap;
 use crate::error::ModelError;
 
 pub mod deterministic;
+pub mod fallback;
 pub mod litellm;
 
 pub use deterministic::DeterministicModel;
+pub use fallback::FallbackModel;
 pub use litellm::{AnthropicBackend, LitellmBackend};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/tests/fallback.rs
+++ b/tests/fallback.rs
@@ -1,0 +1,11 @@
+use rust_swe_agent::model::{FallbackModel, DeterministicModel, QueryOpts, Model};
+
+#[tokio::test]
+async fn test_fallback_integration() {
+    let primary = Box::new(DeterministicModel::new(vec![]));
+    let secondary = Box::new(DeterministicModel::new(vec!["secondary_success".into()]));
+    let model = FallbackModel::new(primary, secondary);
+
+    let res = model.query(&[], &QueryOpts::default()).await.unwrap();
+    assert_eq!(res.content, "secondary_success");
+}


### PR DESCRIPTION
💡 **The Spark:** "I noticed we interact with models like OpenAI or Anthropic but don't easily have a way to gracefully recover if a primary provider fails or rate-limits us."
🚀 **The Feature:** "Implemented a `FallbackModel` decorator that tries a primary model, and falls back to a secondary model if the primary query fails."
🔮 **The Potential:** "Could be used to build a robust LLM pipeline, switching to a backup cheaper model or an alternative provider automatically to reduce downtime."
⚠️ **Risk:** "Low. Isolated additive change in `src/model/fallback.rs`."

---
*PR created automatically by Jules for task [13606357300621130479](https://jules.google.com/task/13606357300621130479) started by @madmax983*