### PR TITLE
🛡️ Sentry: Add test coverage for ModelError transient logic

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -137,6 +137,22 @@ mod tests {
         let e = ModelError::RateLimited("retry after: 90".into());
         assert_eq!(e.retry_after_secs(), Some(90));
     }
+
+    #[test]
+    fn retry_after_secs_handles_missing_digit_after_prefix() {
+        let e = ModelError::RateLimited("retry-after: ".into());
+        assert_eq!(e.retry_after_secs(), None);
+    }
+
+    #[test]
+    fn is_transient_identifies_transient_and_non_transient_errors() {
+        assert!(ModelError::RateLimited(String::new()).is_transient());
+        assert!(ModelError::Request(String::new()).is_transient());
+        assert!(!ModelError::Malformed(String::new()).is_transient());
+        assert!(!ModelError::Refused(String::new()).is_transient());
+        assert!(!ModelError::MissingCredentials(String::new()).is_transient());
+        assert!(!ModelError::AllCandidatesFailed(String::new(), vec![]).is_transient());
+    }
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
🎯 Target: `ModelError::is_transient` and `ModelError::retry_after_secs` in `src/error.rs`
💣 Risk: Missing test coverage for `is_transient` logic and missing coverage for `retry_after_secs` edge case with empty digits.
🧪 Strategy: Added explicit tests for all `ModelError` variants in `is_transient` and added an empty digit case for `retry_after_secs`.
🔬 Verification: `cargo test`

---
*PR created automatically by Jules for task [6057140230659353202](https://jules.google.com/task/6057140230659353202) started by @madmax983*