### PR TITLE
🗺️ Atlas: [Architectural change] Encapsulate purely internal submodules

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use crate::error::Error;
 
 pub mod default;
-pub mod interactive;
+pub(crate) mod interactive;
 pub mod parse;
 
 pub use default::DefaultAgent;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,7 +8,7 @@ use clap::{Parser, Subcommand};
 use crate::config::Config;
 use crate::error::Error;
 
-pub mod args;
+pub(crate) mod args;
 
 #[derive(Debug, Parser)]
 #[command(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use crate::error::ConfigError;
 
-pub mod schema;
+pub(crate) mod schema;
 
 pub use schema::{AgentCfg, AgentKind, EnvCfg, EnvKind, ModelCfg, PromptCfg, RootCfg};
 

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -12,10 +12,10 @@ use std::time::Duration;
 use crate::error::EnvError;
 
 #[cfg(feature = "chaos")]
-pub mod chaos;
+pub(crate) mod chaos;
 #[cfg(feature = "docker")]
-pub mod docker;
-pub mod local;
+pub(crate) mod docker;
+pub(crate) mod local;
 
 #[cfg(feature = "chaos")]
 pub use chaos::ChaosEnvironment;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeMap;
 
 use crate::error::ModelError;
 
-pub mod deterministic;
+pub(crate) mod deterministic;
 pub mod litellm;
 
 pub use deterministic::DeterministicModel;
@@ -225,4 +225,4 @@ mod tests {
     }
 }
 #[cfg(test)]
-pub mod deterministic_chaos_test;
+pub(crate) mod deterministic_chaos_test;

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -13,8 +13,8 @@
 
 use serde::Serialize;
 
-pub mod broadcast;
-pub mod sse;
+pub(crate) mod broadcast;
+pub(crate) mod sse;
 
 pub use broadcast::BroadcastSink;
 pub use sse::SseServer;


### PR DESCRIPTION
* 🕸️ Tangle: Many internal submodules across the codebase (`cli::args`, `config::schema`, `env::*`, `stream::*`, etc.) were declared as `pub mod`, unnecessarily exposing their internal structures outside the crate boundaries.
* 📐 Blueprint: Changed these submodule declarations from `pub mod` to `pub(crate) mod`, keeping them accessible within the workspace but enforcing a strict public API boundary for external consumers. **Assumption:** Submodules in `run`, `model::litellm`, and `agent::{default, parse}` were kept as `pub` because they are relied upon heavily by the external integration `tests/` suite. Changing them would require a massive restructure of the tests which violates the "Ask first" rule for moving large chunks of code.
* 🧱 Stability: Reduced coupling, cleaner public API surface.
* 🔬 Verification: Checked with `cargo check`, `cargo clippy`, and `cargo test`. Builds successfully and tests pass.

---
*PR created automatically by Jules for task [11133997318357499054](https://jules.google.com/task/11133997318357499054) started by @madmax983*