### PR TITLE
feat: require verification evidence for local runs (issue #94)

### DIFF
--- a/docs/artifact-contract.md
+++ b/docs/artifact-contract.md
@@ -15,7 +15,7 @@ Run artifacts use explicit top-level metadata:
 
 | Kind | File(s) | Required fields | Optional/additive fields |
 | --- | --- | --- | --- |
-| `trajectory` | `*.traj.json`, `<instance>/run-k.traj.json` | `trajectory_format`, `artifact_kind`, `schema_version`, `info`, `messages` | `actual_cost_usd`, `actual_cost_source`, `baseline_cost_usd`, `baseline_cost_model`, extra `info` fields, message `extra` fields |
+| `trajectory` | `*.traj.json`, `<instance>/run-k.traj.json` | `trajectory_format`, `artifact_kind`, `schema_version`, `info`, `messages` | `actual_cost_usd`, `actual_cost_source`, `baseline_cost_usd`, `baseline_cost_model`, `verification_status` (`verified`/`unverified`/`verification_failed`), `verification_results` (array of per-check evidence), extra `info` fields, message `extra` fields |
 | `sweep_results` | `results.json` | `artifact_kind`, `schema_version`, `total`, `submitted`, `skipped`, `errored`, `failures_by_category`, `instances` | `actual_cost_usd`, `actual_cost_source`, `baseline_cost_usd`, `baseline_cost_model`, manifest, filter spec, token, retry, rate-limit, cancellation fields |
 | `evaluation_results` | `evaluation.json` | `artifact_kind`, `schema_version`, `instances` | behavioral metrics, breakdown rows, cost attribution |
 | `forecast_report` | `bench forecast --format json` | `artifact_kind`, `schema_version`, `calibration`, `per_instance`, `forecast`, `resolution_rate`, `threshold` | additional forecast diagnostics |

--- a/docs/spec-secret-redaction.md
+++ b/docs/spec-secret-redaction.md
@@ -28,6 +28,12 @@ Disabling redaction is a run-time decision (`enabled = false` in the run config)
 
 If a submitted patch or prediction artifact contains a configured literal or structured secret shape, the run is downgraded to `failure_category = "secret_leak_detected"` unless `unsafe_allow_secret_leaks = true`.
 
+## Verification Check Output
+
+When operator-supplied verification checks are run after the agent finishes (see `--verify`), the stdout and stderr of each check are captured as bounded previews and saved in the trajectory artifact. `bench inspect` applies the same view-time redactor to these previews before display.
+
+**Warning:** verification command output is subject to the same redaction contract as agent observations, but only configured literals, structured secret shapes, and current-process environment variables are masked. If a verification command prints a secret that does not match any of those patterns (e.g. a raw password from a test fixture file), it will appear in plain text in the trajectory artifact and `bench inspect` output. Until issue #86 (comprehensive DLP) is complete, do not run verification commands that may print secrets that fall outside the configured redaction patterns.
+
 ## Limitations
 
 This is deterministic masking for known values and structured secrets, not an enterprise DLP system. It does not provide semantic PII detection, license scanning, retroactive rewriting of old artifacts, or a guarantee that a model cannot infer a secret from surrounding context.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -171,6 +171,17 @@ pub struct MiniCmd {
     #[arg(long, default_value_t = false)]
     pub skip_patch_validation: bool,
 
+    /// Operator-supplied verification check. Format: `NAME:COMMAND`.
+    /// Can be repeated for multiple checks. After the agent finishes, each
+    /// check is run once; if any fail the artifact is marked
+    /// `verification_failed` and the command exits non-zero.
+    #[arg(long = "verify", value_name = "NAME:COMMAND")]
+    pub verify: Vec<String>,
+
+    /// Per-check timeout in seconds for `--verify` checks. Default: 60.
+    #[arg(long = "verify-timeout-secs", default_value_t = 60)]
+    pub verify_timeout_secs: u64,
+
     #[command(flatten)]
     pub github_pr: MiniGithubPrArgs,
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -598,9 +598,16 @@ fn parse_verify_checks(
                     "--verify must be in NAME:COMMAND format, got `{s}`"
                 )))
             })?;
+            let name = s[..colon].trim();
+            let command = s[colon + 1..].trim();
+            if name.is_empty() || command.is_empty() {
+                return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "--verify NAME:COMMAND requires non-empty name and command, got `{s}`"
+                ))));
+            }
             Ok(crate::trajectory::VerificationCheck {
-                name: s[..colon].to_owned(),
-                command: s[colon + 1..].to_owned(),
+                name: name.to_owned(),
+                command: command.to_owned(),
             })
         })
         .collect()
@@ -975,8 +982,9 @@ mod tests {
     #![allow(clippy::unwrap_used)]
     use super::{
         Cli, args, cancellation_exit_code, maybe_publish_mini_github_pr, mini_github_pr_options,
-        required_github_arg, swebench_args_from_cmd, swebench_github_pr_config,
-        trajectory_submitted, validate_observation_head_ratio, validate_swebench_github_pr_args,
+        parse_verify_checks, required_github_arg, swebench_args_from_cmd,
+        swebench_github_pr_config, trajectory_submitted, validate_observation_head_ratio,
+        validate_swebench_github_pr_args,
     };
     use crate::error::Error;
     use crate::run::github_pr::PublishMode;
@@ -1281,5 +1289,38 @@ mod tests {
          @@ -1 +1 @@\n\
          -base\n\
          +patched\n"
+    }
+
+    #[test]
+    fn parse_verify_checks_parses_valid_specs() {
+        let checks = parse_verify_checks(&["unit-tests:cargo test -q".into()]).unwrap();
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].name, "unit-tests");
+        assert_eq!(checks[0].command, "cargo test -q");
+    }
+
+    #[test]
+    fn parse_verify_checks_trims_whitespace() {
+        let checks = parse_verify_checks(&["  lint  :  cargo clippy  ".into()]).unwrap();
+        assert_eq!(checks[0].name, "lint");
+        assert_eq!(checks[0].command, "cargo clippy");
+    }
+
+    #[test]
+    fn parse_verify_checks_rejects_missing_colon() {
+        let err = parse_verify_checks(&["no-colon-here".into()]).unwrap_err();
+        assert!(matches!(err, Error::Config(_)));
+        assert!(err.to_string().contains("NAME:COMMAND"), "{err}");
+    }
+
+    #[test]
+    fn parse_verify_checks_rejects_empty_name_or_command() {
+        let err = parse_verify_checks(&[":ls".into()]).unwrap_err();
+        assert!(matches!(err, Error::Config(_)));
+        assert!(err.to_string().contains("non-empty"), "{err}");
+
+        let err2 = parse_verify_checks(&["test:".into()]).unwrap_err();
+        assert!(matches!(err2, Error::Config(_)));
+        assert!(err2.to_string().contains("non-empty"), "{err2}");
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -167,10 +167,15 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         verification_timeout_secs: m.verify_timeout_secs,
     };
     let run_result = crate::run::mini::run(args).await;
-    // Always try to publish PR — trajectory and patch are on disk regardless
-    // of whether verification passed.
-    maybe_publish_mini_github_pr(github_pr).await?;
-    // Propagate verification failure after PR publication.
+    // Only publish when the run succeeded or failed at verification — those are
+    // the two cases where the trajectory and patch are guaranteed on disk.
+    // For other errors (env setup, model API, pre-trajectory I/O) propagate
+    // immediately so the real failure isn't masked by a trajectory-read error.
+    let is_verification_failure =
+        matches!(run_result, Err(crate::error::Error::VerificationFailed(..)));
+    if run_result.is_ok() || is_verification_failure {
+        maybe_publish_mini_github_pr(github_pr).await?;
+    }
     run_result?;
     Ok(())
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -150,6 +150,7 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         None => None,
     };
 
+    let verification_checks = parse_verify_checks(&m.verify)?;
     let args = crate::run::mini::MiniArgs {
         task: m.task,
         extra_context: m.extra_context,
@@ -162,9 +163,15 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         cancellation: None,
         stream_addr,
         patch_capture,
+        verification_checks,
+        verification_timeout_secs: m.verify_timeout_secs,
     };
-    crate::run::mini::run(args).await?;
+    let run_result = crate::run::mini::run(args).await;
+    // Always try to publish PR — trajectory and patch are on disk regardless
+    // of whether verification passed.
     maybe_publish_mini_github_pr(github_pr).await?;
+    // Propagate verification failure after PR publication.
+    run_result?;
     Ok(())
 }
 
@@ -573,6 +580,25 @@ fn swebench_args_from_cmd(
         cancellation_signals: None,
         github_pr,
     }
+}
+
+fn parse_verify_checks(
+    specs: &[String],
+) -> Result<Vec<crate::trajectory::VerificationCheck>, Error> {
+    specs
+        .iter()
+        .map(|s| {
+            let colon = s.find(':').ok_or_else(|| {
+                Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "--verify must be in NAME:COMMAND format, got `{s}`"
+                )))
+            })?;
+            Ok(crate::trajectory::VerificationCheck {
+                name: s[..colon].to_owned(),
+                command: s[colon + 1..].to_owned(),
+            })
+        })
+        .collect()
 }
 
 fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
@@ -1145,6 +1171,8 @@ mod tests {
             trajectory_name: None,
             stream: None,
             skip_patch_validation: false,
+            verify: vec![],
+            verify_timeout_secs: 60,
             github_pr: args::MiniGithubPrArgs {
                 open_pr,
                 target_repo: Some("madmax983/rust_swe_agent".into()),

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,11 @@ pub enum Error {
 
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+
+    /// One or more operator-supplied verification checks did not pass.
+    /// `(failed_count, total_count)`.
+    #[error("verification failed: {0} of {1} check(s) did not pass")]
+    VerificationFailed(usize, usize),
 }
 
 #[derive(Debug, Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,5 +36,5 @@ pub use redaction::{RedactionCount, RedactionSummary, Redactor};
 pub use stream::{BroadcastSink, NullSink, SseServer, StreamEvent, StreamSink};
 pub use trajectory::{
     FORMAT_VERSION, FailureCategory, FallbackSummary, MessageRecord, TestInvocation, TokenUsage,
-    Trajectory, TrajectoryInfo,
+    Trajectory, TrajectoryInfo, VerificationCheck, VerificationResult, verification_status,
 };

--- a/src/run/hello_world.rs
+++ b/src/run/hello_world.rs
@@ -29,6 +29,8 @@ pub async fn main(output_dir: PathBuf, config_path: Option<&Path>) -> Result<(),
         cancellation: None,
         stream_addr: None,
         patch_capture: None,
+        verification_checks: vec![],
+        verification_timeout_secs: 60,
     };
     run(args).await?;
     println!("hello-world smoke complete");

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -848,6 +848,9 @@ fn redact_trajectory_for_inspect(trajectory: &mut Trajectory, redactor: &Redacto
         redacted |= redactor.redact_json_value(value, surface::INSPECT);
     }
     for vr in &mut trajectory.info.verification_results {
+        let command = redactor.redact_text(&vr.command, surface::INSPECT);
+        redacted |= command.redacted;
+        vr.command = command.text;
         let stdout = redactor.redact_text(&vr.stdout_preview, surface::INSPECT);
         redacted |= stdout.redacted;
         vr.stdout_preview = stdout.text;
@@ -874,4 +877,118 @@ fn redact_trajectory_for_inspect(trajectory: &mut Trajectory, redactor: &Redacto
         }
     }
     redacted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::trajectory::{VerificationResult, verification_status};
+
+    fn write_trajectory_fixture(
+        sweep: &std::path::Path,
+        instance_id: &str,
+        results: &[VerificationResult],
+        status: &str,
+    ) {
+        let instance_dir = sweep.join(instance_id);
+        std::fs::create_dir_all(&instance_dir).unwrap();
+        let traj = serde_json::json!({
+            "trajectory_format": "mini-swe-agent-1.1",
+            "artifact_kind": "trajectory",
+            "schema_version": {"major": 1, "minor": 1},
+            "info": {
+                "verification_status": status,
+                "verification_results": serde_json::to_value(results).unwrap(),
+            },
+            "messages": [{"role": "assistant", "content": "done"}]
+        });
+        std::fs::write(
+            instance_dir.join("trajectory.json"),
+            serde_json::to_string(&traj).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn timed_out_check_renders_timeout_note() {
+        let dir = tempfile::tempdir().unwrap();
+        write_trajectory_fixture(
+            dir.path(),
+            "task-a",
+            &[VerificationResult {
+                name: "slow-check".into(),
+                command: "sleep 60".into(),
+                exit_code: -1,
+                duration_ms: 5000,
+                passed: false,
+                stdout_preview: String::new(),
+                stderr_preview: String::new(),
+                timed_out: true,
+            }],
+            verification_status::VERIFICATION_FAILED,
+        );
+        let args = InspectArgs {
+            sweep: dir.path().to_path_buf(),
+            instance: Some("task-a".into()),
+            filter: None,
+            full: false,
+        };
+        let output = run(&args).unwrap();
+        let text = render_text(&output);
+        assert!(
+            text.contains("(timed_out)"),
+            "expected timed_out note in:\n{text}"
+        );
+        assert!(
+            text.contains("verification:"),
+            "expected verification line in:\n{text}"
+        );
+        if let InspectOutput::Instance(report) = &output {
+            assert_eq!(report.verification_results.len(), 1);
+            assert!(report.verification_results[0].timed_out);
+        } else {
+            panic!("expected Instance output");
+        }
+    }
+
+    #[test]
+    fn verification_command_and_output_redacted_at_view_time() {
+        let secret = "ghp_0123456789ABCDEF0123456789ABCDEF0123";
+        let dir = tempfile::tempdir().unwrap();
+        write_trajectory_fixture(
+            dir.path(),
+            "task-b",
+            &[VerificationResult {
+                name: "secret-check".into(),
+                command: format!("curl -H 'Authorization: Bearer {secret}'"),
+                exit_code: 0,
+                duration_ms: 50,
+                passed: true,
+                stdout_preview: format!("token={secret}"),
+                stderr_preview: String::new(),
+                timed_out: false,
+            }],
+            verification_status::VERIFIED,
+        );
+        let args = InspectArgs {
+            sweep: dir.path().to_path_buf(),
+            instance: Some("task-b".into()),
+            filter: None,
+            full: false,
+        };
+        let output = run(&args).unwrap();
+        if let InspectOutput::Instance(report) = &output {
+            let vr = &report.verification_results[0];
+            assert!(
+                !vr.command.contains(secret),
+                "command should be redacted at view time"
+            );
+            assert!(
+                !vr.stdout_preview.contains(secret),
+                "stdout_preview should be redacted at view time"
+            );
+        } else {
+            panic!("expected Instance output");
+        }
+    }
 }

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -15,7 +15,9 @@ use crate::redaction::{Redactor, surface};
 use crate::run::evaluate::EvaluationResults;
 use crate::run::patch_stats::PatchStats;
 use crate::run::swebench::{InstanceResult, ProvenanceManifest};
-use crate::trajectory::{FailureCategory, FallbackSummary, TokenUsage, Trajectory};
+use crate::trajectory::{
+    FailureCategory, FallbackSummary, TokenUsage, Trajectory, VerificationResult,
+};
 
 const TRUNCATE_MAX_LINES: usize = 40;
 const TRUNCATE_MAX_BYTES: usize = 2 * 1024;
@@ -97,6 +99,10 @@ pub struct InspectReport {
     pub last_tests_passed: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fallback_summary: Option<FallbackSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verification_status: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub verification_results: Vec<VerificationResult>,
     #[serde(default)]
     pub warnings: Vec<String>,
     #[serde(default)]
@@ -252,6 +258,8 @@ fn build_instance_report(
                 tests_run_before_submit: false,
                 last_tests_passed: None,
                 fallback_summary: None,
+                verification_status: None,
+                verification_results: vec![],
                 warnings,
                 steps: vec![],
             });
@@ -306,6 +314,8 @@ fn build_instance_report(
         tests_run_before_submit: traj.info.tests_run_before_submit,
         last_tests_passed: traj.info.last_tests_passed,
         fallback_summary: traj.info.fallback_summary,
+        verification_status: traj.info.verification_status,
+        verification_results: traj.info.verification_results,
         warnings,
         steps,
     })
@@ -525,6 +535,25 @@ fn render_instance_text(report: &InspectReport) -> String {
         );
         if !fb.attempted_models.is_empty() {
             let _ = writeln!(s, "fallback_chain:   {}", fb.attempted_models.join(" → "));
+        }
+    }
+    if report.verification_status.is_some() || !report.verification_results.is_empty() {
+        let _ = writeln!(
+            s,
+            "verification:     status={} checks={}",
+            report
+                .verification_status
+                .as_deref()
+                .unwrap_or("unverified"),
+            report.verification_results.len(),
+        );
+        for r in &report.verification_results {
+            let timeout_note = if r.timed_out { " (timed_out)" } else { "" };
+            let _ = writeln!(
+                s,
+                "  [{}] passed={} exit_code={} duration={}ms{}",
+                r.name, r.passed, r.exit_code, r.duration_ms, timeout_note,
+            );
         }
     }
     for w in &report.warnings {

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -880,6 +880,7 @@ fn redact_trajectory_for_inspect(trajectory: &mut Trajectory, redactor: &Redacto
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::trajectory::{VerificationResult, verification_status};

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -847,6 +847,14 @@ fn redact_trajectory_for_inspect(trajectory: &mut Trajectory, redactor: &Redacto
     for value in trajectory.info.other.values_mut() {
         redacted |= redactor.redact_json_value(value, surface::INSPECT);
     }
+    for vr in &mut trajectory.info.verification_results {
+        let stdout = redactor.redact_text(&vr.stdout_preview, surface::INSPECT);
+        redacted |= stdout.redacted;
+        vr.stdout_preview = stdout.text;
+        let stderr = redactor.redact_text(&vr.stderr_preview, surface::INSPECT);
+        redacted |= stderr.redacted;
+        vr.stderr_preview = stderr.text;
+    }
     for message in &mut trajectory.messages {
         let outcome = redactor.redact_text(&message.content, surface::INSPECT);
         redacted |= outcome.redacted;

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -330,6 +330,10 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         .await
     };
 
+    // Refresh redaction summary: verification may have redacted command text
+    // or stdout/stderr previews after finalize_run_metadata already stamped
+    // info.redaction, so update it before writing the artifact.
+    agent.trajectory.info.redaction = Some(agent.redactor.summary());
     agent.trajectory.save_pretty(&traj_path)?;
 
     let exit = match run_result {

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -719,8 +719,7 @@ async fn run_verification_checks(
     for check in checks {
         let start = Instant::now();
         let req = attach_cancellation(
-            RunRequest::new(check.command.clone())
-                .with_timeout(Duration::from_secs(timeout_secs)),
+            RunRequest::new(check.command.clone()).with_timeout(Duration::from_secs(timeout_secs)),
             cancellation.clone(),
         );
 

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -322,6 +322,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         run_verification_checks(
             &mut agent.trajectory,
             agent.env.as_ref(),
+            &agent.redactor,
             &args.verification_checks,
             args.verification_timeout_secs,
             args.cancellation.clone(),
@@ -703,6 +704,7 @@ async fn build_docker_env(_cfg: &Config) -> Result<Box<dyn Environment>, Error> 
 async fn run_verification_checks(
     trajectory: &mut crate::trajectory::Trajectory,
     env: &dyn crate::env::Environment,
+    redactor: &crate::redaction::Redactor,
     checks: &[crate::trajectory::VerificationCheck],
     timeout_secs: u64,
     cancellation: Option<MiniCancellation>,
@@ -727,6 +729,9 @@ async fn run_verification_checks(
             Ok(r) => r,
             Err(e) => {
                 failed += 1;
+                let stderr_preview = redactor
+                    .redact_text(&truncate_preview(&e.to_string()), surface::TRAJECTORY)
+                    .text;
                 results.push(crate::trajectory::VerificationResult {
                     name: check.name.clone(),
                     command: check.command.clone(),
@@ -734,7 +739,7 @@ async fn run_verification_checks(
                     duration_ms: elapsed_ms(start),
                     passed: false,
                     stdout_preview: String::new(),
-                    stderr_preview: truncate_preview(&e.to_string()),
+                    stderr_preview,
                     timed_out: false,
                 });
                 continue;
@@ -746,14 +751,20 @@ async fn run_verification_checks(
         if !passed {
             failed += 1;
         }
+        let stdout_preview = redactor
+            .redact_text(&truncate_preview(&run_result.stdout), surface::TRAJECTORY)
+            .text;
+        let stderr_preview = redactor
+            .redact_text(&truncate_preview(&run_result.stderr), surface::TRAJECTORY)
+            .text;
         results.push(crate::trajectory::VerificationResult {
             name: check.name.clone(),
             command: check.command.clone(),
             exit_code: run_result.exit_code,
             duration_ms,
             passed,
-            stdout_preview: truncate_preview(&run_result.stdout),
-            stderr_preview: truncate_preview(&run_result.stderr),
+            stdout_preview,
+            stderr_preview,
             timed_out: run_result.timed_out,
         });
     }

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -5,7 +5,7 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::agent::{Agent, DefaultAgent, default::DefaultAgentBuilder};
 use crate::config::{Config, EnvKind};
@@ -22,6 +22,7 @@ use crate::trajectory::FailureCategory;
 pub use crate::env::CancellationToken as MiniCancellation;
 
 const PATCH_BASE_ENV: &str = "RUST_SWE_AGENT_PATCH_BASE";
+const VERIFICATION_PREVIEW_MAX_BYTES: usize = 2 * 1024;
 
 #[cfg(test)]
 struct CancelBeforePatchCaptureHook {
@@ -105,6 +106,12 @@ pub struct MiniArgs {
     /// `patch_path`. Capture failures downgrade the run's recorded
     /// outcome to `error` rather than crashing the runner.
     pub patch_capture: Option<PatchCaptureSpec>,
+    /// Operator-supplied checks that run after the agent finishes.
+    /// Empty vec preserves previous behavior but marks the run as
+    /// `unverified` in the trajectory artifact.
+    pub verification_checks: Vec<crate::trajectory::VerificationCheck>,
+    /// Per-check timeout in seconds. Defaults to 60.
+    pub verification_timeout_secs: u64,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -172,6 +179,8 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         match capture_patch(agent.env.as_ref(), spec, args.cancellation.clone()).await {
             Ok(diff) => {
                 if finalize_cancelled_if_requested(&mut agent, args.cancellation.as_ref()) {
+                    agent.trajectory.info.verification_status =
+                        Some(crate::trajectory::verification_status::UNVERIFIED.into());
                     agent.trajectory.save_pretty(&traj_path)?;
                     tracing::info!(?traj_path, patch_written, "trajectory written");
                     if let Some(server) = server {
@@ -205,6 +214,8 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
                         }),
                     );
                     agent.finalize_run_metadata(crate::trajectory::outcome::ERROR);
+                    agent.trajectory.info.verification_status =
+                        Some(crate::trajectory::verification_status::UNVERIFIED.into());
                     agent.trajectory.save_pretty(&traj_path)?;
                     tracing::info!(?traj_path, patch_written, "trajectory written");
                     if let Some(server) = server {
@@ -294,6 +305,30 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         }
     }
 
+    // ── Verification ─────────────────────────────────────────────────────────
+    // Runs after all patch-capture logic, for any exit that is not a
+    // cancellation or an agent-internal error (which would already have
+    // returned Err above). Sets `verification_status` on the trajectory so
+    // every persisted artifact carries a deterministic verification outcome.
+    let skip_verification = run_result.is_err()
+        || run_result
+            .as_ref()
+            .is_ok_and(|r| matches!(r, crate::agent::ExitReason::UserInterrupt));
+    let verification_err = if skip_verification {
+        agent.trajectory.info.verification_status =
+            Some(crate::trajectory::verification_status::UNVERIFIED.into());
+        None
+    } else {
+        run_verification_checks(
+            &mut agent.trajectory,
+            agent.env.as_ref(),
+            &args.verification_checks,
+            args.verification_timeout_secs,
+            args.cancellation.clone(),
+        )
+        .await
+    };
+
     agent.trajectory.save_pretty(&traj_path)?;
 
     let exit = match run_result {
@@ -317,6 +352,9 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
 
     if let Some(server) = server {
         server.shutdown().await;
+    }
+    if let Some(err) = verification_err {
+        return Err(err);
     }
     Ok(())
 }
@@ -654,6 +692,99 @@ async fn build_docker_env(_cfg: &Config) -> Result<Box<dyn Environment>, Error> 
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "docker support not compiled in — rebuild with --features docker".into(),
     )))
+}
+
+/// Run operator-supplied verification checks after the agent finishes.
+///
+/// Sets `trajectory.info.verification_status` and
+/// `trajectory.info.verification_results` unconditionally.
+/// Returns `Some(Error::VerificationFailed(...))` when at least one check
+/// fails; `None` when all pass or no checks were configured.
+async fn run_verification_checks(
+    trajectory: &mut crate::trajectory::Trajectory,
+    env: &dyn crate::env::Environment,
+    checks: &[crate::trajectory::VerificationCheck],
+    timeout_secs: u64,
+    cancellation: Option<MiniCancellation>,
+) -> Option<Error> {
+    if checks.is_empty() {
+        trajectory.info.verification_status =
+            Some(crate::trajectory::verification_status::UNVERIFIED.into());
+        return None;
+    }
+
+    let mut results = Vec::with_capacity(checks.len());
+    let mut failed = 0usize;
+
+    for check in checks {
+        let start = Instant::now();
+        let req = attach_cancellation(
+            RunRequest::new(check.command.clone())
+                .with_timeout(Duration::from_secs(timeout_secs)),
+            cancellation.clone(),
+        );
+
+        let run_result = match env.run(req).await {
+            Ok(r) => r,
+            Err(e) => {
+                failed += 1;
+                results.push(crate::trajectory::VerificationResult {
+                    name: check.name.clone(),
+                    command: check.command.clone(),
+                    exit_code: -1,
+                    duration_ms: elapsed_ms(start),
+                    passed: false,
+                    stdout_preview: String::new(),
+                    stderr_preview: truncate_preview(&e.to_string()),
+                    timed_out: false,
+                });
+                continue;
+            }
+        };
+
+        let duration_ms = elapsed_ms(start);
+        let passed = !run_result.timed_out && run_result.exit_code == 0;
+        if !passed {
+            failed += 1;
+        }
+        results.push(crate::trajectory::VerificationResult {
+            name: check.name.clone(),
+            command: check.command.clone(),
+            exit_code: run_result.exit_code,
+            duration_ms,
+            passed,
+            stdout_preview: truncate_preview(&run_result.stdout),
+            stderr_preview: truncate_preview(&run_result.stderr),
+            timed_out: run_result.timed_out,
+        });
+    }
+
+    trajectory.info.verification_results = results;
+
+    if failed == 0 {
+        trajectory.info.verification_status =
+            Some(crate::trajectory::verification_status::VERIFIED.into());
+        None
+    } else {
+        trajectory.info.verification_status =
+            Some(crate::trajectory::verification_status::VERIFICATION_FAILED.into());
+        Some(Error::VerificationFailed(failed, checks.len()))
+    }
+}
+
+fn elapsed_ms(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+fn truncate_preview(text: &str) -> String {
+    if text.len() <= VERIFICATION_PREVIEW_MAX_BYTES {
+        return text.to_owned();
+    }
+    let mut end = VERIFICATION_PREVIEW_MAX_BYTES;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    text[..end].to_owned()
 }
 
 /// Derive a filename-safe trajectory name from a task string.
@@ -1199,6 +1330,8 @@ index 8a1218a..24c5735 100644\n\
                 patch_path: patch_path.clone(),
                 skip_patch_validation: false,
             }),
+            verification_checks: vec![],
+            verification_timeout_secs: 60,
         };
 
         run(args).await.unwrap();
@@ -1281,6 +1414,8 @@ index 8a1218a..24c5735 100644\n\
                 patch_path: patch_path.clone(),
                 skip_patch_validation: true,
             }),
+            verification_checks: vec![],
+            verification_timeout_secs: 60,
         };
 
         run(args).await.unwrap();

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -1485,4 +1485,71 @@ index 8a1218a..24c5735 100644\n\
             "cancelled submission should not write final output artifact"
         );
     }
+
+    /// Environment that always returns `Err(EnvError::CommandFailed(...))`.
+    struct FailingEnvironment {
+        message: String,
+    }
+
+    #[async_trait]
+    impl Environment for FailingEnvironment {
+        async fn run(
+            &self,
+            _req: RunRequest,
+        ) -> Result<crate::env::RunResult, crate::error::EnvError> {
+            Err(crate::error::EnvError::CommandFailed(self.message.clone()))
+        }
+    }
+
+    #[tokio::test]
+    async fn env_error_during_verification_records_failed_check() {
+        let env = FailingEnvironment {
+            message: "spawn failed".into(),
+        };
+        let redactor = crate::redaction::Redactor::disabled();
+        let checks = vec![crate::trajectory::VerificationCheck {
+            name: "my-check".into(),
+            command: "exit 0".into(),
+        }];
+        let mut traj = crate::trajectory::Trajectory::default();
+        let err = run_verification_checks(&mut traj, &env, &redactor, &checks, 30, None).await;
+        assert!(err.is_some(), "expected VerificationFailed error");
+        assert_eq!(traj.info.verification_results.len(), 1);
+        let vr = &traj.info.verification_results[0];
+        assert!(!vr.passed);
+        assert_eq!(vr.exit_code, -1);
+        assert!(!vr.timed_out);
+        assert!(
+            vr.stderr_preview.contains("spawn failed"),
+            "stderr_preview should carry env error: {}",
+            vr.stderr_preview
+        );
+        assert_eq!(
+            traj.info.verification_status.as_deref(),
+            Some(crate::trajectory::verification_status::VERIFICATION_FAILED)
+        );
+    }
+
+    #[tokio::test]
+    async fn env_error_with_cancellation_sets_unverified() {
+        let (_tx, rx) = watch::channel(true); // pre-fired
+        let cancellation = MiniCancellation::new(rx);
+        let env = FailingEnvironment {
+            message: "interrupted".into(),
+        };
+        let redactor = crate::redaction::Redactor::disabled();
+        let checks = vec![crate::trajectory::VerificationCheck {
+            name: "my-check".into(),
+            command: "exit 0".into(),
+        }];
+        let mut traj = crate::trajectory::Trajectory::default();
+        let err =
+            run_verification_checks(&mut traj, &env, &redactor, &checks, 30, Some(cancellation))
+                .await;
+        assert!(err.is_none(), "cancelled run should not return an error");
+        assert_eq!(
+            traj.info.verification_status.as_deref(),
+            Some(crate::trajectory::verification_status::UNVERIFIED)
+        );
+    }
 }

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -725,16 +725,21 @@ async fn run_verification_checks(
             cancellation.clone(),
         );
 
+        let command = redactor
+            .redact_text(&check.command, surface::TRAJECTORY)
+            .text;
         let run_result = match env.run(req).await {
             Ok(r) => r,
             Err(e) => {
                 failed += 1;
-                let stderr_preview = redactor
-                    .redact_text(&truncate_preview(&e.to_string()), surface::TRAJECTORY)
-                    .text;
+                let stderr_preview = truncate_preview(
+                    &redactor
+                        .redact_text(&e.to_string(), surface::TRAJECTORY)
+                        .text,
+                );
                 results.push(crate::trajectory::VerificationResult {
                     name: check.name.clone(),
-                    command: check.command.clone(),
+                    command,
                     exit_code: -1,
                     duration_ms: elapsed_ms(start),
                     passed: false,
@@ -751,15 +756,19 @@ async fn run_verification_checks(
         if !passed {
             failed += 1;
         }
-        let stdout_preview = redactor
-            .redact_text(&truncate_preview(&run_result.stdout), surface::TRAJECTORY)
-            .text;
-        let stderr_preview = redactor
-            .redact_text(&truncate_preview(&run_result.stderr), surface::TRAJECTORY)
-            .text;
+        let stdout_preview = truncate_preview(
+            &redactor
+                .redact_text(&run_result.stdout, surface::TRAJECTORY)
+                .text,
+        );
+        let stderr_preview = truncate_preview(
+            &redactor
+                .redact_text(&run_result.stderr, surface::TRAJECTORY)
+                .text,
+        );
         results.push(crate::trajectory::VerificationResult {
             name: check.name.clone(),
-            command: check.command.clone(),
+            command,
             exit_code: run_result.exit_code,
             duration_ms,
             passed,

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -731,6 +731,15 @@ async fn run_verification_checks(
         let run_result = match env.run(req).await {
             Ok(r) => r,
             Err(e) => {
+                // If the error was caused by cancellation, stop and mark unverified.
+                if cancellation
+                    .as_ref()
+                    .is_some_and(MiniCancellation::is_cancelled)
+                {
+                    trajectory.info.verification_status =
+                        Some(crate::trajectory::verification_status::UNVERIFIED.into());
+                    return None;
+                }
                 failed += 1;
                 let stderr_preview = truncate_preview(
                     &redactor
@@ -750,6 +759,18 @@ async fn run_verification_checks(
                 continue;
             }
         };
+
+        // Cancellation fires after the command finishes with exit_code=-1 and
+        // stderr="cancelled" (not an Err). Detect it here so a Ctrl-C during
+        // verification produces `unverified` rather than `verification_failed`.
+        if cancellation
+            .as_ref()
+            .is_some_and(MiniCancellation::is_cancelled)
+        {
+            trajectory.info.verification_status =
+                Some(crate::trajectory::verification_status::UNVERIFIED.into());
+            return None;
+        }
 
         let duration_ms = elapsed_ms(start);
         let passed = !run_result.timed_out && run_result.exit_code == 0;

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -3457,6 +3457,8 @@ async fn run_one(inst: SweBenchInstance, run_index: u32, params: RunOneParams) -
                 patch_path: patch_path.clone(),
                 skip_patch_validation,
             }),
+            verification_checks: vec![],
+            verification_timeout_secs: 60,
         };
         let run_err = crate::run::mini::run(args).await.err();
 

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -48,6 +48,34 @@ fn is_false(b: &bool) -> bool {
     !b
 }
 
+/// Operator-supplied verification check run after the agent finishes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct VerificationCheck {
+    pub name: String,
+    pub command: String,
+}
+
+/// Per-check evidence recorded after a verification check runs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct VerificationResult {
+    pub name: String,
+    pub command: String,
+    pub exit_code: i32,
+    pub duration_ms: u64,
+    pub passed: bool,
+    pub stdout_preview: String,
+    pub stderr_preview: String,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub timed_out: bool,
+}
+
+/// Operator-facing verification status values.
+pub mod verification_status {
+    pub const VERIFIED: &str = "verified";
+    pub const UNVERIFIED: &str = "unverified";
+    pub const VERIFICATION_FAILED: &str = "verification_failed";
+}
+
 /// Coarse run outcome. Exactly one of three values, suitable for computing
 /// pass@1-style metrics from trajectory files alone:
 /// `"submitted"` | `"step_limit_reached"` | `"error"`.
@@ -359,6 +387,14 @@ pub struct TrajectoryInfo {
     /// for single-model runs (preserves legacy artifact shape).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fallback_summary: Option<FallbackSummary>,
+    /// Operator-facing verification outcome. `"verified"` | `"unverified"` |
+    /// `"verification_failed"`. Set on every run that reaches the verification
+    /// phase; absent on trajectories written before this feature was added.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verification_status: Option<String>,
+    /// Per-check evidence for runs where verification checks were configured.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub verification_results: Vec<VerificationResult>,
     #[serde(flatten, default)]
     pub other: std::collections::BTreeMap<String, serde_json::Value>,
 }

--- a/tests/fixtures/artifact_schema/current/trajectory.traj.json
+++ b/tests/fixtures/artifact_schema/current/trajectory.traj.json
@@ -25,6 +25,7 @@
     "steps": 1,
     "test_invocations": [],
     "tests_run_before_submit": false,
+    "verification_status": "unverified",
     "started_at": "2026-05-01T00:00:00Z",
     "ended_at": "2026-05-01T00:00:01Z"
   },

--- a/tests/verification.rs
+++ b/tests/verification.rs
@@ -295,6 +295,73 @@ async fn cancellation_during_verification_sets_unverified() {
     );
 }
 
+/// Large verification output is truncated to VERIFICATION_PREVIEW_MAX_BYTES.
+#[tokio::test]
+async fn large_verification_output_is_truncated() {
+    let work = tempfile::tempdir().unwrap();
+    // seq 1 1000 produces ~3893 bytes (> 2048 VERIFICATION_PREVIEW_MAX_BYTES).
+    let checks = vec![VerificationCheck {
+        name: "big-output".into(),
+        command: "seq 1 1000".into(),
+    }];
+    run(mini_args(&work, "big-output", checks)).await.unwrap();
+
+    let traj = read_traj(&work, "big-output");
+    let preview = traj["info"]["verification_results"][0]["stdout_preview"]
+        .as_str()
+        .unwrap_or("");
+    assert!(
+        preview.len() <= 2048,
+        "stdout_preview should be truncated to ≤2048 bytes; got {}",
+        preview.len()
+    );
+    assert!(!preview.is_empty(), "stdout_preview should not be empty");
+}
+
+/// inspect renders timed_out=true with a "(timed_out)" note.
+#[test]
+fn inspect_shows_timed_out_note_in_verification_detail() {
+    use rust_swe_agent::trajectory::{Trajectory, VerificationResult, outcome};
+
+    let sweep = tempfile::tempdir().unwrap();
+    let mut t = Trajectory::new();
+    t.info.outcome = Some(outcome::SUBMITTED.into());
+    t.info.verification_status = Some(verification_status::VERIFICATION_FAILED.into());
+    t.info.verification_results = vec![VerificationResult {
+        name: "slow-check".into(),
+        command: "sleep 300".into(),
+        exit_code: -1,
+        duration_ms: 1000,
+        passed: false,
+        stdout_preview: String::new(),
+        stderr_preview: "timed out after 1s".into(),
+        timed_out: true,
+    }];
+    std::fs::write(
+        sweep.path().join("timedout.traj.json"),
+        serde_json::to_string_pretty(&t).unwrap(),
+    )
+    .unwrap();
+
+    let out = std::process::Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "timedout",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("(timed_out)"),
+        "expected '(timed_out)' in inspect output; stdout={stdout}"
+    );
+}
+
 /// AC: `bench inspect` shows verification summary in the run header.
 #[test]
 fn inspect_shows_verification_summary_in_header() {

--- a/tests/verification.rs
+++ b/tests/verification.rs
@@ -16,11 +16,7 @@ use support::binary_path;
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 
-fn mini_args(
-    work: &tempfile::TempDir,
-    name: &str,
-    checks: Vec<VerificationCheck>,
-) -> MiniArgs {
+fn mini_args(work: &tempfile::TempDir, name: &str, checks: Vec<VerificationCheck>) -> MiniArgs {
     let mut cfg = Config::defaults().unwrap();
     cfg.root.agent.step_limit = 5;
     MiniArgs {
@@ -65,7 +61,7 @@ async fn no_verification_check_sets_unverified_status() {
     assert!(
         traj["info"]["verification_results"]
             .as_array()
-            .map_or(true, |a| a.is_empty()),
+            .is_none_or(Vec::is_empty),
         "expected empty verification_results; traj={traj}"
     );
 }
@@ -79,7 +75,10 @@ async fn single_passing_check_sets_verified_status() {
         command: "true".into(),
     }];
     let result = run(mini_args(&work, "passing-check", checks)).await;
-    assert!(result.is_ok(), "expected Ok for passing check; got {result:?}");
+    assert!(
+        result.is_ok(),
+        "expected Ok for passing check; got {result:?}"
+    );
 
     let traj = read_traj(&work, "passing-check");
     assert_eq!(

--- a/tests/verification.rs
+++ b/tests/verification.rs
@@ -1,0 +1,381 @@
+//! Verification evidence for local runs — TDD tests for issue #94.
+//!
+//! RED phase: all tests below assert behaviour that does not yet exist.
+//! GREEN phase: implement `run_verification_checks` in `run/mini.rs`.
+
+#![allow(clippy::unwrap_used)]
+
+use rust_swe_agent::{
+    config::Config,
+    run::mini::{MiniArgs, run},
+    trajectory::{VerificationCheck, verification_status},
+};
+
+mod support;
+use support::binary_path;
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+fn mini_args(
+    work: &tempfile::TempDir,
+    name: &str,
+    checks: Vec<VerificationCheck>,
+) -> MiniArgs {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+    MiniArgs {
+        task: "test task".into(),
+        extra_context: None,
+        config: cfg,
+        output_dir: work.path().to_path_buf(),
+        trajectory_name: name.into(),
+        deterministic_responses: Some(vec![
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\ndone\n```".into(),
+        ]),
+        deterministic_usage_per_call: None,
+        task_timeout_secs: Some(30),
+        cancellation: None,
+        stream_addr: None,
+        patch_capture: None,
+        verification_checks: checks,
+        verification_timeout_secs: 10,
+    }
+}
+
+fn read_traj(work: &tempfile::TempDir, name: &str) -> serde_json::Value {
+    let path = work.path().join(format!("{name}.traj.json"));
+    let json = std::fs::read_to_string(&path).unwrap();
+    serde_json::from_str(&json).unwrap()
+}
+
+// ── RED-phase tests ──────────────────────────────────────────────────────────
+
+/// AC: no verification check supplied → trajectory has verification_status: "unverified".
+#[tokio::test]
+async fn no_verification_check_sets_unverified_status() {
+    let work = tempfile::tempdir().unwrap();
+    run(mini_args(&work, "no-checks", vec![])).await.unwrap();
+    let traj = read_traj(&work, "no-checks");
+    assert_eq!(
+        traj["info"]["verification_status"].as_str(),
+        Some(verification_status::UNVERIFIED),
+        "expected verification_status=unverified; traj={traj}"
+    );
+    // No checks → results array absent or empty
+    assert!(
+        traj["info"]["verification_results"]
+            .as_array()
+            .map_or(true, |a| a.is_empty()),
+        "expected empty verification_results; traj={traj}"
+    );
+}
+
+/// AC: one passing check → trajectory has verification_status: "verified".
+#[tokio::test]
+async fn single_passing_check_sets_verified_status() {
+    let work = tempfile::tempdir().unwrap();
+    let checks = vec![VerificationCheck {
+        name: "always-pass".into(),
+        command: "true".into(),
+    }];
+    let result = run(mini_args(&work, "passing-check", checks)).await;
+    assert!(result.is_ok(), "expected Ok for passing check; got {result:?}");
+
+    let traj = read_traj(&work, "passing-check");
+    assert_eq!(
+        traj["info"]["verification_status"].as_str(),
+        Some(verification_status::VERIFIED),
+        "expected verified; traj={traj}"
+    );
+    let results = traj["info"]["verification_results"].as_array().unwrap();
+    assert_eq!(results.len(), 1, "expected 1 check result");
+    assert_eq!(results[0]["name"].as_str(), Some("always-pass"));
+    assert_eq!(results[0]["passed"].as_bool(), Some(true));
+    assert_eq!(results[0]["exit_code"].as_i64(), Some(0));
+    assert!(
+        results[0]["duration_ms"].as_u64().is_some(),
+        "expected duration_ms present"
+    );
+}
+
+/// AC: one failing check → verification_status: "verification_failed", process exits non-zero.
+#[tokio::test]
+async fn single_failing_check_sets_verification_failed_and_returns_error() {
+    let work = tempfile::tempdir().unwrap();
+    let checks = vec![VerificationCheck {
+        name: "always-fail".into(),
+        command: "false".into(),
+    }];
+    let result = run(mini_args(&work, "failing-check", checks)).await;
+    assert!(result.is_err(), "expected Err for failing check");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("verification failed"),
+        "expected 'verification failed' in error; got: {err_msg}"
+    );
+
+    let traj = read_traj(&work, "failing-check");
+    assert_eq!(
+        traj["info"]["verification_status"].as_str(),
+        Some(verification_status::VERIFICATION_FAILED),
+        "expected verification_failed; traj={traj}"
+    );
+    let results = traj["info"]["verification_results"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["passed"].as_bool(), Some(false));
+    // `false` exits 1 on Linux/macOS
+    assert_ne!(
+        results[0]["exit_code"].as_i64(),
+        Some(0),
+        "expected non-zero exit_code"
+    );
+}
+
+/// AC: multiple checks all pass → verified.
+#[tokio::test]
+async fn multiple_checks_all_pass_sets_verified() {
+    let work = tempfile::tempdir().unwrap();
+    let checks = vec![
+        VerificationCheck {
+            name: "check-1".into(),
+            command: "true".into(),
+        },
+        VerificationCheck {
+            name: "check-2".into(),
+            command: "echo hello".into(),
+        },
+    ];
+    let result = run(mini_args(&work, "all-pass", checks)).await;
+    assert!(result.is_ok(), "expected Ok; got {result:?}");
+
+    let traj = read_traj(&work, "all-pass");
+    assert_eq!(
+        traj["info"]["verification_status"].as_str(),
+        Some(verification_status::VERIFIED)
+    );
+    assert_eq!(
+        traj["info"]["verification_results"]
+            .as_array()
+            .unwrap()
+            .len(),
+        2,
+        "expected 2 check results"
+    );
+}
+
+/// AC: mixed results → verification_failed.
+#[tokio::test]
+async fn multiple_checks_mixed_results_sets_verification_failed() {
+    let work = tempfile::tempdir().unwrap();
+    let checks = vec![
+        VerificationCheck {
+            name: "pass".into(),
+            command: "true".into(),
+        },
+        VerificationCheck {
+            name: "fail".into(),
+            command: "false".into(),
+        },
+        VerificationCheck {
+            name: "pass2".into(),
+            command: "echo ok".into(),
+        },
+    ];
+    let result = run(mini_args(&work, "mixed", checks)).await;
+    assert!(result.is_err(), "expected Err for mixed (some failing)");
+
+    let traj = read_traj(&work, "mixed");
+    assert_eq!(
+        traj["info"]["verification_status"].as_str(),
+        Some(verification_status::VERIFICATION_FAILED)
+    );
+    let results = traj["info"]["verification_results"].as_array().unwrap();
+    assert_eq!(results.len(), 3);
+    let passed: usize = results
+        .iter()
+        .filter(|r| r["passed"].as_bool() == Some(true))
+        .count();
+    let failed: usize = results
+        .iter()
+        .filter(|r| r["passed"].as_bool() == Some(false))
+        .count();
+    assert_eq!(passed, 2);
+    assert_eq!(failed, 1);
+}
+
+/// AC: verification result captures name, command, exit_code, duration, stdout/stderr preview.
+#[tokio::test]
+async fn verification_result_captures_required_fields() {
+    let work = tempfile::tempdir().unwrap();
+    let checks = vec![VerificationCheck {
+        name: "with-output".into(),
+        command: "echo hello_from_verify".into(),
+    }];
+    run(mini_args(&work, "capture-output", checks))
+        .await
+        .unwrap();
+
+    let traj = read_traj(&work, "capture-output");
+    let r = &traj["info"]["verification_results"][0];
+    assert_eq!(r["name"].as_str(), Some("with-output"));
+    assert_eq!(r["command"].as_str(), Some("echo hello_from_verify"));
+    assert_eq!(r["exit_code"].as_i64(), Some(0));
+    assert!(r["duration_ms"].as_u64().is_some());
+    assert_eq!(r["passed"].as_bool(), Some(true));
+    assert!(
+        r["stdout_preview"]
+            .as_str()
+            .unwrap_or("")
+            .contains("hello_from_verify"),
+        "stdout_preview should contain command output; result={r}"
+    );
+}
+
+/// AC: timed-out check is treated as failure.
+#[tokio::test]
+async fn timed_out_check_treated_as_failure() {
+    let work = tempfile::tempdir().unwrap();
+    let mut args = mini_args(
+        &work,
+        "timeout-check",
+        vec![VerificationCheck {
+            name: "slow".into(),
+            command: "sleep 300".into(),
+        }],
+    );
+    args.verification_timeout_secs = 1;
+
+    let result = run(args).await;
+    assert!(result.is_err(), "expected Err for timed-out check");
+
+    let traj = read_traj(&work, "timeout-check");
+    assert_eq!(
+        traj["info"]["verification_status"].as_str(),
+        Some(verification_status::VERIFICATION_FAILED)
+    );
+    let results = traj["info"]["verification_results"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["passed"].as_bool(), Some(false));
+    assert_eq!(results[0]["timed_out"].as_bool(), Some(true));
+}
+
+/// AC: `bench inspect` shows verification summary in the run header.
+#[test]
+fn inspect_shows_verification_summary_in_header() {
+    use rust_swe_agent::trajectory::{Trajectory, VerificationResult, outcome};
+
+    let sweep = tempfile::tempdir().unwrap();
+    let mut t = Trajectory::new();
+    t.info.outcome = Some(outcome::SUBMITTED.into());
+    t.info.verification_status = Some(verification_status::VERIFIED.into());
+    t.info.verification_results = vec![VerificationResult {
+        name: "unit-tests".into(),
+        command: "cargo test -q".into(),
+        exit_code: 0,
+        duration_ms: 1234,
+        passed: true,
+        stdout_preview: "test ok".into(),
+        stderr_preview: String::new(),
+        timed_out: false,
+    }];
+    std::fs::write(
+        sweep.path().join("abc.traj.json"),
+        serde_json::to_string_pretty(&t).unwrap(),
+    )
+    .unwrap();
+
+    let out = std::process::Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "abc",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("verification:"),
+        "expected 'verification:' in header; stdout={stdout}"
+    );
+    assert!(
+        stdout.contains("verified"),
+        "expected status 'verified'; stdout={stdout}"
+    );
+    assert!(
+        stdout.contains("unit-tests"),
+        "expected check name 'unit-tests'; stdout={stdout}"
+    );
+}
+
+/// AC: verification evidence is included in machine-readable run artifacts.
+#[test]
+fn inspect_json_includes_verification_evidence() {
+    use rust_swe_agent::trajectory::{Trajectory, VerificationResult, outcome};
+
+    let sweep = tempfile::tempdir().unwrap();
+    let mut t = Trajectory::new();
+    t.info.outcome = Some(outcome::SUBMITTED.into());
+    t.info.verification_status = Some(verification_status::VERIFICATION_FAILED.into());
+    t.info.verification_results = vec![
+        VerificationResult {
+            name: "pass-check".into(),
+            command: "true".into(),
+            exit_code: 0,
+            duration_ms: 5,
+            passed: true,
+            stdout_preview: String::new(),
+            stderr_preview: String::new(),
+            timed_out: false,
+        },
+        VerificationResult {
+            name: "fail-check".into(),
+            command: "false".into(),
+            exit_code: 1,
+            duration_ms: 3,
+            passed: false,
+            stdout_preview: String::new(),
+            stderr_preview: String::new(),
+            timed_out: false,
+        },
+    ];
+    std::fs::write(
+        sweep.path().join("xyz.traj.json"),
+        serde_json::to_string_pretty(&t).unwrap(),
+    )
+    .unwrap();
+
+    let out = std::process::Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "xyz",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(
+        v["verification_status"].as_str(),
+        Some(verification_status::VERIFICATION_FAILED),
+        "expected verification_failed in json; v={v}"
+    );
+    let results = v["verification_results"].as_array().unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0]["name"].as_str(), Some("pass-check"));
+    assert_eq!(results[0]["passed"].as_bool(), Some(true));
+    assert_eq!(results[1]["name"].as_str(), Some("fail-check"));
+    assert_eq!(results[1]["passed"].as_bool(), Some(false));
+}

--- a/tests/verification.rs
+++ b/tests/verification.rs
@@ -258,6 +258,43 @@ async fn timed_out_check_treated_as_failure() {
     assert_eq!(results[0]["timed_out"].as_bool(), Some(true));
 }
 
+/// AC: Ctrl-C during verification produces `unverified`, not `verification_failed`.
+#[tokio::test]
+async fn cancellation_during_verification_sets_unverified() {
+    use rust_swe_agent::env::CancellationToken;
+
+    let work = tempfile::tempdir().unwrap();
+    // Pre-fire the cancellation token so the first verification check is
+    // immediately interrupted before it can complete.
+    let (tx, rx) = tokio::sync::watch::channel(false);
+    tx.send(true).unwrap();
+    let cancel = CancellationToken::new(rx);
+
+    let mut args = mini_args(
+        &work,
+        "cancelled-verify",
+        vec![VerificationCheck {
+            name: "slow".into(),
+            command: "sleep 300".into(),
+        }],
+    );
+    args.cancellation = Some(cancel);
+
+    // Should NOT return VerificationFailed — the run was cancelled.
+    let result = run(args).await;
+    assert!(
+        result.is_ok(),
+        "expected Ok (cancelled, not verification_failed); got {result:?}"
+    );
+
+    let traj = read_traj(&work, "cancelled-verify");
+    assert_eq!(
+        traj["info"]["verification_status"].as_str(),
+        Some(verification_status::UNVERIFIED),
+        "expected unverified after cancellation; traj={traj}"
+    );
+}
+
 /// AC: `bench inspect` shows verification summary in the run header.
 #[test]
 fn inspect_shows_verification_summary_in_header() {

--- a/tests/verification.rs
+++ b/tests/verification.rs
@@ -315,6 +315,49 @@ fn inspect_shows_verification_summary_in_header() {
     );
 }
 
+/// AC: inspect output for unverified status (no checks supplied).
+#[test]
+fn inspect_shows_unverified_status_in_header() {
+    use rust_swe_agent::trajectory::{Trajectory, outcome};
+
+    let sweep = tempfile::tempdir().unwrap();
+    let mut t = Trajectory::new();
+    t.info.outcome = Some(outcome::SUBMITTED.into());
+    t.info.verification_status = Some(verification_status::UNVERIFIED.into());
+    // verification_results stays empty — that's the no-checks case
+    std::fs::write(
+        sweep.path().join("unverified.traj.json"),
+        serde_json::to_string_pretty(&t).unwrap(),
+    )
+    .unwrap();
+
+    let out = std::process::Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "unverified",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("verification:"),
+        "expected 'verification:' in header; stdout={stdout}"
+    );
+    assert!(
+        stdout.contains("unverified"),
+        "expected status 'unverified'; stdout={stdout}"
+    );
+}
+
 /// AC: verification evidence is included in machine-readable run artifacts.
 #[test]
 fn inspect_json_includes_verification_evidence() {


### PR DESCRIPTION
Adds operator-supplied verification checks that run after the agent
finishes, recording evidence in trajectory artifacts and surfacing
results in `bench inspect` output.

- New trajectory types: VerificationCheck, VerificationResult,
  verification_status constants (verified/unverified/verification_failed)
- TrajectoryInfo gains verification_status and verification_results fields
- MiniArgs gains verification_checks and verification_timeout_secs fields
- run_verification_checks() runs each check via the agent environment,
  captures bounded stdout/stderr previews, handles per-check timeouts,
  and sets trajectory.info.verification_status accordingly
- Early-return paths (cancellation, secret leak) set status=unverified
- Error::VerificationFailed returned when any checks fail (non-zero exit)
- --verify NAME:COMMAND and --verify-timeout-secs CLI flags on mini cmd
- InspectReport gains verification_status/verification_results; rendered
  in both text and JSON inspect output
- 9 integration tests in tests/verification.rs covering all acceptance
  criteria from the issue

https://claude.ai/code/session_015cM752ztarvN2zkbQ1E8iC