### PR TITLE
Add nightly E2E smoke test against OpenRouter free-tier model

### DIFF
--- a/.github/workflows/swe-bench-nightly.yml
+++ b/.github/workflows/swe-bench-nightly.yml
@@ -57,6 +57,13 @@ jobs:
 
       - name: Run smoke sweep
         id: sweep
+        # IMPORTANT: cwd must be the cloned SWE-bench repo. The agent
+        # builds bash commands without an explicit `cwd`, so the model's
+        # edits land in whatever directory the binary inherits. Patch
+        # capture, in contrast, always diffs `environment.workdir`. Run
+        # from the clone so both halves agree, and pass absolute paths
+        # for inputs/outputs so artifacts land at repo root.
+        working-directory: runs-input/workdir
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
@@ -64,11 +71,11 @@ jobs:
             echo "::error::OPENROUTER_API_KEY secret is not set on this repository."
             exit 1
           fi
-          ./target/release/rust-swe-agent bench swebench \
-            --dataset-path runs-input/dataset.jsonl \
-            --output runs \
+          "${GITHUB_WORKSPACE}/target/release/rust-swe-agent" bench swebench \
+            --dataset-path "${GITHUB_WORKSPACE}/runs-input/dataset.jsonl" \
+            --output "${GITHUB_WORKSPACE}/runs" \
             --model "${SWE_BENCH_MODEL}" \
-            --config runs-input/config.toml \
+            --config "${GITHUB_WORKSPACE}/runs-input/config.toml" \
             --parallel 1 \
             --step-limit 8 \
             --task-timeout-secs 300 \

--- a/.github/workflows/swe-bench-nightly.yml
+++ b/.github/workflows/swe-bench-nightly.yml
@@ -1,10 +1,12 @@
 name: SWE-bench Nightly Smoke
 
 # End-to-end harness check against an OpenRouter free model. The point is
-# to catch regressions in the sweep runner / patch capture / trajectory
-# pipeline, NOT to measure solve rate. Free-tier models routinely fail to
-# produce a working patch; the gate below treats that as an acceptable
-# outcome and only fails on harness-level errors (errored > 0).
+# to catch regressions in the sweep runner, agent loop, patch capture, and
+# trajectory pipeline. The gate fails on any sweep-level error
+# (errored > 0), which includes empty-diff and invalid-diff downgrades —
+# those are the exact failure modes a patch-capture regression produces,
+# so we keep validation enabled even though it can also flag a weak
+# free-tier model that simply fails to edit anything.
 #
 # Required repo secret:
 #   OPENROUTER_API_KEY  — OpenRouter API key with access to the pinned
@@ -80,8 +82,7 @@ jobs:
             --step-limit 8 \
             --task-timeout-secs 300 \
             --max-retries 0 \
-            --skip-preflight \
-            --skip-patch-validation
+            --skip-preflight
 
       - name: Gate on harness errors
         id: gate

--- a/.github/workflows/swe-bench-nightly.yml
+++ b/.github/workflows/swe-bench-nightly.yml
@@ -1,0 +1,137 @@
+name: SWE-bench Nightly Smoke
+
+# End-to-end harness check against an OpenRouter free model. The point is
+# to catch regressions in the sweep runner / patch capture / trajectory
+# pipeline, NOT to measure solve rate. Free-tier models routinely fail to
+# produce a working patch; the gate below treats that as an acceptable
+# outcome and only fails on harness-level errors (errored > 0).
+#
+# Required repo secret:
+#   OPENROUTER_API_KEY  — OpenRouter API key with access to the pinned
+#                         free-tier model.
+
+on:
+  schedule:
+    # 07:23 UTC daily. Off the top of the hour to dodge the cron stampede.
+    - cron: "23 7 * * *"
+  workflow_dispatch:
+    inputs:
+      offset:
+        description: "SWE-bench Lite offset to pull (0-based)"
+        required: false
+        default: "0"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: swe-bench-nightly
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: openrouter free-tier smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: 1
+      SWE_BENCH_MODEL: openrouter/deepseek/deepseek-chat-v3.1:free
+      SWE_BENCH_OFFSET: ${{ github.event.inputs.offset || '0' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: nightly-smoke
+
+      - name: Build rust-swe-agent (release)
+        run: cargo build --release --bin rust-swe-agent --no-default-features
+
+      - name: Fetch one SWE-bench Lite instance + clone repo
+        id: fetch
+        run: bash scripts/swe-bench-nightly-fetch.sh
+
+      - name: Run smoke sweep
+        id: sweep
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          if [[ -z "${OPENROUTER_API_KEY:-}" ]]; then
+            echo "::error::OPENROUTER_API_KEY secret is not set on this repository."
+            exit 1
+          fi
+          ./target/release/rust-swe-agent bench swebench \
+            --dataset-path runs-input/dataset.jsonl \
+            --output runs \
+            --model "${SWE_BENCH_MODEL}" \
+            --config runs-input/config.toml \
+            --parallel 1 \
+            --step-limit 8 \
+            --task-timeout-secs 300 \
+            --max-retries 0 \
+            --skip-preflight \
+            --skip-patch-validation
+
+      - name: Gate on harness errors
+        id: gate
+        run: |
+          if [[ ! -f runs/results.json ]]; then
+            echo "::error::runs/results.json missing — sweep did not produce a summary"
+            exit 1
+          fi
+          jq '{total, submitted, errored, skipped, failures_by_category}' runs/results.json
+          # Pass criterion: harness completed without errors. Unsolved tasks
+          # are expected on free-tier models.
+          jq -e '.errored == 0' runs/results.json > /dev/null
+
+      - name: Upload trajectories + inputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: swe-bench-nightly-${{ github.run_id }}
+          path: |
+            runs
+            runs-input/dataset.jsonl
+            runs-input/config.toml
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Open issue on scheduled failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        env:
+          INSTANCE_ID: ${{ steps.fetch.outputs.instance_id }}
+          REPO_SLUG: ${{ steps.fetch.outputs.repo }}
+          BASE_COMMIT: ${{ steps.fetch.outputs.base_commit }}
+        with:
+          script: |
+            const today = new Date().toISOString().slice(0, 10);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const instance = process.env.INSTANCE_ID || "(fetch failed)";
+            const repoSlug = process.env.REPO_SLUG || "(unknown)";
+            const baseCommit = process.env.BASE_COMMIT || "(unknown)";
+            const title = `Nightly SWE-bench smoke failed (${today})`;
+            const body = [
+              `The nightly OpenRouter free-tier SWE-bench smoke run failed.`,
+              ``,
+              `- Workflow run: ${runUrl}`,
+              `- Instance:    \`${instance}\``,
+              `- Repo:        \`${repoSlug}\` @ \`${baseCommit}\``,
+              `- Model:       \`openrouter/deepseek/deepseek-chat-v3.1:free\``,
+              ``,
+              `Trajectories and the input dataset are attached as workflow`,
+              `artifacts on the run page.`,
+              ``,
+              `_Auto-filed by .github/workflows/swe-bench-nightly.yml._`,
+            ].join("\n");
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ["nightly-smoke", "ci"],
+            });

--- a/README.md
+++ b/README.md
@@ -12,3 +12,14 @@ A minimal rust port of mini-swe-agent.
 - [`agent scriptability`](docs/spec-scriptability.md): config-defined
   `PreToolUse` and `PostToolUse` hooks for extending the tiny agent loop
   without new Rust tools.
+
+## Nightly E2E smoke
+
+`.github/workflows/swe-bench-nightly.yml` runs a single SWE-bench Lite
+instance through the full `bench swebench` pipeline against an OpenRouter
+free-tier model (`openrouter/deepseek/deepseek-chat-v3.1:free`). It exists
+to catch harness regressions, not to track solve rate — the run passes
+whenever the sweep reports `errored == 0` in `results.json`. Trajectories
+and the input dataset are uploaded as artifacts on every run; scheduled
+failures auto-open a `nightly-smoke` issue. Requires the
+`OPENROUTER_API_KEY` repository secret.

--- a/scripts/swe-bench-nightly-fetch.sh
+++ b/scripts/swe-bench-nightly-fetch.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Fetches one SWE-bench Lite instance from the HuggingFace datasets-server
+# and prepares the workdir for a single-instance E2E smoke sweep:
+#   - runs-input/dataset.jsonl  (the JSONL row for the runner)
+#   - runs-input/config.toml    (config with workdir pointing at the clone)
+#   - runs-input/workdir/       (clone of the instance's repo at base_commit)
+#
+# Used by .github/workflows/swe-bench-nightly.yml. Designed to be invoked
+# from the repository root.
+set -euo pipefail
+
+OFFSET="${SWE_BENCH_OFFSET:-0}"
+DATASET="princeton-nlp/SWE-bench_Lite"
+
+ROOT="$(pwd)"
+INPUT_DIR="${ROOT}/runs-input"
+WORKDIR="${INPUT_DIR}/workdir"
+mkdir -p "${INPUT_DIR}"
+rm -rf "${WORKDIR}"
+
+API_URL="https://datasets-server.huggingface.co/rows?dataset=$(printf '%s' "${DATASET}" | sed 's:/:%2F:g')&config=default&split=test&offset=${OFFSET}&length=1"
+echo "Fetching ${API_URL}"
+
+ROW_JSON="$(curl --fail --silent --show-error --retry 4 --retry-delay 3 "${API_URL}")"
+ROW="$(printf '%s' "${ROW_JSON}" | jq -c '.rows[0].row')"
+
+INSTANCE_ID="$(printf '%s' "${ROW}" | jq -r '.instance_id')"
+REPO="$(printf '%s' "${ROW}"      | jq -r '.repo')"
+BASE_COMMIT="$(printf '%s' "${ROW}" | jq -r '.base_commit')"
+
+if [[ -z "${INSTANCE_ID}" || "${INSTANCE_ID}" == "null" ]]; then
+  echo "fetch: missing instance_id in API response" >&2
+  printf '%s\n' "${ROW_JSON}" >&2
+  exit 1
+fi
+
+echo "Selected instance: ${INSTANCE_ID}"
+echo "Repo:              ${REPO}"
+echo "Base commit:       ${BASE_COMMIT}"
+
+# Persist the JSONL row exactly as the harness expects (one record per line).
+printf '%s\n' "${ROW}" > "${INPUT_DIR}/dataset.jsonl"
+
+# Clone with a blob-less partial clone to avoid pulling full history blobs;
+# the checkout will hydrate the blobs we need.
+git clone --filter=blob:none --no-checkout "https://github.com/${REPO}.git" "${WORKDIR}"
+git -C "${WORKDIR}" fetch --filter=blob:none --depth=1 origin "${BASE_COMMIT}"
+git -C "${WORKDIR}" checkout --detach "${BASE_COMMIT}"
+
+# Config overlay: point environment.workdir at the freshly-prepared clone.
+# The smoke run does not need the model section; the CLI's --model wins.
+cat > "${INPUT_DIR}/config.toml" <<EOF
+[environment]
+kind = "local"
+timeout_secs = 60
+workdir = "${WORKDIR}"
+EOF
+
+# Emit GH Actions outputs so the workflow can label artifacts / messages.
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "instance_id=${INSTANCE_ID}"
+    echo "repo=${REPO}"
+    echo "base_commit=${BASE_COMMIT}"
+  } >> "${GITHUB_OUTPUT}"
+fi
+
+echo "Prepared inputs in ${INPUT_DIR}"


### PR DESCRIPTION
## Summary

Adds a scheduled nightly workflow that runs a single SWE-bench Lite instance through the full `bench swebench` pipeline to catch harness-level regressions. The workflow uses an OpenRouter free-tier model and treats unsolved tasks as acceptable, only failing on actual harness errors.

## Key Changes

- **`.github/workflows/swe-bench-nightly.yml`**: New scheduled workflow that:
  - Runs daily at 07:23 UTC (configurable via `workflow_dispatch`)
  - Fetches one SWE-bench Lite instance and clones its repository
  - Executes a sweep with `--step-limit 8` and `--task-timeout-secs 300`
  - Gates on `errored == 0` in results.json (passes on unsolved tasks)
  - Uploads trajectories and input dataset as artifacts
  - Auto-opens a GitHub issue on scheduled failures with run details

- **`scripts/swe-bench-nightly-fetch.sh`**: Helper script that:
  - Fetches a single SWE-bench Lite instance from HuggingFace datasets-server API
  - Clones the target repository at the specified base commit using blob-less partial clone
  - Generates `runs-input/dataset.jsonl` and `runs-input/config.toml` for the sweep
  - Outputs instance metadata for workflow annotations

- **`README.md`**: Documents the nightly smoke test purpose and requirements

## Implementation Details

- Uses `openrouter/deepseek/deepseek-chat-v3.1:free` model (free-tier, expected to have lower solve rate)
- Implements blob-less partial clone (`--filter=blob:none`) to minimize bandwidth
- Concurrency group prevents overlapping runs; `cancel-in-progress: false` ensures scheduled runs complete
- Requires `OPENROUTER_API_KEY` repository secret
- Artifacts retained for 14 days for post-mortem analysis
- Workflow can be manually triggered with custom `offset` parameter to test different SWE-bench instances

https://claude.ai/code/session_01S7exyeYQFEnxXN3cfYQjuL