### PR TITLE
Truncate large command outputs in observations; add config/CLI flags and tests

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -360,17 +360,23 @@ impl Agent for DefaultAgent {
             self.config.root.agent.observation_max_bytes,
             self.config.root.agent.observation_head_ratio,
         );
+        let merged_output = match (trunc_stdout.text.is_empty(), trunc_stderr.text.is_empty()) {
+            (true, true) => String::new(),
+            (false, true) => trunc_stdout.text.clone(),
+            (true, false) => trunc_stderr.text.clone(),
+            (false, false) => format!("{}\n{}", trunc_stdout.text, trunc_stderr.text),
+        };
+        let trunc_output = truncate_observation_text(
+            &merged_output,
+            self.config.root.agent.observation_max_bytes,
+            self.config.root.agent.observation_head_ratio,
+        );
         // 6. Render observation.
         let obs_text = self.renderer.render_str(
             &self.config.root.agent.observation_template,
             &serde_json::json!({
                 "returncode": result.exit_code,
-                "output": match (trunc_stdout.text.is_empty(), trunc_stderr.text.is_empty()) {
-                    (true, true) => String::new(),
-                    (false, true) => trunc_stdout.text.clone(),
-                    (true, false) => trunc_stderr.text.clone(),
-                    (false, false) => format!("{}\n{}", trunc_stdout.text, trunc_stderr.text),
-                },
+                "output": trunc_output.text,
                 "stdout": trunc_stdout.text,
                 "stderr": trunc_stderr.text,
                 "timed_out": result.timed_out,
@@ -401,6 +407,10 @@ impl Agent for DefaultAgent {
         obs_extra.other.insert(
             "stderr_bytes_omitted".into(),
             serde_json::json!(trunc_stderr.bytes_omitted),
+        );
+        obs_extra.other.insert(
+            "output_bytes_omitted".into(),
+            serde_json::json!(trunc_output.bytes_omitted),
         );
         obs_extra.timestamp = Some(obs_ts.clone());
         self.trajectory.record_with_extra(&obs_msg, obs_extra);
@@ -653,5 +663,24 @@ mod tests {
             .as_str()
             .unwrap();
         assert_eq!(stdout.len(), 100001);
+    }
+
+    #[tokio::test]
+    async fn combined_output_field_is_capped_when_stdout_and_stderr_are_large() {
+        let mut a = make_agent(vec![
+            "```bash\npython - <<'PY'\nimport sys\nprint('o'*6000)\nprint('e'*6000, file=sys.stderr)\nPY\n```"
+                .into(),
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
+        ]);
+        a.config.root.agent.observation_max_bytes = 512;
+        a.config.root.agent.observation_template = "{{ output }}".into();
+        let _ = a.run().await.unwrap();
+        let obs = a
+            .history
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::User && m.content.contains("truncated"))
+            .unwrap();
+        assert!(obs.content.len() <= 512);
     }
 }

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -35,7 +35,14 @@ struct TruncateResult {
     clippy::cast_sign_loss
 )]
 fn truncate_observation_text(input: &str, max_bytes: usize, head_ratio: f64) -> TruncateResult {
-    if max_bytes == 0 || input.len() <= max_bytes {
+    if max_bytes == 0 {
+        return TruncateResult {
+            text: String::new(),
+            bytes_omitted: input.len(),
+            truncated: !input.is_empty(),
+        };
+    }
+    if input.len() <= max_bytes {
         return TruncateResult {
             text: input.to_owned(),
             bytes_omitted: 0,
@@ -644,6 +651,22 @@ mod tests {
         let t = truncate_observation_text(&input, 128, 0.5);
         assert!(t.truncated);
         assert!(t.text.len() <= 128);
+    }
+
+    #[test]
+    fn truncate_observation_text_zero_cap_returns_empty() {
+        let t = truncate_observation_text("abcdef", 0, 0.5);
+        assert!(t.truncated);
+        assert_eq!(t.bytes_omitted, 6);
+        assert!(t.text.is_empty());
+    }
+
+    #[test]
+    fn truncate_observation_text_zero_cap_empty_input_not_truncated() {
+        let t = truncate_observation_text("", 0, 0.5);
+        assert!(!t.truncated);
+        assert_eq!(t.bytes_omitted, 0);
+        assert!(t.text.is_empty());
     }
 
     #[tokio::test]

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -403,7 +403,9 @@ impl Agent for DefaultAgent {
         );
         obs_extra.other.insert(
             "observation_truncated".into(),
-            serde_json::json!(trunc_stdout.truncated || trunc_stderr.truncated),
+            serde_json::json!(
+                trunc_stdout.truncated || trunc_stderr.truncated || trunc_output.truncated
+            ),
         );
         obs_extra.other.insert(
             "stdout_bytes_omitted".into(),
@@ -687,5 +689,37 @@ mod tests {
             .find(|m| m.role == Role::User && m.content.contains("truncated"))
             .unwrap();
         assert!(obs.content.len() <= 512);
+    }
+
+    #[tokio::test]
+    async fn observation_truncated_true_when_only_combined_output_is_elided() {
+        let mut a = make_agent(vec![
+            "```bash\npython - <<'PY'\nimport sys\nprint('o'*300)\nprint('e'*300, file=sys.stderr)\nPY\n```"
+                .into(),
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
+        ]);
+        a.config.root.agent.observation_max_bytes = 512;
+        a.config.root.agent.observation_template = "{{ output }}".into();
+        let _ = a.run().await.unwrap();
+        let rec = a
+            .trajectory
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == "user" && m.extra.other.contains_key("observation_truncated"))
+            .unwrap();
+        assert_eq!(
+            rec.extra.other["stdout_bytes_omitted"],
+            serde_json::json!(0)
+        );
+        assert_eq!(
+            rec.extra.other["stderr_bytes_omitted"],
+            serde_json::json!(0)
+        );
+        assert!(rec.extra.other["output_bytes_omitted"].as_u64().unwrap() > 0);
+        assert_eq!(
+            rec.extra.other["observation_truncated"],
+            serde_json::json!(true)
+        );
     }
 }

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -29,6 +29,11 @@ struct TruncateResult {
     truncated: bool,
 }
 
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
 fn truncate_observation_text(input: &str, max_bytes: usize, head_ratio: f64) -> TruncateResult {
     if max_bytes == 0 || input.len() <= max_bytes {
         return TruncateResult {
@@ -662,7 +667,7 @@ mod tests {
         let stdout = run_result.extra.other["run_result"]["stdout"]
             .as_str()
             .unwrap();
-        assert_eq!(stdout.len(), 100001);
+        assert_eq!(stdout.len(), 100_001);
     }
 
     #[tokio::test]

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -22,6 +22,71 @@ use crate::stream::{NullSink, StreamEvent, StreamSink};
 use crate::template::Renderer;
 use crate::trajectory::{FailureCategory, TokenUsage, Trajectory, exit_reason, outcome};
 
+#[derive(Debug, Clone)]
+struct TruncateResult {
+    text: String,
+    bytes_omitted: usize,
+    truncated: bool,
+}
+
+fn truncate_observation_text(input: &str, max_bytes: usize, head_ratio: f64) -> TruncateResult {
+    if max_bytes == 0 || input.len() <= max_bytes {
+        return TruncateResult {
+            text: input.to_owned(),
+            bytes_omitted: 0,
+            truncated: false,
+        };
+    }
+    let marker_base = "\n... [truncated] ...\n";
+    let marker_budget = marker_base.len().min(max_bytes.saturating_sub(1));
+    let content_budget = max_bytes.saturating_sub(marker_budget);
+    let head_budget = ((content_budget as f64) * head_ratio.clamp(0.0, 1.0)).floor() as usize;
+    let tail_budget = content_budget.saturating_sub(head_budget);
+    let head_end = floor_char_boundary(input, head_budget.min(input.len()));
+    let tail_start = ceil_char_boundary(input, input.len().saturating_sub(tail_budget));
+    let (head_end, tail_start) = if tail_start < head_end {
+        (head_end, head_end)
+    } else {
+        (head_end, tail_start)
+    };
+    let head = &input[..head_end];
+    let tail = &input[tail_start..];
+    let omitted = input.len().saturating_sub(head.len() + tail.len());
+    let elided_lines = input[head_end..tail_start]
+        .bytes()
+        .filter(|b| *b == b'\n')
+        .count();
+    let marker = format!("\n... [truncated {omitted} bytes, {elided_lines} lines] ...\n");
+    let marker = if marker.len() <= marker_budget {
+        marker
+    } else {
+        marker_base[..floor_char_boundary(marker_base, marker_budget)].to_owned()
+    };
+    let text = format!("{head}{marker}{tail}");
+    debug_assert!(text.len() <= max_bytes);
+    TruncateResult {
+        text,
+        bytes_omitted: omitted,
+        truncated: true,
+    }
+}
+
+fn floor_char_boundary(input: &str, idx: usize) -> usize {
+    let mut i = idx.min(input.len());
+    while i > 0 && !input.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+fn ceil_char_boundary(input: &str, idx: usize) -> usize {
+    let mut i = idx.min(input.len());
+    while i < input.len() && !input.is_char_boundary(i) {
+        i += 1;
+    }
+    i
+}
+
 pub struct DefaultAgent {
     pub config: Config,
     pub model: Arc<dyn Model>,
@@ -285,14 +350,29 @@ impl Agent for DefaultAgent {
             timestamp: chrono::Utc::now().to_rfc3339(),
         });
 
+        let trunc_stdout = truncate_observation_text(
+            &result.stdout,
+            self.config.root.agent.observation_max_bytes,
+            self.config.root.agent.observation_head_ratio,
+        );
+        let trunc_stderr = truncate_observation_text(
+            &result.stderr,
+            self.config.root.agent.observation_max_bytes,
+            self.config.root.agent.observation_head_ratio,
+        );
         // 6. Render observation.
         let obs_text = self.renderer.render_str(
             &self.config.root.agent.observation_template,
             &serde_json::json!({
                 "returncode": result.exit_code,
-                "output": result.combined_output(),
-                "stdout": result.stdout,
-                "stderr": result.stderr,
+                "output": match (trunc_stdout.text.is_empty(), trunc_stderr.text.is_empty()) {
+                    (true, true) => String::new(),
+                    (false, true) => trunc_stdout.text.clone(),
+                    (true, false) => trunc_stderr.text.clone(),
+                    (false, false) => format!("{}\n{}", trunc_stdout.text, trunc_stderr.text),
+                },
+                "stdout": trunc_stdout.text,
+                "stderr": trunc_stderr.text,
                 "timed_out": result.timed_out,
             }),
         )?;
@@ -309,6 +389,18 @@ impl Agent for DefaultAgent {
         obs_extra.other.insert(
             "run_result".into(),
             serde_json::to_value(&result).unwrap_or(serde_json::Value::Null),
+        );
+        obs_extra.other.insert(
+            "observation_truncated".into(),
+            serde_json::json!(trunc_stdout.truncated || trunc_stderr.truncated),
+        );
+        obs_extra.other.insert(
+            "stdout_bytes_omitted".into(),
+            serde_json::json!(trunc_stdout.bytes_omitted),
+        );
+        obs_extra.other.insert(
+            "stderr_bytes_omitted".into(),
+            serde_json::json!(trunc_stderr.bytes_omitted),
         );
         obs_extra.timestamp = Some(obs_ts.clone());
         self.trajectory.record_with_extra(&obs_msg, obs_extra);
@@ -510,5 +602,56 @@ mod tests {
         retag_cache_hints(&mut h);
         assert!(matches!(h[3].cache_hint, CacheHint::Auto));
         assert!(matches!(h[0].cache_hint, CacheHint::Breakpoint));
+    }
+
+    #[test]
+    fn truncate_observation_text_elides_middle() {
+        let input = "aaaaabbbbbcccccdddddeeeee";
+        let t = truncate_observation_text(input, 20, 0.5);
+        assert!(t.truncated);
+        assert!(t.bytes_omitted > 0);
+        assert!(t.text.contains("[truncated"));
+    }
+
+    #[test]
+    fn truncate_observation_text_handles_utf8_boundaries() {
+        let input = "αβγδεζηθικλμνξοπρστυφχψω";
+        let t = truncate_observation_text(input, 11, 0.5);
+        assert!(t.truncated);
+        assert!(std::str::from_utf8(t.text.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn truncate_observation_text_respects_max_bytes_hard_cap() {
+        let input = "x".repeat(10_000);
+        let t = truncate_observation_text(&input, 128, 0.5);
+        assert!(t.truncated);
+        assert!(t.text.len() <= 128);
+    }
+
+    #[tokio::test]
+    async fn oversized_stdout_is_truncated_for_model_but_preserved_on_disk() {
+        let mut a = make_agent(vec![
+            "```bash\npython - <<'PY'\nprint('x'*100000)\nPY\n```".into(),
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
+        ]);
+        a.config.root.agent.observation_max_bytes = 1024;
+        let _ = a.run().await.unwrap();
+        let obs = a
+            .history
+            .iter()
+            .find(|m| m.role == Role::User && m.content.contains("Exit code"))
+            .unwrap();
+        assert!(obs.content.len() < 4000);
+        let run_result = a
+            .trajectory
+            .messages
+            .iter()
+            .find(|m| m.role == "user" && m.extra.other.contains_key("run_result"))
+            .unwrap();
+        let stdout = run_result.extra.other["run_result"]["stdout"]
+            .as_str()
+            .unwrap();
+        assert_eq!(stdout.len(), 100001);
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -38,6 +38,10 @@ pub struct MiniCmd {
     /// Max agent steps.
     #[arg(long, default_value_t = 50)]
     pub step_limit: u32,
+    #[arg(long)]
+    pub observation_max_bytes: Option<usize>,
+    #[arg(long)]
+    pub observation_head_ratio: Option<f64>,
 
     /// Per-task wallclock timeout in seconds. Default: unset (no timeout).
     /// Orthogonal to `--step-limit`; whichever fires first wins.
@@ -208,6 +212,10 @@ pub struct SwebenchCmd {
 
     #[arg(long, default_value_t = 50)]
     pub step_limit: u32,
+    #[arg(long)]
+    pub observation_max_bytes: Option<usize>,
+    #[arg(long)]
+    pub observation_head_ratio: Option<f64>,
 
     /// Per-task wallclock timeout in seconds. Default: unset (no timeout).
     /// Orthogonal to `--step-limit`; whichever fires first wins.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -94,6 +94,13 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
     };
     cfg.root.model.name.clone_from(&m.model);
     cfg.root.agent.step_limit = m.step_limit;
+    if let Some(v) = m.observation_max_bytes {
+        cfg.root.agent.observation_max_bytes = v;
+    }
+    if let Some(v) = m.observation_head_ratio {
+        validate_observation_head_ratio(v)?;
+        cfg.root.agent.observation_head_ratio = v;
+    }
     if let Some(kind) = &m.env {
         cfg.root.environment.kind = match kind.as_str() {
             "local" => crate::config::EnvKind::Local,
@@ -306,6 +313,13 @@ fn swebench_config_from_cmd(s: &args::SwebenchCmd) -> Result<Config, Error> {
     };
     cfg.root.model.name.clone_from(&s.model);
     cfg.root.agent.step_limit = s.step_limit;
+    if let Some(v) = s.observation_max_bytes {
+        cfg.root.agent.observation_max_bytes = v;
+    }
+    if let Some(v) = s.observation_head_ratio {
+        validate_observation_head_ratio(v)?;
+        cfg.root.agent.observation_head_ratio = v;
+    }
     if let Some(kind) = &s.env {
         cfg.root.environment.kind = match kind.as_str() {
             "local" => crate::config::EnvKind::Local,
@@ -321,6 +335,16 @@ fn swebench_config_from_cmd(s: &args::SwebenchCmd) -> Result<Config, Error> {
         cfg.root.environment.docker_image = Some(img);
     }
     Ok(cfg)
+}
+
+fn validate_observation_head_ratio(value: f64) -> Result<(), Error> {
+    if value.is_finite() && (0.0..=1.0).contains(&value) {
+        Ok(())
+    } else {
+        Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "--observation-head-ratio must be a finite value in [0,1], got {value}"
+        ))))
+    }
 }
 
 fn swebench_args_from_cmd(
@@ -708,5 +732,26 @@ async fn bench_tail(t: args::TailCmd) -> Result<(), Error> {
             return Ok(());
         }
         tokio::time::sleep(Duration::from_millis(t.interval_ms)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::validate_observation_head_ratio;
+
+    #[test]
+    fn observation_head_ratio_accepts_closed_unit_interval() {
+        assert!(validate_observation_head_ratio(0.0).is_ok());
+        assert!(validate_observation_head_ratio(0.5).is_ok());
+        assert!(validate_observation_head_ratio(1.0).is_ok());
+    }
+
+    #[test]
+    fn observation_head_ratio_rejects_invalid_values() {
+        assert!(validate_observation_head_ratio(-0.01).is_err());
+        assert!(validate_observation_head_ratio(1.01).is_err());
+        assert!(validate_observation_head_ratio(f64::NAN).is_err());
+        assert!(validate_observation_head_ratio(f64::INFINITY).is_err());
     }
 }

--- a/src/config/defaults/default.toml
+++ b/src/config/defaults/default.toml
@@ -22,6 +22,8 @@ Exit code: {{ returncode }}
 Output:
 {{ output }}
 '''
+observation_max_bytes = 16384
+observation_head_ratio = 0.5
 
 [model]
 # String name. Routed by prefix to backend (claude* -> Anthropic).

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -31,6 +31,10 @@ pub struct AgentCfg {
     pub format_error_template: String,
     #[serde(default = "default_observation_template")]
     pub observation_template: String,
+    #[serde(default = "default_observation_max_bytes")]
+    pub observation_max_bytes: usize,
+    #[serde(default = "default_observation_head_ratio")]
+    pub observation_head_ratio: f64,
 }
 
 fn default_step_limit() -> u32 {
@@ -43,6 +47,14 @@ fn default_format_error_template() -> String {
 
 fn default_observation_template() -> String {
     "Exit code: {{ returncode }}\nOutput:\n{{ output }}".into()
+}
+
+fn default_observation_max_bytes() -> usize {
+    16_384
+}
+
+fn default_observation_head_ratio() -> f64 {
+    0.5
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]


### PR DESCRIPTION
### Motivation

- Prevent excessively large command outputs from bloating model inputs and histories by eliding middle parts of observations while preserving full outputs on disk/trajectory.
- Expose truncation behavior via configuration and CLI flags so callers can control the byte cap and head/tail split.

### Description

- Added `truncate_observation_text`, `floor_char_boundary`, and `ceil_char_boundary` helpers to safely elide the middle of UTF-8 text to a byte budget while inserting a human-readable marker. 
- Integrated truncation into `DefaultAgent` so `stdout`/`stderr` are truncated before rendering the observation template and added metadata keys `observation_truncated`, `stdout_bytes_omitted`, and `stderr_bytes_omitted` to the message `extra` while preserving the full `run_result` in the trajectory.
- Added CLI flags `--observation-max-bytes` and `--observation-head-ratio` to `MiniCmd` and `SwebenchCmd` and implemented `validate_observation_head_ratio` to ensure the ratio is finite and in `[0,1]`.
- Added config schema fields and defaults (`observation_max_bytes = 16384`, `observation_head_ratio = 0.5`) in `default.toml` and `schema.rs` with corresponding default functions.
- Added unit and async tests covering truncation behavior, UTF-8 boundary safety, hard byte cap enforcement, CLI validation, and an integration-style test that verifies truncated observations are used for the model while the full stdout remains stored in the trajectory.

### Testing

- Ran unit tests for `truncate_observation_text` and UTF-8/size edge cases in `src/agent/default.rs`, and CLI validation tests in `src/cli/mod.rs`, which all passed.
- Ran the async integration test `oversized_stdout_is_truncated_for_model_but_preserved_on_disk` that asserts user-facing observation size is capped while `trajectory` retains full `stdout`, which passed under `tokio::test`.
- All automated tests in the modified modules completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6ac16fc34832a84e8ef569b2782a6)