### PR TITLE
🛡️ Sentry: [test coverage improvement] Added tests for ConfigError conversion and enum display

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -334,40 +334,6 @@ impl Drop for DockerEnvironment {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn test_env() -> DockerEnvironment {
-        DockerEnvironment {
-            container_id: ContainerId::new("test-container"),
-            image: "test-image".into(),
-            workdir: PathBuf::from("/workspace"),
-            shutdown_sent: AtomicBool::new(false),
-            cleanup_on_drop: false,
-        }
-    }
-
-    #[test]
-    fn failed_container_removal_does_not_mark_shutdown_sent() {
-        let env = test_env();
-
-        let result = env.mark_shutdown_after_remove(Err(EnvError::CommandFailed("boom".into())));
-
-        assert!(result.is_err());
-        assert!(!env.shutdown_sent.load(Ordering::SeqCst));
-    }
-
-    #[test]
-    fn successful_container_removal_marks_shutdown_sent() {
-        let env = test_env();
-
-        env.mark_shutdown_after_remove(Ok(())).unwrap();
-
-        assert!(env.shutdown_sent.load(Ordering::SeqCst));
-    }
-}
-
 /// Reap any container with our label. Called by `rust-swe-agent cleanup`.
 /// Returns the list of reaped container ids.
 pub async fn cleanup_orphans() -> Result<Vec<String>, EnvError> {
@@ -410,3 +376,37 @@ pub async fn cleanup_orphans() -> Result<Vec<String>, EnvError> {
 
 #[allow(dead_code)]
 const _COMPILE_TIME_USED: Duration = Duration::from_secs(0);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_env() -> DockerEnvironment {
+        DockerEnvironment {
+            container_id: ContainerId::new("test-container"),
+            image: "test-image".into(),
+            workdir: PathBuf::from("/workspace"),
+            shutdown_sent: AtomicBool::new(false),
+            cleanup_on_drop: false,
+        }
+    }
+
+    #[test]
+    fn failed_container_removal_does_not_mark_shutdown_sent() {
+        let env = test_env();
+
+        let result = env.mark_shutdown_after_remove(Err(EnvError::CommandFailed("boom".into())));
+
+        assert!(result.is_err());
+        assert!(!env.shutdown_sent.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn successful_container_removal_marks_shutdown_sent() {
+        let env = test_env();
+
+        assert!(env.mark_shutdown_after_remove(Ok(())).is_ok());
+
+        assert!(env.shutdown_sent.load(Ordering::SeqCst));
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -92,3 +92,44 @@ impl From<toml::de::Error> for ConfigError {
         Self::Toml(e.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_error_from_toml_error() {
+        // We simulate a toml deserialization error to test the From trait implementation
+        let Err(toml_err) = toml::from_str::<serde::de::IgnoredAny>("invalid toml = {") else {
+            panic!("expected error")
+        };
+        let config_err: ConfigError = toml_err.into();
+
+        match config_err {
+            ConfigError::Toml(msg) => {
+                assert!(msg.contains("invalid toml"));
+            }
+            _ => panic!("Expected ConfigError::Toml"),
+        }
+    }
+
+    #[test]
+    fn test_error_display_implementations() {
+        // Test that thiserror attributes render expected messages
+        let err = ConfigError::NotFound("missing.toml".to_string());
+        assert_eq!(err.to_string(), "config file not found: missing.toml");
+
+        let err = EnvError::DockerNotInstalled;
+        assert_eq!(err.to_string(), "docker not installed or not on PATH");
+
+        let err = ModelError::RateLimited("too fast".to_string());
+        assert_eq!(err.to_string(), "rate limited: too fast");
+
+        // Test top level Error delegates appropriately
+        let top_err: Error = err.into();
+        assert_eq!(top_err.to_string(), "rate limited: too fast");
+
+        let tmpl_err = Error::Template("bad syntax".to_string());
+        assert_eq!(tmpl_err.to_string(), "template render failed: bad syntax");
+    }
+}


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement] Added tests for ConfigError conversion and enum display

🎯 Target: `src/error.rs` and `src/env/docker.rs`
💣 Risk: `src/error.rs` lacked tests entirely, specifically for the custom `From<toml::de::Error>` implementation. `src/env/docker.rs` had a `unwrap()` on a container teardown function.
🧪 Strategy: 
- Added a `mod tests` block at the bottom of `src/error.rs`
- Wrote tests validating that `toml` deserialization failures cleanly map to `ConfigError::Toml` and assert string values correctly.
- Wrote tests asserting that `thiserror` formats enum strings properly.
- Replaced the `.unwrap()` in `src/env/docker.rs` with `assert!(...is_ok())` and moved `mod tests` to the bottom of the file to adhere to architecture standards.
- Replaced `unwrap_err()` in `src/error.rs` with `let Err(e) = ... else { panic!(...) }` to adhere to strict clippy directives.
🔬 Verification: Run `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings`

---
*PR created automatically by Jules for task [6717681568343598246](https://jules.google.com/task/6717681568343598246) started by @madmax983*