### PR TITLE
Add cost_per_resolved_usd metric and Pareto frontier analysis

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -237,8 +237,8 @@ pub struct FrontierCmd {
     pub dirs: Vec<std::path::PathBuf>,
 
     /// Output format: `text` (default, ASCII chart) or `json` (machine-readable).
-    #[arg(long, default_value = "text")]
-    pub format: String,
+    #[arg(long, value_enum, default_value_t = crate::run::frontier::FrontierFormat::Text)]
+    pub format: crate::run::frontier::FrontierFormat,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -225,6 +225,20 @@ pub enum BenchCmd {
     Inspect(InspectCmd),
     /// Tail live aggregate progress for a running sweep directory.
     Tail(TailCmd),
+    /// Pareto frontier across multiple sweep runs: ASCII chart + JSON dataset.
+    Frontier(FrontierCmd),
+}
+
+#[derive(Debug, Args)]
+pub struct FrontierCmd {
+    /// Sweep output directories to compare (each must contain `results.json`
+    /// and optionally `evaluation.json`).
+    #[arg(required = true)]
+    pub dirs: Vec<std::path::PathBuf>,
+
+    /// Output format: `text` (default, ASCII chart) or `json` (machine-readable).
+    #[arg(long, default_value = "text")]
+    pub format: String,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -753,15 +753,7 @@ fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
 }
 
 fn bench_frontier(f: args::FrontierCmd) -> Result<(), Error> {
-    let format = match f.format.as_str() {
-        "text" => crate::run::frontier::FrontierFormat::Text,
-        "json" => crate::run::frontier::FrontierFormat::Json,
-        other => {
-            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text` or `json`)"
-            ))));
-        }
-    };
+    let format = f.format;
     let report =
         crate::run::frontier::compute(&crate::run::frontier::FrontierArgs { dirs: f.dirs })?;
     match format {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -71,6 +71,9 @@ pub async fn run() -> Result<(), Error> {
         Command::Bench {
             cmd: args::BenchCmd::Tail(t),
         } => bench_tail(t).await,
+        Command::Bench {
+            cmd: args::BenchCmd::Frontier(f),
+        } => bench_frontier(f),
         #[cfg(feature = "docker")]
         Command::Cleanup => cleanup_cmd().await,
         #[cfg(not(feature = "docker"))]
@@ -745,6 +748,29 @@ fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
             "{}",
             crate::run::evaluate::render_cost_attribution_table(&eval.cost_attribution)
         );
+    }
+    Ok(())
+}
+
+fn bench_frontier(f: args::FrontierCmd) -> Result<(), Error> {
+    let format = match f.format.as_str() {
+        "text" => crate::run::frontier::FrontierFormat::Text,
+        "json" => crate::run::frontier::FrontierFormat::Json,
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "unknown --format `{other}` (expected `text` or `json`)"
+            ))));
+        }
+    };
+    let report =
+        crate::run::frontier::compute(&crate::run::frontier::FrontierArgs { dirs: f.dirs })?;
+    match format {
+        crate::run::frontier::FrontierFormat::Text => {
+            print!("{}", crate::run::frontier::render_text(&report));
+        }
+        crate::run::frontier::FrontierFormat::Json => {
+            println!("{}", crate::run::frontier::render_json(&report));
+        }
     }
     Ok(())
 }

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -370,12 +370,7 @@ fn write_compare_cost_and_token_section(s: &mut String, report: &CompareReport) 
     );
 }
 
-fn write_cost_per_resolved_line(
-    s: &mut String,
-    baseline: f64,
-    candidate: f64,
-    delta: f64,
-) {
+fn write_cost_per_resolved_line(s: &mut String, baseline: f64, candidate: f64, delta: f64) {
     let fmt_cpr = |v: f64| {
         if v.is_nan() {
             "NaN".to_owned()
@@ -1143,6 +1138,7 @@ pub fn diff<S: std::hash::BuildHasher>(
     )
 }
 
+#[allow(clippy::too_many_lines)]
 fn diff_with_overrides<S: std::hash::BuildHasher>(
     baseline_dir: &Path,
     candidate_dir: &Path,
@@ -1292,11 +1288,11 @@ fn compute_pareto_verdict(
         (true, true) => {
             if (c_rate - b_rate).abs() < f64::EPSILON {
                 return ParetoVerdict::NonDominated;
-            } else if c_rate > b_rate {
-                return ParetoVerdict::CandidateDominates;
-            } else {
-                return ParetoVerdict::BaselineDominates;
             }
+            if c_rate > b_rate {
+                return ParetoVerdict::CandidateDominates;
+            }
+            return ParetoVerdict::BaselineDominates;
         }
     };
 

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -1307,10 +1307,11 @@ fn compute_pareto_verdict(
     let candidate_dominates = (candidate_better_rate || candidate_equal_rate)
         && (candidate_better_cost || candidate_equal_cost)
         && (candidate_better_rate || candidate_better_cost);
-    let baseline_dominates = !candidate_dominates
-        && (b_rate > c_rate + f64::EPSILON || candidate_equal_rate)
-        && (b_cost_finite < c_cost_finite - f64::EPSILON || candidate_equal_cost)
-        && (b_rate > c_rate + f64::EPSILON || b_cost_finite < c_cost_finite - f64::EPSILON);
+    let baseline_better_rate = b_rate > c_rate + f64::EPSILON;
+    let baseline_better_cost = b_cost_finite < c_cost_finite - f64::EPSILON;
+    let baseline_dominates = (baseline_better_rate || candidate_equal_rate)
+        && (baseline_better_cost || candidate_equal_cost)
+        && (baseline_better_rate || baseline_better_cost);
 
     if candidate_dominates {
         ParetoVerdict::CandidateDominates

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -160,12 +160,15 @@ pub struct CompareReport {
     /// This is the high-signal artifact for CI gating; sorted by
     /// `instance_id` for stable output.
     pub regressions: Vec<TaskTransition>,
-    /// `$/resolved-instance` for the baseline. `f64::NAN` when baseline_resolved == 0.
-    pub baseline_cost_per_resolved_usd: f64,
-    /// `$/resolved-instance` for the candidate. `f64::NAN` when candidate_resolved == 0.
-    pub candidate_cost_per_resolved_usd: f64,
-    /// Candidate minus baseline cost_per_resolved_usd. `f64::NAN` when either is NaN.
-    pub cost_per_resolved_delta_usd: f64,
+    /// `$/resolved-instance` for the baseline. `None` when baseline_resolved == 0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub baseline_cost_per_resolved_usd: Option<f64>,
+    /// `$/resolved-instance` for the candidate. `None` when candidate_resolved == 0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidate_cost_per_resolved_usd: Option<f64>,
+    /// Candidate minus baseline cost_per_resolved_usd. `None` when either is absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_per_resolved_delta_usd: Option<f64>,
     /// Pareto-dominance verdict on the (resolved_rate, cost_per_resolved_usd) plane.
     pub pareto_verdict: ParetoVerdict,
 }
@@ -370,18 +373,19 @@ fn write_compare_cost_and_token_section(s: &mut String, report: &CompareReport) 
     );
 }
 
-fn write_cost_per_resolved_line(s: &mut String, baseline: f64, candidate: f64, delta: f64) {
-    let fmt_cpr = |v: f64| {
-        if v.is_nan() {
-            "NaN".to_owned()
-        } else {
-            format!("${v:.4}")
-        }
+fn write_cost_per_resolved_line(
+    s: &mut String,
+    baseline: Option<f64>,
+    candidate: Option<f64>,
+    delta: Option<f64>,
+) {
+    let fmt_cpr = |v: Option<f64>| match v {
+        Some(x) => format!("${x:.4}"),
+        None => "NaN".to_owned(),
     };
-    let delta_str = if delta.is_nan() {
-        "NaN".to_owned()
-    } else {
-        format!("{delta:+.4}")
+    let delta_str = match delta {
+        Some(d) => format!("{d:+.4}"),
+        None => "NaN".to_owned(),
     };
     let _ = writeln!(
         s,
@@ -1190,17 +1194,18 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
         cost_per_resolved(baseline_total_cost, resolution.baseline_resolved);
     let candidate_cost_per_resolved_usd =
         cost_per_resolved(candidate_total_cost, resolution.candidate_resolved);
-    let cost_per_resolved_delta_usd =
-        if baseline_cost_per_resolved_usd.is_nan() || candidate_cost_per_resolved_usd.is_nan() {
-            f64::NAN
-        } else {
-            candidate_cost_per_resolved_usd - baseline_cost_per_resolved_usd
-        };
+    let cost_per_resolved_delta_usd = match (
+        baseline_cost_per_resolved_usd,
+        candidate_cost_per_resolved_usd,
+    ) {
+        (Some(b), Some(c)) => Some(c - b),
+        _ => None,
+    };
     let pareto_verdict = compute_pareto_verdict(
         resolution.baseline_resolved_rate,
-        baseline_cost_per_resolved_usd,
+        baseline_cost_per_resolved_usd.unwrap_or(f64::NAN),
         resolution.candidate_resolved_rate,
-        candidate_cost_per_resolved_usd,
+        candidate_cost_per_resolved_usd.unwrap_or(f64::NAN),
     );
 
     CompareReport {
@@ -1258,14 +1263,12 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
     }
 }
 
-fn cost_per_resolved(total_cost: f64, resolved: usize) -> f64 {
+fn cost_per_resolved(total_cost: f64, resolved: usize) -> Option<f64> {
     if resolved == 0 {
-        f64::NAN
+        None
     } else {
         #[allow(clippy::cast_precision_loss)]
-        {
-            total_cost / resolved as f64
-        }
+        Some(total_cost / resolved as f64)
     }
 }
 

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -160,6 +160,14 @@ pub struct CompareReport {
     /// This is the high-signal artifact for CI gating; sorted by
     /// `instance_id` for stable output.
     pub regressions: Vec<TaskTransition>,
+    /// `$/resolved-instance` for the baseline. `f64::NAN` when baseline_resolved == 0.
+    pub baseline_cost_per_resolved_usd: f64,
+    /// `$/resolved-instance` for the candidate. `f64::NAN` when candidate_resolved == 0.
+    pub candidate_cost_per_resolved_usd: f64,
+    /// Candidate minus baseline cost_per_resolved_usd. `f64::NAN` when either is NaN.
+    pub cost_per_resolved_delta_usd: f64,
+    /// Pareto-dominance verdict on the (resolved_rate, cost_per_resolved_usd) plane.
+    pub pareto_verdict: ParetoVerdict,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -174,6 +182,20 @@ pub enum CompareVerdict {
     Improvement,
     Regression,
     WithinNoise,
+}
+
+/// Whether one config dominates the other on the efficient frontier
+/// (resolved_rate, cost_per_resolved_usd).
+///
+/// `A` dominates `B` when `A` has a higher (or equal) resolved_rate AND a
+/// lower (or equal) cost_per_resolved_usd, with at least one strict
+/// inequality. Otherwise the configs are non-dominated (a trade-off).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ParetoVerdict {
+    BaselineDominates,
+    CandidateDominates,
+    NonDominated,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -304,6 +326,17 @@ fn write_compare_cost_and_token_section(s: &mut String, report: &CompareReport) 
         "Total cost USD:     ${:.4} -> ${:.4} ({:+.4})",
         report.baseline_total_cost_usd, report.candidate_total_cost_usd, report.cost_delta_usd
     );
+    write_cost_per_resolved_line(
+        s,
+        report.baseline_cost_per_resolved_usd,
+        report.candidate_cost_per_resolved_usd,
+        report.cost_per_resolved_delta_usd,
+    );
+    let _ = writeln!(
+        s,
+        "Pareto verdict:     {}",
+        pareto_verdict_label(report.pareto_verdict)
+    );
     write_u64_delta_line(
         s,
         "Input tokens:       ",
@@ -335,6 +368,41 @@ fn write_compare_cost_and_token_section(s: &mut String, report: &CompareReport) 
         report.candidate_cache_hit_rate * 100.0,
         (report.candidate_cache_hit_rate - report.baseline_cache_hit_rate) * 100.0
     );
+}
+
+fn write_cost_per_resolved_line(
+    s: &mut String,
+    baseline: f64,
+    candidate: f64,
+    delta: f64,
+) {
+    let fmt_cpr = |v: f64| {
+        if v.is_nan() {
+            "NaN".to_owned()
+        } else {
+            format!("${v:.4}")
+        }
+    };
+    let delta_str = if delta.is_nan() {
+        "NaN".to_owned()
+    } else {
+        format!("{delta:+.4}")
+    };
+    let _ = writeln!(
+        s,
+        "Cost/resolved USD:  {} -> {} ({})",
+        fmt_cpr(baseline),
+        fmt_cpr(candidate),
+        delta_str
+    );
+}
+
+fn pareto_verdict_label(verdict: ParetoVerdict) -> &'static str {
+    match verdict {
+        ParetoVerdict::BaselineDominates => "A dominates B",
+        ParetoVerdict::CandidateDominates => "B dominates A",
+        ParetoVerdict::NonDominated => "non-dominated (tradeoff)",
+    }
 }
 
 fn write_u64_delta_line(s: &mut String, label: &str, baseline: u64, candidate: u64) {
@@ -1122,6 +1190,23 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
     let baseline_tests_before_submit_rate = tests_before_submit_rate(baseline);
     let candidate_tests_before_submit_rate = tests_before_submit_rate(candidate);
 
+    let baseline_cost_per_resolved_usd =
+        cost_per_resolved(baseline_total_cost, resolution.baseline_resolved);
+    let candidate_cost_per_resolved_usd =
+        cost_per_resolved(candidate_total_cost, resolution.candidate_resolved);
+    let cost_per_resolved_delta_usd =
+        if baseline_cost_per_resolved_usd.is_nan() || candidate_cost_per_resolved_usd.is_nan() {
+            f64::NAN
+        } else {
+            candidate_cost_per_resolved_usd - baseline_cost_per_resolved_usd
+        };
+    let pareto_verdict = compute_pareto_verdict(
+        resolution.baseline_resolved_rate,
+        baseline_cost_per_resolved_usd,
+        resolution.candidate_resolved_rate,
+        candidate_cost_per_resolved_usd,
+    );
+
     CompareReport {
         baseline_dir: baseline_dir.to_path_buf(),
         candidate_dir: candidate_dir.to_path_buf(),
@@ -1170,6 +1255,70 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
         baseline_rate_limit_events: None,
         candidate_rate_limit_events: None,
         regressions: transition_summary.regressions,
+        baseline_cost_per_resolved_usd,
+        candidate_cost_per_resolved_usd,
+        cost_per_resolved_delta_usd,
+        pareto_verdict,
+    }
+}
+
+fn cost_per_resolved(total_cost: f64, resolved: usize) -> f64 {
+    if resolved == 0 {
+        f64::NAN
+    } else {
+        #[allow(clippy::cast_precision_loss)]
+        {
+            total_cost / resolved as f64
+        }
+    }
+}
+
+fn compute_pareto_verdict(
+    baseline_resolved_rate: f64,
+    baseline_cost_per_resolved: f64,
+    candidate_resolved_rate: f64,
+    candidate_cost_per_resolved: f64,
+) -> ParetoVerdict {
+    let b_rate = baseline_resolved_rate;
+    let c_rate = candidate_resolved_rate;
+    let b_cost = baseline_cost_per_resolved;
+    let c_cost = candidate_cost_per_resolved;
+
+    // NaN handling: if either cost is NaN, fall back to resolved-rate-only comparison
+    let (b_cost_finite, c_cost_finite) = match (b_cost.is_nan(), c_cost.is_nan()) {
+        (false, false) => (b_cost, c_cost),
+        (true, false) => return ParetoVerdict::CandidateDominates,
+        (false, true) => return ParetoVerdict::BaselineDominates,
+        (true, true) => {
+            if (c_rate - b_rate).abs() < f64::EPSILON {
+                return ParetoVerdict::NonDominated;
+            } else if c_rate > b_rate {
+                return ParetoVerdict::CandidateDominates;
+            } else {
+                return ParetoVerdict::BaselineDominates;
+            }
+        }
+    };
+
+    let candidate_better_rate = c_rate > b_rate + f64::EPSILON;
+    let candidate_better_cost = c_cost_finite < b_cost_finite - f64::EPSILON;
+    let candidate_equal_rate = (c_rate - b_rate).abs() <= f64::EPSILON;
+    let candidate_equal_cost = (c_cost_finite - b_cost_finite).abs() <= f64::EPSILON;
+
+    let candidate_dominates = (candidate_better_rate || candidate_equal_rate)
+        && (candidate_better_cost || candidate_equal_cost)
+        && (candidate_better_rate || candidate_better_cost);
+    let baseline_dominates = !candidate_dominates
+        && (b_rate > c_rate + f64::EPSILON || candidate_equal_rate)
+        && (b_cost_finite < c_cost_finite - f64::EPSILON || candidate_equal_cost)
+        && (b_rate > c_rate + f64::EPSILON || b_cost_finite < c_cost_finite - f64::EPSILON);
+
+    if candidate_dominates {
+        ParetoVerdict::CandidateDominates
+    } else if baseline_dominates {
+        ParetoVerdict::BaselineDominates
+    } else {
+        ParetoVerdict::NonDominated
     }
 }
 
@@ -1496,7 +1645,7 @@ fn wilson_ci(successes: u64, total: u64) -> ConfidenceInterval {
     }
 }
 
-fn load_evaluation_results(dir: &Path) -> Result<Option<EvaluationResults>, Error> {
+pub fn load_evaluation_results(dir: &Path) -> Result<Option<EvaluationResults>, Error> {
     let path = crate::run::evaluate::evaluation_path(dir);
     if !path.exists() {
         return Ok(None);

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -339,34 +339,19 @@ pub fn summarize_with_model<S: std::hash::BuildHasher>(
 
     // Exclude budget-exhausted instances from cost_per_resolved_usd so we
     // never silently mix capped and uncapped runs in the efficiency metric.
-    let budget_exhausted_excluded = eval
-        .instances
-        .iter()
-        .filter(|row| {
-            results
-                .get(&row.instance_id)
-                .and_then(|r| r.failure_category)
-                == Some(FailureCategory::BudgetExhausted)
-        })
-        .count();
-
-    let per_instance_samples: Vec<(f64, bool)> = eval
-        .instances
-        .iter()
-        .filter(|row| {
-            results
-                .get(&row.instance_id)
-                .and_then(|r| r.failure_category)
-                != Some(FailureCategory::BudgetExhausted)
-        })
-        .map(|row| {
-            let cost = results
-                .get(&row.instance_id)
+    let mut budget_exhausted_excluded = 0usize;
+    let mut per_instance_samples: Vec<(f64, bool)> = Vec::with_capacity(eval.instances.len());
+    for row in &eval.instances {
+        let result = results.get(&row.instance_id);
+        if result.and_then(|r| r.failure_category) == Some(FailureCategory::BudgetExhausted) {
+            budget_exhausted_excluded += 1;
+        } else {
+            let cost = result
                 .and_then(|r| r.effective_cost_usd(model_name))
                 .unwrap_or(0.0);
-            (cost, row.resolved)
-        })
-        .collect();
+            per_instance_samples.push((cost, row.resolved));
+        }
+    }
 
     let br_resolved = per_instance_samples.iter().filter(|(_, r)| *r).count();
     let cost_per_resolved_usd = if br_resolved == 0 {

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -244,7 +244,12 @@ pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
     };
     let mut eval = run_output.eval;
     eval.behavioral = build_behavioral_metrics(&eval.instances, &results);
-    eval.breakdown = build_breakdown(&eval.instances, &results, &args.breakdown, model_name.as_deref());
+    eval.breakdown = build_breakdown(
+        &eval.instances,
+        &results,
+        &args.breakdown,
+        model_name.as_deref(),
+    );
     if args.cost_attribution {
         let run_slots = load_run_slots(&args.sweep_dir, &results)?;
         eval.cost_attribution = build_cost_attribution_from_run_slots(
@@ -270,6 +275,7 @@ pub fn summarize<S: std::hash::BuildHasher>(
 }
 
 #[must_use]
+#[allow(clippy::too_many_lines)]
 pub fn summarize_with_model<S: std::hash::BuildHasher>(
     eval: &EvaluationResults,
     results: &HashMap<String, InstanceResult, S>,
@@ -421,6 +427,7 @@ fn bootstrap_cost_per_resolved_ci95(samples: &[(f64, bool)]) -> (f64, f64) {
         let mut total_cost = 0.0_f64;
         let mut resolved = 0usize;
         for _ in 0..n {
+            #[allow(clippy::cast_possible_truncation)]
             let idx = (lcg_next(&mut rng) as usize) % n;
             let (cost, is_resolved) = samples[idx];
             total_cost += cost;
@@ -437,7 +444,17 @@ fn bootstrap_cost_per_resolved_ci95(samples: &[(f64, bool)]) -> (f64, f64) {
         return (f64::NAN, f64::NAN);
     }
     estimates.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
     let lower_idx = ((estimates.len() as f64) * 0.025) as usize;
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
     let upper_idx = ((estimates.len() as f64) * 0.975) as usize;
     let lower = estimates[lower_idx];
     let upper = estimates[upper_idx.min(estimates.len() - 1)];
@@ -1559,9 +1576,15 @@ mod tests {
             },
             None,
         );
-        let django = rows.iter().find(|r| r.bucket_value == "django/django").unwrap();
+        let django = rows
+            .iter()
+            .find(|r| r.bucket_value == "django/django")
+            .unwrap();
         assert_eq!(django.cost_per_resolved_usd, Some(3.0));
-        let requests = rows.iter().find(|r| r.bucket_value == "psf/requests").unwrap();
+        let requests = rows
+            .iter()
+            .find(|r| r.bucket_value == "psf/requests")
+            .unwrap();
         assert_eq!(requests.cost_per_resolved_usd, None);
     }
 
@@ -1572,15 +1595,9 @@ mod tests {
         let mut budgeted = submitted("b");
         budgeted.cost_usd = Some(5.0);
         budgeted.failure_category = Some(FailureCategory::BudgetExhausted);
-        let results = HashMap::from([
-            ("a".to_string(), normal),
-            ("b".to_string(), budgeted),
-        ]);
+        let results = HashMap::from([("a".to_string(), normal), ("b".to_string(), budgeted)]);
         let eval = EvaluationResults {
-            instances: vec![
-                eval_row("a", true),
-                eval_row("b", false),
-            ],
+            instances: vec![eval_row("a", true), eval_row("b", false)],
             behavioral: BehavioralMetrics::default(),
             breakdown: vec![],
             cost_attribution: vec![],
@@ -1744,13 +1761,11 @@ mod tests {
 
     #[test]
     fn cost_per_resolved_usd_is_nan_when_resolved_count_is_zero() {
-        let results: HashMap<String, InstanceResult> = HashMap::from([
-            ("a".to_string(), {
-                let mut r = errored("a");
-                r.cost_usd = Some(5.0);
-                r
-            }),
-        ]);
+        let results: HashMap<String, InstanceResult> = HashMap::from([("a".to_string(), {
+            let mut r = errored("a");
+            r.cost_usd = Some(5.0);
+            r
+        })]);
         let eval = EvaluationResults {
             instances: vec![eval_row("a", false)],
             behavioral: BehavioralMetrics::default(),
@@ -1797,13 +1812,11 @@ mod tests {
 
     #[test]
     fn cost_per_resolved_ci95_is_nan_when_nothing_resolved() {
-        let results: HashMap<String, InstanceResult> = HashMap::from([
-            ("a".to_string(), {
-                let mut r = errored("a");
-                r.cost_usd = Some(5.0);
-                r
-            }),
-        ]);
+        let results: HashMap<String, InstanceResult> = HashMap::from([("a".to_string(), {
+            let mut r = errored("a");
+            r.cost_usd = Some(5.0);
+            r
+        })]);
         let eval = EvaluationResults {
             instances: vec![eval_row("a", false)],
             behavioral: BehavioralMetrics::default(),

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -144,6 +144,12 @@ pub struct EvaluationSummary {
     pub total_completion_tokens: u64,
     pub total_cost_usd: f64,
     pub cache_hit_rate: f64,
+    /// Total cost divided by resolved count. `f64::NAN` when `resolved == 0`.
+    pub cost_per_resolved_usd: f64,
+    /// 95% bootstrap CI lower bound. `f64::NAN` when `resolved == 0`.
+    pub cost_per_resolved_ci95_lower: f64,
+    /// 95% bootstrap CI upper bound. `f64::NAN` when `resolved == 0`.
+    pub cost_per_resolved_ci95_upper: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -274,6 +280,9 @@ pub fn summarize_with_model<S: std::hash::BuildHasher>(
             total_completion_tokens: 0,
             total_cost_usd: 0.0,
             cache_hit_rate: 0.0,
+            cost_per_resolved_usd: f64::NAN,
+            cost_per_resolved_ci95_lower: f64::NAN,
+            cost_per_resolved_ci95_upper: f64::NAN,
         };
     }
     let tokens = results
@@ -311,6 +320,30 @@ pub fn summarize_with_model<S: std::hash::BuildHasher>(
         })
         .count();
     let pass_at_k = eval.instances.iter().filter(|row| row.resolved).count();
+
+    let cost_per_resolved_usd = if resolved == 0 {
+        f64::NAN
+    } else {
+        #[allow(clippy::cast_precision_loss)]
+        {
+            total_cost_usd / resolved as f64
+        }
+    };
+
+    let per_instance_samples: Vec<(f64, bool)> = eval
+        .instances
+        .iter()
+        .map(|row| {
+            let cost = results
+                .get(&row.instance_id)
+                .and_then(|r| r.effective_cost_usd(model_name))
+                .unwrap_or(0.0);
+            (cost, row.resolved)
+        })
+        .collect();
+    let (cost_per_resolved_ci95_lower, cost_per_resolved_ci95_upper) =
+        bootstrap_cost_per_resolved_ci95(&per_instance_samples);
+
     EvaluationSummary {
         instances,
         resolved,
@@ -323,7 +356,61 @@ pub fn summarize_with_model<S: std::hash::BuildHasher>(
         total_completion_tokens: tokens.completion_tokens,
         total_cost_usd,
         cache_hit_rate: tokens.cache_hit_rate(),
+        cost_per_resolved_usd,
+        cost_per_resolved_ci95_lower,
+        cost_per_resolved_ci95_upper,
     }
+}
+
+fn lcg_next(state: &mut u64) -> u64 {
+    *state = state
+        .wrapping_mul(6_364_136_223_846_793_005)
+        .wrapping_add(1_442_695_040_888_963_407);
+    *state
+}
+
+/// 95% percentile bootstrap CI for `cost_per_resolved_usd`.
+///
+/// Returns `(f64::NAN, f64::NAN)` when no resolved instances exist in any
+/// resample (i.e., the true resolved count is 0).
+fn bootstrap_cost_per_resolved_ci95(samples: &[(f64, bool)]) -> (f64, f64) {
+    const N_BOOTSTRAP: usize = 1000;
+    const SEED: u64 = 12_345_678_901_234;
+    let n = samples.len();
+    if n == 0 {
+        return (f64::NAN, f64::NAN);
+    }
+    let resolved_count = samples.iter().filter(|(_, r)| *r).count();
+    if resolved_count == 0 {
+        return (f64::NAN, f64::NAN);
+    }
+    let mut rng = SEED;
+    let mut estimates: Vec<f64> = Vec::with_capacity(N_BOOTSTRAP);
+    for _ in 0..N_BOOTSTRAP {
+        let mut total_cost = 0.0_f64;
+        let mut resolved = 0usize;
+        for _ in 0..n {
+            let idx = (lcg_next(&mut rng) as usize) % n;
+            let (cost, is_resolved) = samples[idx];
+            total_cost += cost;
+            if is_resolved {
+                resolved += 1;
+            }
+        }
+        if resolved > 0 {
+            #[allow(clippy::cast_precision_loss)]
+            estimates.push(total_cost / resolved as f64);
+        }
+    }
+    if estimates.is_empty() {
+        return (f64::NAN, f64::NAN);
+    }
+    estimates.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let lower_idx = ((estimates.len() as f64) * 0.025) as usize;
+    let upper_idx = ((estimates.len() as f64) * 0.975) as usize;
+    let lower = estimates[lower_idx];
+    let upper = estimates[upper_idx.min(estimates.len() - 1)];
+    (lower, upper)
 }
 
 fn build_none_eval(results: &HashMap<String, InstanceResult>) -> EvaluationResults {
@@ -1115,6 +1202,18 @@ pub fn render_summary_table(summary: &EvaluationSummary) -> String {
     );
     let _ = writeln!(out, "cache_hit_rate: {:.4}", summary.cache_hit_rate);
     let _ = writeln!(out, "total_cost_usd: {:.4}", summary.total_cost_usd);
+    let _ = writeln!(
+        out,
+        "cost_per_resolved_usd: {:.4}",
+        summary.cost_per_resolved_usd
+    );
+    if !summary.cost_per_resolved_ci95_lower.is_nan() {
+        let _ = writeln!(
+            out,
+            "cost_per_resolved_ci95: [{:.4}, {:.4}]",
+            summary.cost_per_resolved_ci95_lower, summary.cost_per_resolved_ci95_upper
+        );
+    }
     out
 }
 
@@ -1512,6 +1611,140 @@ mod tests {
         assert!(
             rendered.contains("total_cost_usd: 0.4200"),
             "got:\n{rendered}"
+        );
+    }
+
+    // --- RED phase: cost_per_resolved_usd tests ---
+
+    #[test]
+    fn cost_per_resolved_usd_is_nan_when_resolved_count_is_zero() {
+        let results: HashMap<String, InstanceResult> = HashMap::from([
+            ("a".to_string(), {
+                let mut r = errored("a");
+                r.cost_usd = Some(5.0);
+                r
+            }),
+        ]);
+        let eval = EvaluationResults {
+            instances: vec![eval_row("a", false)],
+            behavioral: BehavioralMetrics::default(),
+            breakdown: Vec::new(),
+            cost_attribution: Vec::new(),
+        };
+        let summary = summarize(&eval, &results);
+        assert!(
+            summary.cost_per_resolved_usd.is_nan(),
+            "expected NaN when resolved=0, got {}",
+            summary.cost_per_resolved_usd
+        );
+    }
+
+    #[test]
+    fn cost_per_resolved_usd_divides_total_cost_by_resolved_count() {
+        let mut r1 = submitted("r1");
+        r1.cost_usd = Some(3.0);
+        let mut r2 = submitted("r2");
+        r2.cost_usd = Some(1.0);
+        let mut r3 = errored("r3");
+        r3.cost_usd = Some(2.0);
+        let results = HashMap::from([
+            ("r1".to_string(), r1),
+            ("r2".to_string(), r2),
+            ("r3".to_string(), r3),
+        ]);
+        let eval = EvaluationResults {
+            instances: vec![
+                eval_row("r1", true),
+                eval_row("r2", true),
+                eval_row("r3", false),
+            ],
+            behavioral: BehavioralMetrics::default(),
+            breakdown: Vec::new(),
+            cost_attribution: Vec::new(),
+        };
+        let summary = summarize(&eval, &results);
+        assert_eq!(summary.resolved, 2);
+        assert_f64_eq(summary.total_cost_usd, 6.0);
+        // cost_per_resolved_usd = 6.0 / 2 = 3.0
+        assert_f64_eq(summary.cost_per_resolved_usd, 3.0);
+    }
+
+    #[test]
+    fn cost_per_resolved_ci95_is_nan_when_nothing_resolved() {
+        let results: HashMap<String, InstanceResult> = HashMap::from([
+            ("a".to_string(), {
+                let mut r = errored("a");
+                r.cost_usd = Some(5.0);
+                r
+            }),
+        ]);
+        let eval = EvaluationResults {
+            instances: vec![eval_row("a", false)],
+            behavioral: BehavioralMetrics::default(),
+            breakdown: Vec::new(),
+            cost_attribution: Vec::new(),
+        };
+        let summary = summarize(&eval, &results);
+        assert!(
+            summary.cost_per_resolved_ci95_lower.is_nan(),
+            "expected NaN CI lower when resolved=0"
+        );
+        assert!(
+            summary.cost_per_resolved_ci95_upper.is_nan(),
+            "expected NaN CI upper when resolved=0"
+        );
+    }
+
+    #[test]
+    fn cost_per_resolved_ci95_brackets_true_value() {
+        // 10 resolved at $1.00 each, 0 unresolved -> cost_per_resolved = 1.0
+        let results: HashMap<String, InstanceResult> = (0..10)
+            .map(|i| {
+                let mut r = submitted(&format!("r{i}"));
+                r.cost_usd = Some(1.0);
+                (format!("r{i}"), r)
+            })
+            .collect();
+        let eval = EvaluationResults {
+            instances: (0..10).map(|i| eval_row(&format!("r{i}"), true)).collect(),
+            behavioral: BehavioralMetrics::default(),
+            breakdown: Vec::new(),
+            cost_attribution: Vec::new(),
+        };
+        let summary = summarize(&eval, &results);
+        assert_f64_eq(summary.cost_per_resolved_usd, 1.0);
+        assert!(
+            summary.cost_per_resolved_ci95_lower <= 1.0,
+            "CI lower={} should be <= true value 1.0",
+            summary.cost_per_resolved_ci95_lower
+        );
+        assert!(
+            summary.cost_per_resolved_ci95_upper >= 1.0,
+            "CI upper={} should be >= true value 1.0",
+            summary.cost_per_resolved_ci95_upper
+        );
+    }
+
+    #[test]
+    fn render_summary_table_includes_cost_per_resolved_usd() {
+        let mut r = submitted("a");
+        r.cost_usd = Some(4.0);
+        let results = HashMap::from([("a".to_string(), r)]);
+        let eval = EvaluationResults {
+            instances: vec![eval_row("a", true)],
+            behavioral: BehavioralMetrics::default(),
+            breakdown: Vec::new(),
+            cost_attribution: Vec::new(),
+        };
+        let summary = summarize(&eval, &results);
+        let rendered = render_summary_table(&summary);
+        assert!(
+            rendered.contains("cost_per_resolved_usd:"),
+            "render_summary_table should include cost_per_resolved_usd; got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("4.0000"),
+            "cost_per_resolved_usd should be 4.0000 (1 resolved at $4); got:\n{rendered}"
         );
     }
 }

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -145,11 +145,16 @@ pub struct EvaluationSummary {
     pub total_cost_usd: f64,
     pub cache_hit_rate: f64,
     /// Total cost divided by resolved count. `f64::NAN` when `resolved == 0`.
+    /// Computed on budget-respecting runs only when budget-exhausted instances
+    /// are present in the sweep.
     pub cost_per_resolved_usd: f64,
     /// 95% bootstrap CI lower bound. `f64::NAN` when `resolved == 0`.
     pub cost_per_resolved_ci95_lower: f64,
     /// 95% bootstrap CI upper bound. `f64::NAN` when `resolved == 0`.
     pub cost_per_resolved_ci95_upper: f64,
+    /// Instances excluded from `cost_per_resolved_usd` because they were
+    /// killed by the per-task budget cap. Zero when no budget is active.
+    pub budget_exhausted_excluded: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -159,6 +164,10 @@ pub struct BreakdownBucket {
     pub n: usize,
     pub resolved: usize,
     pub resolved_rate: f64,
+    /// `total_cost_usd / resolved` for this bucket, excluding budget-exhausted
+    /// instances. `None` when no instance in this bucket resolved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_per_resolved_usd: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -235,7 +244,7 @@ pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
     };
     let mut eval = run_output.eval;
     eval.behavioral = build_behavioral_metrics(&eval.instances, &results);
-    eval.breakdown = build_breakdown(&eval.instances, &results, &args.breakdown);
+    eval.breakdown = build_breakdown(&eval.instances, &results, &args.breakdown, model_name.as_deref());
     if args.cost_attribution {
         let run_slots = load_run_slots(&args.sweep_dir, &results)?;
         eval.cost_attribution = build_cost_attribution_from_run_slots(
@@ -283,6 +292,7 @@ pub fn summarize_with_model<S: std::hash::BuildHasher>(
             cost_per_resolved_usd: f64::NAN,
             cost_per_resolved_ci95_lower: f64::NAN,
             cost_per_resolved_ci95_upper: f64::NAN,
+            budget_exhausted_excluded: 0,
         };
     }
     let tokens = results
@@ -321,18 +331,28 @@ pub fn summarize_with_model<S: std::hash::BuildHasher>(
         .count();
     let pass_at_k = eval.instances.iter().filter(|row| row.resolved).count();
 
-    let cost_per_resolved_usd = if resolved == 0 {
-        f64::NAN
-    } else {
-        #[allow(clippy::cast_precision_loss)]
-        {
-            total_cost_usd / resolved as f64
-        }
-    };
+    // Exclude budget-exhausted instances from cost_per_resolved_usd so we
+    // never silently mix capped and uncapped runs in the efficiency metric.
+    let budget_exhausted_excluded = eval
+        .instances
+        .iter()
+        .filter(|row| {
+            results
+                .get(&row.instance_id)
+                .and_then(|r| r.failure_category)
+                == Some(FailureCategory::BudgetExhausted)
+        })
+        .count();
 
     let per_instance_samples: Vec<(f64, bool)> = eval
         .instances
         .iter()
+        .filter(|row| {
+            results
+                .get(&row.instance_id)
+                .and_then(|r| r.failure_category)
+                != Some(FailureCategory::BudgetExhausted)
+        })
         .map(|row| {
             let cost = results
                 .get(&row.instance_id)
@@ -341,6 +361,16 @@ pub fn summarize_with_model<S: std::hash::BuildHasher>(
             (cost, row.resolved)
         })
         .collect();
+
+    let br_resolved = per_instance_samples.iter().filter(|(_, r)| *r).count();
+    let cost_per_resolved_usd = if br_resolved == 0 {
+        f64::NAN
+    } else {
+        #[allow(clippy::cast_precision_loss)]
+        {
+            per_instance_samples.iter().map(|(c, _)| c).sum::<f64>() / br_resolved as f64
+        }
+    };
     let (cost_per_resolved_ci95_lower, cost_per_resolved_ci95_upper) =
         bootstrap_cost_per_resolved_ci95(&per_instance_samples);
 
@@ -359,6 +389,7 @@ pub fn summarize_with_model<S: std::hash::BuildHasher>(
         cost_per_resolved_usd,
         cost_per_resolved_ci95_lower,
         cost_per_resolved_ci95_upper,
+        budget_exhausted_excluded,
     }
 }
 
@@ -904,10 +935,12 @@ fn build_breakdown(
     evals: &[InstanceEvaluation],
     results: &HashMap<String, InstanceResult>,
     selection: &BreakdownSelection,
+    model_name: Option<&str>,
 ) -> Vec<BreakdownBucket> {
     let mut out = Vec::with_capacity(selection.axes.len());
     for axis in &selection.axes {
-        let mut buckets: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+        // (n, resolved, budget_respecting_cost, budget_respecting_resolved)
+        let mut buckets: BTreeMap<String, (usize, usize, f64, usize)> = BTreeMap::new();
         let mut unknown_repo = 0usize;
         for row in evals {
             let bucket_value = match axis {
@@ -931,10 +964,24 @@ fn build_breakdown(
                     }
                 }
             };
-            let entry = buckets.entry(bucket_value).or_insert((0, 0));
+            let is_budget_exhausted = results
+                .get(&row.instance_id)
+                .and_then(|r| r.failure_category)
+                == Some(FailureCategory::BudgetExhausted);
+            let entry = buckets.entry(bucket_value).or_insert((0, 0, 0.0, 0));
             entry.0 += 1;
             if row.resolved {
                 entry.1 += 1;
+            }
+            if !is_budget_exhausted {
+                let cost = results
+                    .get(&row.instance_id)
+                    .and_then(|r| r.effective_cost_usd(model_name))
+                    .unwrap_or(0.0);
+                entry.2 += cost;
+                if row.resolved {
+                    entry.3 += 1;
+                }
             }
         }
         if matches!(axis, BreakdownAxis::Repo) && unknown_repo > 0 {
@@ -945,12 +992,21 @@ fn build_breakdown(
         }
         let mut rows: Vec<BreakdownBucket> = buckets
             .into_iter()
-            .map(|(bucket_value, (n, resolved))| BreakdownBucket {
-                bucket_axis: *axis,
-                bucket_value,
-                n,
-                resolved,
-                resolved_rate: pct(resolved, n),
+            .map(|(bucket_value, (n, resolved, br_cost, br_resolved))| {
+                #[allow(clippy::cast_precision_loss)]
+                let cost_per_resolved_usd = if br_resolved == 0 {
+                    None
+                } else {
+                    Some(br_cost / br_resolved as f64)
+                };
+                BreakdownBucket {
+                    bucket_axis: *axis,
+                    bucket_value,
+                    n,
+                    resolved,
+                    resolved_rate: pct(resolved, n),
+                    cost_per_resolved_usd,
+                }
             })
             .collect();
         rows.sort_by(|a, b| {
@@ -1149,15 +1205,19 @@ fn build_cost_attribution_report(
 
 #[must_use]
 pub fn render_breakdown_table(rows: &[BreakdownBucket]) -> String {
-    let mut out = String::from("axis,bucket,n,resolved,resolved_rate\n");
+    let mut out = String::from("axis,bucket,n,resolved,resolved_rate,cost_per_resolved_usd\n");
     for row in rows {
         let axis = match row.bucket_axis {
             BreakdownAxis::Repo => "repo",
             BreakdownAxis::FailureCategory => "failure_category",
         };
+        let cpr = match row.cost_per_resolved_usd {
+            Some(v) => format!("{v:.4}"),
+            None => "NaN".to_owned(),
+        };
         let _ = writeln!(
             out,
-            "{axis},{},{},{},{:.4}",
+            "{axis},{},{},{},{:.4},{cpr}",
             row.bucket_value, row.n, row.resolved, row.resolved_rate
         );
     }
@@ -1212,6 +1272,13 @@ pub fn render_summary_table(summary: &EvaluationSummary) -> String {
             out,
             "cost_per_resolved_ci95: [{:.4}, {:.4}]",
             summary.cost_per_resolved_ci95_lower, summary.cost_per_resolved_ci95_upper
+        );
+    }
+    if summary.budget_exhausted_excluded > 0 {
+        let _ = writeln!(
+            out,
+            "budget_exhausted_excluded: {} (cost_per_resolved computed on budget-respecting runs only)",
+            summary.budget_exhausted_excluded
         );
     }
     out
@@ -1464,9 +1531,68 @@ mod tests {
             &BreakdownSelection {
                 axes: vec![BreakdownAxis::FailureCategory],
             },
+            None,
         );
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].bucket_value, "none");
+    }
+
+    #[test]
+    fn breakdown_bucket_cost_per_resolved_usd_per_slice() {
+        let mut django_res = submitted("django__django-1");
+        django_res.cost_usd = Some(3.0);
+        let mut requests_unres = submitted("psf__requests-2");
+        requests_unres.cost_usd = Some(2.0);
+        let results = HashMap::from([
+            ("django__django-1".to_string(), django_res),
+            ("psf__requests-2".to_string(), requests_unres),
+        ]);
+        let evals = vec![
+            eval_row("django__django-1", true),
+            eval_row("psf__requests-2", false),
+        ];
+        let rows = build_breakdown(
+            &evals,
+            &results,
+            &BreakdownSelection {
+                axes: vec![BreakdownAxis::Repo],
+            },
+            None,
+        );
+        let django = rows.iter().find(|r| r.bucket_value == "django/django").unwrap();
+        assert_eq!(django.cost_per_resolved_usd, Some(3.0));
+        let requests = rows.iter().find(|r| r.bucket_value == "psf/requests").unwrap();
+        assert_eq!(requests.cost_per_resolved_usd, None);
+    }
+
+    #[test]
+    fn budget_exhausted_instances_excluded_from_cost_per_resolved() {
+        let mut normal = submitted("a");
+        normal.cost_usd = Some(2.0);
+        let mut budgeted = submitted("b");
+        budgeted.cost_usd = Some(5.0);
+        budgeted.failure_category = Some(FailureCategory::BudgetExhausted);
+        let results = HashMap::from([
+            ("a".to_string(), normal),
+            ("b".to_string(), budgeted),
+        ]);
+        let eval = EvaluationResults {
+            instances: vec![
+                eval_row("a", true),
+                eval_row("b", false),
+            ],
+            behavioral: BehavioralMetrics::default(),
+            breakdown: vec![],
+            cost_attribution: vec![],
+        };
+        let summary = summarize_with_model(&eval, &results, None);
+        assert_eq!(summary.budget_exhausted_excluded, 1);
+        // only "a" is budget-respecting and resolved: cost_per_resolved = $2.0 / 1
+        assert!(
+            (summary.cost_per_resolved_usd - 2.0).abs() < 1e-9,
+            "expected cost_per_resolved_usd=2.0, got {}",
+            summary.cost_per_resolved_usd
+        );
     }
 
     #[test]

--- a/src/run/frontier.rs
+++ b/src/run/frontier.rs
@@ -5,13 +5,14 @@
 //! simultaneously cheaper and higher-resolved.  Emits an ASCII chart (text
 //! mode) or a JSON dataset (json mode) suitable for downstream plotting.
 
+use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
 use crate::error::Error;
-use crate::run::compare::{load_evaluation_results, load_sweep, LoadedSweep};
-use crate::run::evaluate::{pct, EvaluationResults};
+use crate::run::compare::{LoadedSweep, load_evaluation_results, load_sweep};
+use crate::run::evaluate::{EvaluationResults, pct};
 use crate::run::swebench::InstanceResult;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -96,10 +97,7 @@ fn load_point(dir: &Path) -> Result<FrontierPoint, Error> {
 }
 
 fn count_sweep_resolved(instances: &std::collections::HashMap<String, InstanceResult>) -> usize {
-    instances
-        .values()
-        .filter(|r| r.resolved_count > 0)
-        .count()
+    instances.values().filter(|r| r.resolved_count > 0).count()
 }
 
 /// Mark each point as on-frontier if no other point dominates it.
@@ -108,7 +106,7 @@ fn count_sweep_resolved(instances: &std::collections::HashMap<String, InstanceRe
 /// a lower (or equal) cost_per_resolved_usd, with at least one strict
 /// inequality. Points with `cost_per_resolved_usd == NaN` (resolved=0) are
 /// never on the frontier unless all points have resolved=0.
-fn mark_pareto_frontier(points: &mut Vec<FrontierPoint>) {
+fn mark_pareto_frontier(points: &mut [FrontierPoint]) {
     let n = points.len();
     let all_nan = points.iter().all(|p| p.cost_per_resolved_usd.is_nan());
     for i in 0..n {
@@ -136,8 +134,7 @@ fn dominates(a: &FrontierPoint, b: &FrontierPoint) -> bool {
     let better_rate = a.resolved_rate > b.resolved_rate + f64::EPSILON;
     let equal_rate = (a.resolved_rate - b.resolved_rate).abs() <= f64::EPSILON;
     let better_cost = a.cost_per_resolved_usd < b.cost_per_resolved_usd - f64::EPSILON;
-    let equal_cost =
-        (a.cost_per_resolved_usd - b.cost_per_resolved_usd).abs() <= f64::EPSILON;
+    let equal_cost = (a.cost_per_resolved_usd - b.cost_per_resolved_usd).abs() <= f64::EPSILON;
     (better_rate || equal_rate) && (better_cost || equal_cost) && (better_rate || better_cost)
 }
 
@@ -196,8 +193,9 @@ pub fn render_text(report: &FrontierReport) -> String {
             format!("${:.4}", p.cost_per_resolved_usd)
         };
         let frontier_mark = if p.on_frontier { "*" } else { " " };
-        out.push_str(&format!(
-            "{} {:<width$}  {:>9.2}%  {:>14}  {:>8}  ${:.4}\n",
+        let _ = writeln!(
+            out,
+            "{} {:<width$}  {:>9.2}%  {:>14}  {:>8}  ${:.4}",
             frontier_mark,
             p.dir.display(),
             p.resolved_rate * 100.0,
@@ -205,15 +203,16 @@ pub fn render_text(report: &FrontierReport) -> String {
             if p.on_frontier { "yes" } else { "no" },
             p.total_cost_usd,
             width = col_width
-        ));
+        );
     }
 
     out.push('\n');
     let frontier_count = report.points.iter().filter(|p| p.on_frontier).count();
-    out.push_str(&format!(
-        "{frontier_count}/{} runs on the efficient frontier\n",
+    let _ = writeln!(
+        out,
+        "{frontier_count}/{} runs on the efficient frontier",
         report.points.len()
-    ));
+    );
 
     // ASCII scatter chart: resolved_rate on Y, cost_per_resolved on X
     write_ascii_chart(&mut out, &sorted);
@@ -255,9 +254,18 @@ fn write_ascii_chart(out: &mut String, points: &[&FrontierPoint]) {
 
     let mut grid = vec![vec![' '; CHART_WIDTH]; CHART_HEIGHT];
     for p in &finite_points {
-        let x = ((p.cost_per_resolved_usd - min_cost) / cost_range
-            * (CHART_WIDTH - 1) as f64)
+        #[allow(
+            clippy::cast_precision_loss,
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss
+        )]
+        let x = ((p.cost_per_resolved_usd - min_cost) / cost_range * (CHART_WIDTH - 1) as f64)
             .round() as usize;
+        #[allow(
+            clippy::cast_precision_loss,
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss
+        )]
         let y = ((p.resolved_rate - min_rate) / rate_range * (CHART_HEIGHT - 1) as f64).round()
             as usize;
         let y = CHART_HEIGHT - 1 - y.min(CHART_HEIGHT - 1);

--- a/src/run/frontier.rs
+++ b/src/run/frontier.rs
@@ -33,8 +33,8 @@ pub struct FrontierPoint {
     pub resolved_rate: f64,
     /// Total USD cost across all instances.
     pub total_cost_usd: f64,
-    /// `total_cost_usd / resolved`. `f64::NAN` when `resolved == 0`.
-    pub cost_per_resolved_usd: f64,
+    /// `total_cost_usd / resolved`. `None` when `resolved == 0`.
+    pub cost_per_resolved_usd: Option<f64>,
     /// Whether this point lies on the Pareto-efficient frontier.
     pub on_frontier: bool,
 }
@@ -76,13 +76,11 @@ fn load_point(dir: &Path) -> Result<FrontierPoint, Error> {
         .filter_map(|r| r.effective_cost_usd(model_name))
         .sum();
 
+    #[allow(clippy::cast_precision_loss)]
     let cost_per_resolved_usd = if resolved == 0 {
-        f64::NAN
+        None
     } else {
-        #[allow(clippy::cast_precision_loss)]
-        {
-            total_cost_usd / resolved as f64
-        }
+        Some(total_cost_usd / resolved as f64)
     };
 
     Ok(FrontierPoint {
@@ -108,12 +106,12 @@ fn count_sweep_resolved(instances: &std::collections::HashMap<String, InstanceRe
 /// never on the frontier unless all points have resolved=0.
 fn mark_pareto_frontier(points: &mut [FrontierPoint]) {
     let n = points.len();
-    let all_nan = points.iter().all(|p| p.cost_per_resolved_usd.is_nan());
+    let all_none = points.iter().all(|p| p.cost_per_resolved_usd.is_none());
     for i in 0..n {
-        let dominated = if all_nan {
+        let dominated = if all_none {
             false
         } else {
-            points[i].cost_per_resolved_usd.is_nan()
+            points[i].cost_per_resolved_usd.is_none()
                 || (0..n)
                     .filter(|&j| j != i)
                     .any(|j| dominates(&points[j], &points[i]))
@@ -125,16 +123,15 @@ fn mark_pareto_frontier(points: &mut [FrontierPoint]) {
 /// Returns true when `a` weakly dominates `b` with at least one strict
 /// improvement on the (resolved_rate, cost_per_resolved_usd) axes.
 fn dominates(a: &FrontierPoint, b: &FrontierPoint) -> bool {
-    if a.cost_per_resolved_usd.is_nan() {
-        return false;
-    }
-    if b.cost_per_resolved_usd.is_nan() {
-        return true;
-    }
+    let (Some(a_cost), Some(b_cost)) = (a.cost_per_resolved_usd, b.cost_per_resolved_usd) else {
+        // a has no resolved instances → cannot dominate
+        // b has no resolved instances → a (with any resolved) dominates
+        return a.cost_per_resolved_usd.is_some();
+    };
     let better_rate = a.resolved_rate > b.resolved_rate + f64::EPSILON;
     let equal_rate = (a.resolved_rate - b.resolved_rate).abs() <= f64::EPSILON;
-    let better_cost = a.cost_per_resolved_usd < b.cost_per_resolved_usd - f64::EPSILON;
-    let equal_cost = (a.cost_per_resolved_usd - b.cost_per_resolved_usd).abs() <= f64::EPSILON;
+    let better_cost = a_cost < b_cost - f64::EPSILON;
+    let equal_cost = (a_cost - b_cost).abs() <= f64::EPSILON;
     (better_rate || equal_rate) && (better_cost || equal_cost) && (better_rate || better_cost)
 }
 
@@ -187,10 +184,9 @@ pub fn render_text(report: &FrontierReport) -> String {
     });
 
     for p in &sorted {
-        let cpr = if p.cost_per_resolved_usd.is_nan() {
-            "NaN".to_owned()
-        } else {
-            format!("${:.4}", p.cost_per_resolved_usd)
+        let cpr = match p.cost_per_resolved_usd {
+            Some(v) => format!("${v:.4}"),
+            None => "NaN".to_owned(),
         };
         let frontier_mark = if p.on_frontier { "*" } else { " " };
         let _ = writeln!(
@@ -224,9 +220,10 @@ fn write_ascii_chart(out: &mut String, points: &[&FrontierPoint]) {
     const CHART_WIDTH: usize = 40;
     const CHART_HEIGHT: usize = 10;
 
-    let finite_points: Vec<&&FrontierPoint> = points
+    // Only plot points that have a finite cost (resolved > 0).
+    let finite_points: Vec<(&FrontierPoint, f64)> = points
         .iter()
-        .filter(|p| !p.cost_per_resolved_usd.is_nan())
+        .filter_map(|p| p.cost_per_resolved_usd.map(|c| (*p, c)))
         .collect();
     if finite_points.is_empty() {
         return;
@@ -234,33 +231,32 @@ fn write_ascii_chart(out: &mut String, points: &[&FrontierPoint]) {
 
     let min_cost = finite_points
         .iter()
-        .map(|p| p.cost_per_resolved_usd)
+        .map(|(_, c)| *c)
         .fold(f64::INFINITY, f64::min);
     let max_cost = finite_points
         .iter()
-        .map(|p| p.cost_per_resolved_usd)
+        .map(|(_, c)| *c)
         .fold(f64::NEG_INFINITY, f64::max);
     let min_rate = finite_points
         .iter()
-        .map(|p| p.resolved_rate)
+        .map(|(p, _)| p.resolved_rate)
         .fold(f64::INFINITY, f64::min);
     let max_rate = finite_points
         .iter()
-        .map(|p| p.resolved_rate)
+        .map(|(p, _)| p.resolved_rate)
         .fold(f64::NEG_INFINITY, f64::max);
 
     let cost_range = (max_cost - min_cost).max(f64::EPSILON);
     let rate_range = (max_rate - min_rate).max(f64::EPSILON);
 
     let mut grid = vec![vec![' '; CHART_WIDTH]; CHART_HEIGHT];
-    for p in &finite_points {
+    for (p, cost) in &finite_points {
         #[allow(
             clippy::cast_precision_loss,
             clippy::cast_possible_truncation,
             clippy::cast_sign_loss
         )]
-        let x = ((p.cost_per_resolved_usd - min_cost) / cost_range * (CHART_WIDTH - 1) as f64)
-            .round() as usize;
+        let x = ((cost - min_cost) / cost_range * (CHART_WIDTH - 1) as f64).round() as usize;
         #[allow(
             clippy::cast_precision_loss,
             clippy::cast_possible_truncation,

--- a/src/run/frontier.rs
+++ b/src/run/frontier.rs
@@ -15,7 +15,7 @@ use crate::run::compare::{LoadedSweep, load_evaluation_results, load_sweep};
 use crate::run::evaluate::{EvaluationResults, pct};
 use crate::run::swebench::InstanceResult;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum FrontierFormat {
     Text,
     Json,
@@ -229,22 +229,22 @@ fn write_ascii_chart(out: &mut String, points: &[&FrontierPoint]) {
         return;
     }
 
-    let min_cost = finite_points
-        .iter()
-        .map(|(_, c)| *c)
-        .fold(f64::INFINITY, f64::min);
-    let max_cost = finite_points
-        .iter()
-        .map(|(_, c)| *c)
-        .fold(f64::NEG_INFINITY, f64::max);
-    let min_rate = finite_points
-        .iter()
-        .map(|(p, _)| p.resolved_rate)
-        .fold(f64::INFINITY, f64::min);
-    let max_rate = finite_points
-        .iter()
-        .map(|(p, _)| p.resolved_rate)
-        .fold(f64::NEG_INFINITY, f64::max);
+    let (min_cost, max_cost, min_rate, max_rate) = finite_points.iter().fold(
+        (
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ),
+        |(min_c, max_c, min_r, max_r), (p, cost)| {
+            (
+                min_c.min(*cost),
+                max_c.max(*cost),
+                min_r.min(p.resolved_rate),
+                max_r.max(p.resolved_rate),
+            )
+        },
+    );
 
     let cost_range = (max_cost - min_cost).max(f64::EPSILON);
     let rate_range = (max_rate - min_rate).max(f64::EPSILON);

--- a/src/run/frontier.rs
+++ b/src/run/frontier.rs
@@ -1,0 +1,282 @@
+//! `bench frontier`: Pareto-frontier view across multiple sweep runs.
+//!
+//! For each sweep directory computes `(resolved_rate, cost_per_resolved_usd)`
+//! and marks which runs lie on the efficient frontier — i.e. no other run is
+//! simultaneously cheaper and higher-resolved.  Emits an ASCII chart (text
+//! mode) or a JSON dataset (json mode) suitable for downstream plotting.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::error::Error;
+use crate::run::compare::{load_evaluation_results, load_sweep, LoadedSweep};
+use crate::run::evaluate::{pct, EvaluationResults};
+use crate::run::swebench::InstanceResult;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrontierFormat {
+    Text,
+    Json,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FrontierPoint {
+    /// Path to the sweep directory.
+    pub dir: PathBuf,
+    /// Total instances in the sweep.
+    pub instances: usize,
+    /// Number resolved (from `evaluation.json` when present, else sweep row).
+    pub resolved: usize,
+    /// `resolved / instances`.
+    pub resolved_rate: f64,
+    /// Total USD cost across all instances.
+    pub total_cost_usd: f64,
+    /// `total_cost_usd / resolved`. `f64::NAN` when `resolved == 0`.
+    pub cost_per_resolved_usd: f64,
+    /// Whether this point lies on the Pareto-efficient frontier.
+    pub on_frontier: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FrontierReport {
+    pub points: Vec<FrontierPoint>,
+}
+
+pub struct FrontierArgs {
+    pub dirs: Vec<PathBuf>,
+}
+
+pub fn compute(args: &FrontierArgs) -> Result<FrontierReport, Error> {
+    let mut points: Vec<FrontierPoint> = Vec::with_capacity(args.dirs.len());
+    for dir in &args.dirs {
+        let point = load_point(dir)?;
+        points.push(point);
+    }
+    mark_pareto_frontier(&mut points);
+    Ok(FrontierReport { points })
+}
+
+fn load_point(dir: &Path) -> Result<FrontierPoint, Error> {
+    let loaded: LoadedSweep = load_sweep(dir)?;
+    let model_name = loaded.manifest.as_ref().map(|m| m.model.name.as_str());
+    let eval: Option<EvaluationResults> = load_evaluation_results(dir)?;
+    let instances = loaded.instances.len();
+
+    let resolved = if let Some(ref ev) = eval {
+        ev.instances.iter().filter(|r| r.resolved).count()
+    } else {
+        count_sweep_resolved(&loaded.instances)
+    };
+
+    let total_cost_usd: f64 = loaded
+        .instances
+        .values()
+        .filter_map(|r| r.effective_cost_usd(model_name))
+        .sum();
+
+    let cost_per_resolved_usd = if resolved == 0 {
+        f64::NAN
+    } else {
+        #[allow(clippy::cast_precision_loss)]
+        {
+            total_cost_usd / resolved as f64
+        }
+    };
+
+    Ok(FrontierPoint {
+        dir: dir.to_path_buf(),
+        instances,
+        resolved,
+        resolved_rate: pct(resolved, instances),
+        total_cost_usd,
+        cost_per_resolved_usd,
+        on_frontier: false,
+    })
+}
+
+fn count_sweep_resolved(instances: &std::collections::HashMap<String, InstanceResult>) -> usize {
+    instances
+        .values()
+        .filter(|r| r.resolved_count > 0)
+        .count()
+}
+
+/// Mark each point as on-frontier if no other point dominates it.
+///
+/// Point A dominates point B if A has a higher (or equal) resolved_rate AND
+/// a lower (or equal) cost_per_resolved_usd, with at least one strict
+/// inequality. Points with `cost_per_resolved_usd == NaN` (resolved=0) are
+/// never on the frontier unless all points have resolved=0.
+fn mark_pareto_frontier(points: &mut Vec<FrontierPoint>) {
+    let n = points.len();
+    let all_nan = points.iter().all(|p| p.cost_per_resolved_usd.is_nan());
+    for i in 0..n {
+        let dominated = if all_nan {
+            false
+        } else {
+            points[i].cost_per_resolved_usd.is_nan()
+                || (0..n)
+                    .filter(|&j| j != i)
+                    .any(|j| dominates(&points[j], &points[i]))
+        };
+        points[i].on_frontier = !dominated;
+    }
+}
+
+/// Returns true when `a` weakly dominates `b` with at least one strict
+/// improvement on the (resolved_rate, cost_per_resolved_usd) axes.
+fn dominates(a: &FrontierPoint, b: &FrontierPoint) -> bool {
+    if a.cost_per_resolved_usd.is_nan() {
+        return false;
+    }
+    if b.cost_per_resolved_usd.is_nan() {
+        return true;
+    }
+    let better_rate = a.resolved_rate > b.resolved_rate + f64::EPSILON;
+    let equal_rate = (a.resolved_rate - b.resolved_rate).abs() <= f64::EPSILON;
+    let better_cost = a.cost_per_resolved_usd < b.cost_per_resolved_usd - f64::EPSILON;
+    let equal_cost =
+        (a.cost_per_resolved_usd - b.cost_per_resolved_usd).abs() <= f64::EPSILON;
+    (better_rate || equal_rate) && (better_cost || equal_cost) && (better_rate || better_cost)
+}
+
+#[must_use]
+pub fn render_json(report: &FrontierReport) -> String {
+    serde_json::to_string_pretty(report).unwrap_or_else(|_| "{}".to_owned())
+}
+
+#[must_use]
+pub fn render_text(report: &FrontierReport) -> String {
+    let mut out = String::new();
+    out.push_str("\n=== bench frontier ===\n");
+    if report.points.is_empty() {
+        out.push_str("No sweep directories provided.\n");
+        return out;
+    }
+
+    let col_width = report
+        .points
+        .iter()
+        .map(|p| p.dir.display().to_string().len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+
+    let header = format!(
+        "  {:<width$}  {:>10}  {:>14}  {:>8}  {}",
+        "dir",
+        "resolved%",
+        "$/resolved",
+        "frontier",
+        "total_cost_usd",
+        width = col_width
+    );
+    out.push_str(&header);
+    out.push('\n');
+    out.push_str(&"-".repeat(header.len()));
+    out.push('\n');
+
+    let mut sorted: Vec<&FrontierPoint> = report.points.iter().collect();
+    sorted.sort_by(|a, b| {
+        b.resolved_rate
+            .partial_cmp(&a.resolved_rate)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                a.cost_per_resolved_usd
+                    .partial_cmp(&b.cost_per_resolved_usd)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+    });
+
+    for p in &sorted {
+        let cpr = if p.cost_per_resolved_usd.is_nan() {
+            "NaN".to_owned()
+        } else {
+            format!("${:.4}", p.cost_per_resolved_usd)
+        };
+        let frontier_mark = if p.on_frontier { "*" } else { " " };
+        out.push_str(&format!(
+            "{} {:<width$}  {:>9.2}%  {:>14}  {:>8}  ${:.4}\n",
+            frontier_mark,
+            p.dir.display(),
+            p.resolved_rate * 100.0,
+            cpr,
+            if p.on_frontier { "yes" } else { "no" },
+            p.total_cost_usd,
+            width = col_width
+        ));
+    }
+
+    out.push('\n');
+    let frontier_count = report.points.iter().filter(|p| p.on_frontier).count();
+    out.push_str(&format!(
+        "{frontier_count}/{} runs on the efficient frontier\n",
+        report.points.len()
+    ));
+
+    // ASCII scatter chart: resolved_rate on Y, cost_per_resolved on X
+    write_ascii_chart(&mut out, &sorted);
+
+    out
+}
+
+fn write_ascii_chart(out: &mut String, points: &[&FrontierPoint]) {
+    const CHART_WIDTH: usize = 40;
+    const CHART_HEIGHT: usize = 10;
+
+    let finite_points: Vec<&&FrontierPoint> = points
+        .iter()
+        .filter(|p| !p.cost_per_resolved_usd.is_nan())
+        .collect();
+    if finite_points.is_empty() {
+        return;
+    }
+
+    let min_cost = finite_points
+        .iter()
+        .map(|p| p.cost_per_resolved_usd)
+        .fold(f64::INFINITY, f64::min);
+    let max_cost = finite_points
+        .iter()
+        .map(|p| p.cost_per_resolved_usd)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let min_rate = finite_points
+        .iter()
+        .map(|p| p.resolved_rate)
+        .fold(f64::INFINITY, f64::min);
+    let max_rate = finite_points
+        .iter()
+        .map(|p| p.resolved_rate)
+        .fold(f64::NEG_INFINITY, f64::max);
+
+    let cost_range = (max_cost - min_cost).max(f64::EPSILON);
+    let rate_range = (max_rate - min_rate).max(f64::EPSILON);
+
+    let mut grid = vec![vec![' '; CHART_WIDTH]; CHART_HEIGHT];
+    for p in &finite_points {
+        let x = ((p.cost_per_resolved_usd - min_cost) / cost_range
+            * (CHART_WIDTH - 1) as f64)
+            .round() as usize;
+        let y = ((p.resolved_rate - min_rate) / rate_range * (CHART_HEIGHT - 1) as f64).round()
+            as usize;
+        let y = CHART_HEIGHT - 1 - y.min(CHART_HEIGHT - 1);
+        let x = x.min(CHART_WIDTH - 1);
+        grid[y][x] = if p.on_frontier { '*' } else { 'o' };
+    }
+
+    out.push('\n');
+    out.push_str("  resolved_rate\n");
+    out.push_str("  ^\n");
+    for row in &grid {
+        out.push_str("  |");
+        for &ch in row {
+            out.push(ch);
+        }
+        out.push('\n');
+    }
+    out.push_str("  +");
+    out.push_str(&"-".repeat(CHART_WIDTH));
+    out.push_str("> cost_per_resolved_usd\n");
+    out.push_str("  (* = on frontier, o = dominated)\n");
+}

--- a/src/run/frontier.rs
+++ b/src/run/frontier.rs
@@ -65,7 +65,10 @@ fn load_point(dir: &Path) -> Result<FrontierPoint, Error> {
     let instances = loaded.instances.len();
 
     let resolved = if let Some(ref ev) = eval {
-        ev.instances.iter().filter(|r| r.resolved).count()
+        ev.instances
+            .iter()
+            .filter(|r| r.resolved && loaded.instances.contains_key(&r.instance_id))
+            .count()
     } else {
         count_sweep_resolved(&loaded.instances)
     };

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -4,6 +4,7 @@
 pub mod compare;
 pub mod evaluate;
 pub mod forecast;
+pub mod frontier;
 pub mod github_pr;
 pub mod hello_world;
 pub mod inspect;

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -2175,6 +2175,55 @@ fn frontier_emits_ascii_chart_in_text_mode() {
     );
 }
 
+// ─── frontier: resolved count restricted to loaded sweep IDs ─────────────────
+
+#[test]
+fn frontier_resolved_count_capped_to_sweep_instance_ids() {
+    // Sweep has only inst-1.  eval.json has inst-1 AND inst-2 (stale / wider
+    // evaluation).  Resolved count must be 1 (not 2), resolved_rate must be
+    // 1.0 (not >1.0), and cost_per_resolved must reflect only the one loaded
+    // instance — otherwise metrics would be impossible / misleading.
+    let dir = tempfile::tempdir().unwrap();
+    let mut r = submitted("inst-1");
+    r.cost_usd = Some(4.0);
+    write_results(dir.path(), vec![r]);
+    write_evaluation_json(
+        dir.path(),
+        &serde_json::json!({"instances": [
+            {"instance_id": "inst-1", "resolved": true, "eval_exit_reason": "resolved", "tests_passed": [], "tests_failed": []},
+            {"instance_id": "inst-2", "resolved": true, "eval_exit_reason": "resolved", "tests_passed": [], "tests_failed": []}
+        ]}),
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "frontier",
+            "--format",
+            "json",
+            dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "bench frontier should succeed; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("expected JSON; err={e}; got:\n{stdout}");
+    });
+    let p = &v["points"][0];
+    assert_eq!(p["instances"].as_u64(), Some(1), "instances must be 1 (only inst-1 in sweep)");
+    assert_eq!(p["resolved"].as_u64(), Some(1), "resolved must be 1, not 2 (inst-2 not in sweep)");
+    let rate = p["resolved_rate"].as_f64().unwrap_or(f64::NAN);
+    assert!(
+        (rate - 1.0).abs() < 1e-9,
+        "resolved_rate must be 1.0, got {rate}"
+    );
+}
+
 // ─── issue #51 AC#6 – budget-exhausted exclusion flag ───────────────────────
 
 #[test]

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -1973,8 +1973,7 @@ fn compare_json_includes_cost_per_resolved_and_pareto_verdict() {
     );
     // Candidate dominates: lower cost AND higher resolved rate
     assert_eq!(
-        v["pareto_verdict"],
-        "candidate_dominates",
+        v["pareto_verdict"], "candidate_dominates",
         "candidate should dominate (better resolved rate, lower cost/resolved); got:\n{v}"
     );
 }
@@ -2135,9 +2134,7 @@ fn frontier_emits_pareto_json_with_efficient_frontier() {
     let dir_c_path = dir_c.path().to_str().unwrap();
     let dir_c_point = points
         .iter()
-        .find(|p| {
-            p["dir"].as_str().is_some_and(|d| d == dir_c_path)
-        })
+        .find(|p| p["dir"].as_str().is_some_and(|d| d == dir_c_path))
         .expect("expected dir_c point in frontier output");
     assert_eq!(
         dir_c_point["on_frontier"].as_bool(),
@@ -2160,11 +2157,7 @@ fn frontier_emits_ascii_chart_in_text_mode() {
     );
 
     let out = Command::new(binary_path())
-        .args([
-            "bench",
-            "frontier",
-            dir_a.path().to_str().unwrap(),
-        ])
+        .args(["bench", "frontier", dir_a.path().to_str().unwrap()])
         .output()
         .unwrap();
     assert!(
@@ -2175,7 +2168,9 @@ fn frontier_emits_ascii_chart_in_text_mode() {
     let stdout = String::from_utf8_lossy(&out.stdout);
     // Should have some kind of chart or table output
     assert!(
-        stdout.contains("frontier") || stdout.contains("cost_per_resolved") || stdout.contains("resolved_rate"),
+        stdout.contains("frontier")
+            || stdout.contains("cost_per_resolved")
+            || stdout.contains("resolved_rate"),
         "expected frontier output in text mode; got:\n{stdout}"
     );
 }

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -2116,7 +2116,7 @@ fn frontier_emits_pareto_json_with_efficient_frontier() {
         panic!("expected JSON from bench frontier; err={e}; got:\n{stdout}");
     });
 
-    let points = v["points"].as_array().expect("expected `points` array");
+    let points = v["points"].as_array().unwrap();
     assert_eq!(points.len(), 3, "expected 3 points (one per dir)");
 
     // dir_b should be on the frontier
@@ -2135,7 +2135,7 @@ fn frontier_emits_pareto_json_with_efficient_frontier() {
     let dir_c_point = points
         .iter()
         .find(|p| p["dir"].as_str().is_some_and(|d| d == dir_c_path))
-        .expect("expected dir_c point in frontier output");
+        .unwrap();
     assert_eq!(
         dir_c_point["on_frontier"].as_bool(),
         Some(false),

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -1189,6 +1189,7 @@ cache_creation_tokens: 0\n\
 completion_tokens: 300\n\
 cache_hit_rate: 0.0000\n\
 total_cost_usd: 0.1500\n\
+cost_per_resolved_usd: NaN\n\
 axis,bucket,n,resolved,resolved_rate\n\
 repo,unknown,2,0,0.0000\n\
 failure_category,model_api,1,0,0.0000\n\
@@ -1788,4 +1789,393 @@ fn compare_breakdown_json_includes_all_buckets_and_threshold_flag() {
             && r["delta_resolved_rate"] == 0.0
             && r["exceeds_threshold"] == false
     }));
+}
+
+// ─── RED phase: issue #51 – $/resolved-instance + Pareto view ───────────────
+
+#[test]
+fn evaluate_outputs_cost_per_resolved_usd_in_text() {
+    let sweep_dir = tempfile::tempdir().unwrap();
+    let mut r1 = submitted("a");
+    r1.cost_usd = Some(2.0);
+    let mut r2 = submitted("b");
+    r2.cost_usd = Some(4.0);
+    write_results(sweep_dir.path(), vec![r1, r2]);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "evaluate",
+            "--sweep",
+            sweep_dir.path().to_str().unwrap(),
+            "--backend",
+            "none",
+            "--cost-attribution",
+            "off",
+            "--breakdown",
+            "none",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("cost_per_resolved_usd:"),
+        "expected cost_per_resolved_usd in output; got:\n{stdout}"
+    );
+    // 2 resolved, total cost $6.00 -> $3.00/resolved (none backend never
+    // truly resolves, so cost_per_resolved should be NaN in none backend)
+    // With none backend resolved=0, so it should print NaN or a sentinel.
+    assert!(
+        stdout.contains("cost_per_resolved_usd: NaN")
+            || stdout.contains("cost_per_resolved_usd: nan"),
+        "expected NaN for cost_per_resolved_usd when backend=none; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn evaluate_cost_per_resolved_usd_correct_when_resolved_present() {
+    // Use evaluation.json to simulate resolved instances in a none-backend run.
+    let sweep_dir = tempfile::tempdir().unwrap();
+    let mut r1 = submitted("django__django-1");
+    r1.cost_usd = Some(3.0);
+    let mut r2 = submitted("django__django-2");
+    r2.cost_usd = Some(1.0);
+    let mut r3 = errored("django__django-3", FailureCategory::StepLimit);
+    r3.cost_usd = Some(2.0);
+    write_results(sweep_dir.path(), vec![r1, r2, r3]);
+
+    // Inject evaluation.json with 2 resolved
+    write_evaluation_json(
+        sweep_dir.path(),
+        &serde_json::json!({
+            "instances": [
+                {"instance_id": "django__django-1", "resolved": true, "eval_exit_reason": "resolved", "tests_passed": [], "tests_failed": []},
+                {"instance_id": "django__django-2", "resolved": true, "eval_exit_reason": "resolved", "tests_passed": [], "tests_failed": []},
+                {"instance_id": "django__django-3", "resolved": false, "eval_exit_reason": "unresolved", "tests_passed": [], "tests_failed": []}
+            ]
+        }),
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "evaluate",
+            "--sweep",
+            sweep_dir.path().to_str().unwrap(),
+            "--backend",
+            "none",
+            "--cost-attribution",
+            "off",
+            "--breakdown",
+            "none",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // none backend doesn't call sb-cli; it marks all as unresolved.
+    // The summarize() function uses eval.instances for resolved count.
+    // Since backend=none, nothing is resolved from its perspective
+    assert!(
+        stdout.contains("cost_per_resolved_usd:"),
+        "expected cost_per_resolved_usd field in output; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn compare_json_includes_cost_per_resolved_and_pareto_verdict() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+
+    // baseline: 1 resolved out of 2, cost $4.00 -> $4.00/resolved
+    let mut b1 = submitted("a");
+    b1.cost_usd = Some(4.0);
+    b1.runs = 1;
+    b1.resolved_count = 1;
+    let mut b2 = errored("b", FailureCategory::StepLimit);
+    b2.cost_usd = Some(0.0);
+    write_results(baseline_dir.path(), vec![b1, b2]);
+    write_evaluation_json(
+        baseline_dir.path(),
+        &serde_json::json!({
+            "instances": [
+                {"instance_id": "a", "resolved": true, "eval_exit_reason": "resolved", "tests_passed": [], "tests_failed": []},
+                {"instance_id": "b", "resolved": false, "eval_exit_reason": "unresolved", "tests_passed": [], "tests_failed": []}
+            ]
+        }),
+    );
+
+    // candidate: 2 resolved out of 2, cost $2.00 -> $1.00/resolved (cheaper AND better)
+    let mut c1 = submitted("a");
+    c1.cost_usd = Some(1.0);
+    c1.runs = 1;
+    c1.resolved_count = 1;
+    let mut c2 = submitted("b");
+    c2.cost_usd = Some(1.0);
+    c2.runs = 1;
+    c2.resolved_count = 1;
+    write_results(candidate_dir.path(), vec![c1, c2]);
+    write_evaluation_json(
+        candidate_dir.path(),
+        &serde_json::json!({
+            "instances": [
+                {"instance_id": "a", "resolved": true, "eval_exit_reason": "resolved", "tests_passed": [], "tests_failed": []},
+                {"instance_id": "b", "resolved": true, "eval_exit_reason": "resolved", "tests_passed": [], "tests_failed": []}
+            ]
+        }),
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+
+    // Both cost_per_resolved fields must be present
+    assert!(
+        v.get("baseline_cost_per_resolved_usd").is_some(),
+        "expected baseline_cost_per_resolved_usd in compare JSON; got:\n{v}"
+    );
+    assert!(
+        v.get("candidate_cost_per_resolved_usd").is_some(),
+        "expected candidate_cost_per_resolved_usd in compare JSON; got:\n{v}"
+    );
+    assert!(
+        v.get("cost_per_resolved_delta_usd").is_some(),
+        "expected cost_per_resolved_delta_usd in compare JSON; got:\n{v}"
+    );
+    assert!(
+        v.get("pareto_verdict").is_some(),
+        "expected pareto_verdict in compare JSON; got:\n{v}"
+    );
+    // Candidate dominates: lower cost AND higher resolved rate
+    assert_eq!(
+        v["pareto_verdict"],
+        "candidate_dominates",
+        "candidate should dominate (better resolved rate, lower cost/resolved); got:\n{v}"
+    );
+}
+
+#[test]
+fn compare_text_output_includes_pareto_verdict() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+
+    let mut b = submitted("a");
+    b.cost_usd = Some(2.0);
+    write_results(baseline_dir.path(), vec![b]);
+
+    let mut c = submitted("a");
+    c.cost_usd = Some(1.0);
+    write_results(candidate_dir.path(), vec![c]);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Pareto verdict:")
+            || stdout.contains("pareto_verdict:")
+            || stdout.contains("Cost/resolved"),
+        "expected pareto verdict in text output; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn frontier_subcommand_exists_in_help() {
+    let out = Command::new(binary_path())
+        .args(["bench", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("frontier"),
+        "expected `frontier` in `bench --help`; got:\n{stdout}"
+    );
+
+    let out = Command::new(binary_path())
+        .args(["bench", "frontier", "--help"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "bench frontier --help should succeed; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--format"),
+        "expected --format in frontier --help; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn frontier_emits_pareto_json_with_efficient_frontier() {
+    let dir_a = tempfile::tempdir().unwrap();
+    let dir_b = tempfile::tempdir().unwrap();
+    let dir_c = tempfile::tempdir().unwrap();
+
+    // dir_a: 1/2 resolved, resolved_rate 0.50
+    let mut a1 = submitted("inst-1");
+    a1.cost_usd = Some(4.0);
+    // Keep errored with default cost_usd ($0.10) so effective_cost_usd returns it directly.
+    let a2 = errored("inst-2", FailureCategory::StepLimit);
+    write_results(dir_a.path(), vec![a1, a2]);
+    write_evaluation_json(
+        dir_a.path(),
+        &serde_json::json!({"instances": [
+            {"instance_id": "inst-1", "resolved": true, "eval_exit_reason": "resolved", "tests_passed": [], "tests_failed": []},
+            {"instance_id": "inst-2", "resolved": false, "eval_exit_reason": "unresolved", "tests_passed": [], "tests_failed": []}
+        ]}),
+    );
+
+    // dir_b: 2/2 resolved, cost $2 -> cost_per_resolved $1.00, resolved_rate 1.00
+    // -> dominates dir_a (better resolved_rate AND lower cost_per_resolved)
+    let mut b1 = submitted("inst-1");
+    b1.cost_usd = Some(1.0);
+    let mut b2 = submitted("inst-2");
+    b2.cost_usd = Some(1.0);
+    write_results(dir_b.path(), vec![b1, b2]);
+    write_evaluation_json(
+        dir_b.path(),
+        &serde_json::json!({"instances": [
+            {"instance_id": "inst-1", "resolved": true, "eval_exit_reason": "resolved", "tests_passed": [], "tests_failed": []},
+            {"instance_id": "inst-2", "resolved": true, "eval_exit_reason": "resolved", "tests_passed": [], "tests_failed": []}
+        ]}),
+    );
+
+    // dir_c: 1/2 resolved, higher cost -> dominated by dir_a (same resolved_rate, lower cost)
+    let mut c1 = submitted("inst-1");
+    c1.cost_usd = Some(10.0); // clearly higher than dir_a's $4.0
+    // keep errored with its default cost so effective_cost_usd returns it directly
+    let c2 = errored("inst-2", FailureCategory::StepLimit);
+    write_results(dir_c.path(), vec![c1, c2]);
+    write_evaluation_json(
+        dir_c.path(),
+        &serde_json::json!({"instances": [
+            {"instance_id": "inst-1", "resolved": true, "eval_exit_reason": "resolved", "tests_passed": [], "tests_failed": []},
+            {"instance_id": "inst-2", "resolved": false, "eval_exit_reason": "unresolved", "tests_passed": [], "tests_failed": []}
+        ]}),
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "frontier",
+            "--format",
+            "json",
+            dir_a.path().to_str().unwrap(),
+            dir_b.path().to_str().unwrap(),
+            dir_c.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "bench frontier should succeed; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("expected JSON from bench frontier; err={e}; got:\n{stdout}");
+    });
+
+    let points = v["points"].as_array().expect("expected `points` array");
+    assert_eq!(points.len(), 3, "expected 3 points (one per dir)");
+
+    // dir_b should be on the frontier
+    let on_frontier: Vec<bool> = points
+        .iter()
+        .map(|p| p["on_frontier"].as_bool().unwrap_or(false))
+        .collect();
+    let frontier_count = on_frontier.iter().filter(|&&x| x).count();
+    // dir_b dominates both: higher resolved_rate AND lower cost_per_resolved
+    assert!(
+        frontier_count >= 1,
+        "at least one point should be on the efficient frontier"
+    );
+    // Identify dir_c by directory path
+    let dir_c_path = dir_c.path().to_str().unwrap();
+    let dir_c_point = points
+        .iter()
+        .find(|p| {
+            p["dir"].as_str().is_some_and(|d| d == dir_c_path)
+        })
+        .expect("expected dir_c point in frontier output");
+    assert_eq!(
+        dir_c_point["on_frontier"].as_bool(),
+        Some(false),
+        "dir_c (same resolved_rate as dir_a but higher cost) should NOT be on frontier; got: {dir_c_point}"
+    );
+}
+
+#[test]
+fn frontier_emits_ascii_chart_in_text_mode() {
+    let dir_a = tempfile::tempdir().unwrap();
+    let mut r = submitted("inst-1");
+    r.cost_usd = Some(2.0);
+    write_results(dir_a.path(), vec![r]);
+    write_evaluation_json(
+        dir_a.path(),
+        &serde_json::json!({"instances": [
+            {"instance_id": "inst-1", "resolved": true, "eval_exit_reason": "resolved", "tests_passed": [], "tests_failed": []}
+        ]}),
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "frontier",
+            dir_a.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "bench frontier (text mode) should succeed; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Should have some kind of chart or table output
+    assert!(
+        stdout.contains("frontier") || stdout.contains("cost_per_resolved") || stdout.contains("resolved_rate"),
+        "expected frontier output in text mode; got:\n{stdout}"
+    );
 }

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -1190,10 +1190,10 @@ completion_tokens: 300\n\
 cache_hit_rate: 0.0000\n\
 total_cost_usd: 0.1500\n\
 cost_per_resolved_usd: NaN\n\
-axis,bucket,n,resolved,resolved_rate\n\
-repo,unknown,2,0,0.0000\n\
-failure_category,model_api,1,0,0.0000\n\
-failure_category,none,1,0,0.0000\n";
+axis,bucket,n,resolved,resolved_rate,cost_per_resolved_usd\n\
+repo,unknown,2,0,0.0000,NaN\n\
+failure_category,model_api,1,0,0.0000,NaN\n\
+failure_category,none,1,0,0.0000,NaN\n";
     assert_eq!(stdout, expected);
 
     let eval_path = sweep_dir.path().join("evaluation.json");
@@ -2177,5 +2177,83 @@ fn frontier_emits_ascii_chart_in_text_mode() {
     assert!(
         stdout.contains("frontier") || stdout.contains("cost_per_resolved") || stdout.contains("resolved_rate"),
         "expected frontier output in text mode; got:\n{stdout}"
+    );
+}
+
+// ─── issue #51 AC#6 – budget-exhausted exclusion flag ───────────────────────
+
+#[test]
+fn evaluate_notes_budget_exhausted_exclusion_in_output() {
+    let sweep_dir = tempfile::tempdir().unwrap();
+    let mut normal = submitted("django__django-1");
+    normal.cost_usd = Some(2.0);
+    let mut budgeted = errored("django__django-2", FailureCategory::BudgetExhausted);
+    budgeted.cost_usd = Some(5.0);
+    write_results(sweep_dir.path(), vec![normal, budgeted]);
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "evaluate",
+            "--sweep",
+            sweep_dir.path().to_str().unwrap(),
+            "--backend",
+            "none",
+            "--breakdown",
+            "none",
+            "--cost-attribution",
+            "off",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("budget_exhausted_excluded: 1"),
+        "expected budget_exhausted_excluded note in output; got:\n{stdout}"
+    );
+}
+
+// ─── issue #51 AC#5 – cost_per_resolved_usd per breakdown slice ──────────────
+
+#[test]
+fn evaluate_breakdown_csv_includes_cost_per_resolved_usd_column() {
+    let sweep_dir = tempfile::tempdir().unwrap();
+    write_results(
+        sweep_dir.path(),
+        vec![submitted("django__django-1"), submitted("psf__requests-2")],
+    );
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "evaluate",
+            "--sweep",
+            sweep_dir.path().to_str().unwrap(),
+            "--backend",
+            "none",
+            "--breakdown",
+            "repo",
+            "--cost-attribution",
+            "off",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("axis,bucket,n,resolved,resolved_rate,cost_per_resolved_usd"),
+        "expected cost_per_resolved_usd column in breakdown header; got:\n{stdout}"
+    );
+    // none backend → nothing resolved → all buckets are NaN
+    assert!(
+        stdout.contains("NaN"),
+        "expected NaN for zero-resolved bucket; got:\n{stdout}"
     );
 }

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -2215,8 +2215,16 @@ fn frontier_resolved_count_capped_to_sweep_instance_ids() {
         panic!("expected JSON; err={e}; got:\n{stdout}");
     });
     let p = &v["points"][0];
-    assert_eq!(p["instances"].as_u64(), Some(1), "instances must be 1 (only inst-1 in sweep)");
-    assert_eq!(p["resolved"].as_u64(), Some(1), "resolved must be 1, not 2 (inst-2 not in sweep)");
+    assert_eq!(
+        p["instances"].as_u64(),
+        Some(1),
+        "instances must be 1 (only inst-1 in sweep)"
+    );
+    assert_eq!(
+        p["resolved"].as_u64(),
+        Some(1),
+        "resolved must be 1, not 2 (inst-2 not in sweep)"
+    );
     let rate = p["resolved_rate"].as_f64().unwrap_or(f64::NAN);
     assert!(
         (rate - 1.0).abs() < 1e-9,


### PR DESCRIPTION
## Summary
This PR implements issue #51 by adding a new efficiency metric `cost_per_resolved_usd` (cost per successfully resolved instance) and a new `bench frontier` subcommand for Pareto-frontier analysis across multiple sweep runs.

## Key Changes

### Core Metric: `cost_per_resolved_usd`
- Added `cost_per_resolved_usd` field to `EvaluationSummary` with 95% bootstrap confidence intervals
- Computed as `total_cost_usd / resolved_count`, returning `NaN` when no instances resolve
- Excludes budget-exhausted instances from the calculation to avoid mixing capped and uncapped runs
- Added `budget_exhausted_excluded` counter to track excluded instances

### Breakdown Analysis
- Extended `BreakdownBucket` with optional `cost_per_resolved_usd` per slice (repo, failure category, etc.)
- Updated CSV rendering to include the new column with `NaN` for zero-resolved buckets
- Budget-exhausted instances excluded from per-bucket calculations as well

### Compare Report Enhancement
- Added `baseline_cost_per_resolved_usd`, `candidate_cost_per_resolved_usd`, and `cost_per_resolved_delta_usd` fields
- Implemented `ParetoVerdict` enum to classify dominance relationships:
  - `candidate_dominates`: candidate has higher resolved rate AND lower cost/resolved
  - `baseline_dominates`: baseline has higher resolved rate AND lower cost/resolved
  - `non_dominated`: trade-off between the two metrics
- Updated text and JSON output to display Pareto verdict alongside cost comparisons

### New `bench frontier` Subcommand
- Analyzes multiple sweep directories to identify the efficient frontier
- Computes `(resolved_rate, cost_per_resolved_usd)` for each sweep
- Marks points on the Pareto frontier (no other point dominates them)
- Outputs in two formats:
  - **Text mode**: ASCII table with frontier markers and scatter chart visualization
  - **JSON mode**: Structured data with all metrics and frontier flags for downstream plotting
- Handles edge cases: NaN costs when resolved=0, all-NaN scenarios

### Implementation Details
- Bootstrap CI calculation uses 1000 resamples with LCG-based PRNG for reproducibility
- Dominance comparison uses `f64::EPSILON` for floating-point tolerance
- Efficient frontier algorithm: O(n²) pairwise dominance checks
- ASCII chart renders resolved_rate (Y-axis) vs cost_per_resolved_usd (X-axis) with `*` for frontier points and `o` for dominated points

### Test Coverage
- Added 10+ integration tests covering:
  - Cost per resolved calculation with zero/non-zero resolved counts
  - Budget-exhausted instance exclusion
  - Per-bucket cost metrics
  - Pareto verdict computation
  - Frontier detection and rendering (JSON and text)
  - Edge cases (all NaN, single point, etc.)

https://claude.ai/code/session_013YNY1WA513W6HsdmfKTAn7