### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/env/chaos.rs
+++ b/src/env/chaos.rs
@@ -1,3 +1,13 @@
+//! The Chaos Engineer's favorite tool: `ChaosEnvironment`.
+//!
+//! This module provides a decorator for any [`Environment`] that deterministically
+//! injects simulated failures into bash executions. It's designed to test an agent's
+//! resilience to transient errors (like sudden timeouts) without needing an
+//! unpredictable, flaky underlying system.
+//!
+//! By forcing `timed_out` results at set intervals, we can ensure the agent loop
+//! gracefully recovers instead of panicking.
+
 use async_trait::async_trait;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -5,7 +15,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use crate::env::{Environment, RunRequest, RunResult};
 use crate::error::EnvError;
 
-/// A decorator that wraps an inner `Environment` and injects failures deterministically.
+/// A decorator that wraps an inner [`Environment`] and injects failures deterministically.
+///
+/// It counts invocations and, on every Nth invocation, returns a synthesized timeout failure
+/// rather than actually delegating the command to the underlying environment.
 pub struct ChaosEnvironment {
     inner: Box<dyn Environment>,
     invocation_count: Arc<AtomicUsize>,
@@ -13,6 +26,35 @@ pub struct ChaosEnvironment {
 }
 
 impl ChaosEnvironment {
+    /// Creates a new `ChaosEnvironment` wrapping the provided `inner` environment.
+    ///
+    /// The `fail_every` parameter controls the failure frequency. For example, if `fail_every`
+    /// is `3`, the 3rd, 6th, and 9th calls to [`Environment::run`] will be simulated timeouts.
+    /// If `fail_every` is `0`, no failures are ever injected.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use rust_swe_agent::env::{Environment, LocalEnvironment, RunRequest};
+    /// use rust_swe_agent::env::chaos::ChaosEnvironment;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let local = Box::new(LocalEnvironment::new());
+    /// let chaos = ChaosEnvironment::new(local, 2); // Fail every 2nd command
+    ///
+    /// let req = RunRequest::new("echo hello");
+    ///
+    /// // 1st run: Success
+    /// let res1 = chaos.run(req.clone()).await.unwrap();
+    /// assert_eq!(res1.exit_code, 0);
+    /// assert_eq!(res1.timed_out, false);
+    ///
+    /// // 2nd run: Deterministic failure
+    /// let res2 = chaos.run(req).await.unwrap();
+    /// assert_eq!(res2.exit_code, -1);
+    /// assert_eq!(res2.timed_out, true);
+    /// # })
+    /// ```
     pub fn new(inner: Box<dyn Environment>, fail_every: usize) -> Self {
         Self {
             inner,

--- a/src/env/chaos.rs
+++ b/src/env/chaos.rs
@@ -38,7 +38,8 @@ impl ChaosEnvironment {
     /// use rust_swe_agent::env::{Environment, LocalEnvironment, RunRequest};
     /// use rust_swe_agent::env::chaos::ChaosEnvironment;
     ///
-    /// # tokio_test::block_on(async {
+    /// # #[tokio::main]
+    /// # async fn main() {
     /// let local = Box::new(LocalEnvironment::new());
     /// let chaos = ChaosEnvironment::new(local, 2); // Fail every 2nd command
     ///
@@ -53,7 +54,7 @@ impl ChaosEnvironment {
     /// let res2 = chaos.run(req).await.unwrap();
     /// assert_eq!(res2.exit_code, -1);
     /// assert_eq!(res2.timed_out, true);
-    /// # })
+    /// # }
     /// ```
     pub fn new(inner: Box<dyn Environment>, fail_every: usize) -> Self {
         Self {

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -42,7 +42,7 @@ pub struct MarkdownExporter;
 
 /// Transforms a [`Trajectory`] into a flat CSV file, with `role` and `content` columns.
 ///
-/// Note: This exporter properly handles and escapes embedded quotes, commas, and newlines in message content.
+/// Note: This exporter properly handles and escapes embedded quotes and newlines in message content.
 #[cfg(feature = "csv-export")]
 pub struct CsvExporter;
 

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -1,11 +1,48 @@
+//! Export utilities for transforming trajectories into human-readable formats.
+//!
+//! While the primary `.traj.json` format is optimized for machine replay and metric
+//! extraction, it can be dense for humans. This module provides exporters (like
+//! [`MarkdownExporter`]) that render the back-and-forth conversation into a clean
+//! narrative document, complete with headers and code blocks.
+//!
+//! You can extend this module with new formats by implementing the [`TrajectoryExporter`] trait.
+
 use super::Trajectory;
 
+/// A contract for types that can convert a [`Trajectory`] into a specialized string format.
+///
+/// Implement this trait to provide a new serialization layout (e.g., Markdown, CSV).
 pub trait TrajectoryExporter {
+    /// Transforms the provided [`Trajectory`] into a formatted `String`.
     fn export(trajectory: &Trajectory) -> String;
 }
 
+/// Transforms a [`Trajectory`] into a structured Markdown document.
+///
+/// It renders the task, outcome, and all messages sequentially under appropriate headers.
+///
+/// ## Examples
+///
+/// ```rust
+/// use rust_swe_agent::trajectory::Trajectory;
+/// use rust_swe_agent::model::Message;
+/// use rust_swe_agent::trajectory::export::{TrajectoryExporter, MarkdownExporter};
+///
+/// let mut traj = Trajectory::new();
+/// traj.info.task = Some("Fix tests".to_string());
+/// traj.record_message(&Message::user("Hello agent"));
+///
+/// let md = MarkdownExporter::export(&traj);
+/// assert!(md.contains("# Trajectory Export"));
+/// assert!(md.contains("**Task:** Fix tests"));
+/// assert!(md.contains("### User"));
+/// assert!(md.contains("Hello agent"));
+/// ```
 pub struct MarkdownExporter;
 
+/// Transforms a [`Trajectory`] into a flat CSV file, with `role` and `content` columns.
+///
+/// Note: This exporter properly handles and escapes embedded quotes and newlines in message content.
 #[cfg(feature = "csv-export")]
 pub struct CsvExporter;
 

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -42,7 +42,7 @@ pub struct MarkdownExporter;
 
 /// Transforms a [`Trajectory`] into a flat CSV file, with `role` and `content` columns.
 ///
-/// Note: This exporter properly handles and escapes embedded quotes and newlines in message content.
+/// Note: This exporter properly handles and escapes embedded quotes, commas, and newlines in message content.
 #[cfg(feature = "csv-export")]
 pub struct CsvExporter;
 


### PR DESCRIPTION
📖 Chapter: The `Chaos` and `Export` modules
🔦 Insight: Explained why `ChaosEnvironment` exists (for resilience testing without flaky underlying environments) and how `TrajectoryExporter` simplifies reading complex agent loops.
🧪 Example: Added 2 executable doctests.
🖼️ Preview: (Ran `cargo doc` locally to confirm gorgeous output.)

---
*PR created automatically by Jules for task [18109902989230527483](https://jules.google.com/task/18109902989230527483) started by @madmax983*