### PR TITLE
⚡ Bolt: avoid redundant allocations and sorts in quantiles computation

### DIFF
--- a/src/run/forecast.rs
+++ b/src/run/forecast.rs
@@ -489,32 +489,19 @@ fn instance_cost_usd(r: &InstanceResult, model_name: Option<&str>) -> f64 {
 }
 
 fn quantiles(values: &[f64]) -> QuantileSummary {
-    QuantileSummary {
-        p10: quantile(values, 0.10),
-        median: quantile(values, 0.50),
-        p90: quantile(values, 0.90),
-    }
-}
-
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-fn quantile(values: &[f64], q: f64) -> f64 {
     if values.is_empty() {
-        return 0.0;
+        return QuantileSummary {
+            p10: 0.0,
+            median: 0.0,
+            p90: 0.0,
+        };
     }
     let mut sorted = values.to_vec();
     sorted.sort_by(f64::total_cmp);
-    if sorted.len() == 1 {
-        return sorted[0];
-    }
-    let span = as_f64_usize(sorted.len() - 1);
-    let pos = q.clamp(0.0, 1.0) * span;
-    let lo = pos.floor() as usize;
-    let hi = pos.ceil() as usize;
-    if lo == hi {
-        sorted[lo]
-    } else {
-        let weight = pos - as_f64_usize(lo);
-        sorted[lo].mul_add(1.0 - weight, sorted[hi] * weight)
+    QuantileSummary {
+        p10: quantile_sorted(&sorted, 0.10),
+        median: quantile_sorted(&sorted, 0.50),
+        p90: quantile_sorted(&sorted, 0.90),
     }
 }
 
@@ -712,21 +699,17 @@ mod tests {
 
     #[test]
     fn test_quantile_empty_slice() {
-        assert_eq!(quantile(&[], 0.5), 0.0);
         assert_eq!(quantile_sorted(&[], 0.5), 0.0);
     }
 
     #[test]
     fn test_quantile_single_element() {
-        assert_eq!(quantile(&[42.0], 0.5), 42.0);
         assert_eq!(quantile_sorted(&[42.0], 0.5), 42.0);
     }
 
     #[test]
     fn test_quantile_clamp_bounds() {
         let values = [10.0, 20.0, 30.0];
-        assert_eq!(quantile(&values, -1.0), 10.0);
-        assert_eq!(quantile(&values, 2.0), 30.0);
         assert_eq!(quantile_sorted(&values, -1.0), 10.0);
         assert_eq!(quantile_sorted(&values, 2.0), 30.0);
     }

--- a/src/run/forecast.rs
+++ b/src/run/forecast.rs
@@ -497,7 +497,7 @@ fn quantiles(values: &[f64]) -> QuantileSummary {
         };
     }
     let mut sorted = values.to_vec();
-    sorted.sort_by(f64::total_cmp);
+    sorted.sort_unstable_by(f64::total_cmp);
     QuantileSummary {
         p10: quantile_sorted(&sorted, 0.10),
         median: quantile_sorted(&sorted, 0.50),


### PR DESCRIPTION
💡 What: Refactored `quantiles` in `src/run/forecast.rs` to clone and sort the slice exactly once.
🎯 Why: Previously, `quantiles` called `quantile` three times (for 10th, 50th, and 90th percentiles). Each call independently cloned and sorted the entire slice, leading to 3 heap allocations and 3 sorting operations for identical data.
📊 Impact: Reduces heap allocations and sorting operations by 66% per `quantiles` call, making the calibration metrics extraction strictly faster and using less memory.
🔬 Measurement: Run `cargo test` to verify there's no logic regression.

---
*PR created automatically by Jules for task [15952639877065905941](https://jules.google.com/task/15952639877065905941) started by @madmax983*