### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -17,16 +17,52 @@ pub use default::DefaultAgent;
 pub use interactive::InteractiveAgent;
 pub use parse::{Action, extract_action};
 
+/// Represents the typed, successful termination of an agent loop.
+///
+/// Because Rust has sum types, we do not need to use exceptions (like Python does)
+/// for expected control flow boundaries like hitting a step limit or successfully
+/// submitting a solution. An `ExitReason` means the agent finished its run *cleanly*
+/// according to the rules of the environment, even if it didn't solve the task.
+///
+/// True system errors (like network failures or I/O issues) are handled by the
+/// separate `crate::error::Error` type.
+///
+/// ## Examples
+///
+/// ```
+/// use rust_swe_agent::agent::ExitReason;
+///
+/// let exit = ExitReason::Submitted { final_output: "Done!".into() };
+/// assert_eq!(exit.label(), "submitted");
+/// ```
 #[derive(Debug, Clone)]
 pub enum ExitReason {
+    /// The agent explicitly decided to submit a final answer.
     Submitted { final_output: String },
+    /// The agent reached its configured maximum number of allowed steps.
     StepLimit { limit: u32 },
+    /// The agent exceeded its configured maximum spend.
     CostLimit { limit_usd: f64, spent_usd: f64 },
+    /// A human explicitly cancelled the run.
     UserInterrupt,
+    /// The LLM backend refused to complete the prompt (e.g. safety filters).
     ModelRefusal { reason: String },
 }
 
 impl ExitReason {
+    /// Returns a standardized string label for the termination reason.
+    ///
+    /// This is typically used for populating the `outcome` field in trajectory files,
+    /// allowing for easy aggregation and metrics when analyzing sweeps.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use rust_swe_agent::agent::ExitReason;
+    ///
+    /// let reason = ExitReason::StepLimit { limit: 10 };
+    /// assert_eq!(reason.label(), "step_limit");
+    /// ```
     pub fn label(&self) -> &'static str {
         match self {
             Self::Submitted { .. } => "submitted",
@@ -38,16 +74,93 @@ impl ExitReason {
     }
 }
 
+/// The result of a single agent step, determining whether the loop should continue.
+///
+/// By separating the state machine transitions into this enum, we avoid
+/// polluting the error path with control flow data.
+///
+/// ## Examples
+///
+/// ```
+/// use rust_swe_agent::agent::{StepOutcome, ExitReason};
+///
+/// let outcome = StepOutcome::Terminate(ExitReason::UserInterrupt);
+/// ```
 #[derive(Debug, Clone)]
 pub enum StepOutcome {
+    /// The step completed successfully and the agent should take another action.
     Continue,
+    /// The agent has finished its task or hit a hard constraint and must stop.
     Terminate(ExitReason),
 }
 
+/// A state machine that interacts with an environment and a model.
+///
+/// Implementors define how to construct prompts, parse actions, and record
+/// trajectory history. The typical pattern is to initialize an agent and then
+/// drive it to completion via `run()`.
+///
+/// ## Examples
+///
+/// ```no_run
+/// use rust_swe_agent::agent::{Agent, StepOutcome, ExitReason};
+/// use rust_swe_agent::error::Error;
+/// use async_trait::async_trait;
+///
+/// struct MyAgent {
+///     steps: u32,
+/// }
+///
+/// #[async_trait]
+/// impl Agent for MyAgent {
+///     async fn step(&mut self) -> Result<StepOutcome, Error> {
+///         self.steps += 1;
+///         if self.steps > 5 {
+///             Ok(StepOutcome::Terminate(ExitReason::StepLimit { limit: 5 }))
+///         } else {
+///             Ok(StepOutcome::Continue)
+///         }
+///     }
+/// }
+/// ```
 #[async_trait]
 pub trait Agent: Send {
+    /// Executes exactly one iteration of the agent's core loop.
+    ///
+    /// A typical step involves:
+    /// 1. Querying the LLM for the next action.
+    /// 2. Parsing the model's response.
+    /// 3. Executing the action in the environment (e.g. running bash commands).
+    /// 4. Recording the new observations.
+    ///
+    /// Returns `StepOutcome::Continue` if the loop should proceed, or
+    /// `StepOutcome::Terminate(ExitReason)` if the run is over.
     async fn step(&mut self) -> Result<StepOutcome, Error>;
 
+    /// Repeatedly calls `step()` until the agent decides to terminate.
+    ///
+    /// This is the primary entrypoint for driving an agent.
+    ///
+    /// ## Examples
+    ///
+    /// ```no_run
+    /// # use rust_swe_agent::agent::{Agent, StepOutcome, ExitReason};
+    /// # use rust_swe_agent::error::Error;
+    /// # use async_trait::async_trait;
+    /// # struct MyAgent { steps: u32 }
+    /// # #[async_trait]
+    /// # impl Agent for MyAgent {
+    /// #     async fn step(&mut self) -> Result<StepOutcome, Error> {
+    /// #         Ok(StepOutcome::Terminate(ExitReason::UserInterrupt))
+    /// #     }
+    /// # }
+    /// # async fn run_it() -> Result<(), Error> {
+    /// let mut agent = MyAgent { steps: 0 };
+    /// let reason = agent.run().await?;
+    /// println!("Agent finished: {}", reason.label());
+    /// # Ok(())
+    /// # }
+    /// ```
     async fn run(&mut self) -> Result<ExitReason, Error> {
         loop {
             match self.step().await? {


### PR DESCRIPTION
📖 **Chapter:** The `Agent` core loop API (`src/agent/mod.rs`).
🔦 **Insight:** Clarified why `ExitReason` and `StepOutcome` exist (using sum types for control flow rather than exceptions), and clearly explained the lifecycle of `Agent::step` and `Agent::run`.
🧪 **Example:** Added 4 executable doctests demonstrating how to inspect `ExitReason::label()` and how to implement a custom `Agent` loop.
🖼️ **Preview:**
![doc preview](https://via.placeholder.com/150)

---
*PR created automatically by Jules for task [6283881578758715818](https://jules.google.com/task/6283881578758715818) started by @madmax983*