### PR TITLE
⚒️ Forge: fix docker env test structure and clippy warnings

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -334,40 +334,6 @@ impl Drop for DockerEnvironment {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn test_env() -> DockerEnvironment {
-        DockerEnvironment {
-            container_id: ContainerId::new("test-container"),
-            image: "test-image".into(),
-            workdir: PathBuf::from("/workspace"),
-            shutdown_sent: AtomicBool::new(false),
-            cleanup_on_drop: false,
-        }
-    }
-
-    #[test]
-    fn failed_container_removal_does_not_mark_shutdown_sent() {
-        let env = test_env();
-
-        let result = env.mark_shutdown_after_remove(Err(EnvError::CommandFailed("boom".into())));
-
-        assert!(result.is_err());
-        assert!(!env.shutdown_sent.load(Ordering::SeqCst));
-    }
-
-    #[test]
-    fn successful_container_removal_marks_shutdown_sent() {
-        let env = test_env();
-
-        env.mark_shutdown_after_remove(Ok(())).unwrap();
-
-        assert!(env.shutdown_sent.load(Ordering::SeqCst));
-    }
-}
-
 /// Reap any container with our label. Called by `rust-swe-agent cleanup`.
 /// Returns the list of reaped container ids.
 pub async fn cleanup_orphans() -> Result<Vec<String>, EnvError> {
@@ -410,3 +376,38 @@ pub async fn cleanup_orphans() -> Result<Vec<String>, EnvError> {
 
 #[allow(dead_code)]
 const _COMPILE_TIME_USED: Duration = Duration::from_secs(0);
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+
+    fn test_env() -> DockerEnvironment {
+        DockerEnvironment {
+            container_id: ContainerId::new("test-container"),
+            image: "test-image".into(),
+            workdir: PathBuf::from("/workspace"),
+            shutdown_sent: AtomicBool::new(false),
+            cleanup_on_drop: false,
+        }
+    }
+
+    #[test]
+    fn failed_container_removal_does_not_mark_shutdown_sent() {
+        let env = test_env();
+
+        let result = env.mark_shutdown_after_remove(Err(EnvError::CommandFailed("boom".into())));
+
+        assert!(result.is_err());
+        assert!(!env.shutdown_sent.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn successful_container_removal_marks_shutdown_sent() {
+        let env = test_env();
+
+        env.mark_shutdown_after_remove(Ok(())).unwrap();
+
+        assert!(env.shutdown_sent.load(Ordering::SeqCst));
+    }
+}


### PR DESCRIPTION
⚒️ Forge: fix docker env test structure and clippy warnings

* 🚮 Smell: The `tests` module in `src/env/docker.rs` was not at the bottom of the file, causing a `clippy::items_after_test_module` warning. Additionally, `unwrap()` was used inside the test module without an explicit allow attribute, causing a `clippy::unwrap_used` warning.
* ✨ Solution: Moved the `tests` module to the end of `src/env/docker.rs` and added `#![allow(clippy::unwrap_used)]` inside the test module.
* 🧼 Benefit: Resolves strict clippy warnings and adheres to standard Rust idiomatic structure where test modules are located at the bottom of the file.
* 🛡️ Verification: Tests passed. No logic changed. Verified using `cargo clippy --all-targets --all-features -- -D warnings`.

---
*PR created automatically by Jules for task [7182047997751397710](https://jules.google.com/task/7182047997751397710) started by @madmax983*