### PR TITLE
feat(redaction): bury secrets before they reach daylight

### DIFF
--- a/docs/spec-secret-redaction.md
+++ b/docs/spec-secret-redaction.md
@@ -1,0 +1,33 @@
+# Secret Redaction Contract
+
+`rust-swe-agent` redacts secrets by default before content reaches model-visible observations, saved trajectories, live streams, `bench inspect`, Markdown/CSV/Mermaid exports, GitHub PR text built from artifacts, and SWE-bench prediction files.
+
+## Threat Model
+
+The redactor is designed for local and CI agent runs where useful debugging artifacts may be shared with teammates, issues, PRs, or evaluation tooling. It masks:
+
+* configured literal secrets for the run;
+* custom regex pattern matches for the run;
+* current-process environment variable values whose names contain `TOKEN`, `SECRET`, `KEY`, `PASSWORD`, or `CREDENTIAL`;
+* common structured shapes such as bearer tokens, GitHub tokens, API keys, and PEM private-key blocks;
+* `.env`-style assignments whose names look sensitive.
+
+Markers are stable within a run, so repeated occurrences of the same secret get the same marker. The marker uses a salted digest and a coarse size class (`short`, `medium`, `long`); it does not include the raw value or exact length.
+
+## Configuration
+
+```toml
+[redaction]
+enabled = true
+secret_literals = ["actual-token-value"]
+custom_patterns = ["INTERNAL-TOKEN-[A-Za-z0-9]{24}"]
+unsafe_allow_secret_leaks = false
+```
+
+Disabling redaction is a run-time decision (`enabled = false` in the run config). `bench inspect` has no flag to print raw secrets from stored artifacts.
+
+If a submitted patch or prediction artifact contains a configured literal or structured secret shape, the run is downgraded to `failure_category = "secret_leak_detected"` unless `unsafe_allow_secret_leaks = true`.
+
+## Limitations
+
+This is deterministic masking for known values and structured secrets, not an enterprise DLP system. It does not provide semantic PII detection, license scanning, retroactive rewriting of old artifacts, or a guarantee that a model cannot infer a secret from surrounding context.

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -176,7 +176,7 @@ impl DefaultAgentBuilder {
         })?;
 
         let mut trajectory = Trajectory::new();
-        trajectory.info.task = Some(self.task.clone());
+        trajectory.info.task = Some(redactor.redact_text(&self.task, surface::TRAJECTORY).text);
         trajectory.info.model_name = Some(self.model.name().to_owned());
         trajectory.info.started_at = Some(started_at.clone());
         for m in &history {

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -131,6 +131,7 @@ pub struct DefaultAgent {
     pub stream: Arc<dyn StreamSink>,
     pub redactor: Redactor,
     pub cancellation: Option<CancellationToken>,
+    raw_task: String,
     test_command_patterns: Vec<TestCommandPattern>,
 }
 
@@ -219,6 +220,7 @@ impl DefaultAgentBuilder {
             stream,
             redactor,
             cancellation: None,
+            raw_task: self.task,
             test_command_patterns,
         })
     }
@@ -914,7 +916,6 @@ impl DefaultAgent {
         command: &str,
         result: Option<&RunResult>,
     ) -> serde_json::Value {
-        let task = self.trajectory.info.task.as_deref().unwrap_or_default();
         let model = self
             .trajectory
             .info
@@ -936,7 +937,7 @@ impl DefaultAgent {
             "tool": {
                 "name": "bash",
             },
-            "task": task,
+            "task": self.raw_task,
             "model": model,
             "step": self.steps,
             "command": command,

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -20,6 +20,7 @@ use crate::config::{Config, ToolHookCfg};
 use crate::env::{CancellationToken, Environment, RunRequest, RunResult};
 use crate::error::Error;
 use crate::model::{CacheHint, Message, MessageExtra, Model, ModelResponse, QueryOpts, Role};
+use crate::redaction::{RedactingSink, Redactor, surface};
 use crate::stream::{NullSink, StreamEvent, StreamSink};
 use crate::template::Renderer;
 use crate::trajectory::{
@@ -128,6 +129,7 @@ pub struct DefaultAgent {
     /// Real-time event sink. Defaults to `NullSink` so non-streaming
     /// callers pay no cost beyond a vtable call.
     pub stream: Arc<dyn StreamSink>,
+    pub redactor: Redactor,
     pub cancellation: Option<CancellationToken>,
     test_command_patterns: Vec<TestCommandPattern>,
 }
@@ -167,15 +169,24 @@ impl DefaultAgentBuilder {
         ];
 
         let started_at = chrono::Utc::now().to_rfc3339();
+        let redactor = Redactor::from_config(&self.config.root.redaction).map_err(|err| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "invalid redaction config: {err}"
+            )))
+        })?;
+
         let mut trajectory = Trajectory::new();
         trajectory.info.task = Some(self.task.clone());
         trajectory.info.model_name = Some(self.model.name().to_owned());
         trajectory.info.started_at = Some(started_at.clone());
         for m in &history {
-            trajectory.record_message(m);
+            record_redacted_message(&mut trajectory, m, m.extra.clone(), &redactor);
         }
 
-        let stream: Arc<dyn StreamSink> = self.stream.unwrap_or_else(|| Arc::new(NullSink));
+        let stream: Arc<dyn StreamSink> = self.stream.map_or_else(
+            || Arc::new(NullSink) as Arc<dyn StreamSink>,
+            |sink| Arc::new(RedactingSink::new(sink, redactor.clone())) as Arc<dyn StreamSink>,
+        );
         let test_command_patterns = effective_test_command_patterns(
             &self.config.root.agent.test_command_patterns,
             self.config.root.agent.test_command_patterns_replace,
@@ -206,6 +217,7 @@ impl DefaultAgentBuilder {
             cache_creation_tokens: 0,
             completion_tokens: 0,
             stream,
+            redactor,
             cancellation: None,
             test_command_patterns,
         })
@@ -251,6 +263,41 @@ async fn query_model_until_cancelled(
         result = model.query(history, opts) => result.map(Some),
         () = cancellation.cancelled() => Ok(None),
     }
+}
+
+fn record_redacted_message(
+    trajectory: &mut Trajectory,
+    message: &Message,
+    extra: MessageExtra,
+    redactor: &Redactor,
+) {
+    let mut redacted = message.clone();
+    redacted.content = redactor
+        .redact_text(&message.content, surface::TRAJECTORY)
+        .text;
+    trajectory.record_with_extra(
+        &redacted,
+        redact_message_extra(extra, redactor, surface::TRAJECTORY),
+    );
+}
+
+fn redact_message_extra(
+    mut extra: MessageExtra,
+    redactor: &Redactor,
+    surface_name: &str,
+) -> MessageExtra {
+    if let Some(actions) = &mut extra.actions {
+        for action in actions {
+            *action = redactor.redact_text(action, surface_name).text;
+        }
+    }
+    if let Some(response) = &mut extra.response {
+        redactor.redact_json_value(response, surface_name);
+    }
+    for value in extra.other.values_mut() {
+        redactor.redact_json_value(value, surface_name);
+    }
+    extra
 }
 
 #[async_trait]
@@ -369,18 +416,28 @@ impl Agent for DefaultAgent {
         match &action {
             Action::Submit(output) => {
                 asst.extra.actions = Some(vec!["__SUBMIT__".into()]);
-                self.history.push(Message::assistant(resp.content.clone()));
-                self.trajectory.record_message(&asst);
+                self.history.push(Message::assistant(
+                    self.redactor
+                        .redact_text(&resp.content, surface::MODEL_OBSERVATION)
+                        .text,
+                ));
+                record_redacted_message(
+                    &mut self.trajectory,
+                    &asst,
+                    asst.extra.clone(),
+                    &self.redactor,
+                );
+                let final_output = self.redactor.redact_text(output, surface::TRAJECTORY).text;
                 self.trajectory.info.exit_reason = Some("submitted".into());
                 self.trajectory.info.failure_category = None;
-                self.trajectory.info.final_output = Some(output.clone());
+                self.trajectory.info.final_output = Some(final_output.clone());
                 self.trajectory.info.steps = Some(self.steps);
                 self.trajectory.info.total_cost_usd = Some(self.total_cost_usd);
                 self.trajectory.info.ended_at = Some(chrono::Utc::now().to_rfc3339());
                 self.finalize_run_metadata(outcome::SUBMITTED);
                 self.emit_run_ended("submitted", None, Some(output.clone()));
                 return Ok(StepOutcome::Terminate(ExitReason::Submitted {
-                    final_output: output.clone(),
+                    final_output,
                 }));
             }
             Action::Bash(cmd) => {
@@ -395,8 +452,17 @@ impl Agent for DefaultAgent {
                     .info
                     .failure_category
                     .get_or_insert(FailureCategory::ModelParse);
-                self.history.push(Message::assistant(resp.content.clone()));
-                self.trajectory.record_message(&asst);
+                self.history.push(Message::assistant(
+                    self.redactor
+                        .redact_text(&resp.content, surface::MODEL_OBSERVATION)
+                        .text,
+                ));
+                record_redacted_message(
+                    &mut self.trajectory,
+                    &asst,
+                    asst.extra.clone(),
+                    &self.redactor,
+                );
                 // Observation = format_error_template, verbatim (no vars in
                 // default template, but we still render to pick up any
                 // future placeholders).
@@ -409,9 +475,18 @@ impl Agent for DefaultAgent {
                     content: err.clone(),
                     timestamp: chrono::Utc::now().to_rfc3339(),
                 });
-                let obs = Message::user(err);
+                let obs = Message::user(
+                    self.redactor
+                        .redact_text(&err, surface::MODEL_OBSERVATION)
+                        .text,
+                );
                 self.history.push(obs.clone());
-                self.trajectory.record_message(&obs);
+                record_redacted_message(
+                    &mut self.trajectory,
+                    &obs,
+                    obs.extra.clone(),
+                    &self.redactor,
+                );
                 self.steps += 1;
                 return Ok(StepOutcome::Continue);
             }
@@ -475,13 +550,38 @@ impl Agent for DefaultAgent {
             self.record_test_invocation_if_matched(&cmd, result.exit_code);
         }
 
+        let result_for_observation = RunResult {
+            stdout: self
+                .redactor
+                .redact_text(&result.stdout, surface::MODEL_OBSERVATION)
+                .text,
+            stderr: self
+                .redactor
+                .redact_text(&result.stderr, surface::MODEL_OBSERVATION)
+                .text,
+            exit_code: result.exit_code,
+            timed_out: result.timed_out,
+        };
+        let result_for_trajectory = RunResult {
+            stdout: self
+                .redactor
+                .redact_text(&result.stdout, surface::TRAJECTORY)
+                .text,
+            stderr: self
+                .redactor
+                .redact_text(&result.stderr, surface::TRAJECTORY)
+                .text,
+            exit_code: result.exit_code,
+            timed_out: result.timed_out,
+        };
+
         let trunc_stdout = truncate_observation_text(
-            &result.stdout,
+            &result_for_observation.stdout,
             self.config.root.agent.observation_max_bytes,
             self.config.root.agent.observation_head_ratio,
         );
         let trunc_stderr = truncate_observation_text(
-            &result.stderr,
+            &result_for_observation.stderr,
             self.config.root.agent.observation_max_bytes,
             self.config.root.agent.observation_head_ratio,
         );
@@ -496,16 +596,28 @@ impl Agent for DefaultAgent {
             self.config.root.agent.observation_max_bytes,
             self.config.root.agent.observation_head_ratio,
         );
-        let pre_hook_results_for_observation = truncate_hook_results_for_observation(
-            &pre_hook_results,
-            self.config.root.agent.observation_max_bytes,
-            self.config.root.agent.observation_head_ratio,
+        let pre_hook_results_for_observation = redact_hook_results_for_surface(
+            truncate_hook_results_for_observation(
+                &pre_hook_results,
+                self.config.root.agent.observation_max_bytes,
+                self.config.root.agent.observation_head_ratio,
+            ),
+            &self.redactor,
+            surface::MODEL_OBSERVATION,
         );
-        let post_hook_results_for_observation = truncate_hook_results_for_observation(
-            &post_hook_results,
-            self.config.root.agent.observation_max_bytes,
-            self.config.root.agent.observation_head_ratio,
+        let post_hook_results_for_observation = redact_hook_results_for_surface(
+            truncate_hook_results_for_observation(
+                &post_hook_results,
+                self.config.root.agent.observation_max_bytes,
+                self.config.root.agent.observation_head_ratio,
+            ),
+            &self.redactor,
+            surface::MODEL_OBSERVATION,
         );
+        let cmd_for_observation = self
+            .redactor
+            .redact_text(&cmd, surface::MODEL_OBSERVATION)
+            .text;
         // 6. Render observation.
         let obs_text = self.renderer.render_str(
             &self.config.root.agent.observation_template,
@@ -515,7 +627,7 @@ impl Agent for DefaultAgent {
                 "stdout": trunc_stdout.text,
                 "stderr": trunc_stderr.text,
                 "timed_out": result.timed_out,
-                "command": cmd,
+                "command": cmd_for_observation,
                 "step": self.steps,
                 "tool_use_blocked": tool_use_blocked,
                 "pre_tool_use_hooks": pre_hook_results_for_observation,
@@ -527,8 +639,17 @@ impl Agent for DefaultAgent {
         let obs_text = self.append_budget_block(obs_text)?;
 
         // Record assistant turn in history & trajectory.
-        self.history.push(Message::assistant(resp.content.clone()));
-        self.trajectory.record_message(&asst);
+        self.history.push(Message::assistant(
+            self.redactor
+                .redact_text(&resp.content, surface::MODEL_OBSERVATION)
+                .text,
+        ));
+        record_redacted_message(
+            &mut self.trajectory,
+            &asst,
+            asst.extra.clone(),
+            &self.redactor,
+        );
 
         // Record user observation.
         let obs_ts = chrono::Utc::now().to_rfc3339();
@@ -537,16 +658,20 @@ impl Agent for DefaultAgent {
         let mut obs_extra = MessageExtra::default();
         obs_extra.other.insert(
             "run_result".into(),
-            serde_json::to_value(&result).unwrap_or(serde_json::Value::Null),
+            serde_json::to_value(&result_for_trajectory).unwrap_or(serde_json::Value::Null),
         );
-        obs_extra.other.insert(
-            "pre_tool_use_hooks".into(),
-            serde_json::to_value(&pre_hook_results)?,
-        );
-        obs_extra.other.insert(
-            "post_tool_use_hooks".into(),
-            serde_json::to_value(&post_hook_results)?,
-        );
+        let mut pre_hook_value = serde_json::to_value(&pre_hook_results)?;
+        self.redactor
+            .redact_json_value(&mut pre_hook_value, surface::TRAJECTORY);
+        obs_extra
+            .other
+            .insert("pre_tool_use_hooks".into(), pre_hook_value);
+        let mut post_hook_value = serde_json::to_value(&post_hook_results)?;
+        self.redactor
+            .redact_json_value(&mut post_hook_value, surface::TRAJECTORY);
+        obs_extra
+            .other
+            .insert("post_tool_use_hooks".into(), post_hook_value);
         obs_extra.other.insert(
             "tool_use_blocked".into(),
             serde_json::Value::Bool(tool_use_blocked),
@@ -570,7 +695,7 @@ impl Agent for DefaultAgent {
             serde_json::json!(trunc_output.bytes_omitted),
         );
         obs_extra.timestamp = Some(obs_ts.clone());
-        self.trajectory.record_with_extra(&obs_msg, obs_extra);
+        record_redacted_message(&mut self.trajectory, &obs_msg, obs_extra, &self.redactor);
 
         self.stream.emit(StreamEvent::Observation {
             step: self.steps,
@@ -595,7 +720,7 @@ impl DefaultAgent {
     }
 
     fn emit_run_ended(
-        &self,
+        &mut self,
         exit_reason: &str,
         failure_category: Option<FailureCategory>,
         final_output: Option<String>,
@@ -608,6 +733,7 @@ impl DefaultAgent {
             total_cost_usd: self.total_cost_usd,
             ended_at: chrono::Utc::now().to_rfc3339(),
         });
+        self.trajectory.info.redaction = Some(self.redactor.summary());
     }
 
     /// Stamp the trajectory with the coarse `outcome`, accumulated
@@ -623,6 +749,7 @@ impl DefaultAgent {
             completion_tokens: self.completion_tokens,
         });
         self.trajectory.info.duration_secs = Some(self.started_at_instant.elapsed().as_secs_f64());
+        self.trajectory.info.redaction = Some(self.redactor.summary());
         self.refresh_test_metadata();
     }
 
@@ -684,7 +811,7 @@ impl DefaultAgent {
         if let Some(matched_pattern) = detect_test_command(command, &self.test_command_patterns) {
             self.trajectory.info.test_invocations.push(TestInvocation {
                 step_index: self.steps,
-                command: command.to_owned(),
+                command: self.redactor.redact_text(command, surface::TRAJECTORY).text,
                 exit_code,
                 matched_pattern,
             });
@@ -858,6 +985,26 @@ fn truncate_hook_results_for_observation(
     results
         .iter()
         .map(|result| result.truncated_for_observation(max_bytes, head_ratio))
+        .collect()
+}
+
+fn redact_hook_results_for_surface(
+    results: Vec<ToolHookResult>,
+    redactor: &Redactor,
+    surface_name: &str,
+) -> Vec<ToolHookResult> {
+    results
+        .into_iter()
+        .map(|result| ToolHookResult {
+            phase: result.phase,
+            name: result.name,
+            command: redactor.redact_text(&result.command, surface_name).text,
+            stdout: redactor.redact_text(&result.stdout, surface_name).text,
+            stderr: redactor.redact_text(&result.stderr, surface_name).text,
+            output: redactor.redact_text(&result.output, surface_name).text,
+            exit_code: result.exit_code,
+            timed_out: result.timed_out,
+        })
         .collect()
 }
 

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -637,6 +637,10 @@ impl Agent for DefaultAgent {
 
         // 6b. Optionally append the budget block.
         let obs_text = self.append_budget_block(obs_text)?;
+        let obs_text = self
+            .redactor
+            .redact_text(&obs_text, surface::MODEL_OBSERVATION)
+            .text;
 
         // Record assistant turn in history & trajectory.
         self.history.push(Message::assistant(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -405,7 +405,7 @@ fn validate_observation_head_ratio(value: f64) -> Result<(), Error> {
 
 fn mini_github_pr_options(
     m: &args::MiniCmd,
-    _cfg: &Config,
+    cfg: &Config,
     trajectory_name: &str,
 ) -> Result<Option<crate::run::github_pr::GithubPrOptions>, Error> {
     if !m.github_pr.open_pr && !m.github_pr.github_pr_dry_run {
@@ -434,6 +434,7 @@ fn mini_github_pr_options(
         timeout_secs: m.github_pr.github_pr_timeout_secs,
         max_retries: m.github_pr.github_pr_max_retries,
         backoff_base_ms: m.github_pr.github_pr_backoff_base_ms,
+        redaction: cfg.root.redaction.clone(),
     }))
 }
 
@@ -1053,6 +1054,7 @@ mod tests {
             timeout_secs: 30,
             max_retries: 2,
             backoff_base_ms: 250,
+            redaction: crate::config::RedactionCfg::default(),
         }))
         .await
         .unwrap();
@@ -1219,6 +1221,7 @@ mod tests {
             timeout_secs: 30,
             max_retries: 2,
             backoff_base_ms: 250,
+            redaction: crate::config::RedactionCfg::default(),
         }
     }
 

--- a/src/config/defaults/default.toml
+++ b/src/config/defaults/default.toml
@@ -101,6 +101,22 @@ workdir = "/workspace"
 # Maps to --max-input-tpm on the CLI. CLI value always wins over this key.
 # max_input_tpm = 400000
 
+[redaction]
+# Secret redaction is enabled by default for trajectories, model-visible
+# observations, streams, inspect/export output, and submission artifacts.
+enabled = true
+#
+# Add per-run literals and regexes here or in an overlay config. Literal values
+# are redacted from resolved config manifests before they are written.
+# secret_literals = ["actual-token-value"]
+# custom_patterns = ["INTERNAL-TOKEN-[A-Za-z0-9]{24}"]
+#
+# Unsafe escape hatch: when false, submitted patches/prediction artifacts that
+# contain configured literals or structured secret shapes are downgraded to
+# failure_category = "secret_leak_detected". Leave this off unless you are
+# intentionally producing a private, non-shareable artifact.
+unsafe_allow_secret_leaks = false
+
 [prompts]
 system = '''
 You are a skilled software engineer working at a terminal. You have

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,8 +12,8 @@ use crate::error::ConfigError;
 pub mod schema;
 
 pub use schema::{
-    AgentCfg, AgentKind, EnvCfg, EnvKind, ModelCfg, PromptCfg, RootCfg, SweepCfg, ToolHookCfg,
-    ToolHooksCfg,
+    AgentCfg, AgentKind, EnvCfg, EnvKind, ModelCfg, PromptCfg, RedactionCfg, RootCfg, SweepCfg,
+    ToolHookCfg, ToolHooksCfg,
 };
 
 const DEFAULT_TOML: &str = include_str!("defaults/default.toml");
@@ -63,6 +63,13 @@ fn validate_test_command_patterns(root: &RootCfg) -> Result<(), ConfigError> {
         Regex::new(pattern).map_err(|err| {
             ConfigError::Invalid(format!(
                 "invalid agent.test_command_patterns regex {pattern:?}: {err}"
+            ))
+        })?;
+    }
+    for pattern in &root.redaction.custom_patterns {
+        Regex::new(pattern).map_err(|err| {
+            ConfigError::Invalid(format!(
+                "invalid redaction.custom_patterns regex {pattern:?}: {err}"
             ))
         })?;
     }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -159,6 +159,41 @@ pub struct SweepCfg {
     pub max_input_tpm: Option<u64>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RedactionCfg {
+    /// Enable runtime redaction before observations, trajectories, streams,
+    /// exports, and shareable artifacts are persisted or emitted.
+    #[serde(default = "default_redaction_enabled")]
+    pub enabled: bool,
+    /// Explicit literal values to redact for this run. Values are used at run
+    /// time only and are themselves redacted from exported config manifests.
+    #[serde(default)]
+    pub secret_literals: Vec<String>,
+    /// Extra regex patterns whose full matches are redacted for this run.
+    #[serde(default)]
+    pub custom_patterns: Vec<String>,
+    /// Unsafe escape hatch: allow submitted patch/prediction artifacts to
+    /// contain configured secret literals. Redaction remains enabled unless
+    /// `enabled = false` is also set.
+    #[serde(default)]
+    pub unsafe_allow_secret_leaks: bool,
+}
+
+impl Default for RedactionCfg {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            secret_literals: Vec::new(),
+            custom_patterns: Vec::new(),
+            unsafe_allow_secret_leaks: false,
+        }
+    }
+}
+
+const fn default_redaction_enabled() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RootCfg {
     #[serde(default)]
@@ -171,6 +206,8 @@ pub struct RootCfg {
     pub prompts: PromptCfg,
     #[serde(default)]
     pub sweep: SweepCfg,
+    #[serde(default)]
+    pub redaction: RedactionCfg,
     /// Optional `extends: <path>` field — handled before serde sees this
     /// struct, but we accept/ignore it here for round-tripping.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -362,7 +362,7 @@ mod tests {
     fn successful_container_removal_marks_shutdown_sent() {
         let env = test_env();
 
-        env.mark_shutdown_after_remove(Ok(())).unwrap();
+        assert!(env.mark_shutdown_after_remove(Ok(())).is_ok());
 
         assert!(env.shutdown_sent.load(Ordering::SeqCst));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,14 @@ pub mod env;
 pub mod error;
 pub mod ids;
 pub mod model;
+pub mod redaction;
 pub mod run;
 pub mod stream;
 pub mod template;
 pub mod trajectory;
 
 pub use agent::{Agent, DefaultAgent, ExitReason, InteractiveAgent, StepOutcome};
-pub use config::{Config, ToolHookCfg, ToolHooksCfg};
+pub use config::{Config, RedactionCfg, ToolHookCfg, ToolHooksCfg};
 #[cfg(feature = "docker")]
 pub use env::DockerEnvironment;
 pub use env::{Environment, LocalEnvironment, RunRequest, RunResult};
@@ -24,6 +25,7 @@ pub use model::{
     AnthropicBackend, CacheHint, DeterministicModel, LitellmBackend, Message, MessageExtra, Model,
     ModelResponse, ModelUsage, QueryOpts, Role,
 };
+pub use redaction::{RedactionCount, RedactionSummary, Redactor};
 pub use stream::{BroadcastSink, NullSink, SseServer, StreamEvent, StreamSink};
 pub use trajectory::{
     FORMAT_VERSION, FailureCategory, MessageRecord, TestInvocation, TokenUsage, Trajectory,

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -87,6 +87,9 @@ enum RuleMatcher {
         regex: Regex,
         capture_group: Option<usize>,
     },
+    EnvAssignment {
+        regex: Regex,
+    },
 }
 
 #[derive(Debug)]
@@ -332,6 +335,21 @@ impl Redactor {
                         }
                     }
                 }
+                RuleMatcher::EnvAssignment { regex } => {
+                    for captures in regex.captures_iter(input) {
+                        let (Some(name), Some(value)) = (captures.get(1), captures.get(2)) else {
+                            continue;
+                        };
+                        if env_name_is_sensitive(name.as_str()) && value.start() < value.end() {
+                            out.push(RedactionMatch {
+                                start: value.start(),
+                                end: value.end(),
+                                kind: rule.kind.clone(),
+                                raw: value.as_str().to_owned(),
+                            });
+                        }
+                    }
+                }
             }
         }
         out
@@ -543,29 +561,20 @@ fn default_rules() -> Result<Vec<RedactionRule>, regex::Error> {
         },
         RedactionRule {
             kind: KIND_ENV_ASSIGNMENT.to_owned(),
-            matcher: RuleMatcher::Regex {
-                regex: Regex::new(
-                    r#"(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*\s*=\s*)([^ \t\r\n'"]{4,})"#,
-                )?,
-                capture_group: Some(2),
+            matcher: RuleMatcher::EnvAssignment {
+                regex: Regex::new(r#"(?i)\b([A-Z0-9_-]+)\s*=\s*([^ \t\r\n'"]{4,})"#)?,
             },
         },
         RedactionRule {
             kind: KIND_ENV_ASSIGNMENT.to_owned(),
-            matcher: RuleMatcher::Regex {
-                regex: Regex::new(
-                    r#"(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*\s*=\s*")([^"\r\n]{4,})"#,
-                )?,
-                capture_group: Some(2),
+            matcher: RuleMatcher::EnvAssignment {
+                regex: Regex::new(r#"(?i)\b([A-Z0-9_-]+)\s*=\s*"([^"\r\n]{4,})"#)?,
             },
         },
         RedactionRule {
             kind: KIND_ENV_ASSIGNMENT.to_owned(),
-            matcher: RuleMatcher::Regex {
-                regex: Regex::new(
-                    r#"(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*\s*=\s*')([^'\r\n]{4,})"#,
-                )?,
-                capture_group: Some(2),
+            matcher: RuleMatcher::EnvAssignment {
+                regex: Regex::new(r#"(?i)\b([A-Z0-9_-]+)\s*=\s*'([^'\r\n]{4,})"#)?,
             },
         },
     ])
@@ -757,6 +766,44 @@ mod tests {
         assert!(env_literal_kind("API_TOKEN", "abc").is_none());
         assert_eq!(env_literal_kind("API_TOKEN", "abcd"), Some("env_token"));
         assert!(env_literal_kind("KEYBOARD_LAYOUT", "us").is_none());
+    }
+
+    #[test]
+    fn env_assignment_redaction_ignores_key_substrings() {
+        let redactor = Redactor::default_enabled();
+
+        let outcome = redactor.redact_text(
+            "MONKEY=abcd\nKEYBOARD_LAYOUT=uspc\nAPI_KEY=secret-value\nGITHUB_TOKEN=\"quoted-token-value\"\n",
+            surface::TRAJECTORY,
+        );
+
+        assert!(outcome.redacted, "expected sensitive assignments to redact");
+        assert!(
+            outcome.text.contains("MONKEY=abcd"),
+            "benign KEY substring was redacted: {}",
+            outcome.text
+        );
+        assert!(
+            outcome.text.contains("KEYBOARD_LAYOUT=uspc"),
+            "ordinary key-containing name was redacted: {}",
+            outcome.text
+        );
+        assert!(
+            !outcome.text.contains("secret-value"),
+            "API_KEY value leaked: {}",
+            outcome.text
+        );
+        assert!(
+            !outcome.text.contains("quoted-token-value"),
+            "GITHUB_TOKEN value leaked: {}",
+            outcome.text
+        );
+        assert!(outcome.text.contains("API_KEY=[REDACTED:env_assignment:"));
+        assert!(
+            outcome
+                .text
+                .contains("GITHUB_TOKEN=\"[REDACTED:env_assignment:")
+        );
     }
 
     #[test]

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -562,19 +562,25 @@ fn default_rules() -> Result<Vec<RedactionRule>, regex::Error> {
         RedactionRule {
             kind: KIND_ENV_ASSIGNMENT.to_owned(),
             matcher: RuleMatcher::EnvAssignment {
-                regex: Regex::new(r#"(?i)\b([A-Z0-9_-]+)\s*=\s*([^ \t\r\n'"]{4,})"#)?,
+                regex: Regex::new(
+                    r#"(?m)^[+\- ]?(?:export\s+)?([A-Z][A-Z0-9_-]*)\s*=\s*([^ \t\r\n'";]{4,})[ \t]*(?:#.*)?$"#,
+                )?,
             },
         },
         RedactionRule {
             kind: KIND_ENV_ASSIGNMENT.to_owned(),
             matcher: RuleMatcher::EnvAssignment {
-                regex: Regex::new(r#"(?i)\b([A-Z0-9_-]+)\s*=\s*"([^"\r\n]{4,})"#)?,
+                regex: Regex::new(
+                    r#"(?m)^[+\- ]?(?:export\s+)?([A-Z][A-Z0-9_-]*)\s*=\s*"([^"\r\n]{4,})"[ \t]*(?:#.*)?$"#,
+                )?,
             },
         },
         RedactionRule {
             kind: KIND_ENV_ASSIGNMENT.to_owned(),
             matcher: RuleMatcher::EnvAssignment {
-                regex: Regex::new(r#"(?i)\b([A-Z0-9_-]+)\s*=\s*'([^'\r\n]{4,})"#)?,
+                regex: Regex::new(
+                    r#"(?m)^[+\- ]?(?:export\s+)?([A-Z][A-Z0-9_-]*)\s*=\s*'([^'\r\n]{4,})'[ \t]*(?:#.*)?$"#,
+                )?,
             },
         },
     ])
@@ -803,6 +809,40 @@ mod tests {
             outcome
                 .text
                 .contains("GITHUB_TOKEN=\"[REDACTED:env_assignment:")
+        );
+    }
+
+    #[test]
+    fn env_assignment_redaction_ignores_lowercase_source_assignments() {
+        let redactor = Redactor::default_enabled();
+
+        let patch =
+            "+let key = \"name\";\n+api_key = \"test\";\n+token = \"none\";\n+API_KEY = test;\n";
+        let outcome = redactor.redact_text(patch, surface::PATCH_SUBMISSION);
+
+        assert!(
+            !outcome.redacted,
+            "ordinary source assignments should not be redacted:\n{}",
+            outcome.text
+        );
+        assert_eq!(outcome.text, patch);
+    }
+
+    #[test]
+    fn env_assignment_redaction_detects_env_style_patch_lines() {
+        let redactor = Redactor::default_enabled();
+
+        let outcome = redactor.redact_text(
+            "+API_KEY=secret-value\n+export GITHUB_TOKEN=\"quoted-token-value\"\n",
+            surface::PATCH_SUBMISSION,
+        );
+
+        assert!(outcome.redacted, "expected env-style assignments to redact");
+        assert!(!outcome.text.contains("secret-value"), "{}", outcome.text);
+        assert!(
+            !outcome.text.contains("quoted-token-value"),
+            "{}",
+            outcome.text
         );
     }
 

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -4,7 +4,7 @@
 //! common structured secret shapes, and current-process environment values
 //! with sensitive names before text reaches persisted or shareable surfaces.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex, PoisonError};
 
 use regex::Regex;
@@ -101,26 +101,29 @@ impl Redactor {
     pub fn from_config(cfg: &RedactionCfg) -> Result<Self, regex::Error> {
         let mut rules = Vec::new();
         let mut blocking_literals = Vec::new();
+        let mut seen_literals = BTreeSet::new();
 
         if cfg.enabled {
             for literal in cfg.secret_literals.iter().filter(|value| !value.is_empty()) {
-                rules.push(RedactionRule {
-                    kind: KIND_CONFIGURED_LITERAL.to_owned(),
-                    matcher: RuleMatcher::Literal(literal.clone()),
-                });
-                blocking_literals.push(literal.clone());
+                push_literal_rule(
+                    &mut rules,
+                    &mut blocking_literals,
+                    &mut seen_literals,
+                    KIND_CONFIGURED_LITERAL,
+                    literal.clone(),
+                );
             }
 
             for (name, value) in std::env::vars() {
-                if value.is_empty() || !env_name_is_sensitive(&name) {
-                    continue;
+                if let Some(kind) = env_literal_kind(&name, &value) {
+                    push_literal_rule(
+                        &mut rules,
+                        &mut blocking_literals,
+                        &mut seen_literals,
+                        kind,
+                        value,
+                    );
                 }
-                let kind = env_secret_kind(&name).to_owned();
-                rules.push(RedactionRule {
-                    kind,
-                    matcher: RuleMatcher::Literal(value.clone()),
-                });
-                blocking_literals.push(value);
             }
 
             rules.extend(default_rules()?);
@@ -586,6 +589,23 @@ fn collect_literal_matches(input: &str, literal: &str, kind: &str, out: &mut Vec
     }
 }
 
+fn push_literal_rule(
+    rules: &mut Vec<RedactionRule>,
+    blocking_literals: &mut Vec<String>,
+    seen_literals: &mut BTreeSet<String>,
+    kind: &str,
+    literal: String,
+) {
+    if literal.is_empty() || !seen_literals.insert(literal.clone()) {
+        return;
+    }
+    rules.push(RedactionRule {
+        kind: kind.to_owned(),
+        matcher: RuleMatcher::Literal(literal.clone()),
+    });
+    blocking_literals.push(literal);
+}
+
 fn new_salt() -> String {
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -607,9 +627,17 @@ fn size_class(value: &str) -> &'static str {
 
 fn env_name_is_sensitive(name: &str) -> bool {
     let upper = name.to_ascii_uppercase();
-    ["TOKEN", "SECRET", "KEY", "PASSWORD", "CREDENTIAL"]
+    if ["TOKEN", "SECRET", "PASSWORD", "CREDENTIAL"]
         .iter()
         .any(|needle| upper.contains(needle))
+    {
+        return true;
+    }
+    upper.split(['_', '-']).any(|segment| segment == "KEY")
+}
+
+fn env_literal_kind(name: &str, value: &str) -> Option<&'static str> {
+    (value.len() >= 4 && env_name_is_sensitive(name)).then(|| env_secret_kind(name))
 }
 
 fn env_secret_kind(name: &str) -> &'static str {
@@ -687,6 +715,48 @@ mod tests {
                 .configured_literal_leak("x literal-secret y")
                 .is_none()
         );
+    }
+
+    #[test]
+    fn configured_literals_are_deduplicated_before_rules() {
+        let cfg = RedactionCfg {
+            secret_literals: vec!["repeat-secret".into(), "repeat-secret".into()],
+            ..RedactionCfg::default()
+        };
+
+        let redactor = Redactor::from_config(&cfg).unwrap();
+        let configured_rules = redactor
+            .inner
+            .rules
+            .iter()
+            .filter(|rule| rule.kind == KIND_CONFIGURED_LITERAL)
+            .count();
+        let blocking_literals = redactor
+            .inner
+            .blocking_literals
+            .iter()
+            .filter(|literal| literal.as_str() == "repeat-secret")
+            .count();
+
+        assert_eq!(configured_rules, 1);
+        assert_eq!(blocking_literals, 1);
+    }
+
+    #[test]
+    fn env_key_matching_ignores_key_substrings() {
+        assert!(!env_name_is_sensitive("KEYBOARD_LAYOUT"));
+        assert!(!env_name_is_sensitive("GNOME_KEYRING_PID"));
+        assert!(!env_name_is_sensitive("MONKEY"));
+        assert!(env_name_is_sensitive("API_KEY"));
+        assert!(env_name_is_sensitive("API-KEY"));
+        assert!(env_name_is_sensitive("GITHUB_TOKEN"));
+    }
+
+    #[test]
+    fn env_literal_candidates_require_minimum_length() {
+        assert!(env_literal_kind("API_TOKEN", "abc").is_none());
+        assert_eq!(env_literal_kind("API_TOKEN", "abcd"), Some("env_token"));
+        assert!(env_literal_kind("KEYBOARD_LAYOUT", "us").is_none());
     }
 
     #[test]

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -1,0 +1,713 @@
+//! Run-scoped secret redaction.
+//!
+//! This is deliberately not a full DLP engine. It masks configured literals,
+//! common structured secret shapes, and current-process environment values
+//! with sensitive names before text reaches persisted or shareable surfaces.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex, PoisonError};
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::config::RedactionCfg;
+use crate::stream::{StreamEvent, StreamSink};
+
+pub mod surface {
+    pub const TRAJECTORY: &str = "trajectory";
+    pub const MODEL_OBSERVATION: &str = "model_observation";
+    pub const STREAM: &str = "stream";
+    pub const INSPECT: &str = "inspect";
+    pub const EXPORT: &str = "export";
+    pub const PATCH_SUBMISSION: &str = "patch_submission";
+    pub const GITHUB_COMMENT: &str = "github_comment";
+}
+
+const KIND_CONFIGURED_LITERAL: &str = "configured_literal";
+const KIND_CUSTOM_PATTERN: &str = "custom_pattern";
+const KIND_PRIVATE_KEY: &str = "private_key";
+const KIND_GITHUB_TOKEN: &str = "github_token";
+const KIND_BEARER_TOKEN: &str = "bearer_token";
+const KIND_API_KEY: &str = "api_key";
+const KIND_ENV_ASSIGNMENT: &str = "env_assignment";
+const KIND_SECRET_FIELD: &str = "secret_field";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RedactionCount {
+    pub surface: String,
+    pub kind: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RedactionSummary {
+    pub enabled: bool,
+    pub redacted: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub counts: Vec<RedactionCount>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretLeak {
+    pub kind: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RedactionOutcome {
+    pub text: String,
+    pub redacted: bool,
+}
+
+#[derive(Clone)]
+pub struct Redactor {
+    inner: Arc<RedactorInner>,
+}
+
+struct RedactorInner {
+    enabled: bool,
+    unsafe_allow_secret_leaks: bool,
+    salt: String,
+    rules: Vec<RedactionRule>,
+    blocking_literals: Vec<String>,
+    markers: Mutex<BTreeMap<String, String>>,
+    counts: Mutex<BTreeMap<(String, String), u64>>,
+}
+
+#[derive(Clone)]
+struct RedactionRule {
+    kind: String,
+    matcher: RuleMatcher,
+}
+
+#[derive(Clone)]
+enum RuleMatcher {
+    Literal(String),
+    Regex {
+        regex: Regex,
+        capture_group: Option<usize>,
+    },
+}
+
+#[derive(Debug)]
+struct RedactionMatch {
+    start: usize,
+    end: usize,
+    kind: String,
+    raw: String,
+}
+
+impl Redactor {
+    pub fn from_config(cfg: &RedactionCfg) -> Result<Self, regex::Error> {
+        let mut rules = Vec::new();
+        let mut blocking_literals = Vec::new();
+
+        if cfg.enabled {
+            for literal in cfg.secret_literals.iter().filter(|value| !value.is_empty()) {
+                rules.push(RedactionRule {
+                    kind: KIND_CONFIGURED_LITERAL.to_owned(),
+                    matcher: RuleMatcher::Literal(literal.clone()),
+                });
+                blocking_literals.push(literal.clone());
+            }
+
+            for (name, value) in std::env::vars() {
+                if value.is_empty() || !env_name_is_sensitive(&name) {
+                    continue;
+                }
+                let kind = env_secret_kind(&name).to_owned();
+                rules.push(RedactionRule {
+                    kind,
+                    matcher: RuleMatcher::Literal(value.clone()),
+                });
+                blocking_literals.push(value);
+            }
+
+            rules.extend(default_rules()?);
+
+            for pattern in &cfg.custom_patterns {
+                rules.push(RedactionRule {
+                    kind: KIND_CUSTOM_PATTERN.to_owned(),
+                    matcher: RuleMatcher::Regex {
+                        regex: Regex::new(pattern)?,
+                        capture_group: None,
+                    },
+                });
+            }
+        }
+
+        Ok(Self {
+            inner: Arc::new(RedactorInner {
+                enabled: cfg.enabled,
+                unsafe_allow_secret_leaks: cfg.unsafe_allow_secret_leaks,
+                salt: new_salt(),
+                rules,
+                blocking_literals,
+                markers: Mutex::new(BTreeMap::new()),
+                counts: Mutex::new(BTreeMap::new()),
+            }),
+        })
+    }
+
+    pub fn from_config_lossy(cfg: &RedactionCfg) -> Self {
+        Self::from_config(cfg).unwrap_or_else(|_| Self::disabled())
+    }
+
+    pub fn default_enabled() -> Self {
+        Self::from_config_lossy(&RedactionCfg::default())
+    }
+
+    pub fn disabled() -> Self {
+        Self {
+            inner: Arc::new(RedactorInner {
+                enabled: false,
+                unsafe_allow_secret_leaks: false,
+                salt: new_salt(),
+                rules: Vec::new(),
+                blocking_literals: Vec::new(),
+                markers: Mutex::new(BTreeMap::new()),
+                counts: Mutex::new(BTreeMap::new()),
+            }),
+        }
+    }
+
+    #[must_use]
+    pub fn redact_text(&self, input: &str, surface: &str) -> RedactionOutcome {
+        if !self.inner.enabled || input.is_empty() {
+            return RedactionOutcome {
+                text: input.to_owned(),
+                redacted: false,
+            };
+        }
+
+        let mut matches = self.collect_matches(input);
+        if matches.is_empty() {
+            return RedactionOutcome {
+                text: input.to_owned(),
+                redacted: false,
+            };
+        }
+
+        matches.sort_by(|a, b| {
+            a.start
+                .cmp(&b.start)
+                .then_with(|| b.end.cmp(&a.end))
+                .then_with(|| a.kind.cmp(&b.kind))
+        });
+
+        let mut filtered = Vec::new();
+        let mut next_available = 0usize;
+        for candidate in matches {
+            if candidate.start < next_available {
+                continue;
+            }
+            next_available = candidate.end;
+            filtered.push(candidate);
+        }
+
+        let mut out = String::with_capacity(input.len());
+        let mut last = 0usize;
+        for matched in filtered {
+            out.push_str(&input[last..matched.start]);
+            let marker = self.marker_for(&matched.raw, &matched.kind);
+            out.push_str(&marker);
+            self.increment(surface, &matched.kind);
+            last = matched.end;
+        }
+        out.push_str(&input[last..]);
+        RedactionOutcome {
+            text: out,
+            redacted: true,
+        }
+    }
+
+    pub fn redact_json_value(&self, value: &mut serde_json::Value, surface: &str) -> bool {
+        if !self.inner.enabled {
+            return false;
+        }
+        match value {
+            serde_json::Value::Object(map) => {
+                let mut redacted = false;
+                for (key, child) in map.iter_mut() {
+                    if let Some(kind) = sensitive_key_kind(key) {
+                        redacted |= self.redact_sensitive_value(child, surface, kind);
+                    } else {
+                        redacted |= self.redact_json_value(child, surface);
+                    }
+                }
+                redacted
+            }
+            serde_json::Value::Array(values) => {
+                let mut redacted = false;
+                for child in values {
+                    redacted |= self.redact_json_value(child, surface);
+                }
+                redacted
+            }
+            serde_json::Value::String(text) => {
+                let outcome = self.redact_text(text, surface);
+                if outcome.redacted {
+                    *text = outcome.text;
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
+
+    #[must_use]
+    pub fn configured_literal_leak(&self, text: &str) -> Option<SecretLeak> {
+        if !self.inner.enabled || self.inner.unsafe_allow_secret_leaks {
+            return None;
+        }
+        self.inner
+            .blocking_literals
+            .iter()
+            .filter(|literal| !literal.is_empty())
+            .find(|literal| text.contains(literal.as_str()))
+            .map(|_| SecretLeak {
+                kind: KIND_CONFIGURED_LITERAL.to_owned(),
+            })
+    }
+
+    #[must_use]
+    pub fn unsafe_allow_secret_leaks(&self) -> bool {
+        self.inner.unsafe_allow_secret_leaks
+    }
+
+    #[must_use]
+    pub fn summary(&self) -> RedactionSummary {
+        let mut rows = {
+            let counts = self
+                .inner
+                .counts
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            counts
+                .iter()
+                .map(|((surface, kind), count)| RedactionCount {
+                    surface: surface.clone(),
+                    kind: kind.clone(),
+                    count: *count,
+                })
+                .collect::<Vec<_>>()
+        };
+        rows.sort_by(|a, b| a.surface.cmp(&b.surface).then_with(|| a.kind.cmp(&b.kind)));
+        RedactionSummary {
+            enabled: self.inner.enabled,
+            redacted: !rows.is_empty(),
+            counts: rows,
+        }
+    }
+
+    fn collect_matches(&self, input: &str) -> Vec<RedactionMatch> {
+        let mut out = Vec::new();
+        for rule in &self.inner.rules {
+            match &rule.matcher {
+                RuleMatcher::Literal(literal) => {
+                    collect_literal_matches(input, literal, &rule.kind, &mut out);
+                }
+                RuleMatcher::Regex {
+                    regex,
+                    capture_group,
+                } => {
+                    for captures in regex.captures_iter(input) {
+                        let matched = capture_group
+                            .and_then(|idx| captures.get(idx))
+                            .or_else(|| captures.get(0));
+                        if let Some(matched) = matched {
+                            if matched.start() < matched.end() {
+                                out.push(RedactionMatch {
+                                    start: matched.start(),
+                                    end: matched.end(),
+                                    kind: rule.kind.clone(),
+                                    raw: matched.as_str().to_owned(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    fn marker_for(&self, raw: &str, kind: &str) -> String {
+        let mut markers = self
+            .inner
+            .markers
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        if let Some(marker) = markers.get(raw) {
+            return marker.clone();
+        }
+        let mut hasher = Sha256::new();
+        hasher.update(self.inner.salt.as_bytes());
+        hasher.update([0]);
+        hasher.update(raw.as_bytes());
+        let digest = format!("{:x}", hasher.finalize());
+        let hash = &digest[..12];
+        let marker = format!("[REDACTED:{kind}:{}:{hash}]", size_class(raw));
+        markers.insert(raw.to_owned(), marker.clone());
+        marker
+    }
+
+    fn increment(&self, surface: &str, kind: &str) {
+        let mut counts = self
+            .inner
+            .counts
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let key = (surface.to_owned(), kind.to_owned());
+        let value = counts.entry(key).or_insert(0);
+        *value = value.saturating_add(1);
+        drop(counts);
+    }
+
+    fn redact_sensitive_value(
+        &self,
+        value: &mut serde_json::Value,
+        surface: &str,
+        kind: &str,
+    ) -> bool {
+        match value {
+            serde_json::Value::String(text) => {
+                if text.is_empty() {
+                    return false;
+                }
+                let marker = self.marker_for(text, kind);
+                *text = marker;
+                self.increment(surface, kind);
+                true
+            }
+            serde_json::Value::Array(values) => {
+                let mut redacted = false;
+                for child in values {
+                    redacted |= self.redact_sensitive_value(child, surface, kind);
+                }
+                redacted
+            }
+            serde_json::Value::Object(map) => {
+                let mut redacted = false;
+                for child in map.values_mut() {
+                    redacted |= self.redact_sensitive_value(child, surface, kind);
+                }
+                redacted
+            }
+            _ => false,
+        }
+    }
+}
+
+pub struct RedactingSink {
+    inner: Arc<dyn StreamSink>,
+    redactor: Redactor,
+}
+
+impl RedactingSink {
+    pub fn new(inner: Arc<dyn StreamSink>, redactor: Redactor) -> Self {
+        Self { inner, redactor }
+    }
+}
+
+impl StreamSink for RedactingSink {
+    fn emit(&self, event: StreamEvent) {
+        self.inner.emit(redact_stream_event(&event, &self.redactor));
+    }
+}
+
+pub fn redact_stream_event(event: &StreamEvent, redactor: &Redactor) -> StreamEvent {
+    match event {
+        StreamEvent::RunStarted {
+            task,
+            model,
+            started_at,
+        } => StreamEvent::RunStarted {
+            task: redactor.redact_text(task, surface::STREAM).text,
+            model: redactor.redact_text(model, surface::STREAM).text,
+            started_at: started_at.clone(),
+        },
+        StreamEvent::AssistantMessage {
+            step,
+            content,
+            cost_usd,
+            timestamp,
+        } => StreamEvent::AssistantMessage {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            cost_usd: *cost_usd,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::BashStart {
+            step,
+            command,
+            timestamp,
+        } => StreamEvent::BashStart {
+            step: *step,
+            command: redactor.redact_text(command, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::BashResult {
+            step,
+            exit_code,
+            stdout,
+            stderr,
+            timed_out,
+            timestamp,
+        } => StreamEvent::BashResult {
+            step: *step,
+            exit_code: *exit_code,
+            stdout: redactor.redact_text(stdout, surface::STREAM).text,
+            stderr: redactor.redact_text(stderr, surface::STREAM).text,
+            timed_out: *timed_out,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::Observation {
+            step,
+            content,
+            timestamp,
+        } => StreamEvent::Observation {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::FormatError {
+            step,
+            content,
+            timestamp,
+        } => StreamEvent::FormatError {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::RunEnded {
+            exit_reason,
+            failure_category,
+            final_output,
+            steps,
+            total_cost_usd,
+            ended_at,
+        } => StreamEvent::RunEnded {
+            exit_reason: exit_reason.clone(),
+            failure_category: *failure_category,
+            final_output: final_output
+                .as_ref()
+                .map(|value| redactor.redact_text(value, surface::STREAM).text),
+            steps: *steps,
+            total_cost_usd: *total_cost_usd,
+            ended_at: ended_at.clone(),
+        },
+    }
+}
+
+fn default_rules() -> Result<Vec<RedactionRule>, regex::Error> {
+    Ok(vec![
+        RedactionRule {
+            kind: KIND_PRIVATE_KEY.to_owned(),
+            matcher: RuleMatcher::Regex {
+                regex: Regex::new(
+                    r"(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+                )?,
+                capture_group: None,
+            },
+        },
+        RedactionRule {
+            kind: KIND_BEARER_TOKEN.to_owned(),
+            matcher: RuleMatcher::Regex {
+                regex: Regex::new(r"(?i)\bBearer\s+([A-Za-z0-9._~+/=-]{16,})")?,
+                capture_group: Some(1),
+            },
+        },
+        RedactionRule {
+            kind: KIND_GITHUB_TOKEN.to_owned(),
+            matcher: RuleMatcher::Regex {
+                regex: Regex::new(
+                    r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b",
+                )?,
+                capture_group: None,
+            },
+        },
+        RedactionRule {
+            kind: KIND_API_KEY.to_owned(),
+            matcher: RuleMatcher::Regex {
+                regex: Regex::new(
+                    r"\b(?:sk-[A-Za-z0-9][A-Za-z0-9_-]{16,}|sk-ant-[A-Za-z0-9_-]{16,}|AKIA[0-9A-Z]{16})\b",
+                )?,
+                capture_group: None,
+            },
+        },
+        RedactionRule {
+            kind: KIND_ENV_ASSIGNMENT.to_owned(),
+            matcher: RuleMatcher::Regex {
+                regex: Regex::new(
+                    r#"(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*\s*=\s*)([^ \t\r\n'"]{4,})"#,
+                )?,
+                capture_group: Some(2),
+            },
+        },
+        RedactionRule {
+            kind: KIND_ENV_ASSIGNMENT.to_owned(),
+            matcher: RuleMatcher::Regex {
+                regex: Regex::new(
+                    r#"(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*\s*=\s*")([^"\r\n]{4,})"#,
+                )?,
+                capture_group: Some(2),
+            },
+        },
+        RedactionRule {
+            kind: KIND_ENV_ASSIGNMENT.to_owned(),
+            matcher: RuleMatcher::Regex {
+                regex: Regex::new(
+                    r#"(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL)[A-Z0-9_]*\s*=\s*')([^'\r\n]{4,})"#,
+                )?,
+                capture_group: Some(2),
+            },
+        },
+    ])
+}
+
+fn collect_literal_matches(input: &str, literal: &str, kind: &str, out: &mut Vec<RedactionMatch>) {
+    if literal.is_empty() {
+        return;
+    }
+    let mut search_start = 0usize;
+    while let Some(offset) = input[search_start..].find(literal) {
+        let start = search_start + offset;
+        let end = start + literal.len();
+        out.push(RedactionMatch {
+            start,
+            end,
+            kind: kind.to_owned(),
+            raw: literal.to_owned(),
+        });
+        search_start = end;
+    }
+}
+
+fn new_salt() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    format!(
+        "{nanos}:{}:{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    )
+}
+
+fn size_class(value: &str) -> &'static str {
+    match value.len() {
+        0..=15 => "short",
+        16..=63 => "medium",
+        _ => "long",
+    }
+}
+
+fn env_name_is_sensitive(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
+    ["TOKEN", "SECRET", "KEY", "PASSWORD", "CREDENTIAL"]
+        .iter()
+        .any(|needle| upper.contains(needle))
+}
+
+fn env_secret_kind(name: &str) -> &'static str {
+    let upper = name.to_ascii_uppercase();
+    if upper.contains("TOKEN") {
+        "env_token"
+    } else if upper.contains("SECRET") {
+        "env_secret"
+    } else if upper.contains("PASSWORD") {
+        "env_password"
+    } else if upper.contains("CREDENTIAL") {
+        "env_credential"
+    } else {
+        "env_key"
+    }
+}
+
+fn sensitive_key_kind(key: &str) -> Option<&'static str> {
+    let lower = key.to_ascii_lowercase();
+    if lower.contains("token") {
+        Some("env_token")
+    } else if lower.contains("secret") {
+        Some("env_secret")
+    } else if lower.contains("password") {
+        Some("env_password")
+    } else if lower.contains("credential") {
+        Some("env_credential")
+    } else if lower.ends_with("key") || lower.contains("_key") || lower.contains("-key") {
+        Some("env_key")
+    } else if lower == "custom_patterns" {
+        Some(KIND_CUSTOM_PATTERN)
+    } else if lower.contains("literal") {
+        Some(KIND_SECRET_FIELD)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+
+    #[test]
+    fn same_value_gets_same_marker() {
+        let redactor = Redactor::default_enabled();
+        let one = redactor.redact_text("ghp_0123456789ABCDEF0123456789ABCDEF0123", "a");
+        let two = redactor.redact_text("x ghp_0123456789ABCDEF0123456789ABCDEF0123", "b");
+        let marker = one.text;
+        assert!(two.text.contains(&marker));
+    }
+
+    #[test]
+    fn configured_literal_detection_respects_unsafe_bypass() {
+        let cfg = RedactionCfg {
+            secret_literals: vec!["literal-secret".into()],
+            ..RedactionCfg::default()
+        };
+        let redactor = Redactor::from_config(&cfg).unwrap();
+        assert!(
+            redactor
+                .configured_literal_leak("x literal-secret y")
+                .is_some()
+        );
+
+        let cfg = RedactionCfg {
+            secret_literals: vec!["literal-secret".into()],
+            unsafe_allow_secret_leaks: true,
+            ..RedactionCfg::default()
+        };
+        let redactor = Redactor::from_config(&cfg).unwrap();
+        assert!(
+            redactor
+                .configured_literal_leak("x literal-secret y")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn json_redaction_visits_every_sensitive_array_member() {
+        let redactor = Redactor::default_enabled();
+        let mut value = serde_json::json!({
+            "api_keys": [
+                "sk-firstsecretvalue000000",
+                "sk-secondsecretvalue00000"
+            ],
+            "nested": [
+                "ghp_0123456789ABCDEF0123456789ABCDEF0123",
+                "MY_SECRET=\"quoted-secret-value\""
+            ]
+        });
+
+        assert!(redactor.redact_json_value(&mut value, surface::TRAJECTORY));
+        let rendered = value.to_string();
+        assert!(!rendered.contains("sk-firstsecretvalue000000"));
+        assert!(!rendered.contains("sk-secondsecretvalue00000"));
+        assert!(!rendered.contains("ghp_0123456789ABCDEF0123456789ABCDEF0123"));
+        assert!(!rendered.contains("quoted-secret-value"));
+    }
+}

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -1954,6 +1954,7 @@ fn failure_label(cat: FailureCategory) -> &'static str {
         FailureCategory::AgentInternal => "agent_internal",
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
+        FailureCategory::SecretLeakDetected => "secret_leak_detected",
         FailureCategory::Unknown => "unknown",
     }
 }

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -16,7 +16,7 @@ use crate::trajectory::{FailureCategory, outcome};
 pub const COST_ATTRIBUTION_RESOLVED_BUCKET: &str = "resolved";
 pub const COST_ATTRIBUTION_UNCATEGORIZED_BUCKET: &str = "uncategorized";
 pub const COST_ATTRIBUTION_TOTAL_BUCKET: &str = "TOTAL";
-pub const ALL_FAILURE_CATEGORIES: [FailureCategory; 10] = [
+pub const ALL_FAILURE_CATEGORIES: [FailureCategory; 11] = [
     FailureCategory::EnvSetup,
     FailureCategory::ModelApi,
     FailureCategory::ModelParse,
@@ -26,6 +26,7 @@ pub const ALL_FAILURE_CATEGORIES: [FailureCategory; 10] = [
     FailureCategory::AgentInternal,
     FailureCategory::PatchApplyInvalid,
     FailureCategory::PatchEmpty,
+    FailureCategory::SecretLeakDetected,
     FailureCategory::Unknown,
 ];
 
@@ -1115,6 +1116,7 @@ pub fn failure_label(cat: FailureCategory) -> &'static str {
         FailureCategory::AgentInternal => "agent_internal",
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
+        FailureCategory::SecretLeakDetected => "secret_leak_detected",
         FailureCategory::Unknown => "unknown",
     }
 }

--- a/src/run/github_pr.rs
+++ b/src/run/github_pr.rs
@@ -11,6 +11,7 @@ use std::process::{Output, Stdio};
 use std::time::Duration;
 
 use crate::error::ConfigError;
+use crate::redaction::{Redactor, surface};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use sha2::{Digest, Sha256};
 use tokio::process::Command;
@@ -145,13 +146,24 @@ pub fn build_pr_plan(
     let task_slug = task_branch_component(task_id);
     let head_branch = format!("{prefix}/{task_slug}");
     let summary = summarize_patch(patch_text);
-    let title = format!("rust-swe-agent: {task_id}");
-    let body = render_pr_body(
-        task_id,
-        &options.trajectory_ref,
-        &options.patch_path,
-        &summary,
-    );
+    let redactor = Redactor::default_enabled();
+    let title = redactor
+        .redact_text(
+            &format!("rust-swe-agent: {task_id}"),
+            surface::GITHUB_COMMENT,
+        )
+        .text;
+    let body = redactor
+        .redact_text(
+            &render_pr_body(
+                task_id,
+                &options.trajectory_ref,
+                &options.patch_path,
+                &summary,
+            ),
+            surface::GITHUB_COMMENT,
+        )
+        .text;
 
     Ok(PullRequestPlan {
         target_repo: format!("{}/{}", repo.owner, repo.name),

--- a/src/run/github_pr.rs
+++ b/src/run/github_pr.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Output, Stdio};
 use std::time::Duration;
 
+use crate::config::RedactionCfg;
 use crate::error::ConfigError;
 use crate::redaction::{Redactor, surface};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
@@ -39,6 +40,7 @@ pub struct GithubPrOptions {
     pub timeout_secs: u64,
     pub max_retries: u32,
     pub backoff_base_ms: u64,
+    pub redaction: RedactionCfg,
 }
 
 #[derive(Debug, Clone)]
@@ -60,6 +62,7 @@ impl GithubPrSweepConfig {
         run_index: u32,
         trajectory_path: &Path,
         patch_path: &Path,
+        redaction: &RedactionCfg,
     ) -> GithubPrOptions {
         let task_id = if run_index == 1 {
             instance_id.to_owned()
@@ -78,6 +81,7 @@ impl GithubPrSweepConfig {
             timeout_secs: self.timeout_secs,
             max_retries: self.max_retries,
             backoff_base_ms: self.backoff_base_ms,
+            redaction: redaction.clone(),
         }
     }
 }
@@ -141,12 +145,15 @@ pub fn build_pr_plan(
             "task id is required for PR publishing".into(),
         ));
     }
+    let redactor = Redactor::from_config_lossy(&options.redaction);
     let base_branch = validate_branch_component(&options.target_branch, "target branch")?;
     let prefix = normalize_branch_prefix(&options.branch_prefix).map_err(Error::Github)?;
-    let task_slug = task_branch_component(task_id);
+    let branch_task_id = normalize_redaction_markers_for_branch(
+        &redactor.redact_text(task_id, surface::GITHUB_COMMENT).text,
+    );
+    let task_slug = task_branch_component(&branch_task_id);
     let head_branch = format!("{prefix}/{task_slug}");
     let summary = summarize_patch(patch_text);
-    let redactor = Redactor::default_enabled();
     let title = redactor
         .redact_text(
             &format!("rust-swe-agent: {task_id}"),
@@ -815,6 +822,23 @@ fn task_branch_component(raw: &str) -> String {
     format!("{slug}-{digest}")
 }
 
+fn normalize_redaction_markers_for_branch(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut remaining = raw;
+    while let Some(start) = remaining.find("[REDACTED:") {
+        out.push_str(&remaining[..start]);
+        let marker_and_rest = &remaining[start..];
+        let Some(end) = marker_and_rest.find(']') else {
+            out.push_str(marker_and_rest);
+            return out;
+        };
+        out.push_str("redacted");
+        remaining = &marker_and_rest[end + 1..];
+    }
+    out.push_str(remaining);
+    out
+}
+
 fn slug_for_branch(raw: &str) -> String {
     let slug = slug_path(raw);
     if slug.is_empty() { "task".into() } else { slug }
@@ -1424,6 +1448,7 @@ mod tests {
             timeout_secs: 30,
             max_retries: 2,
             backoff_base_ms: 250,
+            redaction: RedactionCfg::default(),
         }
     }
 

--- a/src/run/github_pr.rs
+++ b/src/run/github_pr.rs
@@ -153,7 +153,8 @@ pub fn build_pr_plan(
     );
     let task_slug = task_branch_component(&branch_task_id);
     let head_branch = format!("{prefix}/{task_slug}");
-    let summary = summarize_patch(patch_text);
+    let mut summary = summarize_patch(patch_text);
+    redact_patch_summary_files(&mut summary, &redactor);
     let title = redactor
         .redact_text(
             &format!("rust-swe-agent: {task_id}"),
@@ -304,6 +305,12 @@ fn summarize_patch(patch_text: &str) -> PatchSummary {
         deletions,
         files: files.into_iter().collect(),
         bytes: patch_text.len(),
+    }
+}
+
+fn redact_patch_summary_files(summary: &mut PatchSummary, redactor: &Redactor) {
+    for file in &mut summary.files {
+        *file = redactor.redact_text(file, surface::GITHUB_COMMENT).text;
     }
 }
 

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 
 use crate::env::RunResult;
 use crate::error::Error;
+use crate::redaction::{Redactor, surface};
 use crate::run::evaluate::EvaluationResults;
 use crate::run::patch_stats::PatchStats;
 use crate::run::swebench::{InstanceResult, ProvenanceManifest};
@@ -196,7 +197,7 @@ fn build_instance_report(
     })?;
     let text = std::fs::read_to_string(&traj_path)?;
     let mut warnings = Vec::new();
-    let traj: Trajectory = match serde_json::from_str(&text) {
+    let mut traj: Trajectory = match serde_json::from_str(&text) {
         Ok(t) => t,
         Err(err) => {
             warnings.push(format!(
@@ -229,6 +230,20 @@ fn build_instance_report(
             });
         }
     };
+
+    let inspect_redactor = Redactor::default_enabled();
+    let redacted_at_view = redact_trajectory_for_inspect(&mut traj, &inspect_redactor);
+    if traj
+        .info
+        .redaction
+        .as_ref()
+        .is_some_and(|summary| summary.redacted)
+    {
+        warnings.push("content was redacted at run time".into());
+    }
+    if redacted_at_view {
+        warnings.push("bench inspect redacted secret-shaped content at view time".into());
+    }
 
     let steps = build_inspect_steps(&traj, full);
 
@@ -708,6 +723,43 @@ fn failure_label(c: FailureCategory) -> &'static str {
         FailureCategory::AgentInternal => "agent_internal",
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
+        FailureCategory::SecretLeakDetected => "secret_leak_detected",
         FailureCategory::Unknown => "unknown",
     }
+}
+
+fn redact_trajectory_for_inspect(trajectory: &mut Trajectory, redactor: &Redactor) -> bool {
+    let mut redacted = false;
+    if let Some(task) = &mut trajectory.info.task {
+        let outcome = redactor.redact_text(task, surface::INSPECT);
+        redacted |= outcome.redacted;
+        *task = outcome.text;
+    }
+    if let Some(final_output) = &mut trajectory.info.final_output {
+        let outcome = redactor.redact_text(final_output, surface::INSPECT);
+        redacted |= outcome.redacted;
+        *final_output = outcome.text;
+    }
+    for value in trajectory.info.other.values_mut() {
+        redacted |= redactor.redact_json_value(value, surface::INSPECT);
+    }
+    for message in &mut trajectory.messages {
+        let outcome = redactor.redact_text(&message.content, surface::INSPECT);
+        redacted |= outcome.redacted;
+        message.content = outcome.text;
+        if let Some(actions) = &mut message.extra.actions {
+            for action in actions {
+                let outcome = redactor.redact_text(action, surface::INSPECT);
+                redacted |= outcome.redacted;
+                *action = outcome.text;
+            }
+        }
+        if let Some(response) = &mut message.extra.response {
+            redacted |= redactor.redact_json_value(response, surface::INSPECT);
+        }
+        for value in message.extra.other.values_mut() {
+            redacted |= redactor.redact_json_value(value, surface::INSPECT);
+        }
+    }
+    redacted
 }

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -15,6 +15,7 @@ use crate::env::{Environment, LocalEnvironment, RunRequest};
 use crate::error::Error;
 use crate::model::litellm::LitellmBackend;
 use crate::model::{DeterministicModel, Model, ModelUsage};
+use crate::redaction::surface;
 use crate::stream::{BroadcastSink, SseServer, StreamSink};
 use crate::trajectory::FailureCategory;
 
@@ -180,7 +181,43 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
                 }
                 // Always write the patch file — operators need to inspect
                 // failed patches too.
-                std::fs::write(&spec.patch_path, &diff)?;
+                let redacted_patch = agent.redactor.redact_text(&diff, surface::PATCH_SUBMISSION);
+                let detected_configured_literal = agent.redactor.configured_literal_leak(&diff);
+                if (detected_configured_literal.is_some() || redacted_patch.redacted)
+                    && !agent.redactor.unsafe_allow_secret_leaks()
+                {
+                    std::fs::write(&spec.patch_path, redacted_patch.text)?;
+                    patch_written = true;
+                    tracing::warn!(
+                        instance = %args.trajectory_name,
+                        "secret leak detected in submitted patch; downgrading outcome to error"
+                    );
+                    agent.trajectory.info.exit_reason = Some("error".into());
+                    agent.trajectory.info.failure_category =
+                        Some(FailureCategory::SecretLeakDetected);
+                    let leak_kind = detected_configured_literal
+                        .map_or_else(|| "structured_secret".to_owned(), |leak| leak.kind);
+                    agent.trajectory.info.other.insert(
+                        "secret_leak_detected".into(),
+                        serde_json::json!({
+                            "surface": surface::PATCH_SUBMISSION,
+                            "kind": leak_kind,
+                        }),
+                    );
+                    agent.finalize_run_metadata(crate::trajectory::outcome::ERROR);
+                    agent.trajectory.save_pretty(&traj_path)?;
+                    tracing::info!(?traj_path, patch_written, "trajectory written");
+                    if let Some(server) = server {
+                        server.shutdown().await;
+                    }
+                    return Ok(());
+                }
+                let patch_text = if agent.redactor.unsafe_allow_secret_leaks() {
+                    diff.clone()
+                } else {
+                    redacted_patch.text
+                };
+                std::fs::write(&spec.patch_path, patch_text)?;
                 patch_written = true;
 
                 match check_patch_validity(
@@ -210,6 +247,10 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
                         if finalize_cancelled_if_requested(&mut agent, args.cancellation.as_ref()) {
                             run_result = Ok(crate::agent::ExitReason::UserInterrupt);
                         } else {
+                            let reason = agent
+                                .redactor
+                                .redact_text(&reason, surface::TRAJECTORY)
+                                .text;
                             tracing::warn!(
                                 instance = %args.trajectory_name,
                                 error = %reason,
@@ -231,6 +272,10 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
                 if finalize_cancelled_if_requested(&mut agent, args.cancellation.as_ref()) {
                     run_result = Ok(crate::agent::ExitReason::UserInterrupt);
                 } else {
+                    let reason = agent
+                        .redactor
+                        .redact_text(&reason, surface::TRAJECTORY)
+                        .text;
                     tracing::warn!(
                         instance = %args.trajectory_name,
                         error = %reason,
@@ -312,7 +357,14 @@ fn finalize_error_trajectory(agent: &mut DefaultAgent, err: &Error) {
         .info
         .other
         .entry("error_message".into())
-        .or_insert_with(|| serde_json::Value::String(err.to_string()));
+        .or_insert_with(|| {
+            serde_json::Value::String(
+                agent
+                    .redactor
+                    .redact_text(&err.to_string(), surface::TRAJECTORY)
+                    .text,
+            )
+        });
     agent.finalize_run_metadata(crate::trajectory::outcome::ERROR);
 }
 

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -26,6 +26,7 @@ use crate::config::Config;
 use crate::error::Error;
 use crate::model::litellm::is_anthropic_model;
 use crate::model::{Model, ModelUsage};
+use crate::redaction::{Redactor, surface};
 use crate::trajectory::{FailureCategory, TokenUsage, Trajectory, exit_reason, outcome};
 
 /// Sentinel `exit_reason` for tasks that never started because the
@@ -1592,7 +1593,12 @@ pub async fn run(mut args: SwebenchArgs) -> Result<SweepResults, Error> {
         }
     }
 
-    write_predictions_file(&args.output_dir, &results, &args.config.root.model.name)?;
+    write_predictions_file(
+        &args.output_dir,
+        &results,
+        &args.config.root.model.name,
+        &args.config.root.redaction,
+    )?;
 
     let token_breakdown = accounting.tokens;
     let total_cost_usd = sum_f64(
@@ -2009,7 +2015,8 @@ fn build_manifest(
         args.config.root.prompts.system, args.config.root.prompts.instance
     );
     let mut config_raw = effective_runtime_config(&args.config);
-    redact_json_secrets(&mut config_raw);
+    let redactor = Redactor::from_config_lossy(&args.config.root.redaction);
+    redactor.redact_json_value(&mut config_raw, surface::TRAJECTORY);
     let resolved = toml::to_string(&strip_json_nulls(config_raw)).unwrap_or_default();
     ProvenanceManifest {
         purpose: None,
@@ -2055,7 +2062,7 @@ fn build_manifest(
             rust_version: rust_version(),
         },
         cli: CliManifest {
-            argv: redact_argv(std::env::args().collect()),
+            argv: redact_argv(std::env::args().collect(), &args.config.root.redaction),
         },
     }
 }
@@ -2074,6 +2081,9 @@ fn effective_runtime_config(cfg: &Config) -> serde_json::Value {
         }
         if let Ok(prompts) = serde_json::to_value(&cfg.root.prompts) {
             m.insert("prompts".into(), prompts);
+        }
+        if let Ok(redaction) = serde_json::to_value(&cfg.root.redaction) {
+            m.insert("redaction".into(), redaction);
         }
     }
     raw
@@ -2150,7 +2160,8 @@ fn model_base_url() -> Option<String> {
     })
 }
 
-fn redact_argv(argv: Vec<String>) -> Vec<String> {
+fn redact_argv(argv: Vec<String>, redaction_cfg: &crate::config::RedactionCfg) -> Vec<String> {
+    let redactor = Redactor::from_config_lossy(redaction_cfg);
     let secret_values: Vec<String> = std::env::vars()
         .filter_map(|(k, v)| {
             let key = k.to_ascii_lowercase();
@@ -2177,52 +2188,14 @@ fn redact_argv(argv: Vec<String>) -> Vec<String> {
             }
             continue;
         }
-        if secret_values.iter().any(|s| arg.contains(s)) {
-            out.push("<redacted>".into());
+        let redacted_arg = redactor.redact_text(&arg, surface::TRAJECTORY);
+        if redacted_arg.redacted || secret_values.iter().any(|s| arg.contains(s)) {
+            out.push(redacted_arg.text);
             continue;
         }
         out.push(arg);
     }
     out
-}
-
-fn redact_json_secrets(v: &mut serde_json::Value) {
-    let secret_values: Vec<String> = std::env::vars()
-        .filter_map(|(k, v)| {
-            let key = k.to_ascii_lowercase();
-            ((key.ends_with("_key") || key.ends_with("_token") || key.ends_with("_secret"))
-                && !v.is_empty())
-            .then_some(v)
-        })
-        .collect();
-    redact_json_secrets_inner(v, &secret_values);
-}
-
-fn redact_json_secrets_inner(v: &mut serde_json::Value, secret_values: &[String]) {
-    match v {
-        serde_json::Value::Object(m) => {
-            for (k, val) in m.iter_mut() {
-                if json_key_is_sensitive(k) {
-                    *val = serde_json::Value::String("<redacted>".into());
-                } else {
-                    redact_json_secrets_inner(val, secret_values);
-                }
-            }
-        }
-        serde_json::Value::Array(xs) => {
-            for x in xs {
-                redact_json_secrets_inner(x, secret_values);
-            }
-        }
-        serde_json::Value::String(s)
-            if secret_values
-                .iter()
-                .any(|secret| !secret.is_empty() && s.contains(secret)) =>
-        {
-            *s = "<redacted>".into();
-        }
-        _ => {}
-    }
 }
 
 fn strip_json_nulls(v: serde_json::Value) -> serde_json::Value {
@@ -2238,25 +2211,6 @@ fn strip_json_nulls(v: serde_json::Value) -> serde_json::Value {
         }
         other => other,
     }
-}
-
-fn json_key_is_sensitive(key: &str) -> bool {
-    let k = key.to_ascii_lowercase();
-    matches!(
-        k.as_str(),
-        "api_key"
-            | "apikey"
-            | "key"
-            | "token"
-            | "secret"
-            | "password"
-            | "access_token"
-            | "auth_token"
-            | "bearer_token"
-    ) || k.ends_with("_key")
-        || k.ends_with("_token")
-        || k.ends_with("_secret")
-        || k.ends_with("_password")
 }
 
 fn flag_name_is_sensitive(flag: &str) -> bool {
@@ -2775,7 +2729,9 @@ fn write_predictions_file(
     output_dir: &std::path::Path,
     results: &[RunSlotResult],
     model_name: &str,
+    redaction_cfg: &crate::config::RedactionCfg,
 ) -> Result<(), Error> {
+    let redactor = Redactor::from_config_lossy(redaction_cfg);
     let max_run = results.iter().map(|r| r.run_index).max().unwrap_or(1);
     let use_unique_prediction_ids = max_run > 1;
     let mut aggregate = String::new();
@@ -2792,7 +2748,21 @@ fn write_predictions_file(
         }
         let patch_path =
             existing_patch_path_for_run(output_dir, &r.result.instance_id, r.run_index);
-        let model_patch = std::fs::read_to_string(&patch_path).unwrap_or_default();
+        let raw_model_patch = std::fs::read_to_string(&patch_path).unwrap_or_default();
+        let redacted_patch = redactor.redact_text(&raw_model_patch, surface::PATCH_SUBMISSION);
+        if (redactor.configured_literal_leak(&raw_model_patch).is_some() || redacted_patch.redacted)
+            && !redactor.unsafe_allow_secret_leaks()
+        {
+            return Err(Error::Trajectory(format!(
+                "secret_leak_detected in prediction artifact for `{}` run {}",
+                r.result.instance_id, r.run_index
+            )));
+        }
+        let model_patch = if redactor.unsafe_allow_secret_leaks() {
+            raw_model_patch
+        } else {
+            redacted_patch.text
+        };
         let run_line = serde_json::json!({
             "instance_id": r.result.instance_id,
             "model_patch": model_patch,
@@ -3076,6 +3046,7 @@ fn parse_failure_category_label(s: &str) -> Result<FailureCategory, Error> {
         "agent_internal" => Ok(FailureCategory::AgentInternal),
         "patch_apply_invalid" => Ok(FailureCategory::PatchApplyInvalid),
         "patch_empty" => Ok(FailureCategory::PatchEmpty),
+        "secret_leak_detected" => Ok(FailureCategory::SecretLeakDetected),
         "unknown" => Ok(FailureCategory::Unknown),
         _ => Err(Error::Config(crate::error::ConfigError::Invalid(format!(
             "unknown retry category `{s}`"
@@ -3430,6 +3401,7 @@ fn is_failed_instance(r: &InstanceResult) -> bool {
                     | FailureCategory::CostLimit
                     | FailureCategory::BudgetExhausted
                     | FailureCategory::WallclockTimeout
+                    | FailureCategory::SecretLeakDetected
             )
         )
 }
@@ -3446,6 +3418,7 @@ fn failure_category_label(cat: FailureCategory) -> &'static str {
         FailureCategory::AgentInternal => "agent_internal",
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
+        FailureCategory::SecretLeakDetected => "secret_leak_detected",
         FailureCategory::Unknown => "unknown",
     }
 }
@@ -4445,23 +4418,29 @@ mod tests {
 
     #[test]
     fn redact_argv_masks_secret_flags() {
-        let redacted = redact_argv(vec![
-            "rust-swe-agent".into(),
-            "--anthropic-api-key".into(),
-            "sk-test".into(),
-            "--github-token=ghp_123".into(),
-        ]);
+        let redacted = redact_argv(
+            vec![
+                "rust-swe-agent".into(),
+                "--anthropic-api-key".into(),
+                "sk-test".into(),
+                "--github-token=ghp_123".into(),
+            ],
+            &crate::config::RedactionCfg::default(),
+        );
         assert_eq!(redacted[2], "<redacted>");
         assert_eq!(redacted[3], "--github-token=<redacted>");
     }
 
     #[test]
     fn redact_argv_does_not_mask_max_tokens_flag() {
-        let redacted = redact_argv(vec![
-            "rust-swe-agent".into(),
-            "--max-tokens".into(),
-            "4096".into(),
-        ]);
+        let redacted = redact_argv(
+            vec![
+                "rust-swe-agent".into(),
+                "--max-tokens".into(),
+                "4096".into(),
+            ],
+            &crate::config::RedactionCfg::default(),
+        );
         assert_eq!(redacted[1], "--max-tokens");
         assert_eq!(redacted[2], "4096");
     }
@@ -4478,9 +4457,15 @@ mod tests {
         let mut cfg = serde_json::json!({
             "model": { "max_tokens": 4096, "api_key": "sk-test" }
         });
-        redact_json_secrets(&mut cfg);
+        let redactor = Redactor::default_enabled();
+        redactor.redact_json_value(&mut cfg, surface::TRAJECTORY);
         assert_eq!(cfg["model"]["max_tokens"], 4096);
-        assert_eq!(cfg["model"]["api_key"], "<redacted>");
+        assert!(
+            cfg["model"]["api_key"]
+                .as_str()
+                .is_some_and(|value| value.starts_with("[REDACTED:env_key:")),
+            "{cfg}"
+        );
     }
 
     #[test]

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -1130,6 +1130,7 @@ pub async fn run(mut args: SwebenchArgs) -> Result<SweepResults, Error> {
     )?;
     let total = instances.len();
     let summary_path = args.output_dir.join("results.json");
+    let redactor = Redactor::from_config_lossy(&args.config.root.redaction);
     let initial_manifest = build_manifest(
         &args,
         &dataset_sha,
@@ -1277,17 +1278,19 @@ pub async fn run(mut args: SwebenchArgs) -> Result<SweepResults, Error> {
                             &inst.instance_id,
                             run_index,
                         );
-                        r = publish_github_pr_for_result(
-                            r,
-                            GithubPrPublication {
-                                config: args.github_pr.as_ref(),
-                                instance_id: &inst.instance_id,
-                                run_index,
-                                trajectory_path: &traj_path,
-                                patch_path: &patch_path,
-                            },
-                        )
-                        .await;
+                        if !downgrade_patch_secret_leak_if_needed(&mut r, &patch_path, &redactor)? {
+                            r = publish_github_pr_for_result(
+                                r,
+                                GithubPrPublication {
+                                    config: args.github_pr.as_ref(),
+                                    instance_id: &inst.instance_id,
+                                    run_index,
+                                    trajectory_path: &traj_path,
+                                    patch_path: &patch_path,
+                                },
+                            )
+                            .await;
+                        }
                         bump_cost(
                             r.effective_cost_usd(Some(&model_name)).unwrap_or(0.0),
                             &mut cumulative_cost,
@@ -2764,15 +2767,11 @@ fn write_predictions_file(
         }
         let patch_path =
             existing_patch_path_for_run(output_dir, &r.result.instance_id, r.run_index);
-        let raw_model_patch = std::fs::read_to_string(&patch_path).unwrap_or_default();
-        let redacted_patch = redactor.redact_text(&raw_model_patch, surface::PATCH_SUBMISSION);
-        if (redactor.configured_literal_leak(&raw_model_patch).is_some() || redacted_patch.redacted)
-            && !redactor.unsafe_allow_secret_leaks()
-        {
-            std::fs::write(&patch_path, &redacted_patch.text)?;
-            downgrade_prediction_secret_leak(&mut r.result);
+        if downgrade_patch_secret_leak_if_needed(&mut r.result, &patch_path, &redactor)? {
             continue;
         }
+        let raw_model_patch = std::fs::read_to_string(&patch_path).unwrap_or_default();
+        let redacted_patch = redactor.redact_text(&raw_model_patch, surface::PATCH_SUBMISSION);
         let model_patch = if redactor.unsafe_allow_secret_leaks() {
             raw_model_patch
         } else {
@@ -2818,6 +2817,26 @@ fn write_predictions_file(
         std::fs::write(predictions_path_for_run(output_dir, run_index), text)?;
     }
     Ok(())
+}
+
+fn downgrade_patch_secret_leak_if_needed(
+    result: &mut InstanceResult,
+    patch_path: &std::path::Path,
+    redactor: &Redactor,
+) -> Result<bool, Error> {
+    if result.outcome.as_deref() != Some(outcome::SUBMITTED) || !result.patch_present {
+        return Ok(false);
+    }
+    let raw_model_patch = std::fs::read_to_string(patch_path).unwrap_or_default();
+    let redacted_patch = redactor.redact_text(&raw_model_patch, surface::PATCH_SUBMISSION);
+    if (redactor.configured_literal_leak(&raw_model_patch).is_some() || redacted_patch.redacted)
+        && !redactor.unsafe_allow_secret_leaks()
+    {
+        std::fs::write(patch_path, &redacted_patch.text)?;
+        downgrade_prediction_secret_leak(result);
+        return Ok(true);
+    }
+    Ok(false)
 }
 
 fn downgrade_prediction_secret_leak(result: &mut InstanceResult) {

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -1283,6 +1283,7 @@ pub async fn run(mut args: SwebenchArgs) -> Result<SweepResults, Error> {
                                 r,
                                 GithubPrPublication {
                                     config: args.github_pr.as_ref(),
+                                    redaction: &args.config.root.redaction,
                                     instance_id: &inst.instance_id,
                                     run_index,
                                     trajectory_path: &traj_path,
@@ -3321,6 +3322,7 @@ async fn run_one(inst: SweBenchInstance, run_index: u32, params: RunOneParams) -
             current,
             GithubPrPublication {
                 config: github_pr.as_ref(),
+                redaction: &cfg.root.redaction,
                 instance_id: &id,
                 run_index,
                 trajectory_path: &traj_path,
@@ -3382,6 +3384,7 @@ async fn sleep_or_cancelled(
 
 struct GithubPrPublication<'a> {
     config: Option<&'a crate::run::github_pr::GithubPrSweepConfig>,
+    redaction: &'a crate::config::RedactionCfg,
     instance_id: &'a str,
     run_index: u32,
     trajectory_path: &'a Path,
@@ -3404,6 +3407,7 @@ async fn publish_github_pr_for_result(
         publication.run_index,
         publication.trajectory_path,
         publication.patch_path,
+        publication.redaction,
     );
     match crate::run::github_pr::publish(pr_options).await {
         Ok(result) => {
@@ -3922,11 +3926,13 @@ mod tests {
     #[tokio::test]
     async fn github_pr_publication_is_noop_when_disabled() {
         let result = test_instance_result("inst", true, false);
+        let redaction = crate::config::RedactionCfg::default();
 
         let actual = publish_github_pr_for_result(
             result.clone(),
             GithubPrPublication {
                 config: None,
+                redaction: &redaction,
                 instance_id: "inst",
                 run_index: 1,
                 trajectory_path: std::path::Path::new("inst/run-1.traj.json"),
@@ -3945,6 +3951,7 @@ mod tests {
     #[tokio::test]
     async fn github_pr_publication_failure_preserves_submission_outcome() {
         let result = test_instance_result("inst", true, true);
+        let redaction = crate::config::RedactionCfg::default();
         let config = crate::run::github_pr::GithubPrSweepConfig {
             target_repo: "not-a-valid-owner-repo".into(),
             target_branch: "trunk".into(),
@@ -3960,6 +3967,7 @@ mod tests {
             result.clone(),
             GithubPrPublication {
                 config: Some(&config),
+                redaction: &redaction,
                 instance_id: "inst",
                 run_index: 1,
                 trajectory_path: std::path::Path::new("inst/run-1.traj.json"),

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -2162,14 +2162,6 @@ fn model_base_url() -> Option<String> {
 
 fn redact_argv(argv: Vec<String>, redaction_cfg: &crate::config::RedactionCfg) -> Vec<String> {
     let redactor = Redactor::from_config_lossy(redaction_cfg);
-    let secret_values: Vec<String> = std::env::vars()
-        .filter_map(|(k, v)| {
-            let key = k.to_ascii_lowercase();
-            ((key.ends_with("_key") || key.ends_with("_token") || key.ends_with("_secret"))
-                && !v.is_empty())
-            .then_some(v)
-        })
-        .collect();
     let mut out = Vec::with_capacity(argv.len());
     let mut redact_next = false;
     for arg in argv {
@@ -2189,7 +2181,7 @@ fn redact_argv(argv: Vec<String>, redaction_cfg: &crate::config::RedactionCfg) -
             continue;
         }
         let redacted_arg = redactor.redact_text(&arg, surface::TRAJECTORY);
-        if redacted_arg.redacted || secret_values.iter().any(|s| arg.contains(s)) {
+        if redacted_arg.redacted {
             out.push(redacted_arg.text);
             continue;
         }
@@ -4443,6 +4435,24 @@ mod tests {
         );
         assert_eq!(redacted[1], "--max-tokens");
         assert_eq!(redacted[2], "4096");
+    }
+
+    #[test]
+    fn redact_argv_uses_redactor_for_embedded_literals() {
+        let cfg = crate::config::RedactionCfg {
+            secret_literals: vec!["review-secret-value".into()],
+            ..crate::config::RedactionCfg::default()
+        };
+        let redacted = redact_argv(
+            vec![
+                "rust-swe-agent".into(),
+                "--note=prefix-review-secret-value-suffix".into(),
+            ],
+            &cfg,
+        );
+
+        assert!(!redacted[1].contains("review-secret-value"));
+        assert!(redacted[1].contains("[REDACTED:configured_literal:"));
     }
 
     #[test]

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -1311,7 +1311,7 @@ pub async fn run(mut args: SwebenchArgs) -> Result<SweepResults, Error> {
     }
 
     let mut results = skipped_results;
-    let skipped = results
+    let mut skipped = results
         .iter()
         .filter(|r| r.result.exit_reason == "skipped_resume")
         .count();
@@ -1584,6 +1584,37 @@ pub async fn run(mut args: SwebenchArgs) -> Result<SweepResults, Error> {
         }
     }
 
+    write_predictions_file(
+        &args.output_dir,
+        &mut results,
+        &args.config.root.model.name,
+        &args.config.root.redaction,
+    )?;
+
+    skipped = results
+        .iter()
+        .filter(|r| r.result.exit_reason == "skipped_resume")
+        .count();
+    submitted = results
+        .iter()
+        .filter(|r| {
+            r.result.exit_reason != "skipped_resume"
+                && r.result.outcome.as_deref() == Some(outcome::SUBMITTED)
+        })
+        .count();
+    errored = results
+        .iter()
+        .filter(|r| r.result.outcome.as_deref() == Some(outcome::ERROR))
+        .count();
+    budget_halted = results
+        .iter()
+        .filter(|r| r.result.exit_reason == EXIT_REASON_BUDGET_HALT)
+        .count();
+    accounting = SweepAccounting::default();
+    for r in &results {
+        accounting.add_result(&r.result);
+    }
+
     let instance_results = aggregate_run_results(&results, args.reruns);
     let pass_at_k = pass_at_k(&instance_results);
     let mut failures_by_category: BTreeMap<FailureCategory, usize> = BTreeMap::new();
@@ -1592,13 +1623,6 @@ pub async fn run(mut args: SwebenchArgs) -> Result<SweepResults, Error> {
             *failures_by_category.entry(cat).or_insert(0) += 1;
         }
     }
-
-    write_predictions_file(
-        &args.output_dir,
-        &results,
-        &args.config.root.model.name,
-        &args.config.root.redaction,
-    )?;
 
     let token_breakdown = accounting.tokens;
     let total_cost_usd = sum_f64(
@@ -2719,7 +2743,7 @@ pub fn is_resolved_instance_result(row: &InstanceResult) -> bool {
 /// to sb-cli, which rejects duplicate `instance_id` rows.
 fn write_predictions_file(
     output_dir: &std::path::Path,
-    results: &[RunSlotResult],
+    results: &mut [RunSlotResult],
     model_name: &str,
     redaction_cfg: &crate::config::RedactionCfg,
 ) -> Result<(), Error> {
@@ -2745,10 +2769,9 @@ fn write_predictions_file(
         if (redactor.configured_literal_leak(&raw_model_patch).is_some() || redacted_patch.redacted)
             && !redactor.unsafe_allow_secret_leaks()
         {
-            return Err(Error::Trajectory(format!(
-                "secret_leak_detected in prediction artifact for `{}` run {}",
-                r.result.instance_id, r.run_index
-            )));
+            std::fs::write(&patch_path, &redacted_patch.text)?;
+            downgrade_prediction_secret_leak(&mut r.result);
+            continue;
         }
         let model_patch = if redactor.unsafe_allow_secret_leaks() {
             raw_model_patch
@@ -2795,6 +2818,15 @@ fn write_predictions_file(
         std::fs::write(predictions_path_for_run(output_dir, run_index), text)?;
     }
     Ok(())
+}
+
+fn downgrade_prediction_secret_leak(result: &mut InstanceResult) {
+    result.exit_reason = "error".into();
+    result.outcome = Some(outcome::ERROR.into());
+    result.failure_category = Some(FailureCategory::SecretLeakDetected);
+    result.error = Some("secret_leak_detected in prediction artifact".into());
+    result.resolved_count = 0;
+    result.pass_at_1 = false;
 }
 
 /// Build an `InstanceResult` for a task skipped via `--resume`. Mirrors what

--- a/src/run/tail.rs
+++ b/src/run/tail.rs
@@ -773,6 +773,7 @@ fn failure_label(category: FailureCategory) -> &'static str {
         FailureCategory::AgentInternal => "agent_internal",
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
+        FailureCategory::SecretLeakDetected => "secret_leak_detected",
         FailureCategory::Unknown => "unknown",
     }
 }

--- a/src/run/trajectory_diff.rs
+++ b/src/run/trajectory_diff.rs
@@ -1033,6 +1033,7 @@ fn failure_label(category: FailureCategory) -> &'static str {
         FailureCategory::AgentInternal => "agent_internal",
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
+        FailureCategory::SecretLeakDetected => "secret_leak_detected",
         FailureCategory::Unknown => "unknown",
     }
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -8,6 +8,7 @@
 //! You can extend this module with new formats by implementing the [`TrajectoryExporter`] trait.
 
 use super::Trajectory;
+use crate::redaction::{Redactor, surface};
 
 /// A contract for types that can convert a [`Trajectory`] into a specialized string format.
 ///
@@ -54,20 +55,22 @@ use std::fmt::Write;
 #[cfg(feature = "csv-export")]
 impl TrajectoryExporter for CsvExporter {
     fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
         let mut csv = String::new();
         csv.push_str("role,content\n");
 
         for msg in &trajectory.messages {
             let role = msg.role.as_str();
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
 
-            let escaped_content = if msg.content.contains('"')
-                || msg.content.contains(',')
-                || msg.content.contains('\n')
-                || msg.content.contains('\r')
+            let escaped_content = if content.contains('"')
+                || content.contains(',')
+                || content.contains('\n')
+                || content.contains('\r')
             {
-                format!("\"{}\"", msg.content.replace('"', "\"\""))
+                format!("\"{}\"", content.replace('"', "\"\""))
             } else {
-                msg.content.clone()
+                content
             };
 
             let _ = writeln!(csv, "{role},{escaped_content}");
@@ -79,11 +82,13 @@ impl TrajectoryExporter for CsvExporter {
 
 impl TrajectoryExporter for MarkdownExporter {
     fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
         let mut md = String::new();
 
         md.push_str("# Trajectory Export\n\n");
 
         if let Some(task) = &trajectory.info.task {
+            let task = redactor.redact_text(task, surface::EXPORT).text;
             let _ = write!(md, "**Task:** {task}\n\n");
         }
 
@@ -102,7 +107,8 @@ impl TrajectoryExporter for MarkdownExporter {
                 other => other,
             };
 
-            let _ = write!(md, "### {role_title}\n\n{}\n\n", msg.content);
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            let _ = write!(md, "### {role_title}\n\n{content}\n\n");
         }
 
         md
@@ -112,10 +118,12 @@ impl TrajectoryExporter for MarkdownExporter {
 #[cfg(feature = "mermaid-export")]
 impl TrajectoryExporter for MermaidExporter {
     fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
         let mut mermaid = String::new();
         mermaid.push_str("sequenceDiagram\n");
 
         if let Some(task) = &trajectory.info.task {
+            let task = redactor.redact_text(task, surface::EXPORT).text;
             let _ = writeln!(mermaid, "    title {task}");
         }
 
@@ -133,8 +141,8 @@ impl TrajectoryExporter for MermaidExporter {
                 _ => "U",
             };
 
-            let safe_content = msg
-                .content
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            let safe_content = content
                 .replace('&', "&amp;")
                 .replace('<', "&lt;")
                 .replace('>', "&gt;")

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -16,11 +16,6 @@ pub const FORMAT_VERSION: &str = "mini-swe-agent-1.1";
 /// Coarse run outcome. Exactly one of three values, suitable for computing
 /// pass@1-style metrics from trajectory files alone:
 /// `"submitted"` | `"step_limit_reached"` | `"error"`.
-#[cfg(any(
-    feature = "markdown-export",
-    feature = "csv-export",
-    feature = "mermaid-export"
-))]
 pub mod export;
 
 pub mod outcome {
@@ -53,6 +48,8 @@ pub enum FailureCategory {
     PatchApplyInvalid,
     /// Agent submitted but the captured diff was empty (zero bytes).
     PatchEmpty,
+    /// A configured secret literal was found in a submission artifact.
+    SecretLeakDetected,
     Unknown,
 }
 
@@ -298,6 +295,8 @@ pub struct TrajectoryInfo {
     pub token_usage: Option<TokenUsage>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub duration_secs: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redaction: Option<crate::redaction::RedactionSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub steps: Option<u32>,
     #[serde(default)]

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -738,6 +738,59 @@ async fn pre_tool_use_hook_env_preserves_full_command_for_policy_checks() {
     assert!(matches!(exit, ExitReason::Submitted { .. }));
 }
 
+#[tokio::test]
+async fn tool_hook_task_context_keeps_raw_task_while_trajectory_is_redacted() {
+    let configured_secret = "task-hook-secret-value";
+    let structured_secret = "ghp_0123456789ABCDEF0123456789ABCDEF0123";
+    let task = format!("fix {configured_secret} for {structured_secret}");
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+    cfg.root.redaction.secret_literals = vec![configured_secret.into()];
+    cfg.root.agent.hooks.pre_tool_use = vec![ToolHookCfg {
+        name: "task-probe".into(),
+        command: "hook-task={{ task }}".into(),
+        timeout_secs: None,
+    }];
+
+    let model = Arc::new(DeterministicModel::new(vec![
+        "```bash\necho primary\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(TaskHookEnv {
+        expected_task: task.clone(),
+        calls: Mutex::new(0),
+    });
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: task.clone(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+    assert!(matches!(exit, ExitReason::Submitted { .. }));
+
+    let trajectory_json = agent.trajectory.to_json_pretty().unwrap();
+    for leaked in [configured_secret, structured_secret] {
+        assert!(!trajectory_json.contains(leaked), "{trajectory_json}");
+    }
+    assert!(
+        agent
+            .trajectory
+            .info
+            .task
+            .as_deref()
+            .is_some_and(|task| task.contains("[REDACTED:configured_literal:")
+                && task.contains("[REDACTED:github_token:")),
+        "{trajectory_json}"
+    );
+}
+
 fn hook_command(vars: &[&str]) -> String {
     if cfg!(windows) {
         vars.chunks_exact(2)
@@ -778,6 +831,11 @@ struct LargeHookOutputEnv {
 #[derive(Default)]
 struct CommandPolicyHookEnv {
     calls: std::sync::Mutex<u32>,
+}
+
+struct TaskHookEnv {
+    expected_task: String,
+    calls: Mutex<u32>,
 }
 
 struct FixedExitEnvironment {
@@ -881,6 +939,54 @@ impl Environment for CommandPolicyHookEnv {
                 exit_code: 0,
                 timed_out: false,
             }),
+            other => Err(EnvError::CommandFailed(format!(
+                "unexpected env call {other}"
+            ))),
+        }
+    }
+}
+
+#[async_trait]
+impl Environment for TaskHookEnv {
+    async fn run(&self, req: RunRequest) -> Result<RunResult, EnvError> {
+        let mut calls = self.calls.lock().unwrap();
+        *calls += 1;
+        match *calls {
+            1 => {
+                let expected_command = format!("hook-task={}", self.expected_task);
+                if req.command != expected_command {
+                    return Err(EnvError::CommandFailed(format!(
+                        "hook command used redacted task: {}",
+                        req.command
+                    )));
+                }
+                let Some(task_env) = req.env.get("RUST_SWE_AGENT_TASK") else {
+                    return Err(EnvError::CommandFailed("missing task env".into()));
+                };
+                if task_env != &self.expected_task {
+                    return Err(EnvError::CommandFailed(format!(
+                        "task env used redacted task: {task_env}"
+                    )));
+                }
+                let context_json = req.env.get("RUST_SWE_AGENT_CONTEXT_JSON").unwrap();
+                let context: serde_json::Value = serde_json::from_str(context_json).unwrap();
+                assert_eq!(context["task"].as_str(), Some(self.expected_task.as_str()));
+                Ok(RunResult {
+                    stdout: "hook-ok\n".into(),
+                    stderr: String::new(),
+                    exit_code: 0,
+                    timed_out: false,
+                })
+            }
+            2 => {
+                assert_eq!(req.command, "echo primary");
+                Ok(RunResult {
+                    stdout: "primary\n".into(),
+                    stderr: String::new(),
+                    exit_code: 0,
+                    timed_out: false,
+                })
+            }
             other => Err(EnvError::CommandFailed(format!(
                 "unexpected env call {other}"
             ))),

--- a/tests/github_pr.rs
+++ b/tests/github_pr.rs
@@ -2,6 +2,7 @@
 
 use std::path::PathBuf;
 
+use rust_swe_agent::config::RedactionCfg;
 use rust_swe_agent::run::github_pr::{GithubPrOptions, PublishMode, build_pr_plan, render_dry_run};
 
 const SIMPLE_PATCH: &str = "diff --git a/src/lib.rs b/src/lib.rs\n\
@@ -28,6 +29,7 @@ fn options() -> GithubPrOptions {
         timeout_secs: 30,
         max_retries: 2,
         backoff_base_ms: 10,
+        redaction: RedactionCfg::default(),
     }
 }
 
@@ -101,4 +103,26 @@ fn dry_run_renders_pr_fields_without_token_material() {
         );
     }
     assert!(!rendered.contains("GITHUB_TOKEN_VALUE"));
+}
+
+#[test]
+fn pr_text_redaction_uses_configured_run_literals() {
+    let configured_secret = "configured-pr-secret-value";
+    let mut options = options();
+    options.task_id = format!("task-{configured_secret}");
+    options.trajectory_ref = format!("runs/{configured_secret}/run-1.traj.json");
+    options.patch_path = PathBuf::from(format!("runs/{configured_secret}/run-1.patch"));
+    options.redaction.secret_literals = vec![configured_secret.into()];
+
+    let plan = build_pr_plan(&options, SIMPLE_PATCH).unwrap();
+    let rendered = render_dry_run(&plan);
+
+    assert!(!plan.head_branch.contains(configured_secret), "{plan:#?}");
+    assert!(!plan.title.contains(configured_secret), "{plan:#?}");
+    assert!(!plan.body.contains(configured_secret), "{plan:#?}");
+    assert!(!rendered.contains(configured_secret), "{rendered}");
+    assert!(
+        rendered.contains("[REDACTED:configured_literal:"),
+        "{rendered}"
+    );
 }

--- a/tests/github_pr.rs
+++ b/tests/github_pr.rs
@@ -126,3 +126,51 @@ fn pr_text_redaction_uses_configured_run_literals() {
         "{rendered}"
     );
 }
+
+#[test]
+fn pr_dry_run_redacts_secret_bearing_summary_filenames() {
+    let configured_secret = "configured-file-secret-value";
+    let structured_secret = "ghp_0123456789ABCDEF0123456789ABCDEF0123";
+    let patch = format!(
+        "diff --git a/src/{configured_secret}.rs b/src/{configured_secret}.rs\n\
+         index e69de29..8ab686e 100644\n\
+         --- a/src/{configured_secret}.rs\n\
+         +++ b/src/{configured_secret}.rs\n\
+         @@ -0,0 +1 @@\n\
+         +configured\n\
+         diff --git a/src/{structured_secret}.rs b/src/{structured_secret}.rs\n\
+         index e69de29..8ab686e 100644\n\
+         --- a/src/{structured_secret}.rs\n\
+         +++ b/src/{structured_secret}.rs\n\
+         @@ -0,0 +1 @@\n\
+         +structured\n"
+    );
+    let mut options = options();
+    options.redaction.secret_literals = vec![configured_secret.into()];
+
+    let plan = build_pr_plan(&options, &patch).unwrap();
+    let rendered = render_dry_run(&plan);
+
+    assert_eq!(plan.summary.files_changed, 2);
+    for leaked in [configured_secret, structured_secret] {
+        assert!(
+            !plan.summary.files.iter().any(|file| file.contains(leaked)),
+            "{plan:#?}"
+        );
+        assert!(!rendered.contains(leaked), "{rendered}");
+    }
+    assert!(
+        plan.summary
+            .files
+            .iter()
+            .any(|file| file.contains("[REDACTED:configured_literal:")),
+        "{plan:#?}"
+    );
+    assert!(
+        plan.summary
+            .files
+            .iter()
+            .any(|file| file.contains("[REDACTED:github_token:")),
+        "{plan:#?}"
+    );
+}

--- a/tests/secret_redaction.rs
+++ b/tests/secret_redaction.rs
@@ -389,6 +389,93 @@ secret_literals = ["{configured_secret}"]
     );
 }
 
+#[tokio::test]
+async fn lowercase_key_token_assignments_in_patch_do_not_block_predictions() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    let base_commit = init_repo_with_file(&repo, "fixture.rs", "fn main() {}\n");
+    let dataset = work.path().join("dataset.jsonl");
+    let output = work.path().join("runs");
+    std::fs::create_dir_all(&output).unwrap();
+    write_dataset(&dataset, "ordinary-key-fixture", &base_commit);
+
+    let source = "let key = name; let api_key = test; let token = none;";
+    let edit_cmd = write_file_command(&repo.join("fixture.rs"), source);
+    let cfg = Config::from_toml_str(&format!(
+        r#"
+[environment]
+workdir = "{}"
+
+[model]
+name = "scripted-test-model"
+"#,
+        toml_escape_path(&repo)
+    ))
+    .unwrap();
+
+    let results = run_sweep(SwebenchArgs {
+        dataset_path: dataset,
+        output_dir: output.clone(),
+        parallel: 1,
+        reruns: 1,
+        config: cfg,
+        resume: false,
+        cost_limit_usd: None,
+        task_timeout_secs: None,
+        instance_ids: None,
+        limit: None,
+        sample: None,
+        seed: None,
+        stratify_by: None,
+        stratify_mode: rust_swe_agent::run::swebench::StratifyMode::Proportional,
+        max_retries: 0,
+        retry_on: None,
+        retry_backoff_base_ms: 0,
+        retry_backoff_cap_s: 0,
+        retry_on_resume: false,
+        deterministic_responses: Some(vec![
+            format!("```bash\n{edit_cmd}\n```"),
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
+        ]),
+        deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
+        skip_patch_validation: true,
+        max_rpm: None,
+        max_input_tpm: None,
+        cancel_deadline_secs: 30,
+        install_os_signal_handlers: false,
+        cancellation_signals: None,
+        github_pr: None,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(results.submitted, 1, "{results:#?}");
+    assert_eq!(results.errored, 0, "{results:#?}");
+    assert_eq!(results.instances[0].failure_category, None);
+
+    let patch_text =
+        std::fs::read_to_string(patch_path_for_run(&output, "ordinary-key-fixture", 1))
+            .unwrap_or_default();
+    assert!(patch_text.contains(source), "{patch_text}");
+    assert!(!patch_text.contains("[REDACTED:"), "{patch_text}");
+
+    let predictions = std::fs::read_to_string(output.join("all_preds.jsonl")).unwrap();
+    assert!(predictions.contains(source), "{predictions}");
+    assert!(
+        !predictions.contains("secret_leak_detected"),
+        "{predictions}"
+    );
+}
+
 #[test]
 fn bench_inspect_redacts_legacy_raw_trajectory_and_warns() {
     let work = tempfile::tempdir().unwrap();

--- a/tests/secret_redaction.rs
+++ b/tests/secret_redaction.rs
@@ -17,7 +17,9 @@ use rust_swe_agent::run::swebench::{
     SwebenchArgs, patch_path_for_run, run as run_sweep, trajectory_path_for_run,
 };
 use rust_swe_agent::stream::{BroadcastSink, StreamSink};
-use rust_swe_agent::{Agent, Config, DeterministicModel, Environment, ExitReason, RunResult};
+use rust_swe_agent::{
+    Agent, Config, DeterministicModel, Environment, ExitReason, Model, RunResult,
+};
 
 #[derive(Debug, Clone)]
 struct StaticEnvironment {
@@ -186,6 +188,83 @@ secret_literals = ["{configured_secret}"]
             .as_deref()
             .is_some_and(|task| task.contains("[REDACTED:configured_literal:")),
         "{trajectory_json}"
+    );
+}
+
+#[tokio::test]
+async fn rendered_observation_template_static_literals_are_redacted_before_history() {
+    let configured_secret = "static-observation-template-secret";
+    let mut cfg = Config::from_toml_str(&format!(
+        r#"
+[agent]
+step_limit = 5
+
+[redaction]
+secret_literals = ["{configured_secret}"]
+"#
+    ))
+    .unwrap();
+    cfg.root.agent.observation_template = format!(
+        "ci annotation: {configured_secret}\nExit code: {{{{ returncode }}}}\nOutput:\n{{{{ output }}}}"
+    );
+
+    let model = Arc::new(DeterministicModel::new(vec![
+        "```bash\necho visible-output\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
+    ]));
+    let model_for_agent: Arc<dyn Model> = model.clone();
+    let env: Box<dyn Environment> = Box::new(StaticEnvironment {
+        result: RunResult {
+            stdout: "visible-output\n".into(),
+            stderr: String::new(),
+            exit_code: 0,
+            timed_out: false,
+        },
+    });
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model: model_for_agent,
+        env,
+        task: "redact static observation template text".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+    assert!(matches!(exit, ExitReason::Submitted { .. }));
+
+    let history_text = agent
+        .history
+        .iter()
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(!history_text.contains(configured_secret), "{history_text}");
+    assert!(
+        history_text.contains("[REDACTED:configured_literal:"),
+        "{history_text}"
+    );
+
+    let recorded_inputs = model.recorded_inputs();
+    assert!(
+        recorded_inputs.len() >= 2,
+        "expected a second model query, got {recorded_inputs:#?}"
+    );
+    let second_prompt = recorded_inputs[1]
+        .iter()
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !second_prompt.contains(configured_secret),
+        "{second_prompt}"
+    );
+    assert!(
+        second_prompt.contains("[REDACTED:configured_literal:"),
+        "{second_prompt}"
     );
 }
 

--- a/tests/secret_redaction.rs
+++ b/tests/secret_redaction.rs
@@ -140,6 +140,55 @@ custom_patterns = ["CUSTOMSECRET-[0-9]{{3}}"]
     );
 }
 
+#[test]
+fn trajectory_task_metadata_redacts_configured_literals_on_build() {
+    let configured_secret = "task-metadata-secret-value";
+    let cfg = Config::from_toml_str(&format!(
+        r#"
+[redaction]
+secret_literals = ["{configured_secret}"]
+"#
+    ))
+    .unwrap();
+    let model = Arc::new(DeterministicModel::new(Vec::new()));
+    let env: Box<dyn Environment> = Box::new(StaticEnvironment {
+        result: RunResult {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: 0,
+            timed_out: false,
+        },
+    });
+
+    let agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: format!("fix the leak with {configured_secret}"),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let trajectory_json = agent.trajectory.to_json_pretty().unwrap();
+    assert_no_raw_values(
+        "trajectory task metadata",
+        &trajectory_json,
+        [configured_secret],
+    );
+    assert!(
+        agent
+            .trajectory
+            .info
+            .task
+            .as_deref()
+            .is_some_and(|task| task.contains("[REDACTED:configured_literal:")),
+        "{trajectory_json}"
+    );
+}
+
 #[cfg(feature = "markdown-export")]
 #[test]
 fn markdown_export_redacts_raw_trajectory_content() {

--- a/tests/secret_redaction.rs
+++ b/tests/secret_redaction.rs
@@ -1,0 +1,428 @@
+//! Secret redaction contract tests for trajectories, streams, exports, inspect,
+//! and submission artifacts.
+
+#![allow(clippy::unwrap_used)]
+
+use std::fmt::Write as _;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rust_swe_agent::agent::default::DefaultAgentBuilder;
+use rust_swe_agent::env::RunRequest;
+use rust_swe_agent::error::EnvError;
+use rust_swe_agent::run::inspect::{InspectArgs, InspectOutput};
+use rust_swe_agent::run::swebench::{
+    SwebenchArgs, patch_path_for_run, run as run_sweep, trajectory_path_for_run,
+};
+use rust_swe_agent::stream::{BroadcastSink, StreamSink};
+use rust_swe_agent::{Agent, Config, DeterministicModel, Environment, ExitReason, RunResult};
+
+#[derive(Debug, Clone)]
+struct StaticEnvironment {
+    result: RunResult,
+}
+
+#[async_trait]
+impl Environment for StaticEnvironment {
+    async fn run(&self, _req: RunRequest) -> Result<RunResult, EnvError> {
+        Ok(self.result.clone())
+    }
+}
+
+#[tokio::test]
+async fn redacts_hundred_secret_fixture_from_trajectory_and_streams() {
+    let secrets = synthetic_secret_corpus();
+    assert_eq!(secrets.len(), 100);
+    let custom_literal = "literal-secret-fixture-value";
+    let custom_pattern_secret = "CUSTOMSECRET-042";
+
+    let stdout = format!(
+        "{}\nrepeat={}\ncustom={custom_literal}\npattern={custom_pattern_secret}\n",
+        secrets[..50].join("\n"),
+        secrets[0]
+    );
+    let stderr = format!("{}\nrepeat={}\n", secrets[50..99].join("\n"), secrets[0]);
+    let assistant_command_secret = &secrets[99];
+    let command = format!(
+        "curl -H 'Authorization: Bearer {assistant_command_secret}' https://example.invalid"
+    );
+
+    let cfg = Config::from_toml_str(&format!(
+        r#"
+[agent]
+step_limit = 5
+
+[redaction]
+secret_literals = ["{custom_literal}"]
+custom_patterns = ["CUSTOMSECRET-[0-9]{{3}}"]
+"#
+    ))
+    .unwrap();
+    let bcast = Arc::new(BroadcastSink::default());
+    let mut rx = bcast.subscribe();
+    let model = Arc::new(DeterministicModel::new(vec![
+        format!("```bash\n{command}\n```"),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(StaticEnvironment {
+        result: RunResult {
+            stdout,
+            stderr,
+            exit_code: 0,
+            timed_out: false,
+        },
+    });
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "redact all the sharp things".into(),
+        extra_context: None,
+        renderer: None,
+        stream: Some(bcast as Arc<dyn StreamSink>),
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+    assert!(matches!(exit, ExitReason::Submitted { .. }));
+
+    let trajectory_json = agent.trajectory.to_json_pretty().unwrap();
+    assert_no_raw_values(
+        "trajectory",
+        &trajectory_json,
+        secrets
+            .iter()
+            .map(String::as_str)
+            .chain([custom_literal, custom_pattern_secret]),
+    );
+    assert!(
+        trajectory_json.contains("[REDACTED:"),
+        "trajectory should include stable redaction markers:\n{trajectory_json}"
+    );
+    assert!(
+        trajectory_json.contains("\"redaction\""),
+        "trajectory info should report redaction counts:\n{trajectory_json}"
+    );
+    assert!(
+        trajectory_json.contains("\"stream\"") && trajectory_json.contains("\"trajectory\""),
+        "redaction counts should be grouped by surface:\n{trajectory_json}"
+    );
+
+    let mut stream_json = String::new();
+    while let Ok(event) = rx.try_recv() {
+        writeln!(
+            &mut stream_json,
+            "{}",
+            serde_json::to_string(&event).unwrap()
+        )
+        .unwrap();
+    }
+    assert_no_raw_values(
+        "stream events",
+        &stream_json,
+        secrets
+            .iter()
+            .map(String::as_str)
+            .chain([custom_literal, custom_pattern_secret]),
+    );
+    assert!(
+        stream_json.contains("[REDACTED:"),
+        "stream events should include redaction markers:\n{stream_json}"
+    );
+
+    let markers = markers_for_repeated_secret(&trajectory_json, &stream_json);
+    assert!(
+        markers.len() == 1,
+        "same secret should have one stable marker within the run, got {markers:?}"
+    );
+}
+
+#[cfg(feature = "markdown-export")]
+#[test]
+fn markdown_export_redacts_raw_trajectory_content() {
+    use rust_swe_agent::model::Message;
+    use rust_swe_agent::trajectory::Trajectory;
+    use rust_swe_agent::trajectory::export::{MarkdownExporter, TrajectoryExporter};
+
+    let secret = "ghp_0123456789ABCDEF0123456789ABCDEF0123";
+    let mut trajectory = Trajectory::new();
+    trajectory.info.task = Some(format!("fix with {secret}"));
+    trajectory.record_message(&Message::assistant(format!("```bash\necho {secret}\n```")));
+    trajectory.record_message(&Message::user(format!("stdout: {secret}")));
+
+    let exported = MarkdownExporter::export(&trajectory);
+    assert!(!exported.contains(secret), "{exported}");
+    assert!(exported.contains("[REDACTED:"), "{exported}");
+}
+
+#[tokio::test]
+async fn configured_literal_in_patch_blocks_submission_and_predictions() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    let base_commit = init_repo_with_file(&repo, "secret.txt", "before\n");
+    let configured_secret = "literal-secret-fixture-value";
+    let dataset = work.path().join("dataset.jsonl");
+    let output = work.path().join("runs");
+    std::fs::create_dir_all(&output).unwrap();
+    write_dataset(&dataset, "secret-leak", &base_commit);
+
+    let edit_cmd = write_file_command(&repo.join("secret.txt"), configured_secret);
+    let cfg = Config::from_toml_str(&format!(
+        r#"
+[environment]
+workdir = "{}"
+
+[model]
+name = "scripted-test-model"
+
+[redaction]
+secret_literals = ["{configured_secret}"]
+"#,
+        toml_escape_path(&repo)
+    ))
+    .unwrap();
+
+    let results = run_sweep(SwebenchArgs {
+        dataset_path: dataset,
+        output_dir: output.clone(),
+        parallel: 1,
+        reruns: 1,
+        config: cfg,
+        resume: false,
+        cost_limit_usd: None,
+        task_timeout_secs: None,
+        instance_ids: None,
+        limit: None,
+        sample: None,
+        seed: None,
+        stratify_by: None,
+        stratify_mode: rust_swe_agent::run::swebench::StratifyMode::Proportional,
+        max_retries: 0,
+        retry_on: None,
+        retry_backoff_base_ms: 0,
+        retry_backoff_cap_s: 0,
+        retry_on_resume: false,
+        deterministic_responses: Some(vec![
+            format!("```bash\n{edit_cmd}\n```"),
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
+        ]),
+        deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
+        skip_patch_validation: true,
+        max_rpm: None,
+        max_input_tpm: None,
+        cancel_deadline_secs: 30,
+        install_os_signal_handlers: false,
+        cancellation_signals: None,
+        github_pr: None,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(results.submitted, 0, "{results:#?}");
+    assert_eq!(results.errored, 1, "{results:#?}");
+    let failure = serde_json::to_value(results.instances[0].failure_category).unwrap();
+    assert_eq!(failure, serde_json::json!("secret_leak_detected"));
+
+    let trajectory_path = trajectory_path_for_run(&output, "secret-leak", 1);
+    let trajectory_json = std::fs::read_to_string(&trajectory_path).unwrap();
+    assert!(
+        !trajectory_json.contains(configured_secret),
+        "{trajectory_json}"
+    );
+    assert!(
+        trajectory_json.contains("secret_leak_detected"),
+        "{trajectory_json}"
+    );
+
+    let patch_text =
+        std::fs::read_to_string(patch_path_for_run(&output, "secret-leak", 1)).unwrap_or_default();
+    assert!(!patch_text.contains(configured_secret), "{patch_text}");
+
+    let predictions = std::fs::read_to_string(output.join("all_preds.jsonl")).unwrap();
+    assert!(
+        !predictions.contains(configured_secret),
+        "prediction artifact leaked configured literal:\n{predictions}"
+    );
+    assert!(
+        predictions.trim().is_empty(),
+        "blocked submissions should not emit prediction rows:\n{predictions}"
+    );
+}
+
+#[test]
+fn bench_inspect_redacts_legacy_raw_trajectory_and_warns() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = work.path().join("runs");
+    let instance_dir = sweep.join("legacy-raw");
+    std::fs::create_dir_all(&instance_dir).unwrap();
+    let secret = "ghp_0123456789ABCDEF0123456789ABCDEF0123";
+    let trajectory = serde_json::json!({
+        "trajectory_format": "mini-swe-agent-1.1",
+        "info": {
+            "task": "legacy",
+            "model_name": "model",
+            "outcome": "submitted"
+        },
+        "messages": [
+            {"role": "assistant", "content": format!("```bash\necho {secret}\n```"), "extra": {"actions": [format!("echo {secret}")]}},
+            {
+                "role": "user",
+                "content": format!("Exit code: 0\nOutput:\n{secret}"),
+                "extra": {
+                    "other": {
+                        "run_result": {
+                            "stdout": secret,
+                            "stderr": "",
+                            "exit_code": 0,
+                            "timed_out": false
+                        }
+                    }
+                }
+            }
+        ]
+    });
+    std::fs::write(
+        instance_dir.join("trajectory.json"),
+        serde_json::to_string_pretty(&trajectory).unwrap(),
+    )
+    .unwrap();
+
+    let output = rust_swe_agent::run::inspect::run(&InspectArgs {
+        sweep,
+        instance: Some("legacy-raw".into()),
+        filter: None,
+        full: true,
+    })
+    .unwrap();
+    let text = rust_swe_agent::run::inspect::render_text(&output);
+    assert!(!text.contains(secret), "{text}");
+    assert!(text.contains("[REDACTED:"), "{text}");
+    assert!(text.to_ascii_lowercase().contains("redacted"), "{text}");
+    match output {
+        InspectOutput::Instance(report) => {
+            assert!(
+                report
+                    .warnings
+                    .iter()
+                    .any(|warning| warning.to_ascii_lowercase().contains("redacted")),
+                "{:#?}",
+                report.warnings
+            );
+        }
+        InspectOutput::Summary(_) => panic!("expected instance report"),
+    }
+}
+
+fn synthetic_secret_corpus() -> Vec<String> {
+    (0..100)
+        .map(|i| format!("ghp_{i:036X}"))
+        .collect::<Vec<_>>()
+}
+
+fn markers_for_repeated_secret(first: &str, second: &str) -> std::collections::BTreeSet<String> {
+    let mut markers = std::collections::BTreeSet::new();
+    for text in [first, second] {
+        for (start, _) in text.match_indices("repeat=") {
+            let rest = &text[start + "repeat=".len()..];
+            let end = rest
+                .find(['\\', '\n', '\r', '"', '\'', ',', '}'])
+                .unwrap_or(rest.len());
+            let marker = rest[..end].trim();
+            if marker.starts_with("[REDACTED:") {
+                markers.insert(marker.to_owned());
+            }
+        }
+    }
+    markers
+}
+
+fn assert_no_raw_values<'a>(label: &str, text: &str, values: impl IntoIterator<Item = &'a str>) {
+    for value in values {
+        assert!(
+            !text.contains(value),
+            "{label} leaked raw secret {value:?}:\n{text}"
+        );
+    }
+}
+
+fn init_repo_with_file(dir: &Path, filename: &str, contents: &str) -> String {
+    git(dir, &["init", "-q", "-b", "main"]);
+    git(dir, &["config", "user.email", "test@test"]);
+    git(dir, &["config", "user.name", "test"]);
+    git(dir, &["config", "commit.gpgSign", "false"]);
+    git(dir, &["config", "tag.gpgSign", "false"]);
+    std::fs::write(dir.join(filename), contents).unwrap();
+    git(dir, &["add", filename]);
+    git(dir, &["commit", "-q", "-m", "base"]);
+    git_stdout(dir, &["rev-parse", "HEAD"]).trim().to_owned()
+}
+
+fn write_dataset(path: &Path, instance_id: &str, base_commit: &str) {
+    std::fs::write(
+        path,
+        format!(
+            "{{\"instance_id\":\"{instance_id}\",\"problem_statement\":\"noop\",\"base_commit\":\"{base_commit}\"}}\n"
+        ),
+    )
+    .unwrap();
+}
+
+fn write_file_command(path: &Path, contents: &str) -> String {
+    if cfg!(windows) {
+        format!(
+            "powershell -NoProfile -Command \"Set-Content -LiteralPath '{}' -Value '{}'\"",
+            path.display(),
+            contents
+        )
+    } else {
+        format!("printf '%s\\n' '{}' > '{}'", contents, path.display())
+    }
+}
+
+fn toml_escape_path(path: &Path) -> String {
+    path.display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
+fn git(dir: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn git_stdout(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).unwrap()
+}

--- a/tests/swebench_patch.rs
+++ b/tests/swebench_patch.rs
@@ -17,7 +17,7 @@ use rust_swe_agent::Config;
 use rust_swe_agent::run::swebench::{
     SwebenchArgs, patch_path_for_run, run, trajectory_path_for_run,
 };
-use rust_swe_agent::trajectory::{Trajectory, outcome};
+use rust_swe_agent::trajectory::{FailureCategory, Trajectory, outcome};
 
 /// Initialize a git repo at `dir` with one tracked file at the base
 /// commit. The file's existence is what makes the working tree's
@@ -267,6 +267,107 @@ async fn sweep_emits_empty_patch_when_agent_changes_nothing() {
     )
     .unwrap();
     assert_eq!(traj.info.outcome.as_deref(), Some(outcome::SUBMITTED));
+}
+
+#[tokio::test]
+async fn benign_key_substring_assignments_do_not_trigger_secret_leak() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    let base_commit = init_repo_with_file(&repo, "settings.env", "before\n");
+
+    let dataset = work.path().join("dataset.jsonl");
+    let output = work.path().join("runs");
+    std::fs::create_dir_all(&output).unwrap();
+    write_dataset(&dataset, &["benign-key-substrings"], &base_commit);
+
+    let settings_path = repo.join("settings.env");
+    let mod_cmd = format!(
+        "echo MONKEY=abcd> {} && echo KEYBOARD_LAYOUT=uspc>> {}",
+        settings_path.display(),
+        settings_path.display()
+    );
+    let responses = vec![
+        format!("```bash\n{mod_cmd}\n```"),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nmodified\n```".into(),
+    ];
+
+    let toml = format!(
+        "[environment]\nworkdir = \"{}\"\n\n[model]\nname = \"scripted-test-model\"\n",
+        toml_escape_path(&repo)
+    );
+    let cfg = Config::from_toml_str(&toml).unwrap();
+    let results = run(SwebenchArgs {
+        dataset_path: dataset,
+        output_dir: output.clone(),
+        parallel: 1,
+        reruns: 1,
+        config: cfg,
+        resume: false,
+        cost_limit_usd: None,
+        task_timeout_secs: None,
+        instance_ids: None,
+        limit: None,
+        sample: None,
+        seed: None,
+        stratify_by: None,
+        stratify_mode: rust_swe_agent::run::swebench::StratifyMode::Proportional,
+        max_retries: 0,
+        retry_on: None,
+        retry_backoff_base_ms: 0,
+        retry_backoff_cap_s: 0,
+        retry_on_resume: false,
+        deterministic_responses: Some(responses),
+        deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
+        skip_patch_validation: true,
+        max_rpm: None,
+        max_input_tpm: None,
+        cancel_deadline_secs: 30,
+        install_os_signal_handlers: false,
+        cancellation_signals: None,
+        github_pr: None,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(results.total, 1);
+    assert_eq!(results.submitted, 1, "{results:#?}");
+    assert_eq!(results.errored, 0, "{results:#?}");
+    assert_eq!(
+        results
+            .failures_by_category
+            .get(&FailureCategory::SecretLeakDetected),
+        None
+    );
+
+    let patch_text =
+        std::fs::read_to_string(patch_path_for_run(&output, "benign-key-substrings", 1)).unwrap();
+    assert!(patch_text.contains("+MONKEY=abcd"), "{patch_text}");
+    assert!(patch_text.contains("+KEYBOARD_LAYOUT=uspc"), "{patch_text}");
+    assert!(!patch_text.contains("[REDACTED:"), "{patch_text}");
+
+    let preds_text = std::fs::read_to_string(output.join("all_preds.jsonl")).unwrap();
+    let lines: Vec<&str> = preds_text.lines().filter(|line| !line.is_empty()).collect();
+    assert_eq!(lines.len(), 1, "expected one prediction line: {preds_text}");
+    let row: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    let model_patch = row
+        .get("model_patch")
+        .and_then(|value| value.as_str())
+        .unwrap();
+    assert!(model_patch.contains("+MONKEY=abcd"), "{model_patch}");
+    assert!(
+        model_patch.contains("+KEYBOARD_LAYOUT=uspc"),
+        "{model_patch}"
+    );
+    assert!(!model_patch.contains("[REDACTED:"), "{model_patch}");
 }
 
 #[tokio::test]

--- a/tests/swebench_resume.rs
+++ b/tests/swebench_resume.rs
@@ -15,7 +15,9 @@ use rust_swe_agent::run::github_pr::{GithubPrSweepConfig, PublishMode};
 use rust_swe_agent::run::swebench::{
     SwebenchArgs, patch_path_for_run, run, trajectory_path_for_run,
 };
-use rust_swe_agent::trajectory::{FORMAT_VERSION, Trajectory, TrajectoryInfo, outcome};
+use rust_swe_agent::trajectory::{
+    FORMAT_VERSION, FailureCategory, Trajectory, TrajectoryInfo, outcome,
+};
 
 fn write_dataset(path: &Path, instance_ids: &[&str]) {
     let mut s = String::new();
@@ -88,6 +90,24 @@ fn config_with_workdir(dir: &Path) -> Config {
         .replace('\\', "\\\\")
         .replace('"', "\\\"");
     let toml = format!("[environment]\nworkdir = \"{workdir}\"\n");
+    Config::from_toml_str(&toml).unwrap()
+}
+
+fn config_with_workdir_and_redaction(dir: &Path, secret: &str) -> Config {
+    let workdir = dir
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let toml = format!(
+        r#"
+[environment]
+workdir = "{workdir}"
+
+[redaction]
+secret_literals = ["{secret}"]
+"#
+    );
     Config::from_toml_str(&toml).unwrap()
 }
 
@@ -513,6 +533,109 @@ async fn resume_uses_on_disk_patch_flags_even_if_prior_summary_is_false() {
         pred.get("model_patch").and_then(serde_json::Value::as_str),
         Some("diff --git a/x b/x\n")
     );
+}
+
+#[tokio::test]
+async fn resume_raw_secret_patch_downgrades_instance_and_writes_results() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+    let dataset = work.path().join("dataset.jsonl");
+    let output = work.path().join("runs");
+    std::fs::create_dir_all(&output).unwrap();
+    write_dataset(&dataset, &["leaky", "clean"]);
+
+    let secret = "legacy-prediction-secret-value";
+    write_valid_trajectory(&output.join("leaky.traj.json"), "leaky");
+    write_valid_trajectory(&output.join("clean.traj.json"), "clean");
+    std::fs::write(
+        output.join("leaky.patch"),
+        format!("diff --git a/x b/x\n+{secret}\n"),
+    )
+    .unwrap();
+    std::fs::write(output.join("clean.patch"), "diff --git a/x b/x\n+clean\n").unwrap();
+
+    let cfg = config_with_workdir_and_redaction(&repo, secret);
+    let results = run(SwebenchArgs {
+        dataset_path: dataset,
+        output_dir: output.clone(),
+        parallel: 1,
+        reruns: 1,
+        config: cfg,
+        resume: true,
+        cost_limit_usd: None,
+        task_timeout_secs: None,
+        instance_ids: None,
+        limit: None,
+        sample: None,
+        seed: None,
+        stratify_by: None,
+        stratify_mode: rust_swe_agent::run::swebench::StratifyMode::Proportional,
+        max_retries: 0,
+        retry_on: None,
+        retry_backoff_base_ms: 0,
+        retry_backoff_cap_s: 0,
+        retry_on_resume: false,
+        deterministic_responses: Some(submit_only_responses()),
+        deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
+        skip_patch_validation: true,
+        max_rpm: None,
+        max_input_tpm: None,
+        cancel_deadline_secs: 30,
+        install_os_signal_handlers: false,
+        cancellation_signals: None,
+        github_pr: None,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(results.total, 2);
+    assert_eq!(results.skipped, 1, "{results:#?}");
+    assert_eq!(results.errored, 1, "{results:#?}");
+    assert_eq!(results.submitted, 0, "{results:#?}");
+    assert_eq!(
+        results
+            .failures_by_category
+            .get(&FailureCategory::SecretLeakDetected),
+        Some(&1)
+    );
+
+    let leaky = results
+        .instances
+        .iter()
+        .find(|row| row.instance_id == "leaky")
+        .unwrap();
+    assert_eq!(leaky.outcome.as_deref(), Some(outcome::ERROR));
+    assert_eq!(leaky.exit_reason, "error");
+    assert_eq!(
+        leaky.failure_category,
+        Some(FailureCategory::SecretLeakDetected)
+    );
+    assert!(!leaky.pass_at_1);
+    assert_eq!(leaky.resolved_count, 0);
+
+    let results_json = std::fs::read_to_string(output.join("results.json")).unwrap();
+    assert!(results_json.contains("\"sweep_status\": \"completed\""));
+    assert!(results_json.contains("secret_leak_detected"));
+    assert!(!results_json.contains(secret), "{results_json}");
+
+    let preds = std::fs::read_to_string(output.join("all_preds.jsonl")).unwrap();
+    assert_eq!(preds.lines().count(), 1, "{preds}");
+    assert!(preds.contains("\"instance_id\":\"clean\""), "{preds}");
+    assert!(!preds.contains(secret), "{preds}");
+
+    let leaky_patch = std::fs::read_to_string(output.join("leaky.patch")).unwrap();
+    assert!(!leaky_patch.contains(secret), "{leaky_patch}");
+    assert!(leaky_patch.contains("[REDACTED:configured_literal:"));
 }
 
 #[tokio::test]

--- a/tests/swebench_resume.rs
+++ b/tests/swebench_resume.rs
@@ -639,6 +639,108 @@ async fn resume_raw_secret_patch_downgrades_instance_and_writes_results() {
 }
 
 #[tokio::test]
+async fn resume_raw_secret_patch_blocks_github_pr_publication_before_publish() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+    let dataset = work.path().join("dataset.jsonl");
+    let output = work.path().join("runs");
+    std::fs::create_dir_all(&output).unwrap();
+    write_dataset(&dataset, &["leaky-pr"]);
+
+    let secret = "legacy-pr-secret-value";
+    write_valid_trajectory(&output.join("leaky-pr.traj.json"), "leaky-pr");
+    std::fs::write(
+        output.join("leaky-pr.patch"),
+        format!("diff --git a/x b/x\n+{secret}\n"),
+    )
+    .unwrap();
+
+    let cfg = config_with_workdir_and_redaction(&repo, secret);
+    let results = run(SwebenchArgs {
+        dataset_path: dataset,
+        output_dir: output.clone(),
+        parallel: 1,
+        reruns: 1,
+        config: cfg,
+        resume: true,
+        cost_limit_usd: None,
+        task_timeout_secs: None,
+        instance_ids: None,
+        limit: None,
+        sample: None,
+        seed: None,
+        stratify_by: None,
+        stratify_mode: rust_swe_agent::run::swebench::StratifyMode::Proportional,
+        max_retries: 0,
+        retry_on: None,
+        retry_backoff_base_ms: 0,
+        retry_backoff_cap_s: 0,
+        retry_on_resume: false,
+        deterministic_responses: Some(submit_only_responses()),
+        deterministic_usage_per_call: None,
+        config_overlay_paths: Vec::new(),
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
+        skip_patch_validation: true,
+        max_rpm: None,
+        max_input_tpm: None,
+        cancel_deadline_secs: 30,
+        install_os_signal_handlers: false,
+        cancellation_signals: None,
+        github_pr: Some(GithubPrSweepConfig {
+            target_repo: "not-a-valid-owner-repo".into(),
+            target_branch: "trunk".into(),
+            token_env: "GITHUB_TOKEN".into(),
+            mode: PublishMode::DryRun,
+            timeout_secs: 1,
+            max_retries: 0,
+            backoff_base_ms: 1,
+            branch_prefix: "rust-swe-agent".into(),
+        }),
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(results.total, 1);
+    assert_eq!(results.errored, 1, "{results:#?}");
+    assert_eq!(results.submitted, 0, "{results:#?}");
+    assert_eq!(results.github_pr_failures, 0, "{results:#?}");
+    assert_eq!(
+        results
+            .failures_by_category
+            .get(&FailureCategory::SecretLeakDetected),
+        Some(&1)
+    );
+
+    let row = &results.instances[0];
+    assert_eq!(row.instance_id, "leaky-pr");
+    assert_eq!(row.outcome.as_deref(), Some(outcome::ERROR));
+    assert_eq!(
+        row.failure_category,
+        Some(FailureCategory::SecretLeakDetected)
+    );
+    assert!(
+        row.github_pr_error.is_none(),
+        "leaky resumed patch reached PR publisher: {:?}",
+        row.github_pr_error
+    );
+
+    let leaky_patch = std::fs::read_to_string(output.join("leaky-pr.patch")).unwrap();
+    assert!(!leaky_patch.contains(secret), "{leaky_patch}");
+    assert!(leaky_patch.contains("[REDACTED:configured_literal:"));
+
+    let preds = std::fs::read_to_string(output.join("all_preds.jsonl")).unwrap();
+    assert!(preds.is_empty(), "{preds}");
+}
+
+#[tokio::test]
 async fn resume_skipped_submitted_runs_still_attempt_github_pr_publication() {
     let work = tempfile::tempdir().unwrap();
     let repo = work.path().join("repo");


### PR DESCRIPTION
  Add default secret redaction across trajectories, streams, inspect/export
  surfaces, GitHub PR text, patches, and SWE-bench predictions.

  Submitted artifacts that still contain detected secrets now fail as
  secret_leak_detected unless explicitly bypassed, because leaking tokens is
  not a feature, it is a summoning circle.