### PR TITLE
⚡ Bolt: Remove intermediate Vec allocations in Litellm text extraction

### DIFF
--- a/src/model/litellm.rs
+++ b/src/model/litellm.rs
@@ -174,7 +174,7 @@ impl Model for LitellmBackend {
     }
 }
 
-/// ⚡ Bolt Optimization: Avoids intermediate Vec allocation for zero-cost string concatenation.
+/// Extracts and concatenates all text parts from a model response choice.
 fn extract_text_content(choice: &litellm_rs::Choice) -> String {
     use litellm_rs::core::types::content::ContentPart;
     use litellm_rs::core::types::message::MessageContent;

--- a/src/model/litellm.rs
+++ b/src/model/litellm.rs
@@ -174,6 +174,7 @@ impl Model for LitellmBackend {
     }
 }
 
+/// ⚡ Bolt Optimization: Avoids intermediate Vec allocation for zero-cost string concatenation.
 fn extract_text_content(choice: &litellm_rs::Choice) -> String {
     use litellm_rs::core::types::content::ContentPart;
     use litellm_rs::core::types::message::MessageContent;
@@ -186,8 +187,7 @@ fn extract_text_content(choice: &litellm_rs::Choice) -> String {
                 ContentPart::Text { text } => Some(text.as_str()),
                 _ => None,
             })
-            .collect::<Vec<_>>()
-            .join(""),
+            .collect::<String>(),
         None => String::new(),
     }
 }


### PR DESCRIPTION
* 💡 What: Replaced `.collect::<Vec<_>>().join("")` with `.collect::<String>()` in `extract_text_content` inside `src/model/litellm.rs`.
* 🎯 Why: The original code unnecessarily allocated an intermediate heap `Vec` to concatenate string parts. 
* 📊 Impact: Eliminates one `Vec` allocation per multi-part model response, moving to zero-cost iterator abstraction.
* 🔬 Measurement: Observe reduction in allocations under heavy `litellm` usage using memory profiler, or by verifying `cargo bench` throughput metrics.

---
*PR created automatically by Jules for task [12952301825991467203](https://jules.google.com/task/12952301825991467203) started by @madmax983*