### PR TITLE
👺 Havoc: Fix panic in parse_retry_after_from_error due to multibyte lowercase misalignment

### DIFF
--- a/src/run/rate_limit.rs
+++ b/src/run/rate_limit.rs
@@ -336,7 +336,7 @@ impl RateLimitGovernor {
         let lower = msg.to_lowercase();
         for prefix in ["retry-after: ", "retry_after: ", "retry after: "] {
             if let Some(pos) = lower.find(prefix) {
-                let rest = msg[pos + prefix.len()..].trim();
+                let rest = lower[pos + prefix.len()..].trim();
                 // Try numeric seconds first.
                 let num: String = rest.chars().take_while(char::is_ascii_digit).collect();
                 if let Ok(secs) = num.parse::<u64>() {
@@ -420,4 +420,21 @@ pub(crate) fn civil_to_unix(
     #[allow(clippy::cast_sign_loss)]
     let total = days as u64 * 86_400 + h * 3_600 + m * 60 + s;
     Some(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_retry_after_multibyte_lowercase() {
+        // 'Ⱥ' (U+023A) is 2 bytes, but its lowercase 'ⱥ' (U+2C65) is 3 bytes.
+        // If the code uses the byte index from the lowercased string to slice
+        // the original string, it will panic due to unaligned char boundaries.
+        let msg = "Ⱥretry-after: 10";
+        assert_eq!(
+            RateLimitGovernor::parse_retry_after_from_error(msg),
+            Some(10)
+        );
+    }
 }


### PR DESCRIPTION
🧨 **The Trigger:** An attacker or malicious model supplying a `retry-after` error string containing multi-byte unicode characters that change length when lowercased (such as `Ⱥ` U+023A, which expands from 2 to 3 bytes). Slicing the original string using an index mapped from the lowercased version results in an out-of-bounds or invalid char boundary panic!

📉 **The Stack Trace:**
```
thread 'doesn_crash' panicked at src/run/rate_limit.rs:339:31:
byte index 16 is not a char boundary; it is inside '¡' (bytes 15..17) of `Ⱥretry-after: ¡`
```

🧪 **Reproduction:**
Run the proptest regression: `cargo test test_parse_retry_after_multibyte_lowercase`

😈 **Comment:** You assumed uppercase and lowercase unicode characters take up the same amount of bytes in memory. You were wrong. I sliced your application in half while slicing strings. Next time slice the `lower` string or use safe substring offsets, which I fixed for you to keep the game interesting.

---
*PR created automatically by Jules for task [14711965176261127369](https://jules.google.com/task/14711965176261127369) started by @madmax983*