### PR TITLE
🗺️ Atlas: Replace stringly-typed TemplateError with strongly typed minijinja::Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,7 @@ pub enum Error {
     Config(#[from] ConfigError),
 
     #[error("template render failed: {0}")]
-    Template(String),
+    Template(#[from] minijinja::Error),
 
     #[error("trajectory io: {0}")]
     Trajectory(String),

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -40,13 +40,11 @@ impl Renderer {
     pub fn render_str<T: Serialize>(&self, tmpl: &str, ctx: &T) -> Result<String, Error> {
         self.env
             .render_str(tmpl, Value::from_serialize(ctx))
-            .map_err(|e| Error::Template(e.to_string()))
+            .map_err(Error::Template)
     }
 
     pub fn render_with(&self, tmpl: &str, ctx: Value) -> Result<String, Error> {
-        self.env
-            .render_str(tmpl, ctx)
-            .map_err(|e| Error::Template(e.to_string()))
+        self.env.render_str(tmpl, ctx).map_err(Error::Template)
     }
 }
 
@@ -67,7 +65,7 @@ pub fn render_simple(tmpl: &str, vars: &[(&str, &str)]) -> Result<String, Error>
     env.set_auto_escape_callback(|_| minijinja::AutoEscape::None);
     let map: BTreeMap<&str, &str> = vars.iter().copied().collect();
     env.render_str(tmpl, Value::from_serialize(&map))
-        .map_err(|e| Error::Template(e.to_string()))
+        .map_err(Error::Template)
 }
 
 /// Keep `Arc<Renderer>` cheap in hot paths.


### PR DESCRIPTION
🗺️ Atlas: [architectural change]

* 🕸️ Tangle: The codebase was using a stringly-typed error (`Error::Template(String)`) to represent template rendering failures, which loses context and forces early stringification via `.to_string()`.
* 📐 Blueprint: Replaced the `Template(String)` variant with `Template(#[from] minijinja::Error)` in `src/error.rs` to preserve the underlying error chain. Updated `src/template/mod.rs` to pass the raw error to the new constructor via `.map_err(Error::Template)`.
* 🧱 Stability: Standardizes the error handling for template rendering and removes stringly-typed errors, ensuring high cohesion and better error reporting via `thiserror`.
* 🔬 Verification: Checked with `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt`. All checks passed.

---
*PR created automatically by Jules for task [12393287316574857296](https://jules.google.com/task/12393287316574857296) started by @madmax983*