### PR TITLE
Add configuration reference documentation and drift verification tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ budget. This avoids beginning with a multi-instance spendfest. Tiny mercy.
 Start with the first-run path above, then use these deeper specs once you have
 a valid trajectory in hand:
 
+- [`configuration reference`](docs/config-reference.md): every config field,
+  default value, valid values, precedence rules, copy-pasteable TOML examples,
+  and secret handling guidance. Start here before tuning a sweep.
 - [`bench tail`](docs/spec-tail.md): live aggregate progress, cost burn, ETA,
   and failure mix for running SWE-bench sweeps.
 - [`bench evaluate`](docs/spec-evaluation.md): evaluator output, rerun metrics,

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -27,20 +27,27 @@ Resolution order, lowest to highest:
 Deep merge semantics: object keys recurse, leaf values prefer the higher
 layer, arrays are replaced wholesale (not appended).
 
-**Example 1 — model name:** The built-in default is
-`model.name = "claude-opus-4-7"`. If your config file sets
-`model.name = "claude-sonnet-4-6"`, the CLI flag `--model claude-haiku-4-5`
-wins over both. Final model used: `claude-haiku-4-5`.
+**Example 1 — per-task budget:** The built-in default is
+`per_task_budget_usd = null` (no cap). A config file that sets
+`per_task_budget_usd = 0.50` applies a $0.50 ceiling per task for every run
+using that file. Passing `--per-task-budget-usd 0.10` on the CLI tightens the
+cap to $0.10 for that single invocation only.
 
-**Example 2 — step limit:** Built-in default is `agent.step_limit = 50`. A
-config file overlay of `step_limit = 20` takes effect for every run using that
-file. Passing `--step-limit 5` on the CLI overrides the file value for that
-single invocation only.
+**Example 2 — observation truncation:** Built-in default is
+`observation_max_bytes = 16384`. A config file that sets
+`observation_max_bytes = 8192` halves the truncation window for all runs
+using that file. Passing `--observation-max-bytes 4096` on the CLI overrides
+the file value for that invocation only.
 
-**Example 3 — per-task budget:** `per_task_budget_usd` is `null` (no cap) in
-defaults. A config file that sets `per_task_budget_usd = 0.50` applies a
-$0.50 ceiling per task. Passing `--per-task-budget-usd 0.10` on the CLI
-tightens the cap to $0.10 for that run, regardless of the file value.
+**Example 3 — model name (clap-default caveat):** For `mini` and
+`bench swebench`, `--model` has a clap default of `claude-opus-4-7` that is
+written back over the config unconditionally. Setting `model.name` in a
+config file has **no effect** for those commands unless you also pass `--model`
+explicitly. To use a model from config, always supply the flag:
+`mini --config cfg.toml --model claude-sonnet-4-6`. The same caveat applies
+to `agent.step_limit` (clap default: `50`) for those two commands.
+Fields without a clap default — such as `per_task_budget_usd`,
+`observation_max_bytes`, and template fields — layer correctly from config.
 
 ---
 
@@ -91,7 +98,7 @@ Controls the inner agent loop.
 | `kind` | string | `"default"` | `"default"`, `"interactive"` | `"interactive"` prompts for human approval; in CI it fails closed |
 | `step_limit` | integer | `50` | `1`–`∞` | Hard cap on conversation turns; prevents runaway loops |
 | `per_task_budget_usd` | float \| null | `null` | Any positive float | Per-task spend ceiling; loop terminates with `budget_exhausted` when reached |
-| `cost_limit_usd` | float \| null | `null` | Any positive float | Sweep-level total spend ceiling |
+| `cost_limit_usd` | float \| null | `null` | Any positive float | Per-task spend ceiling inside the agent loop; terminates the current task with `cost_limit` failure when reached. Does **not** cap the whole sweep — for a sweep-wide aggregate cap use `--sweep-cost-limit-usd` (CLI only, no config equivalent) |
 | `hide_budget_from_agent` | bool | `false` | `true`, `false` | When `true`, the budget block is not appended to observations (A/B flag) |
 | `budget_block_template` | string | see defaults | Handlebars template | Variables: `budget_used`, `budget_limit`, `budget_remaining_pct`, `turn`, `max_turns` |
 | `format_error_template` | string | see defaults | Any string | Rendered when the model response contains no valid bash action |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,0 +1,362 @@
+# Operator Configuration Reference
+
+This document is the single configuration reference for `rust_swe_agent`.
+It covers every supported top-level section and field, explains configuration
+precedence, shows copy-pasteable TOML examples, and describes safe secret
+handling.
+
+**Format:** All run configuration files are **TOML** (`.toml`). YAML is not
+supported. If you have YAML examples from earlier experiments or community
+posts, translate them to TOML before use (migration note: rename `:`
+key/value separators to `=` and replace YAML indented blocks with TOML
+`[[array-of-tables]]` syntax).
+
+---
+
+## Configuration Precedence
+
+Resolution order, lowest to highest:
+
+| Layer | Source | Notes |
+|---|---|---|
+| 1 (lowest) | Built-in defaults | Compiled into the binary from `src/config/defaults/default.toml` |
+| 2 | Config file | Loaded via `--config <path>`; overlaid on defaults via deep merge |
+| 3 | Environment variables | Provider credentials and a small set of harness overrides |
+| 4 (highest) | CLI flags | Always win over every other layer |
+
+Deep merge semantics: object keys recurse, leaf values prefer the higher
+layer, arrays are replaced wholesale (not appended).
+
+**Example 1 — model name:** The built-in default is
+`model.name = "claude-opus-4-7"`. If your config file sets
+`[model]\nname = "claude-sonnet-4-6"`, the CLI flag `--model claude-haiku-4-5`
+wins over both. Final model used: `claude-haiku-4-5`.
+
+**Example 2 — step limit:** Built-in default is `agent.step_limit = 50`. A
+config file overlay of `step_limit = 20` takes effect for every run using that
+file. Passing `--step-limit 5` on the CLI overrides the file value for that
+single invocation only.
+
+**Example 3 — per-task budget:** `per_task_budget_usd` is `null` (no cap) in
+defaults. A config file that sets `per_task_budget_usd = 0.50` applies a
+$0.50 ceiling per task. Passing `--per-task-budget-usd 0.10` on the CLI
+tightens the cap to $0.10 for that run, regardless of the file value.
+
+---
+
+## Secret Handling
+
+Credentials must come from **environment variables** or a local secret store.
+Raw secrets must **never** appear in committed config files or TOML examples.
+
+| Provider | Environment variable |
+|---|---|
+| Anthropic (Claude) | `ANTHROPIC_API_KEY` |
+| OpenAI | `OPENAI_API_KEY` |
+| OpenRouter | `OPENROUTER_API_KEY` |
+
+- Do **not** put token values in `[redaction].secret_literals` in committed
+  configs; use that field only in local, git-ignored overlay files.
+- `unsafe_allow_secret_leaks = false` (the default) ensures submitted patches
+  containing configured secret shapes are downgraded to a failure rather than
+  leaked. Do **not** set this to `true` in shared configs.
+- For the full redaction contract, cross-reference
+  [`docs/spec-secret-redaction.md`](spec-secret-redaction.md).
+
+---
+
+## Top-Level Sections
+
+```toml
+[agent]        # Agent loop behaviour: step limit, budget, templates, hooks
+[model]        # Model selection and parameters
+[environment]  # Execution environment: local shell or Docker
+[prompts]      # System and instance prompt templates
+[sweep]        # Rate-limiting for parallel sweeps
+[redaction]    # Secret redaction policy
+[policy]       # Pre-execution command policy (safe / ask / yolo)
+```
+
+An optional `extends = "<path>"` top-level key (not a section) resolves a
+parent config first, then overlays the current file. Maximum include depth: 16.
+
+---
+
+## `[agent]`
+
+Controls the inner agent loop.
+
+| Field | Type | Default | Valid values | Notes |
+|---|---|---|---|---|
+| `kind` | string | `"default"` | `"default"`, `"interactive"` | `"interactive"` prompts for human approval; in CI it fails closed |
+| `step_limit` | integer | `50` | `1`–`∞` | Hard cap on conversation turns; prevents runaway loops |
+| `per_task_budget_usd` | float \| null | `null` | Any positive float | Per-task spend ceiling; loop terminates with `budget_exhausted` when reached |
+| `cost_limit_usd` | float \| null | `null` | Any positive float | Sweep-level total spend ceiling |
+| `hide_budget_from_agent` | bool | `false` | `true`, `false` | When `true`, the budget block is not appended to observations (A/B flag) |
+| `budget_block_template` | string | see defaults | Handlebars template | Variables: `budget_used`, `budget_limit`, `budget_remaining_pct`, `turn`, `max_turns` |
+| `format_error_template` | string | see defaults | Any string | Rendered when the model response contains no valid bash action |
+| `observation_template` | string | see defaults | Jinja2/Handlebars template | Variables: `returncode`, `output`, `tool_use_blocked`, `pre_tool_use_hooks`, `post_tool_use_hooks` |
+| `observation_max_bytes` | integer | `16384` | `1`–`∞` | Truncation limit for observations before they reach the model |
+| `observation_head_ratio` | float | `0.5` | `0.0`–`1.0` | Head/tail split ratio when truncating; `0.5` = equal halves |
+| `tool_hook_timeout_secs` | integer | `10` | `1`–`∞` | Default timeout for pre/post tool hooks unless a hook overrides it |
+| `test_command_patterns` | array of strings | `[]` | Valid regexes | Extends the built-in test-command corpus; see `spec-test-telemetry.md` |
+| `test_command_patterns_replace` | bool | `false` | `true`, `false` | When `true`, replaces rather than extends the built-in corpus |
+
+### `[[agent.hooks.pre_tool_use]]` / `[[agent.hooks.post_tool_use]]`
+
+Optional inline hooks that run before or after each bash tool invocation.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `name` | string | yes | Label shown in hook output |
+| `command` | string | yes | Shell command to execute |
+| `timeout_secs` | integer | no | Overrides `tool_hook_timeout_secs` for this hook |
+
+A non-zero PreToolUse exit code blocks the command and reports the result to
+the model. PostToolUse hooks are diagnostic only.
+
+---
+
+## `[model]`
+
+Selects and configures the language model.
+
+| Field | Type | Default | Valid values | Notes |
+|---|---|---|---|---|
+| `name` | string | `"claude-opus-4-7"` | Any LiteLLM-routable model name | Prefix determines backend: `claude*` → Anthropic, `openai/*` → OpenAI, `openrouter/*` → OpenRouter |
+| `temperature` | float \| null | `null` | `0.0`–`2.0` | `null` uses the backend default |
+| `max_tokens` | integer | `4096` | `1`–provider limit | Maximum tokens in the model response |
+| `fallback_models` | array of strings | `[]` | Any model names | Tried in order on transient provider failures; empty = no fallback |
+
+---
+
+## `[environment]`
+
+Controls where agent commands run.
+
+| Field | Type | Default | Valid values | Notes |
+|---|---|---|---|---|
+| `kind` | string | `"local"` | `"local"`, `"docker"` | `"docker"` requires the `docker` Cargo feature and a running Docker daemon |
+| `timeout_secs` | integer | `60` | `1`–`∞` | Per-command wall-clock timeout; maps to `--task-timeout-secs` on the CLI |
+| `docker_image` | string \| null | `null` | Any Docker image reference | Required when `kind = "docker"` |
+| `workdir` | string | `"/workspace"` | Any absolute path | Working directory inside the environment |
+
+---
+
+## `[prompts]`
+
+Handlebars/Jinja2 templates for the agent conversation.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `system` | string | see defaults | Sent as the system message; sets agent persona and output format |
+| `instance` | string | see defaults | Rendered per-task; variables: `task`, `extra_context` |
+
+---
+
+## `[sweep]`
+
+Adaptive rate-limiting for parallel sweeps (issue #44). Both fields are
+opt-in: when unset, no ceiling is applied.
+
+| Field | Type | Default | Valid values | Notes |
+|---|---|---|---|---|
+| `max_rpm` | integer \| null | `null` | Any positive integer | Cap aggregate provider requests/minute across all workers; maps to `--max-rpm` |
+| `max_input_tpm` | integer \| null | `null` | Any positive integer | Cap aggregate input tokens/minute; maps to `--max-input-tpm` |
+
+CLI values always win over config file values for both fields.
+
+---
+
+## `[redaction]`
+
+Controls secret redaction across trajectories, observations, streams,
+inspect/export output, and submission artifacts.
+
+| Field | Type | Default | Valid values | Notes |
+|---|---|---|---|---|
+| `enabled` | bool | `true` | `true`, `false` | When `false`, all redaction is disabled for this run |
+| `secret_literals` | array of strings | `[]` | Any strings | Literal values redacted at runtime; these values are themselves redacted from exported config manifests |
+| `custom_patterns` | array of strings | `[]` | Valid regex patterns | Full-match patterns redacted at runtime; validated at config load |
+| `unsafe_allow_secret_leaks` | bool | `false` | `true`, `false` | When `false` (recommended), submitted patches containing secret shapes are downgraded to `secret_leak_detected` failure |
+
+See [`docs/spec-secret-redaction.md`](spec-secret-redaction.md) for the full
+redaction contract.
+
+---
+
+## `[policy]`
+
+Pre-execution command guardrail (issue #90). This is a safety layer, not a
+sandbox replacement.
+
+| Field | Type | Default | Valid values | Notes |
+|---|---|---|---|---|
+| `profile` | string | `"safe"` | `"safe"`, `"ask"`, `"yolo"` | `"safe"` blocks built-in dangerous commands; `"ask"` prompts for human approval (fails closed in CI); `"yolo"` disables all blocking |
+| `extra_deny_patterns` | array of strings | `[]` | Valid regexes | Appended after the built-in corpus; always denied regardless of profile |
+| `extra_allow_patterns` | array of strings | `[]` | Valid regexes | Always allowed even when the built-in corpus would deny them |
+
+---
+
+## Copy-Pasteable TOML Examples
+
+### Deterministic no-key smoke run
+
+Runs the built-in scripted model — no API credentials required, costs $0.
+
+<!-- config-example:no-key-smoke -->
+```toml
+# smoke.toml — deterministic no-key run; safe to commit
+[agent]
+kind = "default"
+step_limit = 5
+
+[model]
+name = "claude-opus-4-7"
+max_tokens = 1024
+
+[environment]
+kind = "local"
+timeout_secs = 30
+workdir = "/workspace"
+
+[redaction]
+enabled = true
+unsafe_allow_secret_leaks = false
+```
+
+Run with:
+
+```bash
+cargo run --quiet -- --log error hello-world --output runs/smoke
+```
+
+### Local live-model run with budget and timeout guards
+
+Requires `ANTHROPIC_API_KEY` (or the relevant provider key). Sets a per-task
+spend cap and a short step limit to bound cost during initial exploration.
+
+<!-- config-example:live-model -->
+```toml
+# live.toml — local live-model run; do NOT commit raw API keys
+[agent]
+kind = "default"
+step_limit = 10
+per_task_budget_usd = 0.25
+
+[model]
+name = "claude-opus-4-7"
+max_tokens = 4096
+temperature = 0.0
+
+[environment]
+kind = "local"
+timeout_secs = 120
+workdir = "/workspace"
+
+[redaction]
+enabled = true
+unsafe_allow_secret_leaks = false
+```
+
+Run with:
+
+```bash
+export ANTHROPIC_API_KEY="<your key>"  # never commit this value
+cargo run --quiet -- --log info mini \
+  --config live.toml \
+  --task "Write a hello-world Python script." \
+  --output runs/live
+```
+
+### Docker SWE-bench sweep with rate limiting and cost cap
+
+Uses Docker isolation and configures sweep-level rate limits. Pair this with
+`--resume` (CLI flag) and `bench forecast` to cap total spend before a full
+sweep.
+
+<!-- config-example:docker-sweep -->
+```toml
+# sweep.toml — Docker SWE-bench sweep
+[agent]
+kind = "default"
+step_limit = 50
+per_task_budget_usd = 2.00
+
+[model]
+name = "claude-opus-4-7"
+max_tokens = 4096
+fallback_models = ["claude-sonnet-4-6"]
+
+[environment]
+kind = "docker"
+docker_image = "swebench/sweb.eval.x86_64.django__django:latest"
+timeout_secs = 120
+workdir = "/workspace"
+
+[sweep]
+max_rpm = 500
+max_input_tpm = 100000
+
+[redaction]
+enabled = true
+unsafe_allow_secret_leaks = false
+```
+
+Run with:
+
+```bash
+export ANTHROPIC_API_KEY="<your key>"
+cargo run --quiet -- --log info bench swebench \
+  --config sweep.toml \
+  --dataset-path ./data/swebench.jsonl \
+  --output runs/sweep \
+  --limit 10
+```
+
+### Interactive local confirmation
+
+Prompts the operator for approval before each bash command. In non-interactive
+contexts (CI, sweeps), `"interactive"` kind fails closed (denies all).
+
+<!-- config-example:interactive-local -->
+```toml
+# interactive.toml — human approval for each command
+[agent]
+kind = "interactive"
+step_limit = 20
+per_task_budget_usd = 1.00
+
+[model]
+name = "claude-opus-4-7"
+max_tokens = 4096
+
+[environment]
+kind = "local"
+timeout_secs = 300
+workdir = "/workspace"
+
+[policy]
+profile = "ask"
+
+[redaction]
+enabled = true
+unsafe_allow_secret_leaks = false
+```
+
+---
+
+## Docs Drift Verification
+
+`tests/config_reference.rs` enforces that this document stays in sync with
+the implementation:
+
+- Every non-comment field in `src/config/defaults/default.toml` must appear
+  verbatim in this document.
+- All four TOML examples above must parse without error via `Config::from_toml_str`.
+- `README.md` must link to this file.
+- Config validation errors must reference `config-reference` so operators can
+  self-serve.
+
+When you add or rename a config field, update this document and the examples
+before the test suite will pass.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -29,7 +29,7 @@ layer, arrays are replaced wholesale (not appended).
 
 **Example 1 — model name:** The built-in default is
 `model.name = "claude-opus-4-7"`. If your config file sets
-`[model]\nname = "claude-sonnet-4-6"`, the CLI flag `--model claude-haiku-4-5`
+`model.name = "claude-sonnet-4-6"`, the CLI flag `--model claude-haiku-4-5`
 wins over both. Final model used: `claude-haiku-4-5`.
 
 **Example 2 — step limit:** Built-in default is `agent.step_limit = 50`. A

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -95,7 +95,7 @@ Controls the inner agent loop.
 
 | Field | Type | Default | Valid values | Notes |
 |---|---|---|---|---|
-| `kind` | string | `"default"` | `"default"`, `"interactive"` | `"interactive"` prompts for human approval; in CI it fails closed |
+| `kind` | string | `"default"` | `"default"`, `"interactive"` | **Not yet dispatched** — the `interactive` variant is defined in the schema but `mini`, `bench swebench`, and `hello-world` all construct `DefaultAgent` unconditionally. Setting `kind = "interactive"` has no effect in those commands today. |
 | `step_limit` | integer | `50` | `1`–`∞` | Hard cap on conversation turns; prevents runaway loops |
 | `per_task_budget_usd` | float \| null | `null` | Any positive float | Per-task spend ceiling; loop terminates with `budget_exhausted` when reached |
 | `cost_limit_usd` | float \| null | `null` | Any positive float | Per-task spend ceiling inside the agent loop; terminates the current task with `cost_limit` failure when reached. Does **not** cap the whole sweep — for a sweep-wide aggregate cap use `--sweep-cost-limit-usd` (CLI only, no config equivalent) |
@@ -144,7 +144,7 @@ Controls where agent commands run.
 | Field | Type | Default | Valid values | Notes |
 |---|---|---|---|---|
 | `kind` | string | `"local"` | `"local"`, `"docker"` | `"docker"` requires the `docker` Cargo feature and a running Docker daemon |
-| `timeout_secs` | integer | `60` | `1`–`∞` | Per-command wall-clock timeout; maps to `--task-timeout-secs` on the CLI |
+| `timeout_secs` | integer | `60` | `1`–`∞` | Per-**command** wall-clock timeout — applied to each individual shell command. This is **not** the same as `--task-timeout-secs`, which is a whole-task wallclock budget passed via CLI only (no config equivalent). Setting `timeout_secs` only caps individual commands; a multi-step task can still run much longer. |
 | `docker_image` | string \| null | `null` | Any Docker image reference | Required when `kind = "docker"` |
 | `workdir` | string | `"/workspace"` | Any absolute path | Working directory inside the environment |
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -179,6 +179,10 @@ pub struct MiniCmd {
 pub struct HelloWorldCmd {
     #[arg(long, default_value = "./runs")]
     pub output: PathBuf,
+
+    /// Optional path to a TOML config (overlays defaults).
+    #[arg(long)]
+    pub config: Option<PathBuf>,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -48,7 +48,9 @@ pub async fn run() -> Result<(), Error> {
 
     match cli.command {
         Command::Mini(m) => mini_cmd(m).await,
-        Command::HelloWorld(h) => crate::run::hello_world::main(h.output).await,
+        Command::HelloWorld(h) => {
+            crate::run::hello_world::main(h.output, h.config.as_deref()).await
+        }
         Command::Replay(r) => replay_cmd(r).await,
         Command::Bench {
             cmd: args::BenchCmd::Swebench(s),

--- a/src/error.rs
+++ b/src/error.rs
@@ -169,7 +169,7 @@ pub enum ConfigError {
     #[error("include chain exceeded {0} levels (possible cycle)")]
     IncludeDepthExceeded(usize),
 
-    #[error("invalid config: {0}")]
+    #[error("invalid config: {0} (see docs/config-reference.md for valid values and examples)")]
     Invalid(String),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -163,7 +163,7 @@ pub enum ConfigError {
     #[error("config file not found: {0}")]
     NotFound(String),
 
-    #[error("toml parse failed: {0}")]
+    #[error("toml parse failed: {0} (see docs/config-reference.md for format and examples)")]
     Toml(String),
 
     #[error("include chain exceeded {0} levels (possible cycle)")]

--- a/src/run/hello_world.rs
+++ b/src/run/hello_world.rs
@@ -1,14 +1,17 @@
 //! Sanity-check the pipeline with a scripted model. Runs a two-turn agent that
 //! echoes hello, then submits "ok".
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::mini::{MiniArgs, run};
 use crate::config::Config;
 use crate::error::Error;
 
-pub async fn main(output_dir: PathBuf) -> Result<(), Error> {
-    let cfg = Config::defaults()?;
+pub async fn main(output_dir: PathBuf, config_path: Option<&Path>) -> Result<(), Error> {
+    let cfg = match config_path {
+        Some(p) => Config::load(p)?,
+        None => Config::defaults()?,
+    };
     let traj_path = output_dir.join("hello-world.traj.json");
     let out_path = output_dir.join("hello-world.output.txt");
     let args = MiniArgs {
@@ -43,7 +46,7 @@ mod tests {
     #[tokio::test]
     async fn hello_world_smoke() {
         let dir = tempdir().unwrap();
-        main(dir.path().to_path_buf()).await.unwrap();
+        main(dir.path().to_path_buf(), None).await.unwrap();
         let entries: Vec<_> = std::fs::read_dir(dir.path())
             .unwrap()
             .filter_map(Result::ok)

--- a/tests/config_reference.rs
+++ b/tests/config_reference.rs
@@ -1,0 +1,260 @@
+//! Docs drift verification for the operator configuration reference (issue #92).
+//!
+//! These tests drive creation of `docs/config-reference.md` and its integration
+//! with `README.md` and the config validation error path. A test here fails
+//! whenever a documented field, default, valid-value set, or CLI override changes
+//! without updating the reference.
+
+#![allow(clippy::unwrap_used)]
+
+use rust_swe_agent::config::Config;
+
+const CONFIG_REFERENCE_PATH: &str = "docs/config-reference.md";
+const DEFAULT_TOML_PATH: &str = "src/config/defaults/default.toml";
+const README_PATH: &str = "README.md";
+
+fn read_config_reference() -> String {
+    std::fs::read_to_string(CONFIG_REFERENCE_PATH).unwrap_or_else(|_| {
+        panic!(
+            "{CONFIG_REFERENCE_PATH} must exist — create it to pass this test (issue #92)"
+        )
+    })
+}
+
+/// Extract the content of a fenced TOML block that immediately follows a
+/// `<!-- config-example:<marker> -->` comment in the reference doc.
+fn extract_toml_example(doc: &str, marker: &str) -> String {
+    let marker_text = format!("<!-- config-example:{marker} -->");
+    let after_marker = doc
+        .split_once(&marker_text)
+        .map(|(_, rest)| rest)
+        .unwrap_or_else(|| {
+            panic!(
+                "{CONFIG_REFERENCE_PATH} is missing marker `{marker_text}`; \
+                 add it before the ```toml block for the '{marker}' example"
+            )
+        });
+    let after_fence = after_marker
+        .split_once("```toml")
+        .map(|(_, rest)| rest)
+        .unwrap_or_else(|| {
+            panic!(
+                "Marker `{marker_text}` in {CONFIG_REFERENCE_PATH} must be \
+                 followed by a ```toml block"
+            )
+        });
+    let (block, _) = after_fence.split_once("```").unwrap_or_else(|| {
+        panic!(
+            "TOML block after `{marker_text}` in {CONFIG_REFERENCE_PATH} is \
+             unterminated"
+        )
+    });
+    block.trim().to_string()
+}
+
+// ── Existence and README link ────────────────────────────────────────────────
+
+#[test]
+fn config_reference_exists() {
+    let doc = read_config_reference();
+    assert!(!doc.is_empty(), "{CONFIG_REFERENCE_PATH} must not be empty");
+}
+
+#[test]
+fn readme_links_to_config_reference() {
+    let readme = std::fs::read_to_string(README_PATH).unwrap();
+    assert!(
+        readme.contains("docs/config-reference.md"),
+        "README.md must link to docs/config-reference.md (required by issue #92)"
+    );
+}
+
+// ── Section and field coverage ───────────────────────────────────────────────
+
+#[test]
+fn config_reference_documents_all_top_level_sections() {
+    let doc = read_config_reference();
+    for section in &[
+        "[agent]",
+        "[model]",
+        "[environment]",
+        "[sweep]",
+        "[redaction]",
+        "[prompts]",
+        "[policy]",
+    ] {
+        assert!(
+            doc.contains(section),
+            "{CONFIG_REFERENCE_PATH} must document section {section}"
+        );
+    }
+}
+
+/// Drift guard: every non-comment, non-section leaf key in `default.toml`
+/// must appear verbatim in the reference. When a new field is added to
+/// `default.toml` this test fails until the reference is updated.
+#[test]
+fn config_reference_documents_all_default_toml_fields() {
+    let doc = read_config_reference();
+    let default_toml = std::fs::read_to_string(DEFAULT_TOML_PATH).unwrap();
+
+    let field_names: Vec<&str> = default_toml
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.starts_with('#') || trimmed.starts_with('[') || trimmed.is_empty() {
+                return None;
+            }
+            trimmed.split_once('=').map(|(key, _)| key.trim())
+        })
+        .collect();
+
+    for field in &field_names {
+        assert!(
+            doc.contains(field),
+            "{CONFIG_REFERENCE_PATH} must document field '{field}' \
+             found in {DEFAULT_TOML_PATH}. Add an entry for it to pass this drift check."
+        );
+    }
+}
+
+// ── TOML example round-trip checks ──────────────────────────────────────────
+
+#[test]
+fn no_key_smoke_example_parses() {
+    let doc = read_config_reference();
+    let toml = extract_toml_example(&doc, "no-key-smoke");
+    Config::from_toml_str(&toml).unwrap_or_else(|e| {
+        panic!(
+            "no-key-smoke TOML example in {CONFIG_REFERENCE_PATH} must parse \
+             without error; got: {e}"
+        )
+    });
+}
+
+#[test]
+fn live_model_example_parses() {
+    let doc = read_config_reference();
+    let toml = extract_toml_example(&doc, "live-model");
+    Config::from_toml_str(&toml).unwrap_or_else(|e| {
+        panic!(
+            "live-model TOML example in {CONFIG_REFERENCE_PATH} must parse \
+             without error; got: {e}"
+        )
+    });
+}
+
+#[test]
+fn docker_sweep_example_parses() {
+    let doc = read_config_reference();
+    let toml = extract_toml_example(&doc, "docker-sweep");
+    Config::from_toml_str(&toml).unwrap_or_else(|e| {
+        panic!(
+            "docker-sweep TOML example in {CONFIG_REFERENCE_PATH} must parse \
+             without error; got: {e}"
+        )
+    });
+}
+
+#[test]
+fn interactive_local_example_parses() {
+    let doc = read_config_reference();
+    let toml = extract_toml_example(&doc, "interactive-local");
+    Config::from_toml_str(&toml).unwrap_or_else(|e| {
+        panic!(
+            "interactive-local TOML example in {CONFIG_REFERENCE_PATH} must \
+             parse without error; got: {e}"
+        )
+    });
+}
+
+// ── Content requirements ─────────────────────────────────────────────────────
+
+#[test]
+fn config_reference_explains_precedence() {
+    let doc = read_config_reference();
+    // Must name all four layers.
+    for keyword in &[
+        "default",
+        "config file",
+        "environment variable",
+        "CLI",
+    ] {
+        assert!(
+            doc.to_ascii_lowercase().contains(&keyword.to_ascii_lowercase()),
+            "{CONFIG_REFERENCE_PATH} must mention '{keyword}' in the precedence section"
+        );
+    }
+    // Must include at least three concrete conflict examples (look for numbered
+    // list items or example headings that follow the precedence section).
+    let precedence_section = doc
+        .split_once("recedence")
+        .map(|(_, rest)| rest)
+        .unwrap_or("");
+    let example_count = precedence_section
+        .lines()
+        .filter(|l| {
+            let l = l.trim().to_ascii_lowercase();
+            l.starts_with("**example") || l.starts_with("example ") || l.starts_with("- example")
+        })
+        .count();
+    assert!(
+        example_count >= 3,
+        "{CONFIG_REFERENCE_PATH} must include at least three concrete precedence \
+         examples labelled 'Example N' or '**Example N**'; found {example_count}"
+    );
+}
+
+#[test]
+fn config_reference_covers_secret_handling() {
+    let doc = read_config_reference();
+    // Must mention where credentials come from.
+    assert!(
+        doc.contains("ANTHROPIC_API_KEY") || doc.contains("OPENAI_API_KEY"),
+        "{CONFIG_REFERENCE_PATH} must name at least one provider key env var \
+         (ANTHROPIC_API_KEY, OPENAI_API_KEY)"
+    );
+    // Must prohibit raw secrets in committed configs.
+    let lower = doc.to_ascii_lowercase();
+    assert!(
+        lower.contains("never") || lower.contains("must not") || lower.contains("do not"),
+        "{CONFIG_REFERENCE_PATH} must explicitly prohibit committing raw secrets"
+    );
+    // Must cross-link the redaction spec.
+    assert!(
+        doc.contains("spec-secret-redaction"),
+        "{CONFIG_REFERENCE_PATH} must link to docs/spec-secret-redaction.md"
+    );
+}
+
+#[test]
+fn config_reference_states_toml_format_and_migration_note() {
+    let doc = read_config_reference();
+    assert!(
+        doc.contains("TOML"),
+        "{CONFIG_REFERENCE_PATH} must state that the config format is TOML"
+    );
+    // Migration note for stale YAML-era docs.
+    let lower = doc.to_ascii_lowercase();
+    assert!(
+        lower.contains("yaml") || lower.contains("migration"),
+        "{CONFIG_REFERENCE_PATH} must include a migration note for stale YAML-era \
+         examples (mention 'YAML' or 'migration')"
+    );
+}
+
+// ── Error message integration ────────────────────────────────────────────────
+
+#[test]
+fn config_validation_error_points_to_reference() {
+    // An invalid regex in agent.test_command_patterns produces ConfigError::Invalid.
+    // The error message must mention the reference so operators can self-serve.
+    let err = Config::from_toml_str("[agent]\ntest_command_patterns = [\"(\"]")
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("config-reference") || err.contains("configuration reference"),
+        "Config validation errors must point to docs/config-reference.md so \
+         operators can self-serve; got: {err}"
+    );
+}

--- a/tests/config_reference.rs
+++ b/tests/config_reference.rs
@@ -7,7 +7,11 @@
 
 #![allow(clippy::unwrap_used)]
 
+use std::process::Command;
+
 use rust_swe_agent::config::Config;
+
+mod support;
 
 const CONFIG_REFERENCE_PATH: &str = "docs/config-reference.md";
 const DEFAULT_TOML_PATH: &str = "src/config/defaults/default.toml";
@@ -243,18 +247,134 @@ fn config_reference_states_toml_format_and_migration_note() {
     );
 }
 
-// ── Error message integration ────────────────────────────────────────────────
+// ── Error message integration (AC 9) ─────────────────────────────────────────
 
 #[test]
 fn config_validation_error_points_to_reference() {
-    // An invalid regex in agent.test_command_patterns produces ConfigError::Invalid.
-    // The error message must mention the reference so operators can self-serve.
-    let err = Config::from_toml_str("[agent]\ntest_command_patterns = [\"(\"]")
+    // ConfigError::Invalid (regex validation failure) must mention the reference.
+    let invalid_err = Config::from_toml_str("[agent]\ntest_command_patterns = [\"(\"]")
         .unwrap_err()
         .to_string();
     assert!(
-        err.contains("config-reference") || err.contains("configuration reference"),
-        "Config validation errors must point to docs/config-reference.md so \
-         operators can self-serve; got: {err}"
+        invalid_err.contains("config-reference") || invalid_err.contains("configuration reference"),
+        "ConfigError::Invalid must point to docs/config-reference.md; got: {invalid_err}"
+    );
+
+    // ConfigError::Toml (TOML parse failure) must also mention the reference so
+    // operators aren't left with only a parser diagnostic.
+    let toml_err = Config::from_toml_str("[[[ not valid toml").unwrap_err().to_string();
+    assert!(
+        toml_err.contains("config-reference") || toml_err.contains("configuration reference"),
+        "ConfigError::Toml must point to docs/config-reference.md; got: {toml_err}"
+    );
+}
+
+// ── Default value drift (AC 7 extension) ─────────────────────────────────────
+
+/// Verifies that actual runtime default *values* (not just field names) are
+/// documented. Catches changes like `step_limit` moving from 50 → 100 when the
+/// field name stays the same — the field-name drift guard would miss that.
+#[test]
+fn config_reference_documents_actual_default_values() {
+    let doc = read_config_reference();
+    let cfg = Config::defaults().unwrap();
+
+    let checks: &[(&str, String)] = &[
+        ("agent.step_limit", cfg.root.agent.step_limit.to_string()),
+        (
+            "agent.observation_max_bytes",
+            cfg.root.agent.observation_max_bytes.to_string(),
+        ),
+        (
+            "agent.observation_head_ratio",
+            cfg.root.agent.observation_head_ratio.to_string(),
+        ),
+        (
+            "agent.tool_hook_timeout_secs",
+            cfg.root.agent.tool_hook_timeout_secs.to_string(),
+        ),
+        (
+            "model.name",
+            format!("\"{}\"", cfg.root.model.name),
+        ),
+        ("model.max_tokens", cfg.root.model.max_tokens.to_string()),
+        (
+            "environment.timeout_secs",
+            cfg.root.environment.timeout_secs.to_string(),
+        ),
+        (
+            "environment.workdir",
+            format!("\"{}\"", cfg.root.environment.workdir),
+        ),
+    ];
+
+    for (field, value) in checks {
+        assert!(
+            doc.contains(value.as_str()),
+            "{CONFIG_REFERENCE_PATH} must document the actual default value \
+             '{value}' for field '{field}'. Update the reference when defaults change."
+        );
+    }
+}
+
+// ── No-key example binary execution (AC 8) ───────────────────────────────────
+
+/// Extracts the no-key-smoke TOML from the reference, writes it to a tempfile,
+/// runs `hello-world --config <file>`, and verifies the output trajectory is
+/// valid. This is the "produces a valid trajectory" check required by AC 8.
+#[test]
+fn no_key_smoke_example_produces_valid_trajectory() {
+    let doc = read_config_reference();
+    let toml = extract_toml_example(&doc, "no-key-smoke");
+
+    let temp = tempfile::tempdir().unwrap();
+    let config_path = temp.path().join("smoke.toml");
+    let output_dir = temp.path().join("runs");
+    std::fs::write(&config_path, &toml).unwrap();
+
+    let out = Command::new(support::binary_path())
+        .args([
+            "--log",
+            "error",
+            "hello-world",
+            "--config",
+            &config_path.display().to_string(),
+            "--output",
+            &output_dir.display().to_string(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        out.status.success(),
+        "no-key smoke run with reference config failed\n\
+         stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let trajectory_path = output_dir.join("hello-world.traj.json");
+    assert!(
+        trajectory_path.exists(),
+        "trajectory not written at {}",
+        trajectory_path.display()
+    );
+
+    let trajectory: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&trajectory_path).unwrap()).unwrap();
+    assert_eq!(
+        trajectory["trajectory_format"].as_str(),
+        Some("mini-swe-agent-1.1"),
+        "trajectory must be mini-swe-agent-1.1 format"
+    );
+    assert_eq!(
+        trajectory["info"]["outcome"].as_str(),
+        Some("submitted"),
+        "no-key smoke must produce outcome=submitted"
+    );
+    assert_eq!(
+        trajectory["info"]["total_cost_usd"].as_f64(),
+        Some(0.0),
+        "no-key smoke must cost $0"
     );
 }

--- a/tests/config_reference.rs
+++ b/tests/config_reference.rs
@@ -19,9 +19,7 @@ const README_PATH: &str = "README.md";
 
 fn read_config_reference() -> String {
     std::fs::read_to_string(CONFIG_REFERENCE_PATH).unwrap_or_else(|_| {
-        panic!(
-            "{CONFIG_REFERENCE_PATH} must exist — create it to pass this test (issue #92)"
-        )
+        panic!("{CONFIG_REFERENCE_PATH} must exist — create it to pass this test (issue #92)")
     })
 }
 
@@ -29,24 +27,24 @@ fn read_config_reference() -> String {
 /// `<!-- config-example:<marker> -->` comment in the reference doc.
 fn extract_toml_example(doc: &str, marker: &str) -> String {
     let marker_text = format!("<!-- config-example:{marker} -->");
-    let after_marker = doc
-        .split_once(&marker_text)
-        .map(|(_, rest)| rest)
-        .unwrap_or_else(|| {
+    let after_marker = doc.split_once(&marker_text).map_or_else(
+        || {
             panic!(
                 "{CONFIG_REFERENCE_PATH} is missing marker `{marker_text}`; \
                  add it before the ```toml block for the '{marker}' example"
             )
-        });
-    let after_fence = after_marker
-        .split_once("```toml")
-        .map(|(_, rest)| rest)
-        .unwrap_or_else(|| {
+        },
+        |(_, rest)| rest,
+    );
+    let after_fence = after_marker.split_once("```toml").map_or_else(
+        || {
             panic!(
                 "Marker `{marker_text}` in {CONFIG_REFERENCE_PATH} must be \
                  followed by a ```toml block"
             )
-        });
+        },
+        |(_, rest)| rest,
+    );
     let (block, _) = after_fence.split_once("```").unwrap_or_else(|| {
         panic!(
             "TOML block after `{marker_text}` in {CONFIG_REFERENCE_PATH} is \
@@ -94,30 +92,38 @@ fn config_reference_documents_all_top_level_sections() {
     }
 }
 
-/// Drift guard: every non-comment, non-section leaf key in `default.toml`
-/// must appear verbatim in the reference. When a new field is added to
+/// Drift guard: every leaf key in every top-level section of `default.toml`
+/// must appear as a code-formatted field name (`` `field` ``) in the reference.
+/// Uses the `toml` crate to parse the file so template content in multiline
+/// strings can never be misread as field names. When a new field is added to
 /// `default.toml` this test fails until the reference is updated.
 #[test]
 fn config_reference_documents_all_default_toml_fields() {
     let doc = read_config_reference();
     let default_toml = std::fs::read_to_string(DEFAULT_TOML_PATH).unwrap();
+    let parsed: toml::Value = toml::from_str(&default_toml).unwrap();
 
-    let field_names: Vec<&str> = default_toml
-        .lines()
-        .filter_map(|line| {
-            let trimmed = line.trim();
-            if trimmed.starts_with('#') || trimmed.starts_with('[') || trimmed.is_empty() {
-                return None;
-            }
-            trimmed.split_once('=').map(|(key, _)| key.trim())
-        })
-        .collect();
+    let field_names: Vec<String> = if let toml::Value::Table(root) = &parsed {
+        root.iter()
+            .flat_map(|(_, section_val)| {
+                if let toml::Value::Table(section) = section_val {
+                    section.keys().cloned().collect::<Vec<_>>()
+                } else {
+                    vec![]
+                }
+            })
+            .collect()
+    } else {
+        vec![]
+    };
 
     for field in &field_names {
+        let needle = format!("`{field}`");
         assert!(
-            doc.contains(field),
-            "{CONFIG_REFERENCE_PATH} must document field '{field}' \
-             found in {DEFAULT_TOML_PATH}. Add an entry for it to pass this drift check."
+            doc.contains(&needle),
+            "{CONFIG_REFERENCE_PATH} must document field '{field}' as a code \
+             literal (`{field}`) found in {DEFAULT_TOML_PATH}. Add an entry \
+             for it to pass this drift check."
         );
     }
 }
@@ -178,23 +184,16 @@ fn interactive_local_example_parses() {
 fn config_reference_explains_precedence() {
     let doc = read_config_reference();
     // Must name all four layers.
-    for keyword in &[
-        "default",
-        "config file",
-        "environment variable",
-        "CLI",
-    ] {
+    for keyword in &["default", "config file", "environment variable", "CLI"] {
         assert!(
-            doc.to_ascii_lowercase().contains(&keyword.to_ascii_lowercase()),
+            doc.to_ascii_lowercase()
+                .contains(&keyword.to_ascii_lowercase()),
             "{CONFIG_REFERENCE_PATH} must mention '{keyword}' in the precedence section"
         );
     }
     // Must include at least three concrete conflict examples (look for numbered
     // list items or example headings that follow the precedence section).
-    let precedence_section = doc
-        .split_once("recedence")
-        .map(|(_, rest)| rest)
-        .unwrap_or("");
+    let precedence_section = doc.split_once("recedence").map_or("", |(_, rest)| rest);
     let example_count = precedence_section
         .lines()
         .filter(|l| {
@@ -262,7 +261,9 @@ fn config_validation_error_points_to_reference() {
 
     // ConfigError::Toml (TOML parse failure) must also mention the reference so
     // operators aren't left with only a parser diagnostic.
-    let toml_err = Config::from_toml_str("[[[ not valid toml").unwrap_err().to_string();
+    let toml_err = Config::from_toml_str("[[[ not valid toml")
+        .unwrap_err()
+        .to_string();
     assert!(
         toml_err.contains("config-reference") || toml_err.contains("configuration reference"),
         "ConfigError::Toml must point to docs/config-reference.md; got: {toml_err}"
@@ -293,10 +294,7 @@ fn config_reference_documents_actual_default_values() {
             "agent.tool_hook_timeout_secs",
             cfg.root.agent.tool_hook_timeout_secs.to_string(),
         ),
-        (
-            "model.name",
-            format!("\"{}\"", cfg.root.model.name),
-        ),
+        ("model.name", format!("\"{}\"", cfg.root.model.name)),
         ("model.max_tokens", cfg.root.model.max_tokens.to_string()),
         (
             "environment.timeout_secs",


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive configuration reference document (`docs/config-reference.md`) and an automated test suite (`tests/config_reference.rs`) to prevent documentation drift. The reference covers all supported configuration sections, fields, defaults, precedence rules, secret handling, and includes copy-pasteable TOML examples. The test suite enforces that the documentation stays synchronized with the implementation.

## Key Changes

- **New documentation file** (`docs/config-reference.md`):
  - Complete reference for all top-level TOML sections: `[agent]`, `[model]`, `[environment]`, `[prompts]`, `[sweep]`, `[redaction]`, `[policy]`
  - Configuration precedence explanation with three concrete examples
  - Secret handling guidelines and provider credential mapping
  - Four copy-pasteable TOML examples (no-key smoke, live-model, docker-sweep, interactive-local)
  - Drift verification requirements

- **New test suite** (`tests/config_reference.rs`):
  - Existence and README linkage checks
  - Section and field coverage validation (ensures all fields in `default.toml` are documented)
  - TOML example round-trip parsing tests for all four examples
  - Content requirement checks (precedence explanation, secret handling, TOML format statement)
  - Config validation error integration test (verifies errors point to the reference)
  - Default value drift detection (catches runtime default changes)
  - Binary execution test (runs `hello-world` with the no-key-smoke example and validates trajectory output)

- **Error message improvements** (`src/error.rs`):
  - `ConfigError::Toml` now references `docs/config-reference.md` to guide operators to documentation
  - `ConfigError::Invalid` also points to the reference for validation failures

- **CLI enhancements**:
  - `HelloWorldCmd` now accepts an optional `--config` flag to load custom configuration
  - `hello_world::main()` updated to accept and load config from the provided path

- **Documentation updates** (`README.md`):
  - Added link to the new configuration reference in the "Deeper specs" section

## Notable Implementation Details

- The test suite uses marker comments (`<!-- config-example:<name> -->`) to extract TOML examples from the reference document, ensuring examples are always tested for validity
- The no-key-smoke example execution test validates the full trajectory output format and verifies zero cost
- Field coverage validation parses `default.toml` to extract all non-comment, non-section keys and ensures they appear in the reference
- Default value drift detection checks actual runtime values (not just field names) against documented defaults

https://claude.ai/code/session_01987t81oaXQ3Rv9bHFQb4ak