### PR TITLE
🎨 Mosaic: UI Polish for [bench inspect summary]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +314,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -397,6 +431,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1070,6 +1113,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,6 +1654,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "comfy-table",
  "dialoguer",
  "futures",
  "indicatif",
@@ -2283,6 +2333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,6 +2576,28 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ litellm-rs = { version = "*", default-features = false }
 # Misc
 chrono = { version = "0.4", features = ["serde"] }
 sha2 = "0.10"
+comfy-table = "7.2.2"
 
 # NOTE on model backend:
 # `litellm-rs` ships a library API (`completion`, message constructors,

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -274,6 +274,10 @@ pub fn render_text(output: &InspectOutput) -> String {
     }
 }
 
+use comfy_table::Table;
+use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+use comfy_table::presets::UTF8_FULL;
+
 fn render_summary_text(report: &SummaryReport) -> String {
     let mut s = String::new();
     s.push_str("\n=== bench inspect summary ===\n");
@@ -291,21 +295,37 @@ fn render_summary_text(report: &SummaryReport) -> String {
     } else {
         s.push_str("Manifest: unavailable\n");
     }
-    s.push_str("\ninstance_id | outcome | failure_category | cost_usd | resolved\n");
-    s.push_str("----------------------------------------------------------------\n");
+    s.push('\n');
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec![
+            "instance_id",
+            "outcome",
+            "failure_category",
+            "cost_usd",
+            "resolved",
+        ]);
+
     for row in &report.rows {
-        let _ = writeln!(
-            s,
-            "{} | {} | {} | {} | {}",
-            row.instance_id,
-            row.outcome.as_deref().unwrap_or("?"),
-            row.failure_category.map_or("none", failure_label),
+        table.add_row(vec![
+            row.instance_id.clone(),
+            row.outcome.as_deref().unwrap_or("?").to_string(),
+            row.failure_category
+                .map_or("none", failure_label)
+                .to_string(),
             row.cost_usd
                 .map_or_else(|| "?".into(), |c| format!("{c:.4}")),
             row.resolved
                 .map_or("?", |v| if v { "true" } else { "false" })
-        );
+                .to_string(),
+        ]);
     }
+
+    s.push_str(&table.to_string());
+    s.push('\n');
     s
 }
 

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -1091,7 +1091,7 @@ fn filter_mode_lists_matching_instances() {
         .unwrap();
     assert!(out.status.success());
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("instance_id | outcome"), "{stdout}");
-    assert!(stdout.contains("a | error | step_limit"), "{stdout}");
-    assert!(!stdout.contains("b | error | model_api"), "{stdout}");
+    assert!(stdout.contains("│ instance_id ┆ outcome"), "{stdout}");
+    assert!(stdout.contains("│ a           ┆ error"), "{stdout}");
+    assert!(!stdout.contains("│ b           ┆ error"), "{stdout}");
 }


### PR DESCRIPTION
* 🖌️ **Before:** `rust-swe-agent bench inspect --sweep <SWEEP>` generated an ugly ASCII text wall for its summary using manual padding and manual `|` bars.
* ✨ **After:** The output is structured logically, spacing is mathematically correct, and corners use rounded UTF8 rendering, matching a modern dashboard layout.
* 🖼️ **Visuals:** Migrated formatting logic away from manual concatenations and towards the `comfy-table` ecosystem. This improves spacing and layout, and enables line-wrapping or column-truncation natively in the future.

---
*PR created automatically by Jules for task [13632493061664118844](https://jules.google.com/task/13632493061664118844) started by @madmax983*