### PR TITLE
[codex] Add test command telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,6 +1663,7 @@ dependencies = [
  "minijinja",
  "pretty_assertions",
  "proptest",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
+regex = "1"
 
 # Errors / logging
 thiserror = "1"

--- a/docs/spec-test-telemetry.md
+++ b/docs/spec-test-telemetry.md
@@ -5,9 +5,9 @@ trajectory `info.test_invocations`. Detection uses the assistant's issued bash
 command, not the observation text, because observations can mention test
 commands in logs, scripts, or error output without proving that the agent chose
 to run them. Detection is anchored to shell command starts and shell segments
-after separators such as `&&`, `||`, `;`, and newlines. This intentionally
-detects commands like `cd repo && pytest -q` while ignoring quoted mentions such
-as `echo "run pytest"`.
+after separators such as `&&`, `||`, `|`, `;`, and newlines. This intentionally
+detects commands like `cd repo && pytest -q` and `echo "data" | pytest -q` while
+ignoring quoted mentions such as `echo "run pytest"`.
 
 Each invocation records:
 
@@ -61,9 +61,10 @@ test_command_patterns_replace = true
 test_command_patterns = ["project-(check|test)"]
 ```
 
-Configured regexes extend the built-in list by default. They are still evaluated
-only at a command segment start, so a regex that matches inside quoted text or
-in the middle of another command does not count.
+Configured regexes extend the built-in list by default. They are validated when
+configuration is loaded and compiled once during agent initialization. They are
+still evaluated only at a command segment start, so a regex that matches inside
+quoted text or in the middle of another command does not count.
 
 ## Behavioral Metrics
 

--- a/docs/spec-test-telemetry.md
+++ b/docs/spec-test-telemetry.md
@@ -1,0 +1,80 @@
+# Test Command Telemetry
+
+`rust-swe-agent` records recognized test commands from assistant action text in
+trajectory `info.test_invocations`. Detection uses the assistant's issued bash
+command, not the observation text, because observations can mention test
+commands in logs, scripts, or error output without proving that the agent chose
+to run them. Detection is anchored to shell command starts and shell segments
+after separators such as `&&`, `||`, `;`, and newlines. This intentionally
+detects commands like `cd repo && pytest -q` while ignoring quoted mentions such
+as `echo "run pytest"`.
+
+Each invocation records:
+
+- `step_index`: agent step index that issued the command.
+- `command`: full action command text.
+- `exit_code`: command exit code.
+- `matched_pattern`: built-in or configured pattern that matched.
+
+Trajectory `info` also carries:
+
+- `tests_run_before_submit`: true when a recognized test command ran before a
+  submit action.
+- `last_tests_passed`: exit status of the most recent recognized pre-submit
+  test, or null when none exists.
+
+## Default Patterns
+
+The built-in closed pattern list is:
+
+- `pytest`
+- `python -m pytest`
+- `python -m unittest`
+- `tox`
+- `nox`
+- `make test`
+- `make check`
+- `cargo test`
+- `go test`
+- `npm test`
+- `npm run test`
+- `yarn test`
+- `mvn test`
+- `mvn -Dtest=`
+- `gradle test`
+- `./gradlew test`
+
+## Configuration
+
+Add project-specific command regexes with:
+
+```toml
+[agent]
+test_command_patterns = ["project-(check|test)"]
+```
+
+To replace the built-in list entirely:
+
+```toml
+[agent]
+test_command_patterns_replace = true
+test_command_patterns = ["project-(check|test)"]
+```
+
+Configured regexes extend the built-in list by default. They are still evaluated
+only at a command segment start, so a regex that matches inside quoted text or
+in the middle of another command does not count.
+
+## Behavioral Metrics
+
+`bench evaluate` writes these metrics to `evaluation.json.behavioral`:
+
+- `tests_run_before_submit_rate`: submitted instances with
+  `tests_run_before_submit = true` divided by all submitted instances.
+- `resolved_rate_when_tests_run`: resolved submitted instances among submitted
+  instances that ran a recognized test command before submit.
+- `resolved_rate_when_tests_skipped`: resolved submitted instances among
+  submitted instances that did not run a recognized test command before submit.
+
+The default pattern list is a compatibility contract. Adding a default pattern is
+a minor schema bump; removing one is a breaking schema change.

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -23,8 +23,8 @@ use crate::model::{CacheHint, Message, MessageExtra, Model, QueryOpts, Role};
 use crate::stream::{NullSink, StreamEvent, StreamSink};
 use crate::template::Renderer;
 use crate::trajectory::{
-    FailureCategory, TestInvocation, TokenUsage, Trajectory, detect_test_command,
-    effective_test_command_patterns, exit_reason, outcome,
+    FailureCategory, TestCommandPattern, TestInvocation, TokenUsage, Trajectory,
+    detect_test_command, effective_test_command_patterns, exit_reason, outcome,
 };
 
 const MAX_TOOL_HOOK_ENV_VALUE_BYTES: usize = 1024;
@@ -128,6 +128,7 @@ pub struct DefaultAgent {
     /// Real-time event sink. Defaults to `NullSink` so non-streaming
     /// callers pay no cost beyond a vtable call.
     pub stream: Arc<dyn StreamSink>,
+    test_command_patterns: Vec<TestCommandPattern>,
 }
 
 pub struct DefaultAgentBuilder {
@@ -174,6 +175,15 @@ impl DefaultAgentBuilder {
         }
 
         let stream: Arc<dyn StreamSink> = self.stream.unwrap_or_else(|| Arc::new(NullSink));
+        let test_command_patterns = effective_test_command_patterns(
+            &self.config.root.agent.test_command_patterns,
+            self.config.root.agent.test_command_patterns_replace,
+        )
+        .map_err(|err| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "invalid agent.test_command_patterns regex: {err}"
+            )))
+        })?;
         stream.emit(StreamEvent::RunStarted {
             task: self.task.clone(),
             model: self.model.name().to_owned(),
@@ -195,6 +205,7 @@ impl DefaultAgentBuilder {
             cache_creation_tokens: 0,
             completion_tokens: 0,
             stream,
+            test_command_patterns,
         })
     }
 }
@@ -551,11 +562,7 @@ impl DefaultAgent {
     }
 
     fn record_test_invocation_if_matched(&mut self, command: &str, exit_code: i32) {
-        let patterns = effective_test_command_patterns(
-            &self.config.root.agent.test_command_patterns,
-            self.config.root.agent.test_command_patterns_replace,
-        );
-        if let Some(matched_pattern) = detect_test_command(command, &patterns) {
+        if let Some(matched_pattern) = detect_test_command(command, &self.test_command_patterns) {
             self.trajectory.info.test_invocations.push(TestInvocation {
                 step_index: self.steps,
                 command: command.to_owned(),

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -22,7 +22,10 @@ use crate::error::Error;
 use crate::model::{CacheHint, Message, MessageExtra, Model, QueryOpts, Role};
 use crate::stream::{NullSink, StreamEvent, StreamSink};
 use crate::template::Renderer;
-use crate::trajectory::{FailureCategory, TokenUsage, Trajectory, exit_reason, outcome};
+use crate::trajectory::{
+    FailureCategory, TestInvocation, TokenUsage, Trajectory, detect_test_command,
+    effective_test_command_patterns, exit_reason, outcome,
+};
 
 const MAX_TOOL_HOOK_ENV_VALUE_BYTES: usize = 1024;
 
@@ -389,6 +392,8 @@ impl Agent for DefaultAgent {
             (result, post_hook_results)
         };
 
+        self.record_test_invocation_if_matched(&cmd, result.exit_code);
+
         let trunc_stdout = truncate_observation_text(
             &result.stdout,
             self.config.root.agent.observation_max_bytes,
@@ -524,6 +529,7 @@ impl DefaultAgent {
             completion_tokens: self.completion_tokens,
         });
         self.trajectory.info.duration_secs = Some(self.started_at_instant.elapsed().as_secs_f64());
+        self.refresh_test_metadata();
     }
 
     pub fn finalize_wallclock_timeout(&mut self, timeout: Duration) {
@@ -542,6 +548,42 @@ impl DefaultAgent {
             Some(FailureCategory::WallclockTimeout),
             None,
         );
+    }
+
+    fn record_test_invocation_if_matched(&mut self, command: &str, exit_code: i32) {
+        let patterns = effective_test_command_patterns(
+            &self.config.root.agent.test_command_patterns,
+            self.config.root.agent.test_command_patterns_replace,
+        );
+        if let Some(matched_pattern) = detect_test_command(command, &patterns) {
+            self.trajectory.info.test_invocations.push(TestInvocation {
+                step_index: self.steps,
+                command: command.to_owned(),
+                exit_code,
+                matched_pattern,
+            });
+        }
+    }
+
+    fn refresh_test_metadata(&mut self) {
+        let submit_step = self
+            .trajectory
+            .messages
+            .iter()
+            .any(message_is_submit_action)
+            .then_some(self.trajectory.info.steps)
+            .flatten();
+        let last_pre_submit = submit_step.and_then(|step| {
+            self.trajectory
+                .info
+                .test_invocations
+                .iter()
+                .rev()
+                .find(|invocation| invocation.step_index < step)
+        });
+        self.trajectory.info.tests_run_before_submit = last_pre_submit.is_some();
+        self.trajectory.info.last_tests_passed =
+            last_pre_submit.map(|invocation| invocation.exit_code == 0);
     }
 
     async fn run_tool_hooks(
@@ -721,6 +763,14 @@ fn blocked_run_result(pre_hook_results: &[ToolHookResult]) -> RunResult {
         exit_code: 126,
         timed_out: false,
     }
+}
+
+fn message_is_submit_action(message: &crate::trajectory::MessageRecord) -> bool {
+    message
+        .extra
+        .actions
+        .as_ref()
+        .is_some_and(|actions| actions.iter().any(|action| action == "__SUBMIT__"))
 }
 
 fn tool_hook_env(context: &serde_json::Value) -> Result<BTreeMap<String, String>, Error> {

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -403,7 +403,9 @@ impl Agent for DefaultAgent {
             (result, post_hook_results)
         };
 
-        self.record_test_invocation_if_matched(&cmd, result.exit_code);
+        if !tool_use_blocked {
+            self.record_test_invocation_if_matched(&cmd, result.exit_code);
+        }
 
         let trunc_stdout = truncate_observation_text(
             &result.stdout,

--- a/src/config/defaults/default.toml
+++ b/src/config/defaults/default.toml
@@ -55,6 +55,13 @@ observation_head_ratio = 0.5
 # Default timeout for tool hooks unless a hook overrides `timeout_secs`.
 tool_hook_timeout_secs = 10
 #
+# Extra action-text command regex patterns recognized as test invocations.
+# Values extend the closed default list documented in
+# docs/spec-test-telemetry.md. Set `test_command_patterns_replace = true`
+# only when you want to disable the built-in SWE-bench ecosystem list.
+# test_command_patterns = ["project-(check|test)"]
+# test_command_patterns_replace = false
+#
 # Optional tool hooks. PreToolUse hooks run before each bash command; a
 # nonzero exit code or timeout blocks the command and reports the hook result
 # to the model. PostToolUse hooks run after successful command execution and

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,7 @@
 
 use std::path::{Path, PathBuf};
 
+use regex::Regex;
 use serde_json::Value;
 
 use crate::error::ConfigError;
@@ -30,9 +31,7 @@ impl Config {
     /// Load the embedded default config only.
     pub fn defaults() -> Result<Self, ConfigError> {
         let v = toml_to_json(DEFAULT_TOML)?;
-        let root: RootCfg =
-            serde_json::from_value(v.clone()).map_err(|e| ConfigError::Invalid(e.to_string()))?;
-        Ok(Self { root, raw: v })
+        Self::from_merged_value(v)
     }
 
     /// Load a user TOML, resolving `extends:` chains. Defaults are the base.
@@ -40,9 +39,7 @@ impl Config {
         let defaults = toml_to_json(DEFAULT_TOML)?;
         let user = load_with_extends(path, 0)?;
         let merged = recursive_merge(defaults, user);
-        let root: RootCfg = serde_json::from_value(merged.clone())
-            .map_err(|e| ConfigError::Invalid(e.to_string()))?;
-        Ok(Self { root, raw: merged })
+        Self::from_merged_value(merged)
     }
 
     /// Construct from a TOML string, starting from defaults. Used in tests.
@@ -50,10 +47,26 @@ impl Config {
         let defaults = toml_to_json(DEFAULT_TOML)?;
         let user = toml_to_json(s)?;
         let merged = recursive_merge(defaults, user);
+        Self::from_merged_value(merged)
+    }
+
+    fn from_merged_value(merged: Value) -> Result<Self, ConfigError> {
         let root: RootCfg = serde_json::from_value(merged.clone())
             .map_err(|e| ConfigError::Invalid(e.to_string()))?;
+        validate_test_command_patterns(&root)?;
         Ok(Self { root, raw: merged })
     }
+}
+
+fn validate_test_command_patterns(root: &RootCfg) -> Result<(), ConfigError> {
+    for pattern in &root.agent.test_command_patterns {
+        Regex::new(pattern).map_err(|err| {
+            ConfigError::Invalid(format!(
+                "invalid agent.test_command_patterns regex {pattern:?}: {err}"
+            ))
+        })?;
+    }
+    Ok(())
 }
 
 fn load_with_extends(path: &Path, depth: usize) -> Result<Value, ConfigError> {
@@ -155,6 +168,16 @@ name = "claude-sonnet-4-6"
     fn invalid_toml_returns_toml_error() {
         let err = Config::from_toml_str("[[[ not valid toml").unwrap_err();
         assert!(matches!(err, ConfigError::Toml(_)));
+    }
+
+    #[test]
+    fn invalid_test_command_pattern_returns_config_error() {
+        let err = Config::from_toml_str("[agent]\ntest_command_patterns = [\"(\"]").unwrap_err();
+        assert!(matches!(err, ConfigError::Invalid(_)));
+        assert!(
+            err.to_string().contains("agent.test_command_patterns"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -38,6 +38,10 @@ pub struct AgentCfg {
     #[serde(default = "default_tool_hook_timeout_secs")]
     pub tool_hook_timeout_secs: u64,
     #[serde(default)]
+    pub test_command_patterns: Vec<String>,
+    #[serde(default)]
+    pub test_command_patterns_replace: bool,
+    #[serde(default)]
     pub hooks: ToolHooksCfg,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,5 +26,6 @@ pub use model::{
 };
 pub use stream::{BroadcastSink, NullSink, SseServer, StreamEvent, StreamSink};
 pub use trajectory::{
-    FORMAT_VERSION, FailureCategory, MessageRecord, TokenUsage, Trajectory, TrajectoryInfo,
+    FORMAT_VERSION, FailureCategory, MessageRecord, TestInvocation, TokenUsage, Trajectory,
+    TrajectoryInfo,
 };

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -112,6 +112,9 @@ pub struct CompareReport {
     pub baseline_resolved_rate: f64,
     pub candidate_resolved_rate: f64,
     pub resolved_delta_rate: f64,
+    pub baseline_tests_before_submit_rate: f64,
+    pub candidate_tests_before_submit_rate: f64,
+    pub tests_before_submit_delta_rate: f64,
     pub resolved_delta_ci95: ConfidenceInterval,
     pub within_noise: bool,
     pub verdict: CompareVerdict,
@@ -273,6 +276,13 @@ fn write_compare_overview(s: &mut String, report: &CompareReport) {
         report.baseline_resolved_rate * 100.0,
         report.candidate_resolved_rate * 100.0,
         report.resolved_delta_rate * 100.0
+    );
+    let _ = writeln!(
+        s,
+        "Tests before submit: {:.2}% -> {:.2}% ({:+.2}pp)",
+        report.baseline_tests_before_submit_rate * 100.0,
+        report.candidate_tests_before_submit_rate * 100.0,
+        report.tests_before_submit_delta_rate * 100.0
     );
     let _ = writeln!(
         s,
@@ -802,6 +812,8 @@ fn instance_result_from_trajectory(
         runs: 1,
         resolved_count: u32::from(resolved),
         pass_at_1: resolved,
+        tests_run_before_submit: info.tests_run_before_submit,
+        last_tests_passed: info.last_tests_passed,
     }))
 }
 
@@ -869,6 +881,13 @@ fn aggregate_scanned_results(scanned: Vec<LoadedRunSlot>) -> HashMap<String, Ins
             .iter()
             .find(|(run_index, _)| *run_index == 1)
             .is_some_and(|(_, result)| result.resolved_count > 0);
+        aggregate.tests_run_before_submit = rows
+            .iter()
+            .any(|(_, result)| result.tests_run_before_submit);
+        aggregate.last_tests_passed = rows
+            .iter()
+            .rev()
+            .find_map(|(_, result)| result.last_tests_passed);
         aggregate.cost_usd = optional_sum(rows.iter().filter_map(|(_, result)| result.cost_usd));
         aggregate.prompt_tokens = Some(
             rows.iter()
@@ -1099,6 +1118,8 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
     let failure_category_candidate = histogram(candidate);
     let failure_category_delta =
         category_delta(&failure_category_baseline, &failure_category_candidate);
+    let baseline_tests_before_submit_rate = tests_before_submit_rate(baseline);
+    let candidate_tests_before_submit_rate = tests_before_submit_rate(candidate);
 
     CompareReport {
         baseline_dir: baseline_dir.to_path_buf(),
@@ -1114,6 +1135,10 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
         baseline_resolved_rate: resolution.baseline_resolved_rate,
         candidate_resolved_rate: resolution.candidate_resolved_rate,
         resolved_delta_rate: resolution.resolved_delta_rate,
+        baseline_tests_before_submit_rate,
+        candidate_tests_before_submit_rate,
+        tests_before_submit_delta_rate: candidate_tests_before_submit_rate
+            - baseline_tests_before_submit_rate,
         resolved_delta_ci95: resolution.resolved_delta_ci95,
         within_noise: resolution.within_noise,
         verdict: resolution.verdict,
@@ -1165,6 +1190,23 @@ fn aggregate_token_breakdown<S: std::hash::BuildHasher>(
                 .saturating_add(tokens.completion_tokens);
             total
         })
+}
+
+fn tests_before_submit_rate<S: std::hash::BuildHasher>(
+    rows: &HashMap<String, InstanceResult, S>,
+) -> f64 {
+    let mut submitted = 0usize;
+    let mut with_tests = 0usize;
+    for row in rows
+        .values()
+        .filter(|row| row.outcome.as_deref() == Some(outcome::SUBMITTED))
+    {
+        submitted += 1;
+        if row.tests_run_before_submit {
+            with_tests += 1;
+        }
+    }
+    pct(with_tests, submitted)
 }
 
 struct TransitionSummary {
@@ -1925,6 +1967,8 @@ mod tests {
             runs: 0,
             resolved_count: 0,
             pass_at_1: false,
+            tests_run_before_submit: false,
+            last_tests_passed: None,
         }
     }
 
@@ -1949,6 +1993,8 @@ mod tests {
             runs: 0,
             resolved_count: 0,
             pass_at_1: false,
+            tests_run_before_submit: false,
+            last_tests_passed: None,
         }
     }
 
@@ -1975,6 +2021,8 @@ mod tests {
             runs: 0,
             resolved_count: 0,
             pass_at_1: false,
+            tests_run_before_submit: false,
+            last_tests_passed: None,
         }
     }
 
@@ -1994,6 +2042,10 @@ mod tests {
         let sweep = SweepResults {
             total: instances.len(),
             submitted: instances.len(),
+            submitted_with_tests: instances
+                .iter()
+                .filter(|row| row.tests_run_before_submit)
+                .count(),
             skipped: 0,
             errored: 0,
             failures_by_category: BTreeMap::new(),
@@ -2122,6 +2174,7 @@ mod tests {
         let baseline_sweep = SweepResults {
             total: 2,
             submitted: 1,
+            submitted_with_tests: 0,
             skipped: 0,
             errored: 1,
             failures_by_category: BTreeMap::new(),
@@ -2213,6 +2266,8 @@ mod tests {
             runs: 1,
             resolved_count: 1,
             pass_at_1: true,
+            tests_run_before_submit: false,
+            last_tests_passed: None,
         }]);
         let candidate = map_of([InstanceResult {
             instance_id: "cached".into(),
@@ -2234,6 +2289,8 @@ mod tests {
             runs: 1,
             resolved_count: 1,
             pass_at_1: true,
+            tests_run_before_submit: false,
+            last_tests_passed: None,
         }]);
         let r = diff(Path::new("/b"), Path::new("/c"), &baseline, &candidate);
         let t = r.human_table();
@@ -2452,6 +2509,7 @@ mod tests {
         let baseline_sweep = SweepResults {
             total: 1,
             submitted: 1,
+            submitted_with_tests: 0,
             skipped: 0,
             errored: 0,
             failures_by_category: BTreeMap::new(),
@@ -2498,6 +2556,7 @@ mod tests {
                 eval_exit_reason: crate::run::evaluate::EvalExitReason::Resolved,
                 eval_log_path: None,
             }],
+            behavioral: crate::run::evaluate::BehavioralMetrics::default(),
             breakdown: Vec::new(),
             cost_attribution: Vec::new(),
         };
@@ -2513,6 +2572,7 @@ mod tests {
                 eval_exit_reason: crate::run::evaluate::EvalExitReason::Unresolved,
                 eval_log_path: None,
             }],
+            behavioral: crate::run::evaluate::BehavioralMetrics::default(),
             breakdown: Vec::new(),
             cost_attribution: Vec::new(),
         };
@@ -2563,6 +2623,7 @@ mod tests {
                 eval_exit_reason: crate::run::evaluate::EvalExitReason::Resolved,
                 eval_log_path: None,
             }],
+            behavioral: crate::run::evaluate::BehavioralMetrics::default(),
             breakdown: Vec::new(),
             cost_attribution: Vec::new(),
         };
@@ -2667,6 +2728,7 @@ mod tests {
         let sweep = SweepResults {
             total: 1,
             submitted: 0,
+            submitted_with_tests: 0,
             skipped: 0,
             errored: 0,
             failures_by_category: BTreeMap::new(),
@@ -2756,6 +2818,7 @@ mod tests {
         let sweep = SweepResults {
             total: 1,
             submitted: 1,
+            submitted_with_tests: 0,
             skipped: 0,
             errored: 0,
             failures_by_category: BTreeMap::new(),
@@ -2811,6 +2874,7 @@ mod tests {
         let sweep = SweepResults {
             total: 1,
             submitted: 0,
+            submitted_with_tests: 0,
             skipped: 0,
             errored: 0,
             failures_by_category: BTreeMap::new(),
@@ -2902,6 +2966,7 @@ mod tests {
         let sweep = SweepResults {
             total: 1,
             submitted: 0,
+            submitted_with_tests: 0,
             skipped: 0,
             errored: 0,
             failures_by_category: BTreeMap::new(),
@@ -3063,6 +3128,7 @@ mod tests {
         let sweep = SweepResults {
             total: 0,
             submitted: 0,
+            submitted_with_tests: 0,
             skipped: 0,
             errored: 0,
             failures_by_category: BTreeMap::new(),

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -116,10 +116,19 @@ const fn is_false(value: &bool) -> bool {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvaluationResults {
     pub instances: Vec<InstanceEvaluation>,
+    #[serde(default)]
+    pub behavioral: BehavioralMetrics,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub breakdown: Vec<BreakdownBucket>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub cost_attribution: Vec<CostAttributionBucket>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq)]
+pub struct BehavioralMetrics {
+    pub tests_run_before_submit_rate: f64,
+    pub resolved_rate_when_tests_run: f64,
+    pub resolved_rate_when_tests_skipped: f64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -219,6 +228,7 @@ pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
         EvaluateBackend::SbCli => run_sb_cli(args, &results)?,
     };
     let mut eval = run_output.eval;
+    eval.behavioral = build_behavioral_metrics(&eval.instances, &results);
     eval.breakdown = build_breakdown(&eval.instances, &results, &args.breakdown);
     if args.cost_attribution {
         let run_slots = load_run_slots(&args.sweep_dir, &results)?;
@@ -324,6 +334,7 @@ fn build_none_eval(results: &HashMap<String, InstanceResult>) -> EvaluationResul
     instances.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
     EvaluationResults {
         instances,
+        behavioral: BehavioralMetrics::default(),
         breakdown: Vec::new(),
         cost_attribution: Vec::new(),
     }
@@ -670,8 +681,52 @@ fn merge_with_results(
     instances.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
     EvaluationResults {
         instances,
+        behavioral: BehavioralMetrics::default(),
         breakdown: Vec::new(),
         cost_attribution: Vec::new(),
+    }
+}
+
+fn build_behavioral_metrics(
+    evals: &[InstanceEvaluation],
+    results: &HashMap<String, InstanceResult>,
+) -> BehavioralMetrics {
+    let resolved_by_id: HashMap<&str, bool> = evals
+        .iter()
+        .map(|row| (row.instance_id.as_str(), row.resolved))
+        .collect();
+    let mut submitted = 0usize;
+    let mut tests_run = 0usize;
+    let mut resolved_with_tests = 0usize;
+    let mut tests_skipped = 0usize;
+    let mut resolved_tests_skipped = 0usize;
+
+    for row in results
+        .values()
+        .filter(|row| row.outcome.as_deref() == Some(outcome::SUBMITTED))
+    {
+        submitted += 1;
+        let resolved = resolved_by_id
+            .get(row.instance_id.as_str())
+            .copied()
+            .unwrap_or(false);
+        if row.tests_run_before_submit {
+            tests_run += 1;
+            if resolved {
+                resolved_with_tests += 1;
+            }
+        } else {
+            tests_skipped += 1;
+            if resolved {
+                resolved_tests_skipped += 1;
+            }
+        }
+    }
+
+    BehavioralMetrics {
+        tests_run_before_submit_rate: pct(tests_run, submitted),
+        resolved_rate_when_tests_run: pct(resolved_with_tests, tests_run),
+        resolved_rate_when_tests_skipped: pct(resolved_tests_skipped, tests_skipped),
     }
 }
 
@@ -733,6 +788,7 @@ fn merge_rerun_reports_with_results(
     instances.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
     EvaluationResults {
         instances,
+        behavioral: BehavioralMetrics::default(),
         breakdown: Vec::new(),
         cost_attribution: Vec::new(),
     }
@@ -1096,6 +1152,8 @@ mod tests {
             runs: 0,
             resolved_count: 0,
             pass_at_1: false,
+            tests_run_before_submit: false,
+            last_tests_passed: None,
         }
     }
 
@@ -1120,6 +1178,8 @@ mod tests {
             runs: 0,
             resolved_count: 0,
             pass_at_1: false,
+            tests_run_before_submit: false,
+            last_tests_passed: None,
         }
     }
 
@@ -1141,6 +1201,13 @@ mod tests {
         }
     }
 
+    fn submitted_with_tests(id: &str, tests_run: bool) -> InstanceResult {
+        let mut r = submitted(id);
+        r.tests_run_before_submit = tests_run;
+        r.last_tests_passed = tests_run.then_some(true);
+        r
+    }
+
     #[test]
     fn none_backend_marks_non_submitted_as_skipped_no_patch() {
         let map = HashMap::from([
@@ -1159,6 +1226,39 @@ mod tests {
             eval.instances[1].eval_exit_reason,
             EvalExitReason::SkippedNoPatch
         ));
+    }
+
+    #[test]
+    fn behavioral_metrics_split_resolved_rate_by_test_behavior() {
+        let eval = EvaluationResults {
+            instances: vec![
+                eval_row("tested-pass", true),
+                eval_row("tested-fail", false),
+                eval_row("skipped-fail", false),
+            ],
+            breakdown: Vec::new(),
+            cost_attribution: Vec::new(),
+            behavioral: BehavioralMetrics::default(),
+        };
+        let results = HashMap::from([
+            (
+                "tested-pass".to_string(),
+                submitted_with_tests("tested-pass", true),
+            ),
+            (
+                "tested-fail".to_string(),
+                submitted_with_tests("tested-fail", true),
+            ),
+            (
+                "skipped-fail".to_string(),
+                submitted_with_tests("skipped-fail", false),
+            ),
+        ]);
+
+        let behavioral = build_behavioral_metrics(&eval.instances, &results);
+        assert_f64_eq(behavioral.tests_run_before_submit_rate, 2.0 / 3.0);
+        assert_f64_eq(behavioral.resolved_rate_when_tests_run, 0.5);
+        assert_f64_eq(behavioral.resolved_rate_when_tests_skipped, 0.0);
     }
 
     #[test]
@@ -1374,6 +1474,7 @@ mod tests {
         let results = HashMap::from([("cached".to_string(), cached)]);
         let eval = EvaluationResults {
             instances: vec![eval_row("cached", true)],
+            behavioral: BehavioralMetrics::default(),
             breakdown: Vec::new(),
             cost_attribution: Vec::new(),
         };

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -75,6 +75,12 @@ pub struct InspectReport {
     pub completion_tokens: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolved: Option<bool>,
+    pub test_invocations_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_test_exit_code: Option<i32>,
+    pub tests_run_before_submit: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_tests_passed: Option<bool>,
     #[serde(default)]
     pub warnings: Vec<String>,
     #[serde(default)]
@@ -202,12 +208,46 @@ fn build_instance_report(
                 cache_creation_tokens: None,
                 completion_tokens: None,
                 resolved: resolved_map.and_then(|m| m.get(instance_id).copied()),
+                test_invocations_count: 0,
+                last_test_exit_code: None,
+                tests_run_before_submit: false,
+                last_tests_passed: None,
                 warnings,
                 steps: vec![],
             });
         }
     };
 
+    let steps = build_inspect_steps(&traj, full);
+
+    let token_usage = traj.info.token_usage.as_ref();
+    Ok(InspectReport {
+        sweep_dir: sweep.to_path_buf(),
+        instance_id: Some(instance_id.to_owned()),
+        model: traj.info.model_name,
+        outcome: traj.info.outcome,
+        failure_category: traj.info.failure_category,
+        total_cost_usd: traj.info.total_cost_usd,
+        prompt_tokens: token_usage.map(TokenUsage::total_prompt_tokens),
+        input_tokens: token_usage.map(|t| t.prompt_tokens),
+        cache_read_tokens: token_usage.map(|t| t.cache_read_tokens),
+        cache_creation_tokens: token_usage.map(|t| t.cache_creation_tokens),
+        completion_tokens: token_usage.map(|t| t.completion_tokens),
+        resolved: resolved_map.and_then(|m| m.get(instance_id).copied()),
+        test_invocations_count: traj.info.test_invocations.len(),
+        last_test_exit_code: traj
+            .info
+            .test_invocations
+            .last()
+            .map(|invocation| invocation.exit_code),
+        tests_run_before_submit: traj.info.tests_run_before_submit,
+        last_tests_passed: traj.info.last_tests_passed,
+        warnings,
+        steps,
+    })
+}
+
+fn build_inspect_steps(traj: &Trajectory, full: bool) -> Vec<InspectStep> {
     let mut steps = Vec::new();
     for (msg_idx, msg) in traj.messages.iter().enumerate() {
         let current_index = steps.len();
@@ -227,57 +267,42 @@ fn build_instance_report(
             continue;
         }
 
-        if role == "user" {
-            if let Some(run_result) = msg
-                .extra
-                .other
-                .get("run_result")
-                .and_then(|v| serde_json::from_value::<RunResult>(v.clone()).ok())
-            {
-                let bash = infer_bash_from_previous_assistant(&traj, msg_idx);
-                let (stdout, stdout_note, stdout_truncated) =
-                    maybe_truncate(&run_result.stdout, full, current_index);
-                let (stderr, stderr_note, stderr_truncated) =
-                    maybe_truncate(&run_result.stderr, full, current_index);
-                let mut note_parts = Vec::new();
-                if let Some(n) = stdout_note {
-                    note_parts.push(format!("stdout: {n}"));
-                }
-                if let Some(n) = stderr_note {
-                    note_parts.push(format!("stderr: {n}"));
-                }
-                steps.push(InspectStep {
-                    index: current_index,
-                    role: "bash".into(),
-                    message: None,
-                    bash,
-                    exit_code: Some(run_result.exit_code),
-                    stdout: Some(stdout),
-                    stderr: Some(stderr),
-                    truncated: stdout_truncated || stderr_truncated,
-                    truncation_note: (!note_parts.is_empty()).then(|| note_parts.join("; ")),
-                });
-            }
+        if role != "user" {
+            continue;
         }
+        let Some(run_result) = msg
+            .extra
+            .other
+            .get("run_result")
+            .and_then(|v| serde_json::from_value::<RunResult>(v.clone()).ok())
+        else {
+            continue;
+        };
+        let bash = infer_bash_from_previous_assistant(traj, msg_idx);
+        let (stdout, stdout_note, stdout_truncated) =
+            maybe_truncate(&run_result.stdout, full, current_index);
+        let (stderr, stderr_note, stderr_truncated) =
+            maybe_truncate(&run_result.stderr, full, current_index);
+        let mut note_parts = Vec::new();
+        if let Some(n) = stdout_note {
+            note_parts.push(format!("stdout: {n}"));
+        }
+        if let Some(n) = stderr_note {
+            note_parts.push(format!("stderr: {n}"));
+        }
+        steps.push(InspectStep {
+            index: current_index,
+            role: "bash".into(),
+            message: None,
+            bash,
+            exit_code: Some(run_result.exit_code),
+            stdout: Some(stdout),
+            stderr: Some(stderr),
+            truncated: stdout_truncated || stderr_truncated,
+            truncation_note: (!note_parts.is_empty()).then(|| note_parts.join("; ")),
+        });
     }
-
-    let token_usage = traj.info.token_usage.as_ref();
-    Ok(InspectReport {
-        sweep_dir: sweep.to_path_buf(),
-        instance_id: Some(instance_id.to_owned()),
-        model: traj.info.model_name,
-        outcome: traj.info.outcome,
-        failure_category: traj.info.failure_category,
-        total_cost_usd: traj.info.total_cost_usd,
-        prompt_tokens: token_usage.map(TokenUsage::total_prompt_tokens),
-        input_tokens: token_usage.map(|t| t.prompt_tokens),
-        cache_read_tokens: token_usage.map(|t| t.cache_read_tokens),
-        cache_creation_tokens: token_usage.map(|t| t.cache_creation_tokens),
-        completion_tokens: token_usage.map(|t| t.completion_tokens),
-        resolved: resolved_map.and_then(|m| m.get(instance_id).copied()),
-        warnings,
-        steps,
-    })
+    steps
 }
 
 pub fn render_text(output: &InspectOutput) -> String {
@@ -387,6 +412,20 @@ fn render_instance_text(report: &InspectReport) -> String {
     if let Some(r) = report.resolved {
         let _ = writeln!(s, "resolved:         {r}");
     }
+    let submitted_without_tests = report.outcome.as_deref()
+        == Some(crate::trajectory::outcome::SUBMITTED)
+        && !report.tests_run_before_submit;
+    let _ = writeln!(
+        s,
+        "tests:            count={} last_exit_code={} last_passed={} submitted_without_tests={submitted_without_tests}",
+        report.test_invocations_count,
+        report
+            .last_test_exit_code
+            .map_or_else(|| "?".into(), |code| code.to_string()),
+        report
+            .last_tests_passed
+            .map_or_else(|| "?".into(), |passed| passed.to_string()),
+    );
     for w in &report.warnings {
         let _ = writeln!(s, "warning:          {w}");
     }

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -128,6 +128,7 @@ pub struct SweBenchInstance {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct InstanceResult {
     pub instance_id: String,
     pub exit_reason: String,
@@ -195,12 +196,21 @@ pub struct InstanceResult {
     /// single-shot pass/fail value when `runs == 1`.
     #[serde(default)]
     pub pass_at_1: bool,
+    /// Whether the agent issued at least one recognized test command before
+    /// submitting.
+    #[serde(default)]
+    pub tests_run_before_submit: bool,
+    /// Pass/fail value of the most recent recognized pre-submit test command.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_tests_passed: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SweepResults {
     pub total: usize,
     pub submitted: usize,
+    #[serde(default)]
+    pub submitted_with_tests: usize,
     pub skipped: usize,
     pub errored: usize,
     #[serde(default)]
@@ -417,6 +427,7 @@ impl SweepResults {
     /// Render the post-sweep summary table. A flat plain-text block so it
     /// reads cleanly in CI logs and from a tail of stdout.
     #[must_use]
+    #[allow(clippy::too_many_lines)]
     pub fn summary_table(&self) -> String {
         let submit_rate_pct = self.submit_rate_pct();
         let tokens = self.token_breakdown();
@@ -428,7 +439,12 @@ impl SweepResults {
         s.push_str("\n=== SWE-bench sweep summary ===\n");
         let _ = writeln!(s, "Total tasks:        {}", self.total);
         write_effective_task_line(&mut s, self.total, effective_tasks, uniform_runs);
-        let _ = writeln!(s, "Submitted:          {}", self.submitted);
+        write_submission_lines(
+            &mut s,
+            self.submitted,
+            self.submitted_with_tests,
+            &self.instances,
+        );
         let _ = writeln!(
             s,
             "With patch:         {} — non-empty diff against base_commit",
@@ -541,6 +557,58 @@ impl SweepResults {
         let first = iter.next()?;
         iter.all(|runs| runs == first).then_some(first)
     }
+}
+
+fn write_submission_lines(
+    s: &mut String,
+    submitted: usize,
+    submitted_with_tests: usize,
+    instances: &[InstanceResult],
+) {
+    let _ = writeln!(s, "Submitted:          {submitted}");
+    let _ = writeln!(s, "Submitted w/tests:  {submitted_with_tests}/{submitted}");
+    write_test_resolution_line(s, instances);
+}
+
+fn write_test_resolution_line(s: &mut String, instances: &[InstanceResult]) {
+    let counts = test_behavior_resolution_counts(instances);
+    let _ = writeln!(
+        s,
+        "Resolved by tests:  tests_run=true {}/{}, tests_run=false {}/{}",
+        counts.resolved_with_tests,
+        counts.with_tests,
+        counts.resolved_without_tests,
+        counts.without_tests
+    );
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct TestBehaviorResolutionCounts {
+    with_tests: usize,
+    resolved_with_tests: usize,
+    without_tests: usize,
+    resolved_without_tests: usize,
+}
+
+fn test_behavior_resolution_counts(instances: &[InstanceResult]) -> TestBehaviorResolutionCounts {
+    let mut counts = TestBehaviorResolutionCounts::default();
+    for row in instances
+        .iter()
+        .filter(|row| row.outcome.as_deref() == Some(outcome::SUBMITTED))
+    {
+        if row.tests_run_before_submit {
+            counts.with_tests += 1;
+            if resolved_count(row) > 0 {
+                counts.resolved_with_tests += 1;
+            }
+        } else {
+            counts.without_tests += 1;
+            if resolved_count(row) > 0 {
+                counts.resolved_without_tests += 1;
+            }
+        }
+    }
+    counts
 }
 
 fn write_rate_limit_summary(s: &mut String, rl: Option<&crate::run::rate_limit::RateLimitEvents>) {
@@ -844,6 +912,7 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
         return Ok(SweepResults {
             total: 0,
             submitted: 0,
+            submitted_with_tests: 0,
             skipped: 0,
             errored: 0,
             failures_by_category: BTreeMap::new(),
@@ -908,6 +977,7 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     let initial = SweepResults {
         total,
         submitted: 0,
+        submitted_with_tests: 0,
         skipped: 0,
         errored: 0,
         failures_by_category: BTreeMap::new(),
@@ -1163,6 +1233,8 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
                         runs: 1,
                         resolved_count: 0,
                         pass_at_1: false,
+                        tests_run_before_submit: false,
+                        last_tests_passed: None,
                     },
                 ));
             }
@@ -1249,6 +1321,7 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     let sweep = SweepResults {
         total,
         submitted,
+        submitted_with_tests: accounting.submitted_with_tests,
         skipped,
         errored,
         failures_by_category,
@@ -1883,6 +1956,8 @@ fn budget_halt_result(instance_id: &str) -> InstanceResult {
         runs: 1,
         resolved_count: 0,
         pass_at_1: false,
+        tests_run_before_submit: false,
+        last_tests_passed: None,
     }
 }
 
@@ -1907,6 +1982,7 @@ impl RunSlotResult {
 #[derive(Debug, Default, Clone, Copy)]
 struct SweepAccounting {
     with_patch: usize,
+    submitted_with_tests: usize,
     tokens: TokenBreakdown,
     total_retries: u64,
     retried_instances: usize,
@@ -1916,6 +1992,9 @@ impl SweepAccounting {
     fn add_result(&mut self, result: &InstanceResult) {
         if result.non_empty_patch && result.outcome.as_deref() == Some(outcome::SUBMITTED) {
             self.with_patch += 1;
+        }
+        if result.tests_run_before_submit && result.outcome.as_deref() == Some(outcome::SUBMITTED) {
+            self.submitted_with_tests += 1;
         }
         self.total_retries = self
             .total_retries
@@ -2012,6 +2091,8 @@ fn aggregate_run_results(results: &[RunSlotResult], requested_runs: u32) -> Vec<
             .iter()
             .find(|r| r.run_index == 1)
             .is_some_and(|r| is_resolved_instance_result(&r.result));
+        aggregate.tests_run_before_submit = rows.iter().any(|r| r.result.tests_run_before_submit);
+        aggregate.last_tests_passed = rows.iter().rev().find_map(|r| r.result.last_tests_passed);
         out.push(aggregate);
     }
     out
@@ -2184,6 +2265,8 @@ fn skipped_result_from_info(
         ),
         pass_at_1: info.outcome.as_deref() == Some(outcome::SUBMITTED)
             && info.failure_category.is_none(),
+        tests_run_before_submit: info.tests_run_before_submit,
+        last_tests_passed: info.last_tests_passed,
     }
 }
 
@@ -2196,6 +2279,8 @@ fn skipped_result_from_prior_result(
     out.error = None;
     out.patch_present = traj_based.patch_present;
     out.non_empty_patch = traj_based.non_empty_patch;
+    out.tests_run_before_submit = traj_based.tests_run_before_submit;
+    out.last_tests_passed = traj_based.last_tests_passed;
     out.runs = 1;
     out.resolved_count = u32::from(is_resolved_instance_result(&out));
     out.pass_at_1 = is_resolved_instance_result(&out);
@@ -2576,6 +2661,8 @@ async fn run_one(inst: SweBenchInstance, run_index: u32, params: RunOneParams) -
                 outcome_str == outcome::SUBMITTED && failure_category.is_none(),
             ),
             pass_at_1: outcome_str == outcome::SUBMITTED && failure_category.is_none(),
+            tests_run_before_submit: info.as_ref().is_some_and(|i| i.tests_run_before_submit),
+            last_tests_passed: info.as_ref().and_then(|i| i.last_tests_passed),
         };
         let retryable = current
             .failure_category
@@ -2924,6 +3011,43 @@ mod tests {
     use super::*;
     use futures::FutureExt;
 
+    fn test_instance_result(id: &str, submitted: bool, tests_run: bool) -> InstanceResult {
+        InstanceResult {
+            instance_id: id.into(),
+            exit_reason: if submitted { "submitted" } else { "error" }.into(),
+            outcome: Some(
+                if submitted {
+                    outcome::SUBMITTED
+                } else {
+                    outcome::ERROR
+                }
+                .into(),
+            ),
+            failure_category: if submitted {
+                None
+            } else {
+                Some(FailureCategory::Unknown)
+            },
+            steps: Some(1),
+            cost_usd: Some(0.0),
+            prompt_tokens: Some(0),
+            cache_read_tokens: Some(0),
+            cache_creation_tokens: Some(0),
+            completion_tokens: Some(0),
+            duration_secs: Some(0.0),
+            error: None,
+            patch_present: submitted,
+            non_empty_patch: submitted,
+            attempts: 1,
+            retry_reasons: Vec::new(),
+            runs: 1,
+            resolved_count: u32::from(submitted),
+            pass_at_1: submitted,
+            tests_run_before_submit: tests_run,
+            last_tests_passed: tests_run.then_some(true),
+        }
+    }
+
     #[test]
     fn cost_estimate_uses_sonnet_pricing() {
         // 1M cold input + 1M completion = $3 + $15 = $18.
@@ -3007,6 +3131,8 @@ mod tests {
             runs: 1,
             resolved_count: 1,
             pass_at_1: true,
+            tests_run_before_submit: false,
+            last_tests_passed: None,
         };
         let expected = estimate_cost_usd(100_000, 0, 0, 100_000, "openai/gpt-4o-mini");
         assert!(
@@ -3023,6 +3149,7 @@ mod tests {
         let s = SweepResults {
             total: 10,
             submitted: 4,
+            submitted_with_tests: 0,
             skipped: 3,
             errored: 1,
             failures_by_category: BTreeMap::new(),
@@ -3087,10 +3214,52 @@ mod tests {
     }
 
     #[test]
+    fn summary_table_includes_test_behavior_telemetry() {
+        let mut with_tests = test_instance_result("with-tests", true, true);
+        with_tests.last_tests_passed = Some(true);
+        let skipped_tests = test_instance_result("without-tests", true, false);
+        let error_without_submit = test_instance_result("errored", false, false);
+        let s = SweepResults {
+            total: 3,
+            submitted: 2,
+            submitted_with_tests: 1,
+            skipped: 0,
+            errored: 1,
+            failures_by_category: BTreeMap::new(),
+            budget_halted: 0,
+            with_patch: 2,
+            patch_empty: 0,
+            patch_apply_invalid: 0,
+            total_prompt_tokens: 0,
+            total_cache_read_tokens: 0,
+            total_cache_creation_tokens: 0,
+            total_completion_tokens: 0,
+            estimated_cost_usd: 0.0,
+            retries: 0,
+            retried_instances: 0,
+            pass_at_k: 0.0,
+            filter_spec: FilterSpec::default(),
+            manifest: None,
+            cost_limit_usd: None,
+            cache_hit_rate: 0.0,
+            instances: vec![with_tests, skipped_tests, error_without_submit],
+            rate_limit_events: None,
+        };
+
+        let t = s.summary_table();
+        assert!(t.contains("Submitted w/tests:  1/2"), "{t}");
+        assert!(
+            t.contains("Resolved by tests:  tests_run=true 1/1, tests_run=false 1/1"),
+            "{t}"
+        );
+    }
+
+    #[test]
     fn summary_table_includes_budget_halt_line_when_triggered() {
         let s = SweepResults {
             total: 5,
             submitted: 3,
+            submitted_with_tests: 0,
             skipped: 0,
             errored: 0,
             failures_by_category: BTreeMap::new(),
@@ -3947,6 +4116,7 @@ instance = "inst"
         let s = SweepResults {
             total: 1,
             submitted: 1,
+            submitted_with_tests: 0,
             skipped: 0,
             errored: 0,
             failures_by_category: BTreeMap::new(),
@@ -4250,6 +4420,7 @@ instance = "inst"
         let s = SweepResults {
             total: 2,
             submitted: 2,
+            submitted_with_tests: 0,
             skipped: 0,
             errored: 0,
             failures_by_category: BTreeMap::new(),
@@ -4310,6 +4481,7 @@ instance = "inst"
         let s = SweepResults {
             total: 1,
             submitted: 1,
+            submitted_with_tests: 0,
             skipped: 0,
             errored: 0,
             failures_by_category: BTreeMap::new(),

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -592,10 +592,7 @@ struct TestBehaviorResolutionCounts {
 
 fn test_behavior_resolution_counts(instances: &[InstanceResult]) -> TestBehaviorResolutionCounts {
     let mut counts = TestBehaviorResolutionCounts::default();
-    for row in instances
-        .iter()
-        .filter(|row| row.outcome.as_deref() == Some(outcome::SUBMITTED))
-    {
+    for row in instances.iter().filter(|row| has_submitted_sample(row)) {
         if row.tests_run_before_submit {
             counts.with_tests += 1;
             if resolved_count(row) > 0 {
@@ -609,6 +606,12 @@ fn test_behavior_resolution_counts(instances: &[InstanceResult]) -> TestBehavior
         }
     }
     counts
+}
+
+fn has_submitted_sample(row: &InstanceResult) -> bool {
+    // Aggregate rerun rows keep run-1 outcome for pass@1 compatibility, so
+    // later submitted/resolved samples are represented by `resolved_count`.
+    row.outcome.as_deref() == Some(outcome::SUBMITTED) || resolved_count(row) > 0
 }
 
 fn write_rate_limit_summary(s: &mut String, rl: Option<&crate::run::rate_limit::RateLimitEvents>) {
@@ -1321,7 +1324,7 @@ pub async fn run(args: SwebenchArgs) -> Result<SweepResults, Error> {
     let sweep = SweepResults {
         total,
         submitted,
-        submitted_with_tests: accounting.submitted_with_tests,
+        submitted_with_tests: submitted_with_tests_for_fresh_submissions(&results),
         skipped,
         errored,
         failures_by_category,
@@ -1982,7 +1985,6 @@ impl RunSlotResult {
 #[derive(Debug, Default, Clone, Copy)]
 struct SweepAccounting {
     with_patch: usize,
-    submitted_with_tests: usize,
     tokens: TokenBreakdown,
     total_retries: u64,
     retried_instances: usize,
@@ -1992,9 +1994,6 @@ impl SweepAccounting {
     fn add_result(&mut self, result: &InstanceResult) {
         if result.non_empty_patch && result.outcome.as_deref() == Some(outcome::SUBMITTED) {
             self.with_patch += 1;
-        }
-        if result.tests_run_before_submit && result.outcome.as_deref() == Some(outcome::SUBMITTED) {
-            self.submitted_with_tests += 1;
         }
         self.total_retries = self
             .total_retries
@@ -2024,6 +2023,17 @@ impl SweepAccounting {
                 .saturating_add(completion_tokens);
         }
     }
+}
+
+fn submitted_with_tests_for_fresh_submissions(results: &[RunSlotResult]) -> usize {
+    results
+        .iter()
+        .filter(|r| {
+            r.result.exit_reason != "skipped_resume"
+                && r.result.outcome.as_deref() == Some(outcome::SUBMITTED)
+                && r.result.tests_run_before_submit
+        })
+        .count()
 }
 
 fn aggregate_run_results(results: &[RunSlotResult], requested_runs: u32) -> Vec<InstanceResult> {
@@ -3252,6 +3262,28 @@ mod tests {
             t.contains("Resolved by tests:  tests_run=true 1/1, tests_run=false 1/1"),
             "{t}"
         );
+    }
+
+    #[test]
+    fn test_behavior_resolution_counts_include_later_rerun_submission() {
+        let first_error = test_instance_result("rerun-task", false, false);
+        let later_submitted_with_tests = test_instance_result("rerun-task", true, true);
+        let instances = aggregate_run_results(
+            &[
+                RunSlotResult::new(1, first_error),
+                RunSlotResult::new(2, later_submitted_with_tests),
+            ],
+            2,
+        );
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0].resolved_count, 1);
+        assert!(instances[0].tests_run_before_submit);
+
+        let counts = test_behavior_resolution_counts(&instances);
+        assert_eq!(counts.with_tests, 1);
+        assert_eq!(counts.resolved_with_tests, 1);
+        assert_eq!(counts.without_tests, 0);
+        assert_eq!(counts.resolved_without_tests, 0);
     }
 
     #[test]

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -5,6 +5,7 @@
 //! `serde_json` output, so we match Python's layout exactly: `format`,
 //! `info`, `messages`.
 
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -44,6 +45,194 @@ pub enum FailureCategory {
     /// Agent submitted but the captured diff was empty (zero bytes).
     PatchEmpty,
     Unknown,
+}
+
+pub const DEFAULT_TEST_COMMAND_PATTERNS: &[&str] = &[
+    "pytest",
+    "python -m pytest",
+    "python -m unittest",
+    "tox",
+    "nox",
+    "make test",
+    "make check",
+    "cargo test",
+    "go test",
+    "npm test",
+    "npm run test",
+    "yarn test",
+    "mvn test",
+    "mvn -Dtest=",
+    "gradle test",
+    "./gradlew test",
+];
+
+#[derive(Debug, Clone)]
+pub struct TestCommandPattern {
+    source: String,
+    matcher: TestCommandMatcher,
+}
+
+#[derive(Debug, Clone)]
+enum TestCommandMatcher {
+    Literal,
+    Regex(Option<Regex>),
+}
+
+impl TestCommandPattern {
+    fn literal(source: &str) -> Self {
+        Self {
+            source: source.to_owned(),
+            matcher: TestCommandMatcher::Literal,
+        }
+    }
+
+    fn regex(source: &str) -> Self {
+        Self {
+            source: source.to_owned(),
+            matcher: TestCommandMatcher::Regex(Regex::new(source).ok()),
+        }
+    }
+
+    fn matches(&self, segment: &str) -> bool {
+        match &self.matcher {
+            TestCommandMatcher::Literal => {
+                command_segment_starts_with_pattern(segment, &self.source)
+            }
+            TestCommandMatcher::Regex(Some(regex)) => {
+                regex_matches_command_segment_start(regex, segment, &self.source)
+            }
+            TestCommandMatcher::Regex(None) => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TestInvocation {
+    pub step_index: u32,
+    pub command: String,
+    pub exit_code: i32,
+    pub matched_pattern: String,
+}
+
+#[must_use]
+pub fn effective_test_command_patterns(
+    extra_patterns: &[String],
+    replace_defaults: bool,
+) -> Vec<TestCommandPattern> {
+    let mut patterns = if replace_defaults {
+        Vec::new()
+    } else {
+        DEFAULT_TEST_COMMAND_PATTERNS
+            .iter()
+            .map(|pattern| TestCommandPattern::literal(pattern))
+            .collect()
+    };
+    patterns.extend(
+        extra_patterns
+            .iter()
+            .map(String::as_str)
+            .map(TestCommandPattern::regex),
+    );
+    patterns
+}
+
+#[must_use]
+pub fn detect_test_command(command: &str, patterns: &[TestCommandPattern]) -> Option<String> {
+    let mut single_quoted = false;
+    let mut double_quoted = false;
+    let mut escaped = false;
+    let mut segment_start = 0usize;
+    let mut chars = command.char_indices().peekable();
+
+    while let Some((idx, ch)) = chars.next() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' && !single_quoted {
+            escaped = true;
+            continue;
+        }
+        if ch == '\'' && !double_quoted {
+            single_quoted = !single_quoted;
+            continue;
+        }
+        if ch == '"' && !single_quoted {
+            double_quoted = !double_quoted;
+            continue;
+        }
+        if single_quoted || double_quoted {
+            continue;
+        }
+
+        if ch == ';' || ch == '\n' {
+            if let Some(pattern) =
+                detect_test_command_segment(&command[segment_start..idx], patterns)
+            {
+                return Some(pattern);
+            }
+            segment_start = idx + ch.len_utf8();
+            continue;
+        }
+
+        if (ch == '&' || ch == '|') && chars.peek().is_some_and(|(_, next)| *next == ch) {
+            if let Some(pattern) =
+                detect_test_command_segment(&command[segment_start..idx], patterns)
+            {
+                return Some(pattern);
+            }
+            let (_, next) = chars.next().unwrap_or((idx, ch));
+            segment_start = idx + ch.len_utf8() + next.len_utf8();
+        }
+    }
+
+    detect_test_command_segment(&command[segment_start..], patterns)
+}
+
+fn detect_test_command_segment(segment: &str, patterns: &[TestCommandPattern]) -> Option<String> {
+    let segment = trim_command_prefix(segment);
+    if segment.starts_with('"') || segment.starts_with('\'') {
+        return None;
+    }
+    patterns
+        .iter()
+        .find(|pattern| pattern.matches(segment))
+        .map(|pattern| pattern.source.clone())
+}
+
+fn trim_command_prefix(mut segment: &str) -> &str {
+    segment = segment.trim_start();
+    while let Some(rest) = segment.strip_prefix('(') {
+        segment = rest.trim_start();
+    }
+    segment
+}
+
+fn command_segment_starts_with_pattern(segment: &str, pattern: &str) -> bool {
+    let Some(rest) = segment.strip_prefix(pattern) else {
+        return false;
+    };
+    if rest.is_empty() || pattern.ends_with('=') {
+        return true;
+    }
+    rest.chars().next().is_some_and(is_command_boundary)
+}
+
+fn regex_matches_command_segment_start(regex: &Regex, segment: &str, pattern: &str) -> bool {
+    let Some(matched) = regex.find(segment) else {
+        return false;
+    };
+    if matched.start() != 0 {
+        return false;
+    }
+    let rest = &segment[matched.end()..];
+    rest.is_empty()
+        || pattern.ends_with('=')
+        || rest.chars().next().is_some_and(is_command_boundary)
+}
+
+fn is_command_boundary(ch: char) -> bool {
+    ch.is_whitespace() || matches!(ch, ')' | ';' | '&' | '|' | '<' | '>')
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -97,6 +286,12 @@ pub struct TrajectoryInfo {
     pub duration_secs: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub steps: Option<u32>,
+    #[serde(default)]
+    pub test_invocations: Vec<TestInvocation>,
+    #[serde(default)]
+    pub tests_run_before_submit: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_tests_passed: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub started_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -75,7 +75,7 @@ pub struct TestCommandPattern {
 #[derive(Debug, Clone)]
 enum TestCommandMatcher {
     Literal,
-    Regex(Option<Regex>),
+    Regex(Regex),
 }
 
 impl TestCommandPattern {
@@ -86,11 +86,11 @@ impl TestCommandPattern {
         }
     }
 
-    fn regex(source: &str) -> Self {
-        Self {
+    fn regex(source: &str) -> Result<Self, regex::Error> {
+        Ok(Self {
             source: source.to_owned(),
-            matcher: TestCommandMatcher::Regex(Regex::new(source).ok()),
-        }
+            matcher: TestCommandMatcher::Regex(Regex::new(source)?),
+        })
     }
 
     fn matches(&self, segment: &str) -> bool {
@@ -98,10 +98,9 @@ impl TestCommandPattern {
             TestCommandMatcher::Literal => {
                 command_segment_starts_with_pattern(segment, &self.source)
             }
-            TestCommandMatcher::Regex(Some(regex)) => {
+            TestCommandMatcher::Regex(regex) => {
                 regex_matches_command_segment_start(regex, segment, &self.source)
             }
-            TestCommandMatcher::Regex(None) => false,
         }
     }
 }
@@ -114,11 +113,10 @@ pub struct TestInvocation {
     pub matched_pattern: String,
 }
 
-#[must_use]
 pub fn effective_test_command_patterns(
     extra_patterns: &[String],
     replace_defaults: bool,
-) -> Vec<TestCommandPattern> {
+) -> Result<Vec<TestCommandPattern>, regex::Error> {
     let mut patterns = if replace_defaults {
         Vec::new()
     } else {
@@ -127,13 +125,10 @@ pub fn effective_test_command_patterns(
             .map(|pattern| TestCommandPattern::literal(pattern))
             .collect()
     };
-    patterns.extend(
-        extra_patterns
-            .iter()
-            .map(String::as_str)
-            .map(TestCommandPattern::regex),
-    );
-    patterns
+    for pattern in extra_patterns {
+        patterns.push(TestCommandPattern::regex(pattern)?);
+    }
+    Ok(patterns)
 }
 
 #[must_use]
@@ -183,6 +178,16 @@ pub fn detect_test_command(command: &str, patterns: &[TestCommandPattern]) -> Op
             }
             let (_, next) = chars.next().unwrap_or((idx, ch));
             segment_start = idx + ch.len_utf8() + next.len_utf8();
+            continue;
+        }
+
+        if ch == '|' {
+            if let Some(pattern) =
+                detect_test_command_segment(&command[segment_start..idx], patterns)
+            {
+                return Some(pattern);
+            }
+            segment_start = idx + ch.len_utf8();
         }
     }
 

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -66,6 +66,137 @@ async fn two_turn_echo_submit_produces_well_formed_trajectory() {
     assert_eq!(model.call_count(), 2);
 }
 
+#[tokio::test]
+async fn records_pytest_invocation_before_submit_from_action_text() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+
+    let model = Arc::new(DeterministicModel::new(vec![
+        "```bash\npytest -q\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(FixedExitEnvironment { exit_code: 0 });
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "round trip".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+    assert!(matches!(exit, ExitReason::Submitted { .. }));
+
+    assert!(agent.trajectory.info.tests_run_before_submit);
+    assert_eq!(agent.trajectory.info.last_tests_passed, Some(true));
+    assert_eq!(agent.trajectory.info.test_invocations.len(), 1);
+    let invocation = &agent.trajectory.info.test_invocations[0];
+    assert_eq!(invocation.step_index, 0);
+    assert_eq!(invocation.command, "pytest -q");
+    assert_eq!(invocation.exit_code, 0);
+    assert_eq!(invocation.matched_pattern, "pytest");
+}
+
+#[tokio::test]
+async fn echoing_pytest_does_not_register_as_test_invocation() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+
+    let model = Arc::new(DeterministicModel::new(vec![
+        "```bash\necho \"I should run pytest\"\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(FixedExitEnvironment { exit_code: 0 });
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "round trip".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+    assert!(matches!(exit, ExitReason::Submitted { .. }));
+    assert!(!agent.trajectory.info.tests_run_before_submit);
+    assert_eq!(agent.trajectory.info.last_tests_passed, None);
+    assert!(agent.trajectory.info.test_invocations.is_empty());
+}
+
+#[tokio::test]
+async fn cd_prefix_and_custom_pattern_match_test_commands() {
+    let cfg = Config::from_toml_str(
+        r#"
+[agent]
+step_limit = 5
+test_command_patterns = ["project-(check|test)"]
+"#,
+    )
+    .unwrap();
+
+    let model = Arc::new(DeterministicModel::new(vec![
+        "```bash\ncd repo && pytest tests/\n```".into(),
+        "```bash\nproject-test --suite smoke\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(FixedExitEnvironment { exit_code: 0 });
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "round trip".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+    assert!(matches!(exit, ExitReason::Submitted { .. }));
+    let invocations = &agent.trajectory.info.test_invocations;
+    assert_eq!(invocations.len(), 2);
+    assert_eq!(invocations[0].command, "cd repo && pytest tests/");
+    assert_eq!(invocations[0].matched_pattern, "pytest");
+    assert_eq!(invocations[1].command, "project-test --suite smoke");
+    assert_eq!(invocations[1].matched_pattern, "project-(check|test)");
+}
+
+#[tokio::test]
+async fn submit_without_test_commands_records_no_pre_submit_tests() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+
+    let model = Arc::new(DeterministicModel::new(vec![
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(FixedExitEnvironment { exit_code: 0 });
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "round trip".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+    assert!(matches!(exit, ExitReason::Submitted { .. }));
+    assert!(!agent.trajectory.info.tests_run_before_submit);
+    assert_eq!(agent.trajectory.info.last_tests_passed, None);
+    assert!(agent.trajectory.info.test_invocations.is_empty());
+}
+
 #[test]
 fn cache_retag_is_minimal_and_idempotent() {
     let _ = Role::System;
@@ -510,7 +641,23 @@ struct CommandPolicyHookEnv {
     calls: std::sync::Mutex<u32>,
 }
 
+struct FixedExitEnvironment {
+    exit_code: i32,
+}
+
 struct PreHookSpawnFailureEnv;
+
+#[async_trait]
+impl Environment for FixedExitEnvironment {
+    async fn run(&self, _req: RunRequest) -> Result<RunResult, EnvError> {
+        Ok(RunResult {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: self.exit_code,
+            timed_out: false,
+        })
+    }
+}
 
 #[async_trait]
 impl Environment for PreHookSpawnFailureEnv {

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -170,6 +170,61 @@ test_command_patterns = ["project-(check|test)"]
 }
 
 #[tokio::test]
+async fn pipeline_segment_after_single_pipe_counts_test_command() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+
+    let model = Arc::new(DeterministicModel::new(vec![
+        "```bash\necho \"data\" | pytest -q\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(FixedExitEnvironment { exit_code: 0 });
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "round trip".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+    assert!(matches!(exit, ExitReason::Submitted { .. }));
+    let invocations = &agent.trajectory.info.test_invocations;
+    assert_eq!(invocations.len(), 1);
+    assert_eq!(invocations[0].command, "echo \"data\" | pytest -q");
+    assert_eq!(invocations[0].matched_pattern, "pytest");
+}
+
+#[test]
+fn invalid_custom_test_command_regex_rejects_agent_build() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.test_command_patterns = vec!["(".to_owned()];
+
+    let Err(err) = DefaultAgentBuilder {
+        config: cfg,
+        model: Arc::new(DeterministicModel::new(Vec::new())),
+        env: Box::new(LocalEnvironment::new()),
+        task: "round trip".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build() else {
+        panic!("invalid regex should reject agent build");
+    };
+
+    assert!(matches!(err, Error::Config(_)));
+    assert!(
+        err.to_string().contains("agent.test_command_patterns"),
+        "{err}"
+    );
+}
+
+#[tokio::test]
 async fn submit_without_test_commands_records_no_pre_submit_tests() {
     let mut cfg = Config::defaults().unwrap();
     cfg.root.agent.step_limit = 5;

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -359,6 +359,40 @@ async fn pre_tool_use_hook_can_block_the_bash_command() {
 }
 
 #[tokio::test]
+async fn blocked_pre_tool_use_test_command_does_not_count_as_test_invocation() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+    cfg.root.agent.hooks.pre_tool_use = vec![ToolHookCfg {
+        name: "guard".into(),
+        command: failing_hook_command(),
+        timeout_secs: None,
+    }];
+
+    let model = Arc::new(DeterministicModel::new(vec![
+        "```bash\npytest -q\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "round trip".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+    assert!(matches!(exit, ExitReason::Submitted { .. }));
+    assert!(agent.trajectory.info.test_invocations.is_empty());
+    assert!(!agent.trajectory.info.tests_run_before_submit);
+    assert_eq!(agent.trajectory.info.last_tests_passed, None);
+}
+
+#[tokio::test]
 async fn post_tool_use_hook_output_is_added_to_next_observation() {
     let mut cfg = Config::defaults().unwrap();
     cfg.root.agent.step_limit = 5;

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -53,6 +53,8 @@ fn submitted(id: &str) -> InstanceResult {
         runs: 1,
         resolved_count: 1,
         pass_at_1: true,
+        tests_run_before_submit: false,
+        last_tests_passed: None,
     }
 }
 
@@ -77,6 +79,8 @@ fn errored(id: &str, cat: FailureCategory) -> InstanceResult {
         runs: 1,
         resolved_count: 0,
         pass_at_1: false,
+        tests_run_before_submit: false,
+        last_tests_passed: None,
     }
 }
 
@@ -89,6 +93,13 @@ fn rerun_result(id: &str, runs: u32, resolved_count: u32) -> InstanceResult {
     r.runs = runs;
     r.resolved_count = resolved_count;
     r.pass_at_1 = resolved_count > 0;
+    r
+}
+
+fn submitted_with_tests(id: &str, tests_run: bool) -> InstanceResult {
+    let mut r = submitted(id);
+    r.tests_run_before_submit = tests_run;
+    r.last_tests_passed = tests_run.then_some(true);
     r
 }
 
@@ -120,6 +131,12 @@ fn write_results_with_filter_spec_and_model(
         submitted: instances
             .iter()
             .filter(|r| r.outcome.as_deref() == Some(outcome::SUBMITTED))
+            .count(),
+        submitted_with_tests: instances
+            .iter()
+            .filter(|r| {
+                r.outcome.as_deref() == Some(outcome::SUBMITTED) && r.tests_run_before_submit
+            })
             .count(),
         skipped: 0,
         errored: instances
@@ -649,6 +666,35 @@ fn cli_json_output_is_machine_readable() {
     assert_eq!(v["regressions"][0]["kind"], "pass_fail");
     assert_eq!(v["resolved_delta"], -1);
     assert_eq!(v["transitions"]["pass_fail"], 1);
+}
+
+#[test]
+fn compare_reports_tests_before_submit_rate_drop_with_flat_resolved_rate() {
+    let baseline: std::collections::HashMap<String, InstanceResult> = (0..5)
+        .map(|i| submitted_with_tests(&format!("task-{i}"), i < 4))
+        .map(|row| (row.instance_id.clone(), row))
+        .collect();
+    let candidate: std::collections::HashMap<String, InstanceResult> = (0..5)
+        .map(|i| submitted_with_tests(&format!("task-{i}"), i < 3))
+        .map(|row| (row.instance_id.clone(), row))
+        .collect();
+
+    let report = rust_swe_agent::run::compare::diff(
+        Path::new("/baseline"),
+        Path::new("/candidate"),
+        &baseline,
+        &candidate,
+    );
+
+    assert!((report.baseline_tests_before_submit_rate - 0.8).abs() < f64::EPSILON);
+    assert!((report.candidate_tests_before_submit_rate - 0.6).abs() < f64::EPSILON);
+    assert!((report.tests_before_submit_delta_rate + 0.2).abs() < f64::EPSILON);
+    assert_eq!(report.resolved_delta, 0);
+    let text = report.human_table();
+    assert!(
+        text.contains("Tests before submit: 80.00% -> 60.00% (-20.00pp)"),
+        "{text}"
+    );
 }
 
 #[test]

--- a/tests/bench_forecast.rs
+++ b/tests/bench_forecast.rs
@@ -114,6 +114,8 @@ fn instance(
         runs: 0,
         resolved_count: 0,
         pass_at_1: false,
+        tests_run_before_submit: false,
+        last_tests_passed: None,
     }
 }
 
@@ -130,6 +132,7 @@ fn fixture_results_with_model(model_name: Option<&str>) -> SweepResults {
     SweepResults {
         total: instances.len(),
         submitted: 2,
+        submitted_with_tests: 0,
         skipped: 0,
         errored: 1,
         failures_by_category: Default::default(),
@@ -297,6 +300,8 @@ fn forecast_uses_manifest_model_for_fallback_cost_repricing() {
         runs: 1,
         resolved_count: 1,
         pass_at_1: true,
+        tests_run_before_submit: false,
+        last_tests_passed: None,
     }];
     results.total = 1;
     results.submitted = 1;

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -5,7 +5,9 @@
 use std::path::Path;
 use std::process::Command;
 
-use rust_swe_agent::trajectory::{FailureCategory, TokenUsage, Trajectory, outcome};
+use rust_swe_agent::trajectory::{
+    FailureCategory, TestInvocation, TokenUsage, Trajectory, outcome,
+};
 
 fn binary_path() -> std::path::PathBuf {
     std::env::var("CARGO_BIN_EXE_rust-swe-agent").map_or_else(
@@ -1044,6 +1046,48 @@ fn instance_mode_renders_header_and_steps() {
     assert!(stdout.contains("[step 0] assistant"), "{stdout}");
     assert!(stdout.contains("[step 1] bash"), "{stdout}");
     assert!(stdout.contains("resolved:         false"), "{stdout}");
+}
+
+#[test]
+fn instance_mode_renders_test_telemetry_header_line() {
+    let sweep = tempfile::tempdir().unwrap();
+    let mut t = Trajectory::new();
+    t.info.model_name = Some("deterministic-test".into());
+    t.info.outcome = Some(outcome::SUBMITTED.into());
+    t.info.tests_run_before_submit = true;
+    t.info.last_tests_passed = Some(true);
+    t.info.test_invocations = vec![TestInvocation {
+        step_index: 0,
+        command: "pytest -q".into(),
+        exit_code: 0,
+        matched_pattern: "pytest".into(),
+    }];
+    record_assistant_tool_step(&mut t, "```bash\npytest -q\n```", "pytest -q", "ok\n");
+    std::fs::write(
+        sweep.path().join("abc.traj.json"),
+        serde_json::to_string_pretty(&t).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "abc",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains(
+            "tests:            count=1 last_exit_code=0 last_passed=true submitted_without_tests=false"
+        ),
+        "{stdout}"
+    );
 }
 
 #[test]

--- a/tests/swebench_budget.rs
+++ b/tests/swebench_budget.rs
@@ -649,6 +649,7 @@ async fn resume_uses_prior_results_token_totals_for_budget_accounting() {
     let prior = SweepResults {
         total: 1,
         submitted: 1,
+        submitted_with_tests: 0,
         skipped: 0,
         errored: 0,
         failures_by_category: std::collections::BTreeMap::new(),
@@ -688,6 +689,8 @@ async fn resume_uses_prior_results_token_totals_for_budget_accounting() {
             runs: 0,
             resolved_count: 0,
             pass_at_1: false,
+            tests_run_before_submit: false,
+            last_tests_passed: None,
         }],
         rate_limit_events: None,
     };
@@ -789,6 +792,7 @@ async fn retry_on_resume_instances_are_precharged_before_rerun() {
     let prior = SweepResults {
         total: 1,
         submitted: 0,
+        submitted_with_tests: 0,
         skipped: 0,
         errored: 1,
         failures_by_category: std::collections::BTreeMap::new(),
@@ -828,6 +832,8 @@ async fn retry_on_resume_instances_are_precharged_before_rerun() {
             runs: 0,
             resolved_count: 0,
             pass_at_1: false,
+            tests_run_before_submit: false,
+            last_tests_passed: None,
         }],
         rate_limit_events: None,
     };
@@ -900,6 +906,7 @@ async fn stale_results_json_is_not_trusted_over_newer_trajectory() {
     let stale_summary = SweepResults {
         total: 1,
         submitted: 1,
+        submitted_with_tests: 0,
         skipped: 0,
         errored: 0,
         failures_by_category: std::collections::BTreeMap::new(),
@@ -939,6 +946,8 @@ async fn stale_results_json_is_not_trusted_over_newer_trajectory() {
             runs: 0,
             resolved_count: 0,
             pass_at_1: false,
+            tests_run_before_submit: false,
+            last_tests_passed: None,
         }],
         rate_limit_events: None,
     };

--- a/tests/swebench_rerun.rs
+++ b/tests/swebench_rerun.rs
@@ -116,6 +116,30 @@ fn write_valid_run(output: &Path, instance_id: &str, run_index: u32, marker: &st
     std::fs::write(patch_path_for_run(output, instance_id, run_index), b"").unwrap();
 }
 
+fn write_valid_tested_run(output: &Path, instance_id: &str, run_index: u32, marker: &str) {
+    let mut info = TrajectoryInfo {
+        outcome: Some(outcome::SUBMITTED.into()),
+        exit_reason: Some("submitted".into()),
+        steps: Some(0),
+        tests_run_before_submit: true,
+        last_tests_passed: Some(true),
+        ..Default::default()
+    };
+    info.other.insert(
+        "test_marker".into(),
+        serde_json::Value::String(marker.into()),
+    );
+    let traj = Trajectory {
+        trajectory_format: FORMAT_VERSION.into(),
+        info,
+        messages: vec![],
+    };
+    let traj_path = trajectory_path_for_run(output, instance_id, run_index);
+    std::fs::create_dir_all(traj_path.parent().unwrap()).unwrap();
+    std::fs::write(&traj_path, serde_json::to_string_pretty(&traj).unwrap()).unwrap();
+    std::fs::write(patch_path_for_run(output, instance_id, run_index), b"").unwrap();
+}
+
 #[tokio::test]
 async fn rerun_writes_nested_run_files_and_pass_at_k_summary() {
     let work = tempfile::tempdir().unwrap();
@@ -244,4 +268,31 @@ async fn resume_skips_only_completed_run_slots() {
     );
     assert!(trajectory_path_for_run(&output, "task-a", 2).exists());
     assert!(trajectory_path_for_run(&output, "task-a", 3).exists());
+}
+
+#[tokio::test]
+async fn resumed_tested_run_does_not_inflate_fresh_submitted_with_tests_count() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+    let dataset = work.path().join("dataset.jsonl");
+    let output = work.path().join("runs");
+    write_dataset(&dataset, &["task-a"]);
+
+    write_valid_tested_run(&output, "task-a", 1, "preserved-tested-run-1");
+
+    let mut args = base_args(dataset, output.clone(), config_with_workdir(&repo));
+    args.resume = true;
+    args.reruns = 2;
+    let results = run(args).await.unwrap();
+
+    assert_eq!(results.submitted, 1, "only run-2 should launch fresh");
+    assert_eq!(results.skipped, 1, "run-1 should resume-skip");
+    assert_eq!(
+        results.submitted_with_tests, 0,
+        "resumed test telemetry should not count against fresh submitted denominator"
+    );
+    let table = results.summary_table();
+    assert!(table.contains("Submitted w/tests:  0/1"), "{table}");
 }


### PR DESCRIPTION
## Summary

- Add trajectory-level test command telemetry for recognized assistant bash actions before submit.
- Add configurable regex patterns, derived test-running fields, and documentation for the closed default pattern list.
- Surface test-running behavior in swebench summaries, inspect, compare, and evaluation behavioral metrics.

## Validation

- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- `rg -n "TODO|FIXME|Stub:" src tests docs`

Closes #46