### PR TITLE
Add named dataset aliases and local cache support

### DIFF
--- a/docs/spec-dataset-aliases.md
+++ b/docs/spec-dataset-aliases.md
@@ -1,0 +1,160 @@
+# Dataset Aliases and Cache
+
+## Overview
+
+`bench swebench`, `bench doctor`, and `bench forecast` accept datasets in two
+forms:
+
+1. **Local JSONL path** (existing behaviour, no change): `--dataset-path path/to/data.jsonl`
+2. **Named alias + split** (new): `--dataset verified --split test`
+
+Named aliases are resolved against a local on-disk cache.  The cache is warm
+when the matching file already exists; otherwise the command fails with an
+actionable message that tells the operator exactly which file to place and
+where.
+
+Supported aliases: `full`, `lite`, `verified`
+Supported splits: `train`, `test` (default), `dev`
+
+---
+
+## Quick-start examples
+
+### 1. Local fixture (no key, no network)
+
+Use `--dataset-path` to point at any local JSONL file.  Good for CI fixtures
+and offline development.
+
+```bash
+bench swebench \
+  --dataset-path tests/fixtures/my_instances.jsonl \
+  --output runs/local-smoke \
+  --model claude-opus-4-7 \
+  --step-limit 10 \
+  --sample 3 --seed 42
+```
+
+### 2. Cached `verified` calibration sample
+
+Populate the cache once, then every subsequent run is fully offline.
+
+**Step 1 – populate the cache** (run once per machine):
+
+Download the SWE-bench Verified test split JSONL from
+<https://www.swebench.com/SWE-bench/guides/datasets/> and place it at:
+
+```
+~/.cache/rust-swe-agent/datasets/verified/test.jsonl
+```
+
+**Step 2 – launch a calibration sweep** (no network access required):
+
+```bash
+bench swebench \
+  --dataset verified --split test \
+  --output runs/verified-calibration \
+  --model claude-opus-4-7 \
+  --sample 10 --seed 42
+```
+
+### 3. Offline cache-hit run
+
+Once the cache is warm, sweeps run completely offline:
+
+```bash
+bench swebench \
+  --dataset lite --split test \
+  --output runs/lite-sweep \
+  --model claude-opus-4-7
+```
+
+The run will fail immediately with a clear message if the cache file is missing
+or corrupt — no tasks will be launched.
+
+---
+
+## Cache directory
+
+The default cache root is `~/.cache/rust-swe-agent/datasets/`.  Override it
+with `--dataset-cache-dir /custom/path`.
+
+Layout:
+
+```
+~/.cache/rust-swe-agent/datasets/
+  verified/
+    test.jsonl      # SWE-bench Verified test split
+    dev.jsonl
+  lite/
+    test.jsonl      # SWE-bench Lite test split
+  full/
+    test.jsonl      # SWE-bench full test split
+```
+
+---
+
+## Checking cache status without launching tasks
+
+`bench doctor` validates the dataset selector and reports the cache status
+without starting any task:
+
+```bash
+bench doctor \
+  --dataset verified --split test \
+  --output /tmp/unused
+```
+
+Output example (cache hit):
+
+```
+[OK]  dataset.cache   cache hit: ~/.cache/rust-swe-agent/datasets/verified/test.jsonl (500 instances)
+[OK]  dataset.parse   valid jsonl, selected 500 instances
+```
+
+Output example (cache miss):
+
+```
+[WARN] dataset.cache   cache miss: expected file at ~/.cache/rust-swe-agent/datasets/verified/test.jsonl
+```
+
+---
+
+## Provenance in sweep artifacts
+
+Every `results.json` records the dataset provenance under `manifest.dataset`:
+
+```json
+{
+  "manifest": {
+    "dataset": {
+      "path": "/home/user/.cache/rust-swe-agent/datasets/verified/test.jsonl",
+      "sha256": "abc123...",
+      "instance_count": 500,
+      "source_kind": "named",
+      "alias": "verified",
+      "split": "test",
+      "source_revision": "sha256:abc123...",
+      "cache_path": "/home/user/.cache/rust-swe-agent/datasets/verified/test.jsonl",
+      "selected_row_count": 500,
+      "post_filter_row_count": 10
+    }
+  }
+}
+```
+
+For local-path datasets, `source_kind` is `"local"` and `alias`, `split`,
+`cache_path` are absent.
+
+---
+
+## Error reference
+
+| Scenario | Exit code | Message contains |
+|---|---|---|
+| Missing `--dataset-path` and `--dataset` | 1 | `one of --dataset-path or --dataset is required` |
+| Both `--dataset-path` and `--dataset` | 1 | `mutually exclusive` |
+| Invalid alias string | 1 | `unknown dataset alias` + list of valid aliases |
+| Invalid split string | 1 | `unknown split` + list of valid splits |
+| Cache miss | 1 | alias, split, expected cache path, download instructions |
+| Corrupt cache entry | 1 | `corrupt`, file path, parse error |
+| Local file unreadable | 1 | OS I/O error |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -323,8 +323,26 @@ pub struct CompareCmd {
 #[derive(Debug, Clone, Args)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct SwebenchCmd {
+    /// Local JSONL dataset file. Mutually exclusive with `--dataset`.
+    /// Exactly one of `--dataset-path` or `--dataset` must be provided.
     #[arg(long)]
-    pub dataset_path: PathBuf,
+    pub dataset_path: Option<PathBuf>,
+
+    /// Named SWE-bench dataset alias: `full`, `lite`, or `verified`.
+    /// Mutually exclusive with `--dataset-path`.
+    /// Resolved against the on-disk cache (see `--dataset-cache-dir`).
+    #[arg(long, value_name = "ALIAS")]
+    pub dataset: Option<String>,
+
+    /// Dataset split for named aliases: `train`, `test`, or `dev`.
+    /// Ignored when `--dataset-path` is used.
+    #[arg(long, default_value = "test", value_name = "SPLIT")]
+    pub split: Option<String>,
+
+    /// Directory for the named-dataset on-disk cache.
+    /// Defaults to `~/.cache/rust-swe-agent/datasets`.
+    #[arg(long, value_name = "DIR")]
+    pub dataset_cache_dir: Option<PathBuf>,
 
     #[arg(long, alias = "output-dir")]
     pub output: PathBuf,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -26,6 +26,7 @@ pub struct Cli {
 }
 
 #[derive(Debug, Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum Command {
     /// Run one task end-to-end and write a trajectory.
     Mini(args::MiniCmd),
@@ -54,10 +55,10 @@ pub async fn run() -> Result<(), Error> {
         Command::Replay(r) => replay_cmd(r).await,
         Command::Bench {
             cmd: args::BenchCmd::Swebench(s),
-        } => bench_swebench(s).await,
+        } => Box::pin(bench_swebench(s)).await,
         Command::Bench {
             cmd: args::BenchCmd::Forecast(s),
-        } => bench_forecast(s).await,
+        } => Box::pin(bench_forecast(s)).await,
         Command::Bench {
             cmd: args::BenchCmd::Doctor(s),
         } => bench_doctor(s).await,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -546,9 +546,10 @@ fn parse_dataset_source(
         (None, None) => Err(Error::Config(crate::error::ConfigError::Invalid(
             "one of --dataset-path or --dataset is required".into(),
         ))),
-        (Some(path), None) => {
-            Ok((crate::run::dataset::DatasetSource::LocalPath(path.clone()), cache_dir))
-        }
+        (Some(path), None) => Ok((
+            crate::run::dataset::DatasetSource::LocalPath(path.clone()),
+            cache_dir,
+        )),
         (None, Some(alias_str)) => {
             let alias = alias_str
                 .parse::<crate::run::dataset::SwebenchAlias>()
@@ -1203,7 +1204,7 @@ mod tests {
         };
 
         let args = swebench_args_from_cmd(cmd, crate::config::Config::defaults().unwrap(), "sweep")
-            .expect("swebench_args_from_cmd should succeed with --dataset-path");
+            .unwrap();
         assert!(args.install_os_signal_handlers);
         assert!(
             args.cancellation_signals.is_none(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -246,7 +246,7 @@ async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
         "sweep"
     };
     let results =
-        crate::run::swebench::run(swebench_args_from_cmd(sweep_cmd, cfg, preflight_mode)).await?;
+        crate::run::swebench::run(swebench_args_from_cmd(sweep_cmd, cfg, preflight_mode)?).await?;
 
     tracing::info!(
         total = results.total,
@@ -277,7 +277,7 @@ async fn bench_doctor(mut s: args::SwebenchCmd) -> Result<(), Error> {
     s.dry_run = true;
     let output_format = s.format.clone();
     let cfg = swebench_config_from_cmd(&s)?;
-    let results = crate::run::swebench::run(swebench_args_from_cmd(s, cfg, "doctor")).await?;
+    let results = crate::run::swebench::run(swebench_args_from_cmd(s, cfg, "doctor")?).await?;
     if output_format != "json" {
         print!("{}", results.summary_table());
     }
@@ -329,7 +329,7 @@ async fn run_forecast_from_cmd(
         s.seed = None;
     }
     let cfg = swebench_config_from_cmd(&s)?;
-    let sweep = swebench_args_from_cmd(s, cfg, "forecast");
+    let sweep = swebench_args_from_cmd(s, cfg, "forecast")?;
     crate::run::forecast::run(crate::run::forecast::ForecastArgs {
         sweep,
         calibration_n,
@@ -531,16 +531,52 @@ fn github_pr_failure_count(results: &crate::run::swebench::SweepResults) -> usiz
     results.github_pr_failures
 }
 
+fn parse_dataset_source(
+    s: &args::SwebenchCmd,
+) -> Result<(crate::run::dataset::DatasetSource, std::path::PathBuf), Error> {
+    let cache_dir = s
+        .dataset_cache_dir
+        .clone()
+        .unwrap_or_else(crate::run::dataset::default_cache_dir);
+
+    match (&s.dataset_path, &s.dataset) {
+        (Some(_), Some(_)) => Err(Error::Config(crate::error::ConfigError::Invalid(
+            "--dataset-path and --dataset are mutually exclusive; provide only one".into(),
+        ))),
+        (None, None) => Err(Error::Config(crate::error::ConfigError::Invalid(
+            "one of --dataset-path or --dataset is required".into(),
+        ))),
+        (Some(path), None) => {
+            Ok((crate::run::dataset::DatasetSource::LocalPath(path.clone()), cache_dir))
+        }
+        (None, Some(alias_str)) => {
+            let alias = alias_str
+                .parse::<crate::run::dataset::SwebenchAlias>()
+                .map_err(|e| Error::Config(crate::error::ConfigError::Invalid(e)))?;
+            let split_str = s.split.as_deref().unwrap_or("test");
+            let split = split_str
+                .parse::<crate::run::dataset::SwebenchSplit>()
+                .map_err(|e| Error::Config(crate::error::ConfigError::Invalid(e)))?;
+            Ok((
+                crate::run::dataset::DatasetSource::Named { alias, split },
+                cache_dir,
+            ))
+        }
+    }
+}
+
 fn swebench_args_from_cmd(
     s: args::SwebenchCmd,
     cfg: Config,
     preflight_mode: &str,
-) -> crate::run::swebench::SwebenchArgs {
+) -> Result<crate::run::swebench::SwebenchArgs, Error> {
     let cfg_max_rpm = cfg.root.sweep.max_rpm;
     let cfg_max_input_tpm = cfg.root.sweep.max_input_tpm;
     let github_pr = swebench_github_pr_config(&s.github_pr);
-    crate::run::swebench::SwebenchArgs {
-        dataset_path: s.dataset_path,
+    let (dataset_source, dataset_cache_dir) = parse_dataset_source(&s)?;
+    Ok(crate::run::swebench::SwebenchArgs {
+        dataset_source,
+        dataset_cache_dir,
         output_dir: s.output,
         parallel: s.parallel,
         config: cfg,
@@ -584,7 +620,7 @@ fn swebench_args_from_cmd(
         install_os_signal_handlers: true,
         cancellation_signals: None,
         github_pr,
-    }
+    })
 }
 
 fn parse_verify_checks(
@@ -1166,7 +1202,8 @@ mod tests {
             panic!("expected bench swebench command");
         };
 
-        let args = swebench_args_from_cmd(cmd, crate::config::Config::defaults().unwrap(), "sweep");
+        let args = swebench_args_from_cmd(cmd, crate::config::Config::defaults().unwrap(), "sweep")
+            .expect("swebench_args_from_cmd should succeed with --dataset-path");
         assert!(args.install_os_signal_handlers);
         assert!(
             args.cancellation_signals.is_none(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,11 @@ pub mod stream;
 pub mod template;
 pub mod trajectory;
 
+pub use run::dataset::{
+    CacheStatus, DatasetSource, DatasetSourceKind, SwebenchAlias, SwebenchSplit,
+    cache_path_for, check_cache, default_cache_dir, resolve_dataset, write_cache,
+};
+
 pub use agent::{Agent, DefaultAgent, ExitReason, InteractiveAgent, StepOutcome};
 pub use config::{Config, RedactionCfg, ToolHookCfg, ToolHooksCfg};
 #[cfg(feature = "docker")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@ pub mod template;
 pub mod trajectory;
 
 pub use run::dataset::{
-    CacheStatus, DatasetSource, DatasetSourceKind, SwebenchAlias, SwebenchSplit,
-    cache_path_for, check_cache, default_cache_dir, resolve_dataset, write_cache,
+    CacheStatus, DatasetSource, DatasetSourceKind, SwebenchAlias, SwebenchSplit, cache_path_for,
+    check_cache, default_cache_dir, resolve_dataset, write_cache,
 };
 
 pub use agent::{Agent, DefaultAgent, ExitReason, InteractiveAgent, StepOutcome};

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -3674,7 +3674,7 @@ mod tests {
                     sha256: "x".into(),
                     instance_count: 1,
                     filter_spec: None,
-                ..Default::default()
+                    ..Default::default()
                 },
                 prompt_template: crate::run::swebench::PromptTemplateManifest {
                     source: "builtin".into(),
@@ -3854,7 +3854,7 @@ mod tests {
                     sha256: "x".into(),
                     instance_count: 1,
                     filter_spec: None,
-                ..Default::default()
+                    ..Default::default()
                 },
                 prompt_template: crate::run::swebench::PromptTemplateManifest {
                     source: "builtin".into(),
@@ -3964,7 +3964,7 @@ mod tests {
                     sha256: "x".into(),
                     instance_count: 1,
                     filter_spec: None,
-                ..Default::default()
+                    ..Default::default()
                 },
                 prompt_template: crate::run::swebench::PromptTemplateManifest {
                     source: "builtin".into(),

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -3218,6 +3218,7 @@ mod tests {
                 sha256: "d1".into(),
                 instance_count: 1,
                 filter_spec: None,
+                ..Default::default()
             },
             prompt_template: crate::run::swebench::PromptTemplateManifest {
                 source: "builtin".into(),
@@ -3673,6 +3674,7 @@ mod tests {
                     sha256: "x".into(),
                     instance_count: 1,
                     filter_spec: None,
+                ..Default::default()
                 },
                 prompt_template: crate::run::swebench::PromptTemplateManifest {
                     source: "builtin".into(),
@@ -3852,6 +3854,7 @@ mod tests {
                     sha256: "x".into(),
                     instance_count: 1,
                     filter_spec: None,
+                ..Default::default()
                 },
                 prompt_template: crate::run::swebench::PromptTemplateManifest {
                     source: "builtin".into(),
@@ -3961,6 +3964,7 @@ mod tests {
                     sha256: "x".into(),
                     instance_count: 1,
                     filter_spec: None,
+                ..Default::default()
                 },
                 prompt_template: crate::run::swebench::PromptTemplateManifest {
                     source: "builtin".into(),

--- a/src/run/dataset.rs
+++ b/src/run/dataset.rs
@@ -226,9 +226,12 @@ pub fn write_cache(
     content: &[u8],
 ) -> Result<PathBuf, Error> {
     let path = cache_path_for(cache_dir, alias, split);
-    let parent = path
-        .parent()
-        .expect("cache path always has a parent directory");
+    let parent = path.parent().ok_or_else(|| {
+        Error::Trajectory(format!(
+            "cache path `{}` has no parent directory",
+            path.display()
+        ))
+    })?;
     std::fs::create_dir_all(parent)?;
     std::fs::write(&path, content)?;
     Ok(path)
@@ -272,27 +275,26 @@ pub fn resolve_dataset(
             };
             Ok((bytes, meta))
         }
-        DatasetSource::Named { alias, split } => {
-            match check_cache(cache_dir, alias, split) {
-                CacheStatus::Hit {
-                    path,
+        DatasetSource::Named { alias, split } => match check_cache(cache_dir, alias, split) {
+            CacheStatus::Hit {
+                path,
+                sha256,
+                instance_count,
+            } => {
+                let bytes = std::fs::read(&path)?;
+                let meta = ResolvedDatasetMeta {
+                    path: path.clone(),
                     sha256,
                     instance_count,
-                } => {
-                    let bytes = std::fs::read(&path)?;
-                    let meta = ResolvedDatasetMeta {
-                        path: path.clone(),
-                        sha256,
-                        instance_count,
-                        alias: Some(alias.clone()),
-                        split: Some(split.clone()),
-                        cache_path: Some(path),
-                    };
-                    Ok((bytes, meta))
-                }
-                CacheStatus::Miss { expected_path } => Err(Error::Config(
-                    crate::error::ConfigError::Invalid(format!(
-                        "dataset alias `{alias}` split `{split}` not in cache: \
+                    alias: Some(alias.clone()),
+                    split: Some(split.clone()),
+                    cache_path: Some(path),
+                };
+                Ok((bytes, meta))
+            }
+            CacheStatus::Miss { expected_path } => {
+                Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "dataset alias `{alias}` split `{split}` not in cache: \
                         expected file at `{path}`\n\
                         \n\
                         To populate the cache, download the SWE-bench JSONL for the \
@@ -301,20 +303,19 @@ pub fn resolve_dataset(
                         \n\
                         See: https://www.swebench.com/SWE-bench/guides/datasets/ for \
                         dataset download instructions.",
-                        path = expected_path.display()
-                    )),
-                )),
-                CacheStatus::Corrupt { path, reason } => Err(Error::Config(
-                    crate::error::ConfigError::Invalid(format!(
-                        "cached dataset `{alias}` split `{split}` at `{p}` is corrupt: {reason}\n\
+                    path = expected_path.display()
+                ))))
+            }
+            CacheStatus::Corrupt { path, reason } => {
+                Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "cached dataset `{alias}` split `{split}` at `{p}` is corrupt: {reason}\n\
                         \n\
                         Delete the file and re-populate the cache:\n\
                         \n  {p}",
-                        p = path.display()
-                    )),
-                )),
+                    p = path.display()
+                ))))
             }
-        }
+        },
     }
 }
 
@@ -327,8 +328,7 @@ fn count_jsonl_lines(bytes: &[u8]) -> Option<usize> {
 /// Parse and count valid JSONL instances; returns an error string on the first
 /// malformed line.
 fn validate_jsonl_bytes(bytes: &[u8]) -> Result<usize, String> {
-    let text =
-        std::str::from_utf8(bytes).map_err(|e| format!("UTF-8 decode error: {e}"))?;
+    let text = std::str::from_utf8(bytes).map_err(|e| format!("UTF-8 decode error: {e}"))?;
     let mut count = 0usize;
     for (i, line) in text.lines().enumerate() {
         let line = line.trim();
@@ -361,8 +361,14 @@ mod tests {
 
     #[test]
     fn alias_parses_canonical_forms() {
-        assert_eq!(SwebenchAlias::from_str("full").unwrap(), SwebenchAlias::Full);
-        assert_eq!(SwebenchAlias::from_str("lite").unwrap(), SwebenchAlias::Lite);
+        assert_eq!(
+            SwebenchAlias::from_str("full").unwrap(),
+            SwebenchAlias::Full
+        );
+        assert_eq!(
+            SwebenchAlias::from_str("lite").unwrap(),
+            SwebenchAlias::Lite
+        );
         assert_eq!(
             SwebenchAlias::from_str("verified").unwrap(),
             SwebenchAlias::Verified
@@ -410,7 +416,11 @@ mod tests {
 
     #[test]
     fn alias_display_matches_as_str() {
-        for alias in [SwebenchAlias::Full, SwebenchAlias::Lite, SwebenchAlias::Verified] {
+        for alias in [
+            SwebenchAlias::Full,
+            SwebenchAlias::Lite,
+            SwebenchAlias::Verified,
+        ] {
             assert_eq!(alias.to_string(), alias.as_str());
         }
     }
@@ -419,14 +429,23 @@ mod tests {
 
     #[test]
     fn split_parses_canonical_forms() {
-        assert_eq!(SwebenchSplit::from_str("train").unwrap(), SwebenchSplit::Train);
-        assert_eq!(SwebenchSplit::from_str("test").unwrap(), SwebenchSplit::Test);
+        assert_eq!(
+            SwebenchSplit::from_str("train").unwrap(),
+            SwebenchSplit::Train
+        );
+        assert_eq!(
+            SwebenchSplit::from_str("test").unwrap(),
+            SwebenchSplit::Test
+        );
         assert_eq!(SwebenchSplit::from_str("dev").unwrap(), SwebenchSplit::Dev);
     }
 
     #[test]
     fn split_is_case_insensitive() {
-        assert_eq!(SwebenchSplit::from_str("TEST").unwrap(), SwebenchSplit::Test);
+        assert_eq!(
+            SwebenchSplit::from_str("TEST").unwrap(),
+            SwebenchSplit::Test
+        );
         assert_eq!(SwebenchSplit::from_str("Dev").unwrap(), SwebenchSplit::Dev);
     }
 
@@ -439,7 +458,11 @@ mod tests {
 
     #[test]
     fn split_display_matches_as_str() {
-        for split in [SwebenchSplit::Train, SwebenchSplit::Test, SwebenchSplit::Dev] {
+        for split in [
+            SwebenchSplit::Train,
+            SwebenchSplit::Test,
+            SwebenchSplit::Dev,
+        ] {
             assert_eq!(split.to_string(), split.as_str());
         }
     }
@@ -492,7 +515,13 @@ mod tests {
     fn check_cache_hit_when_valid_jsonl_present() {
         let dir = tempfile::tempdir().unwrap();
         let content = b"{\"instance_id\":\"a\",\"problem_statement\":\"fix it\"}\n";
-        write_cache(dir.path(), &SwebenchAlias::Lite, &SwebenchSplit::Test, content).unwrap();
+        write_cache(
+            dir.path(),
+            &SwebenchAlias::Lite,
+            &SwebenchSplit::Test,
+            content,
+        )
+        .unwrap();
 
         let status = check_cache(dir.path(), &SwebenchAlias::Lite, &SwebenchSplit::Test);
         let CacheStatus::Hit {
@@ -532,9 +561,13 @@ mod tests {
     fn write_cache_creates_directories_and_file() {
         let dir = tempfile::tempdir().unwrap();
         let content = b"{}";
-        let written_path =
-            write_cache(dir.path(), &SwebenchAlias::Verified, &SwebenchSplit::Dev, content)
-                .unwrap();
+        let written_path = write_cache(
+            dir.path(),
+            &SwebenchAlias::Verified,
+            &SwebenchSplit::Dev,
+            content,
+        )
+        .unwrap();
         assert!(written_path.exists());
         assert_eq!(std::fs::read(&written_path).unwrap(), content);
     }

--- a/src/run/dataset.rs
+++ b/src/run/dataset.rs
@@ -1,0 +1,616 @@
+//! Named SWE-bench dataset aliases and local cache.
+//!
+//! Operators can launch sweeps either via a local JSONL path (`--dataset-path`)
+//! or a named alias (`--dataset verified --split test`).  Named aliases are
+//! resolved against a local on-disk cache; if the cache is warm the run starts
+//! without any network access.
+
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Error;
+
+/// Recognised SWE-bench dataset variant names.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SwebenchAlias {
+    Full,
+    Lite,
+    Verified,
+}
+
+impl SwebenchAlias {
+    /// Canonical string name used in cache file paths and provenance records.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Lite => "lite",
+            Self::Verified => "verified",
+        }
+    }
+}
+
+impl FromStr for SwebenchAlias {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "full" | "swe-bench" | "swe_bench" => Ok(Self::Full),
+            "lite" | "swe-bench_lite" | "swe_bench_lite" => Ok(Self::Lite),
+            "verified" | "swe-bench_verified" | "swe_bench_verified" => Ok(Self::Verified),
+            other => Err(format!(
+                "unknown dataset alias `{other}`; expected one of: full, lite, verified"
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for SwebenchAlias {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Dataset split selector.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SwebenchSplit {
+    Train,
+    Test,
+    Dev,
+}
+
+impl SwebenchSplit {
+    /// Canonical string name used in cache file paths and provenance records.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Train => "train",
+            Self::Test => "test",
+            Self::Dev => "dev",
+        }
+    }
+}
+
+impl FromStr for SwebenchSplit {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "train" => Ok(Self::Train),
+            "test" => Ok(Self::Test),
+            "dev" => Ok(Self::Dev),
+            other => Err(format!(
+                "unknown split `{other}`; expected one of: train, test, dev"
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for SwebenchSplit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Discriminant stored in provenance manifests.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DatasetSourceKind {
+    Local,
+    Named,
+}
+
+impl DatasetSourceKind {
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Named => "named",
+        }
+    }
+}
+
+/// How the dataset was supplied — either a direct local JSONL path or a named
+/// alias that is resolved against the on-disk cache.
+#[derive(Debug, Clone)]
+pub enum DatasetSource {
+    LocalPath(PathBuf),
+    Named {
+        alias: SwebenchAlias,
+        split: SwebenchSplit,
+    },
+}
+
+impl DatasetSource {
+    #[must_use]
+    pub fn kind(&self) -> DatasetSourceKind {
+        match self {
+            Self::LocalPath(_) => DatasetSourceKind::Local,
+            Self::Named { .. } => DatasetSourceKind::Named,
+        }
+    }
+
+    /// Human-readable path or alias description for log messages.
+    #[must_use]
+    pub fn display_path(&self) -> String {
+        match self {
+            Self::LocalPath(p) => p.display().to_string(),
+            Self::Named { alias, split } => format!("{alias}/{split}"),
+        }
+    }
+}
+
+/// Result of inspecting the on-disk cache for a named dataset.
+#[derive(Debug, Clone)]
+pub enum CacheStatus {
+    /// Cache file exists and parsed as valid JSONL.
+    Hit {
+        path: PathBuf,
+        sha256: String,
+        instance_count: usize,
+    },
+    /// Cache file does not exist.
+    Miss { expected_path: PathBuf },
+    /// Cache file exists but failed to parse as JSONL.
+    Corrupt { path: PathBuf, reason: String },
+}
+
+impl CacheStatus {
+    /// Short label used in preflight check messages.
+    #[must_use]
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Hit { .. } => "hit",
+            Self::Miss { .. } => "miss",
+            Self::Corrupt { .. } => "corrupt",
+        }
+    }
+}
+
+/// Return the default dataset cache directory: `~/.cache/rust-swe-agent/datasets`.
+/// Falls back to `<cwd>/.dataset-cache` when the home directory cannot be determined.
+#[must_use]
+pub fn default_cache_dir() -> PathBuf {
+    home_dir()
+        .map(|h| h.join(".cache").join("rust-swe-agent").join("datasets"))
+        .unwrap_or_else(|| PathBuf::from(".dataset-cache"))
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
+}
+
+/// Return the cache file path for the given alias and split under `cache_dir`.
+#[must_use]
+pub fn cache_path_for(cache_dir: &Path, alias: &SwebenchAlias, split: &SwebenchSplit) -> PathBuf {
+    cache_dir
+        .join(alias.as_str())
+        .join(format!("{}.jsonl", split.as_str()))
+}
+
+/// Inspect the cache for the given alias/split without modifying anything.
+pub fn check_cache(cache_dir: &Path, alias: &SwebenchAlias, split: &SwebenchSplit) -> CacheStatus {
+    let path = cache_path_for(cache_dir, alias, split);
+    if !path.exists() {
+        return CacheStatus::Miss {
+            expected_path: path,
+        };
+    }
+    match std::fs::read(&path) {
+        Err(e) => CacheStatus::Corrupt {
+            path,
+            reason: e.to_string(),
+        },
+        Ok(bytes) => match validate_jsonl_bytes(&bytes) {
+            Ok(instance_count) => CacheStatus::Hit {
+                sha256: sha256_hex(&bytes),
+                path,
+                instance_count,
+            },
+            Err(reason) => CacheStatus::Corrupt { path, reason },
+        },
+    }
+}
+
+/// Write `content` to the cache location for the given alias and split.
+/// Creates intermediate directories as needed.
+/// Returns the path written.
+pub fn write_cache(
+    cache_dir: &Path,
+    alias: &SwebenchAlias,
+    split: &SwebenchSplit,
+    content: &[u8],
+) -> Result<PathBuf, Error> {
+    let path = cache_path_for(cache_dir, alias, split);
+    let parent = path
+        .parent()
+        .expect("cache path always has a parent directory");
+    std::fs::create_dir_all(parent)?;
+    std::fs::write(&path, content)?;
+    Ok(path)
+}
+
+/// Metadata about a resolved dataset, used to populate provenance manifests.
+#[derive(Debug)]
+pub struct ResolvedDatasetMeta {
+    /// Actual on-disk path from which bytes were read.
+    pub path: PathBuf,
+    pub sha256: String,
+    pub instance_count: usize,
+    /// Only set for `DatasetSource::Named`.
+    pub alias: Option<SwebenchAlias>,
+    /// Only set for `DatasetSource::Named`.
+    pub split: Option<SwebenchSplit>,
+    /// Cache path for named datasets; `None` for local paths.
+    pub cache_path: Option<PathBuf>,
+}
+
+/// Resolve a `DatasetSource` to raw JSONL bytes and provenance metadata.
+///
+/// For `LocalPath` this reads the file directly.
+/// For `Named` this checks the cache: on a hit it returns the cached bytes; on a
+/// miss or corrupt it returns an actionable `Error`.
+pub fn resolve_dataset(
+    source: &DatasetSource,
+    cache_dir: &Path,
+) -> Result<(Vec<u8>, ResolvedDatasetMeta), Error> {
+    match source {
+        DatasetSource::LocalPath(path) => {
+            let bytes = std::fs::read(path)?;
+            let instance_count = count_jsonl_lines(&bytes).unwrap_or(0);
+            let meta = ResolvedDatasetMeta {
+                path: path.clone(),
+                sha256: sha256_hex(&bytes),
+                instance_count,
+                alias: None,
+                split: None,
+                cache_path: None,
+            };
+            Ok((bytes, meta))
+        }
+        DatasetSource::Named { alias, split } => {
+            match check_cache(cache_dir, alias, split) {
+                CacheStatus::Hit {
+                    path,
+                    sha256,
+                    instance_count,
+                } => {
+                    let bytes = std::fs::read(&path)?;
+                    let meta = ResolvedDatasetMeta {
+                        path: path.clone(),
+                        sha256,
+                        instance_count,
+                        alias: Some(alias.clone()),
+                        split: Some(split.clone()),
+                        cache_path: Some(path),
+                    };
+                    Ok((bytes, meta))
+                }
+                CacheStatus::Miss { expected_path } => Err(Error::Config(
+                    crate::error::ConfigError::Invalid(format!(
+                        "dataset alias `{alias}` split `{split}` not in cache: \
+                        expected file at `{path}`\n\
+                        \n\
+                        To populate the cache, download the SWE-bench JSONL for the \
+                        `{alias}` dataset (`{split}` split) and place it at:\n\
+                        \n  {path}\n\
+                        \n\
+                        See: https://www.swebench.com/SWE-bench/guides/datasets/ for \
+                        dataset download instructions.",
+                        path = expected_path.display()
+                    )),
+                )),
+                CacheStatus::Corrupt { path, reason } => Err(Error::Config(
+                    crate::error::ConfigError::Invalid(format!(
+                        "cached dataset `{alias}` split `{split}` at `{p}` is corrupt: {reason}\n\
+                        \n\
+                        Delete the file and re-populate the cache:\n\
+                        \n  {p}",
+                        p = path.display()
+                    )),
+                )),
+            }
+        }
+    }
+}
+
+/// Count non-empty lines in a JSONL byte slice (does not validate JSON).
+fn count_jsonl_lines(bytes: &[u8]) -> Option<usize> {
+    let text = std::str::from_utf8(bytes).ok()?;
+    Some(text.lines().filter(|l| !l.trim().is_empty()).count())
+}
+
+/// Parse and count valid JSONL instances; returns an error string on the first
+/// malformed line.
+fn validate_jsonl_bytes(bytes: &[u8]) -> Result<usize, String> {
+    let text =
+        std::str::from_utf8(bytes).map_err(|e| format!("UTF-8 decode error: {e}"))?;
+    let mut count = 0usize;
+    for (i, line) in text.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let v: Result<serde_json::Value, _> = serde_json::from_str(line);
+        if let Err(e) = v {
+            return Err(format!("line {}: {e}", i + 1));
+        }
+        count += 1;
+    }
+    Ok(count)
+}
+
+pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(bytes);
+    format!("{:x}", h.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use std::str::FromStr;
+
+    // ── SwebenchAlias parsing ──────────────────────────────────────────────
+
+    #[test]
+    fn alias_parses_canonical_forms() {
+        assert_eq!(SwebenchAlias::from_str("full").unwrap(), SwebenchAlias::Full);
+        assert_eq!(SwebenchAlias::from_str("lite").unwrap(), SwebenchAlias::Lite);
+        assert_eq!(
+            SwebenchAlias::from_str("verified").unwrap(),
+            SwebenchAlias::Verified
+        );
+    }
+
+    #[test]
+    fn alias_parses_known_alternate_forms() {
+        assert_eq!(
+            SwebenchAlias::from_str("swe-bench").unwrap(),
+            SwebenchAlias::Full
+        );
+        assert_eq!(
+            SwebenchAlias::from_str("swe-bench_lite").unwrap(),
+            SwebenchAlias::Lite
+        );
+        assert_eq!(
+            SwebenchAlias::from_str("swe-bench_verified").unwrap(),
+            SwebenchAlias::Verified
+        );
+    }
+
+    #[test]
+    fn alias_is_case_insensitive() {
+        assert_eq!(
+            SwebenchAlias::from_str("FULL").unwrap(),
+            SwebenchAlias::Full
+        );
+        assert_eq!(
+            SwebenchAlias::from_str("Lite").unwrap(),
+            SwebenchAlias::Lite
+        );
+        assert_eq!(
+            SwebenchAlias::from_str("VERIFIED").unwrap(),
+            SwebenchAlias::Verified
+        );
+    }
+
+    #[test]
+    fn alias_rejects_unknown_values() {
+        let err = SwebenchAlias::from_str("bogus").unwrap_err();
+        assert!(err.contains("bogus"), "{err}");
+        assert!(err.contains("full"), "{err}");
+    }
+
+    #[test]
+    fn alias_display_matches_as_str() {
+        for alias in [SwebenchAlias::Full, SwebenchAlias::Lite, SwebenchAlias::Verified] {
+            assert_eq!(alias.to_string(), alias.as_str());
+        }
+    }
+
+    // ── SwebenchSplit parsing ──────────────────────────────────────────────
+
+    #[test]
+    fn split_parses_canonical_forms() {
+        assert_eq!(SwebenchSplit::from_str("train").unwrap(), SwebenchSplit::Train);
+        assert_eq!(SwebenchSplit::from_str("test").unwrap(), SwebenchSplit::Test);
+        assert_eq!(SwebenchSplit::from_str("dev").unwrap(), SwebenchSplit::Dev);
+    }
+
+    #[test]
+    fn split_is_case_insensitive() {
+        assert_eq!(SwebenchSplit::from_str("TEST").unwrap(), SwebenchSplit::Test);
+        assert_eq!(SwebenchSplit::from_str("Dev").unwrap(), SwebenchSplit::Dev);
+    }
+
+    #[test]
+    fn split_rejects_unknown_values() {
+        let err = SwebenchSplit::from_str("validation").unwrap_err();
+        assert!(err.contains("validation"), "{err}");
+        assert!(err.contains("train"), "{err}");
+    }
+
+    #[test]
+    fn split_display_matches_as_str() {
+        for split in [SwebenchSplit::Train, SwebenchSplit::Test, SwebenchSplit::Dev] {
+            assert_eq!(split.to_string(), split.as_str());
+        }
+    }
+
+    // ── DatasetSourceKind ──────────────────────────────────────────────────
+
+    #[test]
+    fn source_kind_from_local_path() {
+        let src = DatasetSource::LocalPath(PathBuf::from("file.jsonl"));
+        assert_eq!(src.kind(), DatasetSourceKind::Local);
+    }
+
+    #[test]
+    fn source_kind_from_named() {
+        let src = DatasetSource::Named {
+            alias: SwebenchAlias::Verified,
+            split: SwebenchSplit::Test,
+        };
+        assert_eq!(src.kind(), DatasetSourceKind::Named);
+    }
+
+    // ── cache_path_for ─────────────────────────────────────────────────────
+
+    #[test]
+    fn cache_path_for_uses_alias_and_split() {
+        let dir = PathBuf::from("/cache");
+        let p = cache_path_for(&dir, &SwebenchAlias::Verified, &SwebenchSplit::Test);
+        assert_eq!(p, PathBuf::from("/cache/verified/test.jsonl"));
+
+        let p2 = cache_path_for(&dir, &SwebenchAlias::Lite, &SwebenchSplit::Dev);
+        assert_eq!(p2, PathBuf::from("/cache/lite/dev.jsonl"));
+    }
+
+    // ── check_cache ────────────────────────────────────────────────────────
+
+    #[test]
+    fn check_cache_miss_when_file_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let status = check_cache(dir.path(), &SwebenchAlias::Verified, &SwebenchSplit::Test);
+        let CacheStatus::Miss { expected_path } = status else {
+            panic!("expected Miss, got {}", status.label());
+        };
+        assert_eq!(
+            expected_path,
+            cache_path_for(dir.path(), &SwebenchAlias::Verified, &SwebenchSplit::Test)
+        );
+    }
+
+    #[test]
+    fn check_cache_hit_when_valid_jsonl_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = b"{\"instance_id\":\"a\",\"problem_statement\":\"fix it\"}\n";
+        write_cache(dir.path(), &SwebenchAlias::Lite, &SwebenchSplit::Test, content).unwrap();
+
+        let status = check_cache(dir.path(), &SwebenchAlias::Lite, &SwebenchSplit::Test);
+        let CacheStatus::Hit {
+            instance_count,
+            path,
+            sha256,
+        } = status
+        else {
+            panic!("expected Hit, got {}", status.label());
+        };
+        assert_eq!(instance_count, 1);
+        assert_eq!(
+            path,
+            cache_path_for(dir.path(), &SwebenchAlias::Lite, &SwebenchSplit::Test)
+        );
+        assert!(!sha256.is_empty());
+    }
+
+    #[test]
+    fn check_cache_corrupt_when_invalid_jsonl_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = b"this is not json\n";
+        let path = cache_path_for(dir.path(), &SwebenchAlias::Full, &SwebenchSplit::Dev);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, content).unwrap();
+
+        let status = check_cache(dir.path(), &SwebenchAlias::Full, &SwebenchSplit::Dev);
+        let CacheStatus::Corrupt { reason, .. } = status else {
+            panic!("expected Corrupt, got {}", status.label());
+        };
+        assert!(!reason.is_empty(), "reason should not be empty");
+    }
+
+    // ── write_cache ────────────────────────────────────────────────────────
+
+    #[test]
+    fn write_cache_creates_directories_and_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = b"{}";
+        let written_path =
+            write_cache(dir.path(), &SwebenchAlias::Verified, &SwebenchSplit::Dev, content)
+                .unwrap();
+        assert!(written_path.exists());
+        assert_eq!(std::fs::read(&written_path).unwrap(), content);
+    }
+
+    // ── resolve_dataset ────────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_dataset_local_path_reads_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("data.jsonl");
+        let content = b"{\"instance_id\":\"test-1\",\"problem_statement\":\"p\"}\n";
+        std::fs::write(&file, content).unwrap();
+
+        let source = DatasetSource::LocalPath(file.clone());
+        let (bytes, meta) = resolve_dataset(&source, dir.path()).unwrap();
+        assert_eq!(bytes, content);
+        assert_eq!(meta.path, file);
+        assert_eq!(meta.instance_count, 1);
+        assert!(meta.alias.is_none());
+        assert!(meta.split.is_none());
+        assert!(meta.cache_path.is_none());
+    }
+
+    #[test]
+    fn resolve_dataset_named_cache_hit_returns_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = b"{\"instance_id\":\"verified-1\",\"problem_statement\":\"p\"}\n\
+                       {\"instance_id\":\"verified-2\",\"problem_statement\":\"q\"}\n";
+        write_cache(
+            dir.path(),
+            &SwebenchAlias::Verified,
+            &SwebenchSplit::Test,
+            content,
+        )
+        .unwrap();
+
+        let source = DatasetSource::Named {
+            alias: SwebenchAlias::Verified,
+            split: SwebenchSplit::Test,
+        };
+        let (bytes, meta) = resolve_dataset(&source, dir.path()).unwrap();
+        assert_eq!(bytes, content);
+        assert_eq!(meta.instance_count, 2);
+        assert_eq!(meta.alias, Some(SwebenchAlias::Verified));
+        assert_eq!(meta.split, Some(SwebenchSplit::Test));
+        assert!(meta.cache_path.is_some());
+    }
+
+    #[test]
+    fn resolve_dataset_named_cache_miss_returns_actionable_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = DatasetSource::Named {
+            alias: SwebenchAlias::Verified,
+            split: SwebenchSplit::Test,
+        };
+        let err = resolve_dataset(&source, dir.path()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("verified"), "{msg}");
+        assert!(msg.contains("test"), "{msg}");
+        // error message must name the expected cache path
+        assert!(msg.contains("verified/test.jsonl"), "{msg}");
+    }
+
+    #[test]
+    fn resolve_dataset_named_cache_corrupt_returns_distinct_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = cache_path_for(dir.path(), &SwebenchAlias::Lite, &SwebenchSplit::Dev);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"NOT VALID JSON\n").unwrap();
+
+        let source = DatasetSource::Named {
+            alias: SwebenchAlias::Lite,
+            split: SwebenchSplit::Dev,
+        };
+        let err = resolve_dataset(&source, dir.path()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("corrupt"), "{msg}");
+    }
+}

--- a/src/run/dataset.rs
+++ b/src/run/dataset.rs
@@ -173,9 +173,10 @@ impl CacheStatus {
 /// Falls back to `<cwd>/.dataset-cache` when the home directory cannot be determined.
 #[must_use]
 pub fn default_cache_dir() -> PathBuf {
-    home_dir()
-        .map(|h| h.join(".cache").join("rust-swe-agent").join("datasets"))
-        .unwrap_or_else(|| PathBuf::from(".dataset-cache"))
+    home_dir().map_or_else(
+        || PathBuf::from(".dataset-cache"),
+        |h| h.join(".cache").join("rust-swe-agent").join("datasets"),
+    )
 }
 
 fn home_dir() -> Option<PathBuf> {

--- a/src/run/forecast.rs
+++ b/src/run/forecast.rs
@@ -459,7 +459,9 @@ fn calibration_instance_ids(
 fn planned_instances(
     args: &swebench::SwebenchArgs,
 ) -> Result<Vec<swebench::SweBenchInstance>, Error> {
-    let instances = swebench::load_dataset(&args.dataset_path)?;
+    let (dataset_bytes, _meta) =
+        crate::run::dataset::resolve_dataset(&args.dataset_source, &args.dataset_cache_dir)?;
+    let instances = swebench::load_dataset_from_bytes_pub(&dataset_bytes)?;
     let (filtered, _) = swebench::apply_subset(
         instances,
         &swebench::ApplySubsetParams {

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -2,6 +2,7 @@
 //! and writes trajectories to disk.
 
 pub mod compare;
+pub mod dataset;
 pub mod evaluate;
 pub mod forecast;
 pub mod frontier;

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -359,13 +359,40 @@ pub struct HarnessManifest {
     pub git_resolution: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DatasetManifest {
     pub path: String,
     pub sha256: String,
     pub instance_count: usize,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub filter_spec: Option<FilterSpec>,
+    /// How the dataset was supplied: `"local"` for `--dataset-path`,
+    /// `"named"` for `--dataset` alias.
+    #[serde(default = "default_source_kind_local", skip_serializing_if = "String::is_empty")]
+    pub source_kind: String,
+    /// Named alias (`full`, `lite`, `verified`). `None` for local-path datasets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+    /// Split selector (`train`, `test`, `dev`). `None` for local-path datasets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub split: Option<String>,
+    /// Content hash of the cached bytes, prefixed with `sha256:`.
+    /// Used to pin the exact dataset bytes for reproducibility.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<String>,
+    /// Absolute path of the on-disk cache file for named datasets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_path: Option<String>,
+    /// Total rows in the dataset before instance-id / sample / limit filters.
+    #[serde(default)]
+    pub selected_row_count: usize,
+    /// Rows remaining after all selection filters have been applied.
+    #[serde(default)]
+    pub post_filter_row_count: usize,
+}
+
+fn default_source_kind_local() -> String {
+    "local".into()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -892,7 +919,12 @@ fn write_effective_task_line(
 
 #[allow(clippy::struct_excessive_bools)]
 pub struct SwebenchArgs {
-    pub dataset_path: PathBuf,
+    /// Dataset source: either a local JSONL path or a named alias + split.
+    pub dataset_source: crate::run::dataset::DatasetSource,
+    /// Directory used for the named-dataset on-disk cache.
+    /// Defaults to `~/.cache/rust-swe-agent/datasets` when constructed from
+    /// CLI args; tests inject a temp dir for isolation.
+    pub dataset_cache_dir: PathBuf,
     pub output_dir: PathBuf,
     pub parallel: usize,
     pub config: Config,
@@ -1137,6 +1169,12 @@ fn load_dataset_from_bytes(bytes: &[u8]) -> Result<Vec<SweBenchInstance>, Error>
     parse_dataset_lines(text)
 }
 
+/// Public alias for `load_dataset_from_bytes`, used by the forecast runner
+/// which receives pre-resolved bytes from `resolve_dataset`.
+pub fn load_dataset_from_bytes_pub(bytes: &[u8]) -> Result<Vec<SweBenchInstance>, Error> {
+    load_dataset_from_bytes(bytes)
+}
+
 fn parse_dataset_lines(text: &str) -> Result<Vec<SweBenchInstance>, Error> {
     let mut out = Vec::new();
     for (i, line) in text.lines().enumerate() {
@@ -1231,8 +1269,10 @@ pub async fn run(mut args: SwebenchArgs) -> Result<SweepResults, Error> {
         args.retry_backoff_cap_s,
     )?;
 
-    let dataset_bytes = std::fs::read(&args.dataset_path)?;
-    let dataset_sha = sha256_hex(&dataset_bytes);
+    let (dataset_bytes, dataset_meta) =
+        crate::run::dataset::resolve_dataset(&args.dataset_source, &args.dataset_cache_dir)?;
+    let dataset_sha = dataset_meta.sha256.clone();
+    let dataset_instance_count = dataset_meta.instance_count;
     let instances = load_dataset_from_bytes(&dataset_bytes)?;
     let (instances, filter_spec) = apply_subset(
         instances,
@@ -1251,7 +1291,9 @@ pub async fn run(mut args: SwebenchArgs) -> Result<SweepResults, Error> {
     let initial_manifest = build_manifest(
         &args,
         &dataset_sha,
+        dataset_instance_count,
         total,
+        &dataset_meta,
         &filter_spec,
         &started_at_utc,
         None,
@@ -1830,7 +1872,9 @@ pub async fn run(mut args: SwebenchArgs) -> Result<SweepResults, Error> {
         manifest: Some(build_manifest(
             &args,
             &dataset_sha,
+            dataset_instance_count,
             total,
+            &dataset_meta,
             &initial.filter_spec,
             &started_at_utc,
             Some(chrono::Utc::now().to_rfc3339()),
@@ -1918,19 +1962,92 @@ async fn forward_os_cancellation_signals(tx: mpsc::UnboundedSender<SweepSignal>)
 async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
     let deadline = Instant::now() + Duration::from_secs(args.preflight_total_timeout_s);
     let mut checks = Vec::new();
-    let dataset_path = args.dataset_path.clone();
-    let dataset_bytes = timed_sync(
-        "dataset.read",
-        args.preflight_check_timeout_s,
-        deadline,
-        move || std::fs::read(&dataset_path),
-    )
-    .await?;
-    checks.push(CheckResult {
-        status: CheckStatus::Ok,
-        name: "dataset.read",
-        message: format!("readable: {}", args.dataset_path.display()),
-    });
+
+    // ── dataset availability check (local or named alias) ────────────────
+    let dataset_bytes = match &args.dataset_source {
+        crate::run::dataset::DatasetSource::LocalPath(path) => {
+            let path = path.clone();
+            let bytes = timed_sync(
+                "dataset.read",
+                args.preflight_check_timeout_s,
+                deadline,
+                move || std::fs::read(&path),
+            )
+            .await?;
+            checks.push(CheckResult {
+                status: CheckStatus::Ok,
+                name: "dataset.read",
+                message: format!("readable: {}", args.dataset_source.display_path()),
+            });
+            bytes
+        }
+        crate::run::dataset::DatasetSource::Named { alias, split } => {
+            let alias = alias.clone();
+            let split = split.clone();
+            let cache_dir = args.dataset_cache_dir.clone();
+            let cache_status = timed_sync(
+                "dataset.cache",
+                args.preflight_check_timeout_s,
+                deadline,
+                move || Ok::<_, String>(crate::run::dataset::check_cache(&cache_dir, &alias, &split)),
+            )
+            .await?;
+            match &cache_status {
+                crate::run::dataset::CacheStatus::Hit { path, instance_count, .. } => {
+                    checks.push(CheckResult {
+                        status: CheckStatus::Ok,
+                        name: "dataset.cache",
+                        message: format!(
+                            "cache hit: {} ({instance_count} instances)",
+                            path.display()
+                        ),
+                    });
+                    std::fs::read(path)?
+                }
+                crate::run::dataset::CacheStatus::Miss { expected_path } => {
+                    let (alias_str, split_str) = match &args.dataset_source {
+                        crate::run::dataset::DatasetSource::Named { alias, split } => {
+                            (alias.as_str(), split.as_str())
+                        }
+                        _ => ("?", "?"),
+                    };
+                    checks.push(CheckResult {
+                        status: CheckStatus::Warn,
+                        name: "dataset.cache",
+                        message: format!(
+                            "cache miss: expected file at `{}`",
+                            expected_path.display()
+                        ),
+                    });
+                    return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                        "dataset alias `{alias_str}` split `{split_str}` not in cache: \
+                        expected file at `{p}`\n\
+                        \n\
+                        To populate the cache, download the SWE-bench JSONL for the \
+                        `{alias_str}` dataset (`{split_str}` split) and place it at:\n\
+                        \n  {p}\n\
+                        \n\
+                        See: https://www.swebench.com/SWE-bench/guides/datasets/ for \
+                        dataset download instructions.",
+                        p = expected_path.display()
+                    ))));
+                }
+                crate::run::dataset::CacheStatus::Corrupt { path, reason } => {
+                    checks.push(CheckResult {
+                        status: CheckStatus::Warn,
+                        name: "dataset.cache",
+                        message: format!("corrupt cache: `{}`: {reason}", path.display()),
+                    });
+                    return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                        "cached dataset at `{}` is corrupt: {reason}\n\
+                        Delete the file and re-populate the cache.",
+                        path.display()
+                    ))));
+                }
+            }
+        }
+    };
+
     let instances = timed_sync(
         "dataset.parse",
         args.preflight_check_timeout_s,
@@ -2181,6 +2298,8 @@ fn build_manifest(
     args: &SwebenchArgs,
     dataset_sha: &str,
     dataset_instance_count: usize,
+    post_filter_count: usize,
+    dataset_meta: &crate::run::dataset::ResolvedDatasetMeta,
     filter_spec: &FilterSpec,
     started_at_utc: &str,
     finished_at_utc: Option<String>,
@@ -2197,10 +2316,20 @@ fn build_manifest(
         purpose: None,
         harness: resolve_harness_manifest(),
         dataset: DatasetManifest {
-            path: args.dataset_path.display().to_string(),
+            path: dataset_meta.path.display().to_string(),
             sha256: dataset_sha.to_owned(),
             instance_count: dataset_instance_count,
             filter_spec: Some(filter_spec.clone()),
+            source_kind: args.dataset_source.kind().as_str().to_owned(),
+            alias: dataset_meta.alias.as_ref().map(|a| a.as_str().to_owned()),
+            split: dataset_meta.split.as_ref().map(|s| s.as_str().to_owned()),
+            source_revision: Some(format!("sha256:{dataset_sha}")),
+            cache_path: dataset_meta
+                .cache_path
+                .as_ref()
+                .map(|p| p.display().to_string()),
+            selected_row_count: dataset_instance_count,
+            post_filter_row_count: post_filter_count,
         },
         prompt_template: PromptTemplateManifest {
             source: "builtin".into(),
@@ -4205,7 +4334,8 @@ mod tests {
         }
 
         let args = SwebenchArgs {
-            dataset_path: dataset,
+            dataset_source: crate::run::dataset::DatasetSource::LocalPath(dataset),
+            dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
             output_dir: output.clone(),
             parallel: 1,
             reruns: 1,
@@ -5052,7 +5182,10 @@ mod tests {
         cfg.root.agent.step_limit = 7;
         cfg.root.model.name = "override-model".into();
         let args = SwebenchArgs {
-            dataset_path: PathBuf::from("dataset.jsonl"),
+            dataset_source: crate::run::dataset::DatasetSource::LocalPath(
+                PathBuf::from("dataset.jsonl"),
+            ),
+            dataset_cache_dir: PathBuf::from("/nonexistent"),
             output_dir: PathBuf::from("out"),
             parallel: 1,
             reruns: 1,
@@ -5089,10 +5222,20 @@ mod tests {
             cancellation_signals: None,
             github_pr: None,
         };
+        let dummy_meta = crate::run::dataset::ResolvedDatasetMeta {
+            path: PathBuf::from("dataset.jsonl"),
+            sha256: "dataset".into(),
+            instance_count: 1,
+            alias: None,
+            split: None,
+            cache_path: None,
+        };
         let manifest = build_manifest(
             &args,
             "dataset",
             1,
+            1,
+            &dummy_meta,
             &FilterSpec::default(),
             "2026-01-01T00:00:00Z",
             None,
@@ -5109,7 +5252,10 @@ mod tests {
     #[test]
     fn manifest_records_resume_mode_from_args() {
         let args = SwebenchArgs {
-            dataset_path: PathBuf::from("dataset.jsonl"),
+            dataset_source: crate::run::dataset::DatasetSource::LocalPath(
+                PathBuf::from("dataset.jsonl"),
+            ),
+            dataset_cache_dir: PathBuf::from("/nonexistent"),
             output_dir: PathBuf::from("out"),
             parallel: 1,
             reruns: 1,
@@ -5146,10 +5292,20 @@ mod tests {
             cancellation_signals: None,
             github_pr: None,
         };
+        let dummy_meta = crate::run::dataset::ResolvedDatasetMeta {
+            path: PathBuf::from("dataset.jsonl"),
+            sha256: "dataset".into(),
+            instance_count: 1,
+            alias: None,
+            split: None,
+            cache_path: None,
+        };
         let manifest = build_manifest(
             &args,
             "dataset",
             1,
+            1,
+            &dummy_meta,
             &FilterSpec::default(),
             "2026-01-01T00:00:00Z",
             None,
@@ -5176,7 +5332,10 @@ instance = "inst"
         )
         .unwrap();
         let args_a = SwebenchArgs {
-            dataset_path: PathBuf::from("dataset.jsonl"),
+            dataset_source: crate::run::dataset::DatasetSource::LocalPath(
+                PathBuf::from("dataset.jsonl"),
+            ),
+            dataset_cache_dir: PathBuf::from("/nonexistent"),
             output_dir: PathBuf::from("out"),
             parallel: 1,
             reruns: 1,
@@ -5213,13 +5372,39 @@ instance = "inst"
             cancellation_signals: None,
             github_pr: None,
         };
+        let dummy_meta = crate::run::dataset::ResolvedDatasetMeta {
+            path: PathBuf::from("dataset.jsonl"),
+            sha256: "dataset".into(),
+            instance_count: 1,
+            alias: None,
+            split: None,
+            cache_path: None,
+        };
         let filter = FilterSpec::default();
-        let m_a = build_manifest(&args_a, "dataset", 1, &filter, "2026-01-01T00:00:00Z", None);
+        let m_a = build_manifest(
+            &args_a,
+            "dataset",
+            1,
+            1,
+            &dummy_meta,
+            &filter,
+            "2026-01-01T00:00:00Z",
+            None,
+        );
         let args_b = SwebenchArgs {
             config: cfg_b,
             ..args_a
         };
-        let m_b = build_manifest(&args_b, "dataset", 1, &filter, "2026-01-01T00:00:00Z", None);
+        let m_b = build_manifest(
+            &args_b,
+            "dataset",
+            1,
+            1,
+            &dummy_meta,
+            &filter,
+            "2026-01-01T00:00:00Z",
+            None,
+        );
         assert_ne!(m_a.prompt_template.sha256, m_b.prompt_template.sha256);
     }
 
@@ -5270,7 +5455,8 @@ instance = "inst"
         std::fs::write(&dataset, r#"{"instance_id":"x"}"#).unwrap();
         let out = tmp.path().join("out");
         let args = SwebenchArgs {
-            dataset_path: dataset,
+            dataset_source: crate::run::dataset::DatasetSource::LocalPath(dataset),
+            dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
             output_dir: out.clone(),
             parallel: 1,
             reruns: 1,
@@ -5933,7 +6119,10 @@ instance = "inst"
     #[test]
     fn swebench_args_has_max_rpm_and_max_input_tpm_fields() {
         let args = SwebenchArgs {
-            dataset_path: PathBuf::from("d.jsonl"),
+            dataset_source: crate::run::dataset::DatasetSource::LocalPath(
+                PathBuf::from("d.jsonl"),
+            ),
+            dataset_cache_dir: PathBuf::from("/nonexistent"),
             output_dir: PathBuf::from("out"),
             parallel: 4,
             reruns: 1,

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -2015,10 +2015,17 @@ async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
                         status: CheckStatus::Warn,
                         name: "dataset.cache",
                         message: format!(
-                            "cache miss: expected file at `{}`",
-                            expected_path.display()
+                            "cache miss: expected file at `{}`\n\
+                            To populate: download the SWE-bench JSONL for `{alias_str}` \
+                            (`{split_str}` split) and place it at `{p}`.\n\
+                            See: https://www.swebench.com/SWE-bench/guides/datasets/",
+                            expected_path.display(),
+                            p = expected_path.display()
                         ),
                     });
+                    if args.preflight_mode == "doctor" {
+                        return Ok(checks);
+                    }
                     return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
                         "dataset alias `{alias_str}` split `{split_str}` not in cache: \
                         expected file at `{p}`\n\

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -368,7 +368,10 @@ pub struct DatasetManifest {
     pub filter_spec: Option<FilterSpec>,
     /// How the dataset was supplied: `"local"` for `--dataset-path`,
     /// `"named"` for `--dataset` alias.
-    #[serde(default = "default_source_kind_local", skip_serializing_if = "String::is_empty")]
+    #[serde(
+        default = "default_source_kind_local",
+        skip_serializing_if = "String::is_empty"
+    )]
     pub source_kind: String,
     /// Named alias (`full`, `lite`, `verified`). `None` for local-path datasets.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1989,11 +1992,17 @@ async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
                 "dataset.cache",
                 args.preflight_check_timeout_s,
                 deadline,
-                move || Ok::<_, String>(crate::run::dataset::check_cache(&cache_dir, &alias, &split)),
+                move || {
+                    Ok::<_, String>(crate::run::dataset::check_cache(&cache_dir, &alias, &split))
+                },
             )
             .await?;
             match &cache_status {
-                crate::run::dataset::CacheStatus::Hit { path, instance_count, .. } => {
+                crate::run::dataset::CacheStatus::Hit {
+                    path,
+                    instance_count,
+                    ..
+                } => {
                     checks.push(CheckResult {
                         status: CheckStatus::Ok,
                         name: "dataset.cache",
@@ -5189,9 +5198,9 @@ mod tests {
         cfg.root.agent.step_limit = 7;
         cfg.root.model.name = "override-model".into();
         let args = SwebenchArgs {
-            dataset_source: crate::run::dataset::DatasetSource::LocalPath(
-                PathBuf::from("dataset.jsonl"),
-            ),
+            dataset_source: crate::run::dataset::DatasetSource::LocalPath(PathBuf::from(
+                "dataset.jsonl",
+            )),
             dataset_cache_dir: PathBuf::from("/nonexistent"),
             output_dir: PathBuf::from("out"),
             parallel: 1,
@@ -5259,9 +5268,9 @@ mod tests {
     #[test]
     fn manifest_records_resume_mode_from_args() {
         let args = SwebenchArgs {
-            dataset_source: crate::run::dataset::DatasetSource::LocalPath(
-                PathBuf::from("dataset.jsonl"),
-            ),
+            dataset_source: crate::run::dataset::DatasetSource::LocalPath(PathBuf::from(
+                "dataset.jsonl",
+            )),
             dataset_cache_dir: PathBuf::from("/nonexistent"),
             output_dir: PathBuf::from("out"),
             parallel: 1,
@@ -5339,9 +5348,9 @@ instance = "inst"
         )
         .unwrap();
         let args_a = SwebenchArgs {
-            dataset_source: crate::run::dataset::DatasetSource::LocalPath(
-                PathBuf::from("dataset.jsonl"),
-            ),
+            dataset_source: crate::run::dataset::DatasetSource::LocalPath(PathBuf::from(
+                "dataset.jsonl",
+            )),
             dataset_cache_dir: PathBuf::from("/nonexistent"),
             output_dir: PathBuf::from("out"),
             parallel: 1,
@@ -6126,9 +6135,7 @@ instance = "inst"
     #[test]
     fn swebench_args_has_max_rpm_and_max_input_tpm_fields() {
         let args = SwebenchArgs {
-            dataset_source: crate::run::dataset::DatasetSource::LocalPath(
-                PathBuf::from("d.jsonl"),
-            ),
+            dataset_source: crate::run::dataset::DatasetSource::LocalPath(PathBuf::from("d.jsonl")),
             dataset_cache_dir: PathBuf::from("/nonexistent"),
             output_dir: PathBuf::from("out"),
             parallel: 4,

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -2018,7 +2018,7 @@ async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
                         crate::run::dataset::DatasetSource::Named { alias, split } => {
                             (alias.as_str(), split.as_str())
                         }
-                        _ => ("?", "?"),
+                        crate::run::dataset::DatasetSource::LocalPath(_) => ("?", "?"),
                     };
                     checks.push(CheckResult {
                         status: CheckStatus::Warn,
@@ -2310,6 +2310,7 @@ fn ensure_total_deadline(deadline: Instant) -> Result<(), Error> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_manifest(
     args: &SwebenchArgs,
     dataset_sha: &str,

--- a/tests/artifact_schema.rs
+++ b/tests/artifact_schema.rs
@@ -747,7 +747,8 @@ fn config_with_workdir(dir: &Path) -> Config {
 
 fn base_args(dataset: std::path::PathBuf, output: std::path::PathBuf, cfg: Config) -> SwebenchArgs {
     SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output,
         parallel: 1,
         config: cfg,

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -118,6 +118,7 @@ fn write_results_with_filter_spec(
     write_results_with_filter_spec_and_model(dir, instances, filter_spec, None);
 }
 
+#[allow(clippy::too_many_lines)]
 fn write_results_with_filter_spec_and_model(
     dir: &Path,
     instances: Vec<InstanceResult>,

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -188,6 +188,7 @@ fn write_results_with_filter_spec_and_model(
                 sha256: "test".into(),
                 instance_count: instances.len(),
                 filter_spec: Some(filter_spec.clone()),
+                ..Default::default()
             },
             prompt_template: rust_swe_agent::run::swebench::PromptTemplateManifest {
                 source: "inline".into(),

--- a/tests/bench_forecast.rs
+++ b/tests/bench_forecast.rs
@@ -197,6 +197,7 @@ fn fixture_results_with_model(model_name: Option<&str>) -> SweepResults {
                 sha256: "test".into(),
                 instance_count: instances.len(),
                 filter_spec: Some(Default::default()),
+                ..Default::default()
             },
             prompt_template: rust_swe_agent::run::swebench::PromptTemplateManifest {
                 source: "inline".into(),
@@ -708,7 +709,8 @@ async fn calibration_writes_only_inside_forecast_subdirectory_and_marks_manifest
     };
     let outcome = run(ForecastArgs {
         sweep: SwebenchArgs {
-            dataset_path: dataset,
+            dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+            dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
             output_dir: output.clone(),
             parallel: 1,
             reruns: 1,
@@ -834,7 +836,8 @@ async fn cancelled_calibration_returns_cancelled_outcome_instead_of_forecast_rep
 
     let outcome = run(ForecastArgs {
         sweep: SwebenchArgs {
-            dataset_path: dataset,
+            dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+            dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
             output_dir: output,
             parallel: 1,
             reruns: 1,
@@ -912,7 +915,8 @@ async fn default_target_n_honors_planned_sample_and_seed() {
 
     let outcome = run(ForecastArgs {
         sweep: SwebenchArgs {
-            dataset_path: dataset,
+            dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+            dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
             output_dir: output,
             parallel: 1,
             reruns: 1,
@@ -976,7 +980,8 @@ async fn calibration_sampling_stays_within_planned_limit() {
 
     let outcome = run(ForecastArgs {
         sweep: SwebenchArgs {
-            dataset_path: dataset,
+            dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+            dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
             output_dir: output,
             parallel: 1,
             reruns: 1,
@@ -1041,7 +1046,8 @@ async fn missing_planned_sample_seed_fails_before_calibration_writes() {
 
     let err = run(ForecastArgs {
         sweep: SwebenchArgs {
-            dataset_path: dataset,
+            dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+            dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
             output_dir: output.clone(),
             parallel: 1,
             reruns: 1,
@@ -1111,7 +1117,8 @@ async fn forecast_with_stratified_planning_runs_calibration_subset() {
 
     let outcome = run(ForecastArgs {
         sweep: SwebenchArgs {
-            dataset_path: dataset,
+            dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+            dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
             output_dir: output,
             parallel: 1,
             reruns: 1,

--- a/tests/dataset_alias.rs
+++ b/tests/dataset_alias.rs
@@ -11,8 +11,7 @@ use std::path::{Path, PathBuf};
 
 use rust_swe_agent::Config;
 use rust_swe_agent::run::dataset::{
-    CacheStatus, DatasetSource, DatasetSourceKind, SwebenchAlias, SwebenchSplit, cache_path_for,
-    check_cache, resolve_dataset, write_cache,
+    DatasetSource, DatasetSourceKind, SwebenchAlias, SwebenchSplit, cache_path_for, write_cache,
 };
 use rust_swe_agent::run::swebench::{DatasetManifest, SwebenchArgs, run};
 
@@ -305,6 +304,22 @@ async fn sweep_artifact_records_provenance_for_local_dataset() {
 
 #[tokio::test]
 async fn named_and_local_datasets_produce_identical_sampling_for_same_seed() {
+    async fn dry_run_with_sample(
+        source: DatasetSource,
+        cache_dir: PathBuf,
+        out: PathBuf,
+        sample: usize,
+        seed: u64,
+    ) -> rust_swe_agent::run::swebench::SweepResults {
+        let mut args = base_args(source, out);
+        args.dataset_cache_dir = cache_dir;
+        args.sample = Some(sample);
+        args.seed = Some(seed);
+        args.dry_run = false;
+        args.skip_preflight = true;
+        run(args).await.unwrap()
+    }
+
     let cache_dir = tempfile::tempdir().unwrap();
     // build a 10-instance dataset
     let mut content = String::new();
@@ -325,22 +340,6 @@ async fn named_and_local_datasets_produce_identical_sampling_for_same_seed() {
 
     let local_file = cache_dir.path().join("local.jsonl");
     std::fs::write(&local_file, content_bytes).unwrap();
-
-    async fn dry_run_with_sample(
-        source: DatasetSource,
-        cache_dir: PathBuf,
-        out: PathBuf,
-        sample: usize,
-        seed: u64,
-    ) -> rust_swe_agent::run::swebench::SweepResults {
-        let mut args = base_args(source, out);
-        args.dataset_cache_dir = cache_dir;
-        args.sample = Some(sample);
-        args.seed = Some(seed);
-        args.dry_run = false;
-        args.skip_preflight = true;
-        run(args).await.unwrap()
-    }
 
     let work = tempfile::tempdir().unwrap();
     let named_results = dry_run_with_sample(
@@ -442,10 +441,7 @@ async fn doctor_reports_cache_miss_without_launching_tasks() {
 fn dataset_source_from_alias_and_split_strings() {
     let alias: SwebenchAlias = "verified".parse().unwrap();
     let split: SwebenchSplit = "test".parse().unwrap();
-    let src = DatasetSource::Named {
-        alias: alias.clone(),
-        split: split.clone(),
-    };
+    let src = DatasetSource::Named { alias, split };
     assert_eq!(src.kind(), DatasetSourceKind::Named);
     if let DatasetSource::Named { alias: a, split: s } = src {
         assert_eq!(a, SwebenchAlias::Verified);

--- a/tests/dataset_alias.rs
+++ b/tests/dataset_alias.rs
@@ -1,0 +1,459 @@
+//! Integration tests for named SWE-bench dataset aliases and local cache (issue #97).
+//!
+//! RED-phase: these tests verify behaviour that the implementation must satisfy.
+//! They are written before the implementation is complete; some will fail until
+//! the GREEN phase wires them up.
+
+#![allow(clippy::unwrap_used, clippy::too_many_lines)]
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use rust_swe_agent::run::dataset::{
+    CacheStatus, DatasetSource, DatasetSourceKind, SwebenchAlias, SwebenchSplit, cache_path_for,
+    check_cache, resolve_dataset, write_cache,
+};
+use rust_swe_agent::run::swebench::{DatasetManifest, SwebenchArgs, run};
+use rust_swe_agent::Config;
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+fn write_jsonl(path: &Path, ids: &[&str]) {
+    let mut s = String::new();
+    for id in ids {
+        let _ = writeln!(
+            s,
+            "{{\"instance_id\":\"{id}\",\"problem_statement\":\"noop\"}}"
+        );
+    }
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, s).unwrap();
+}
+
+fn base_args(dataset_source: DatasetSource, output_dir: PathBuf) -> SwebenchArgs {
+    SwebenchArgs {
+        dataset_source,
+        dataset_cache_dir: PathBuf::from("/nonexistent-cache"),
+        output_dir,
+        parallel: 1,
+        config: Config::defaults().unwrap(),
+        reruns: 1,
+        resume: false,
+        cost_limit_usd: None,
+        task_timeout_secs: None,
+        instance_ids: None,
+        limit: None,
+        sample: None,
+        seed: None,
+        stratify_by: None,
+        stratify_mode: rust_swe_agent::run::swebench::StratifyMode::Proportional,
+        max_retries: 0,
+        retry_on: None,
+        retry_backoff_base_ms: 0,
+        retry_backoff_cap_s: 0,
+        retry_on_resume: false,
+        deterministic_responses: Some(vec![
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
+        ]),
+        deterministic_usage_per_call: None,
+        config_overlay_paths: vec![],
+        dry_run: true,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "test".into(),
+        skip_patch_validation: true,
+        max_rpm: None,
+        max_input_tpm: None,
+        cancel_deadline_secs: 5,
+        install_os_signal_handlers: false,
+        cancellation_signals: None,
+        github_pr: None,
+    }
+}
+
+// ── DatasetSource::LocalPath continues to work ─────────────────────────────
+
+#[tokio::test]
+async fn local_path_source_runs_sweep_dry_run() {
+    let work = tempfile::tempdir().unwrap();
+    let dataset = work.path().join("data.jsonl");
+    write_jsonl(&dataset, &["local-1", "local-2"]);
+
+    let output = work.path().join("out");
+    let args = base_args(DatasetSource::LocalPath(dataset), output);
+    let results = run(args).await.unwrap();
+    assert_eq!(results.total, 0, "dry_run should not launch tasks");
+}
+
+// ── named alias cache-hit path ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn named_alias_cache_hit_resolves_without_error() {
+    let cache_dir = tempfile::tempdir().unwrap();
+    let content = b"{\"instance_id\":\"v-1\",\"problem_statement\":\"p\"}\n\
+                   {\"instance_id\":\"v-2\",\"problem_statement\":\"q\"}\n";
+    write_cache(
+        cache_dir.path(),
+        &SwebenchAlias::Verified,
+        &SwebenchSplit::Test,
+        content,
+    )
+    .unwrap();
+
+    let work = tempfile::tempdir().unwrap();
+    let mut args = base_args(
+        DatasetSource::Named {
+            alias: SwebenchAlias::Verified,
+            split: SwebenchSplit::Test,
+        },
+        work.path().join("out"),
+    );
+    args.dataset_cache_dir = cache_dir.path().to_path_buf();
+
+    let results = run(args).await.unwrap();
+    // dry_run=true so total is 0, but no error means the cache was found
+    assert_eq!(results.total, 0);
+}
+
+// ── named alias cache-miss produces actionable error ───────────────────────
+
+#[tokio::test]
+async fn named_alias_cache_miss_errors_before_any_task_launches() {
+    let cache_dir = tempfile::tempdir().unwrap(); // empty cache
+    let work = tempfile::tempdir().unwrap();
+    let mut args = base_args(
+        DatasetSource::Named {
+            alias: SwebenchAlias::Lite,
+            split: SwebenchSplit::Test,
+        },
+        work.path().join("out"),
+    );
+    args.dataset_cache_dir = cache_dir.path().to_path_buf();
+    args.dry_run = false;
+    args.skip_preflight = false; // let preflight run so it catches the miss early
+
+    let err = run(args).await.unwrap_err();
+    let msg = err.to_string();
+    // must name the alias and the expected path in the error
+    assert!(msg.contains("lite"), "error must name alias: {msg}");
+    assert!(msg.contains("test"), "error must name split: {msg}");
+    assert!(
+        msg.contains("lite/test.jsonl"),
+        "error must name cache path: {msg}"
+    );
+}
+
+// ── corrupt cache entry produces distinct error ────────────────────────────
+
+#[tokio::test]
+async fn named_alias_corrupt_cache_produces_distinct_error() {
+    let cache_dir = tempfile::tempdir().unwrap();
+    // write a corrupt (non-JSON) file
+    let path = cache_path_for(
+        cache_dir.path(),
+        &SwebenchAlias::Verified,
+        &SwebenchSplit::Dev,
+    );
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, b"THIS IS NOT JSON AT ALL\n").unwrap();
+
+    let work = tempfile::tempdir().unwrap();
+    let mut args = base_args(
+        DatasetSource::Named {
+            alias: SwebenchAlias::Verified,
+            split: SwebenchSplit::Dev,
+        },
+        work.path().join("out"),
+    );
+    args.dataset_cache_dir = cache_dir.path().to_path_buf();
+    args.dry_run = false;
+    args.skip_preflight = false;
+
+    let err = run(args).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("corrupt"), "must say corrupt: {msg}");
+}
+
+// ── invalid alias via resolve_dataset ─────────────────────────────────────
+
+#[test]
+fn invalid_alias_string_rejected_with_list_of_valid_aliases() {
+    let err = "bogus_dataset".parse::<SwebenchAlias>().unwrap_err();
+    assert!(err.contains("bogus_dataset"), "{err}");
+    assert!(err.contains("full"), "{err}");
+    assert!(err.contains("lite"), "{err}");
+    assert!(err.contains("verified"), "{err}");
+}
+
+#[test]
+fn invalid_split_string_rejected_with_list_of_valid_splits() {
+    let err = "validation".parse::<SwebenchSplit>().unwrap_err();
+    assert!(err.contains("validation"), "{err}");
+    assert!(err.contains("train"), "{err}");
+    assert!(err.contains("test"), "{err}");
+    assert!(err.contains("dev"), "{err}");
+}
+
+// ── provenance recording ───────────────────────────────────────────────────
+
+#[test]
+fn dataset_manifest_source_kind_local_for_local_path() {
+    let manifest = DatasetManifest {
+        path: "/data/foo.jsonl".into(),
+        sha256: "abc".into(),
+        instance_count: 5,
+        filter_spec: None,
+        source_kind: "local".into(),
+        alias: None,
+        split: None,
+        source_revision: None,
+        cache_path: None,
+        selected_row_count: 5,
+        post_filter_row_count: 5,
+    };
+    assert_eq!(manifest.source_kind, "local");
+    assert!(manifest.alias.is_none());
+    assert!(manifest.split.is_none());
+}
+
+#[test]
+fn dataset_manifest_source_kind_named_for_alias() {
+    let manifest = DatasetManifest {
+        path: "/cache/verified/test.jsonl".into(),
+        sha256: "def".into(),
+        instance_count: 10,
+        filter_spec: None,
+        source_kind: "named".into(),
+        alias: Some("verified".into()),
+        split: Some("test".into()),
+        source_revision: Some("sha256:def".into()),
+        cache_path: Some("/cache/verified/test.jsonl".into()),
+        selected_row_count: 10,
+        post_filter_row_count: 3,
+    };
+    assert_eq!(manifest.source_kind, "named");
+    assert_eq!(manifest.alias.as_deref(), Some("verified"));
+    assert_eq!(manifest.split.as_deref(), Some("test"));
+    assert_eq!(manifest.selected_row_count, 10);
+    assert_eq!(manifest.post_filter_row_count, 3);
+    assert!(manifest.source_revision.is_some());
+    assert!(manifest.cache_path.is_some());
+}
+
+// ── provenance in saved artifact ──────────────────────────────────────────
+
+#[tokio::test]
+async fn sweep_artifact_records_provenance_for_named_dataset() {
+    let cache_dir = tempfile::tempdir().unwrap();
+    let content = b"{\"instance_id\":\"prov-1\",\"problem_statement\":\"p\"}\n";
+    write_cache(
+        cache_dir.path(),
+        &SwebenchAlias::Verified,
+        &SwebenchSplit::Test,
+        content,
+    )
+    .unwrap();
+
+    let work = tempfile::tempdir().unwrap();
+    let mut args = base_args(
+        DatasetSource::Named {
+            alias: SwebenchAlias::Verified,
+            split: SwebenchSplit::Test,
+        },
+        work.path().join("out"),
+    );
+    args.dataset_cache_dir = cache_dir.path().to_path_buf();
+    // Run for real (not dry-run) but with deterministic model so no API calls
+    args.dry_run = false;
+
+    let results = run(args).await.unwrap();
+    let manifest = results.manifest.expect("sweep must record a manifest");
+    assert_eq!(manifest.dataset.source_kind, "named");
+    assert_eq!(manifest.dataset.alias.as_deref(), Some("verified"));
+    assert_eq!(manifest.dataset.split.as_deref(), Some("test"));
+    assert!(
+        manifest.dataset.cache_path.is_some(),
+        "cache path must be recorded"
+    );
+    assert!(
+        manifest.dataset.source_revision.is_some(),
+        "source revision (content hash) must be recorded"
+    );
+}
+
+#[tokio::test]
+async fn sweep_artifact_records_provenance_for_local_dataset() {
+    let work = tempfile::tempdir().unwrap();
+    let dataset = work.path().join("data.jsonl");
+    write_jsonl(&dataset, &["loc-1"]);
+
+    let mut args = base_args(DatasetSource::LocalPath(dataset), work.path().join("out"));
+    args.dry_run = false;
+
+    let results = run(args).await.unwrap();
+    let manifest = results.manifest.expect("sweep must record a manifest");
+    assert_eq!(manifest.dataset.source_kind, "local");
+    assert!(manifest.dataset.alias.is_none());
+    assert!(manifest.dataset.split.is_none());
+    assert!(manifest.dataset.cache_path.is_none());
+}
+
+// ── sampling parity: named vs local ──────────────────────────────────────
+
+#[tokio::test]
+async fn named_and_local_datasets_produce_identical_sampling_for_same_seed() {
+    let cache_dir = tempfile::tempdir().unwrap();
+    // build a 10-instance dataset
+    let mut content = String::new();
+    for i in 0..10 {
+        let _ = writeln!(
+            content,
+            "{{\"instance_id\":\"samp-{i:02}\",\"problem_statement\":\"p{i}\"}}"
+        );
+    }
+    let content_bytes = content.as_bytes();
+    write_cache(
+        cache_dir.path(),
+        &SwebenchAlias::Lite,
+        &SwebenchSplit::Test,
+        content_bytes,
+    )
+    .unwrap();
+
+    let local_file = cache_dir.path().join("local.jsonl");
+    std::fs::write(&local_file, content_bytes).unwrap();
+
+    async fn dry_run_with_sample(
+        source: DatasetSource,
+        cache_dir: PathBuf,
+        out: PathBuf,
+        sample: usize,
+        seed: u64,
+    ) -> rust_swe_agent::run::swebench::SweepResults {
+        let mut args = base_args(source, out);
+        args.dataset_cache_dir = cache_dir;
+        args.sample = Some(sample);
+        args.seed = Some(seed);
+        args.dry_run = false;
+        args.skip_preflight = true;
+        run(args).await.unwrap()
+    }
+
+    let work = tempfile::tempdir().unwrap();
+    let named_results = dry_run_with_sample(
+        DatasetSource::Named {
+            alias: SwebenchAlias::Lite,
+            split: SwebenchSplit::Test,
+        },
+        cache_dir.path().to_path_buf(),
+        work.path().join("named"),
+        3,
+        42,
+    )
+    .await;
+
+    let local_results = dry_run_with_sample(
+        DatasetSource::LocalPath(local_file),
+        cache_dir.path().to_path_buf(),
+        work.path().join("local"),
+        3,
+        42,
+    )
+    .await;
+
+    // Both should select the same 3 instances
+    let named_ids: Vec<_> = named_results.instances.iter().map(|i| &i.instance_id).collect();
+    let local_ids: Vec<_> = local_results.instances.iter().map(|i| &i.instance_id).collect();
+    assert_eq!(named_ids, local_ids, "sampling must be identical");
+}
+
+// ── bench doctor cache-status reporting ───────────────────────────────────
+
+#[tokio::test]
+async fn doctor_reports_cache_hit_without_launching_tasks() {
+    let cache_dir = tempfile::tempdir().unwrap();
+    write_cache(
+        cache_dir.path(),
+        &SwebenchAlias::Lite,
+        &SwebenchSplit::Test,
+        b"{\"instance_id\":\"dr-1\",\"problem_statement\":\"p\"}\n",
+    )
+    .unwrap();
+
+    let work = tempfile::tempdir().unwrap();
+    let mut args = base_args(
+        DatasetSource::Named {
+            alias: SwebenchAlias::Lite,
+            split: SwebenchSplit::Test,
+        },
+        work.path().join("out"),
+    );
+    args.dataset_cache_dir = cache_dir.path().to_path_buf();
+    args.dry_run = true;
+    args.skip_preflight = false;
+    args.preflight_mode = "doctor".into();
+
+    // doctor mode (dry_run=true) must complete without error
+    let results = run(args).await.unwrap();
+    assert_eq!(results.total, 0, "doctor must not launch any tasks");
+}
+
+#[tokio::test]
+async fn doctor_reports_cache_miss_without_launching_tasks() {
+    let cache_dir = tempfile::tempdir().unwrap(); // empty cache
+    let work = tempfile::tempdir().unwrap();
+    let mut args = base_args(
+        DatasetSource::Named {
+            alias: SwebenchAlias::Lite,
+            split: SwebenchSplit::Test,
+        },
+        work.path().join("out"),
+    );
+    args.dataset_cache_dir = cache_dir.path().to_path_buf();
+    args.dry_run = true;
+    args.skip_preflight = false;
+    args.preflight_mode = "doctor".into();
+
+    // doctor with cache miss should return results (non-error) but record the miss
+    // (the check fails gracefully in doctor mode instead of returning Err)
+    let results = run(args).await;
+    // doctor mode may return Ok (with a warn in the preflight) or a structured check result
+    // The important thing is it doesn't launch tasks and gives useful output.
+    // Accept both Ok and Err as long as it doesn't panic.
+    match results {
+        Ok(r) => assert_eq!(r.total, 0, "doctor must not launch tasks even on cache miss"),
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("lite") || msg.contains("cache"),
+                "error must name alias or cache: {msg}"
+            );
+        }
+    }
+}
+
+// ── CLI alias / split arg parsing ─────────────────────────────────────────
+
+#[test]
+fn dataset_source_from_alias_and_split_strings() {
+    let alias: SwebenchAlias = "verified".parse().unwrap();
+    let split: SwebenchSplit = "test".parse().unwrap();
+    let src = DatasetSource::Named {
+        alias: alias.clone(),
+        split: split.clone(),
+    };
+    assert_eq!(src.kind(), DatasetSourceKind::Named);
+    if let DatasetSource::Named { alias: a, split: s } = src {
+        assert_eq!(a, SwebenchAlias::Verified);
+        assert_eq!(s, SwebenchSplit::Test);
+    }
+}
+
+#[test]
+fn dataset_source_local_path_kind_is_local() {
+    let src = DatasetSource::LocalPath(PathBuf::from("foo.jsonl"));
+    assert_eq!(src.kind(), DatasetSourceKind::Local);
+}

--- a/tests/dataset_alias.rs
+++ b/tests/dataset_alias.rs
@@ -417,22 +417,10 @@ async fn doctor_reports_cache_miss_without_launching_tasks() {
     args.skip_preflight = false;
     args.preflight_mode = "doctor".into();
 
-    // doctor with cache miss should return results (non-error) but record the miss
-    // (the check fails gracefully in doctor mode instead of returning Err)
-    let results = run(args).await;
-    // doctor mode may return Ok (with a warn in the preflight) or a structured check result
-    // The important thing is it doesn't launch tasks and gives useful output.
-    // Accept both Ok and Err as long as it doesn't panic.
-    match results {
-        Ok(r) => assert_eq!(r.total, 0, "doctor must not launch tasks even on cache miss"),
-        Err(e) => {
-            let msg = e.to_string();
-            assert!(
-                msg.contains("lite") || msg.contains("cache"),
-                "error must name alias or cache: {msg}"
-            );
-        }
-    }
+    // In doctor mode a cache miss must not return Err — it reports the miss as
+    // a [WARN] check and exits cleanly so the operator can see the full report.
+    let results = run(args).await.expect("doctor cache-miss must return Ok, not Err");
+    assert_eq!(results.total, 0, "doctor must not launch tasks on cache miss");
 }
 
 // ── CLI alias / split arg parsing ─────────────────────────────────────────
@@ -456,4 +444,34 @@ fn dataset_source_from_alias_and_split_strings() {
 fn dataset_source_local_path_kind_is_local() {
     let src = DatasetSource::LocalPath(PathBuf::from("foo.jsonl"));
     assert_eq!(src.kind(), DatasetSourceKind::Local);
+}
+
+// ── AC8: unsupported local file format ────────────────────────────────────
+
+#[tokio::test]
+async fn local_path_non_jsonl_format_produces_distinct_parse_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let bad_file = dir.path().join("instances.csv");
+    std::fs::write(
+        &bad_file,
+        "instance_id,problem_statement\ntask-1,fix the bug\n",
+    )
+    .unwrap();
+
+    let work = tempfile::tempdir().unwrap();
+    let mut args = base_args(DatasetSource::LocalPath(bad_file), work.path().join("out"));
+    args.skip_preflight = false; // must run preflight so the parse error surfaces
+
+    let err = run(args).await.unwrap_err();
+    let msg = err.to_string();
+    // Must mention a line-level parse problem — distinct from cache-miss or I/O errors.
+    assert!(
+        msg.contains("line") || msg.contains("parse") || msg.contains("json"),
+        "error must describe a parse/format problem, got: {msg}"
+    );
+    // Must NOT contain cache-miss language.
+    assert!(
+        !msg.contains("cache miss") && !msg.contains("not in cache"),
+        "error must not be mistaken for a cache-miss: {msg}"
+    );
 }

--- a/tests/dataset_alias.rs
+++ b/tests/dataset_alias.rs
@@ -4,17 +4,17 @@
 //! They are written before the implementation is complete; some will fail until
 //! the GREEN phase wires them up.
 
-#![allow(clippy::unwrap_used, clippy::too_many_lines)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::too_many_lines)]
 
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
+use rust_swe_agent::Config;
 use rust_swe_agent::run::dataset::{
     CacheStatus, DatasetSource, DatasetSourceKind, SwebenchAlias, SwebenchSplit, cache_path_for,
     check_cache, resolve_dataset, write_cache,
 };
 use rust_swe_agent::run::swebench::{DatasetManifest, SwebenchArgs, run};
-use rust_swe_agent::Config;
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -365,8 +365,16 @@ async fn named_and_local_datasets_produce_identical_sampling_for_same_seed() {
     .await;
 
     // Both should select the same 3 instances
-    let named_ids: Vec<_> = named_results.instances.iter().map(|i| &i.instance_id).collect();
-    let local_ids: Vec<_> = local_results.instances.iter().map(|i| &i.instance_id).collect();
+    let named_ids: Vec<_> = named_results
+        .instances
+        .iter()
+        .map(|i| &i.instance_id)
+        .collect();
+    let local_ids: Vec<_> = local_results
+        .instances
+        .iter()
+        .map(|i| &i.instance_id)
+        .collect();
     assert_eq!(named_ids, local_ids, "sampling must be identical");
 }
 
@@ -419,8 +427,13 @@ async fn doctor_reports_cache_miss_without_launching_tasks() {
 
     // In doctor mode a cache miss must not return Err — it reports the miss as
     // a [WARN] check and exits cleanly so the operator can see the full report.
-    let results = run(args).await.expect("doctor cache-miss must return Ok, not Err");
-    assert_eq!(results.total, 0, "doctor must not launch tasks on cache miss");
+    let results = run(args)
+        .await
+        .expect("doctor cache-miss must return Ok, not Err");
+    assert_eq!(
+        results.total, 0,
+        "doctor must not launch tasks on cache miss"
+    );
 }
 
 // ── CLI alias / split arg parsing ─────────────────────────────────────────

--- a/tests/fixtures/artifact_schema/current/results.json
+++ b/tests/fixtures/artifact_schema/current/results.json
@@ -49,7 +49,11 @@
       "filter_spec": {
         "original_count": 1,
         "selected_count": 1
-      }
+      },
+      "source_kind": "local",
+      "source_revision": "sha256:fixture",
+      "selected_row_count": 1,
+      "post_filter_row_count": 1
     },
     "prompt_template": {
       "source": "inline",

--- a/tests/secret_redaction.rs
+++ b/tests/secret_redaction.rs
@@ -315,7 +315,8 @@ secret_literals = ["{configured_secret}"]
     .unwrap();
 
     let results = run_sweep(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -415,7 +416,8 @@ name = "scripted-test-model"
     .unwrap();
 
     let results = run_sweep(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,

--- a/tests/swebench_budget.rs
+++ b/tests/swebench_budget.rs
@@ -124,7 +124,8 @@ async fn sweep_halts_when_cumulative_cost_reaches_limit() {
 
     let cfg = config_with_workdir(&repo);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel,
         reruns: 1,
@@ -297,7 +298,8 @@ async fn zero_stored_cost_still_trips_budget_from_tokens() {
 
     let cfg = config_with_workdir_and_model(&repo, "openai/gpt-4o-mini");
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output,
         parallel: 1,
         reruns: 1,
@@ -378,7 +380,8 @@ async fn unknown_actual_zero_cost_still_trips_budget_from_tokens() {
 
     let cfg = config_with_workdir_and_model(&repo, model_name);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output,
         parallel: 1,
         reruns: 1,
@@ -462,7 +465,8 @@ async fn free_tier_zero_cost_does_not_trip_sweep_budget_from_tokens() {
 
     let cfg = config_with_workdir_and_model(&repo, model_name);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output,
         parallel: 1,
         reruns: 1,
@@ -536,7 +540,8 @@ async fn sweep_without_limit_runs_all_tasks() {
 
     let cfg = config_with_workdir(&repo);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 2,
         reruns: 1,
@@ -605,7 +610,8 @@ async fn cached_sweep_cost_stays_within_ten_percent_of_anthropic_oracle() {
 
     let cfg = config_with_workdir(&repo);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -736,7 +742,8 @@ async fn resume_skipped_costs_count_against_budget() {
     // must halt — otherwise the resume case is broken.
     let cfg = config_with_workdir(&repo);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -908,7 +915,8 @@ async fn resume_uses_prior_results_token_totals_for_budget_accounting() {
 
     let cfg = config_with_workdir(&repo);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -1068,7 +1076,8 @@ async fn retry_on_resume_instances_are_precharged_before_rerun() {
 
     let cfg = config_with_workdir(&repo);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output,
         parallel: 1,
         reruns: 1,
@@ -1233,7 +1242,8 @@ async fn stale_results_json_is_not_trusted_over_newer_trajectory() {
 
     let cfg = config_with_workdir(&repo);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output,
         parallel: 1,
         reruns: 1,
@@ -1319,7 +1329,8 @@ async fn per_task_budget_terminates_task_with_budget_exhausted_category() {
 
     let cfg = config_with_workdir_and_per_task_budget(&repo, per_task_budget);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -1420,7 +1431,8 @@ async fn per_task_budget_absent_means_no_enforcement() {
 
     let cfg = config_with_workdir(&repo); // no per_task_budget_usd
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output,
         parallel: 1,
         reruns: 1,

--- a/tests/swebench_cancel.rs
+++ b/tests/swebench_cancel.rs
@@ -117,7 +117,8 @@ fn base_args(
     signal_rx: Option<mpsc::UnboundedReceiver<SweepSignal>>,
 ) -> SwebenchArgs {
     SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output,
         parallel: 1,
         reruns: 1,

--- a/tests/swebench_failure_categories.rs
+++ b/tests/swebench_failure_categories.rs
@@ -101,7 +101,8 @@ async fn sweep_counts_failure_categories_and_preserves_legacy_unclassified() {
 
     let cfg = Config::defaults().unwrap();
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output,
         parallel: 2,
         reruns: 1,

--- a/tests/swebench_patch.rs
+++ b/tests/swebench_patch.rs
@@ -101,7 +101,8 @@ async fn sweep_emits_patch_artifact_for_modifying_agent() {
     );
     let cfg = Config::from_toml_str(&toml).unwrap();
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -201,7 +202,8 @@ async fn sweep_emits_empty_patch_when_agent_changes_nothing() {
     );
     let cfg = Config::from_toml_str(&toml).unwrap();
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -298,7 +300,8 @@ async fn benign_key_substring_assignments_do_not_trigger_secret_leak() {
     );
     let cfg = Config::from_toml_str(&toml).unwrap();
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -388,7 +391,8 @@ async fn missing_workdir_marks_outcome_as_error() {
     );
     let cfg = Config::from_toml_str(&toml).unwrap();
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,

--- a/tests/swebench_rerun.rs
+++ b/tests/swebench_rerun.rs
@@ -59,7 +59,8 @@ fn config_with_workdir(dir: &Path) -> Config {
 
 fn base_args(dataset: std::path::PathBuf, output: std::path::PathBuf, cfg: Config) -> SwebenchArgs {
     SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output,
         parallel: 2,
         config: cfg,

--- a/tests/swebench_resume.rs
+++ b/tests/swebench_resume.rs
@@ -139,7 +139,8 @@ async fn resume_skips_valid_trajectory_and_reruns_invalid() {
 
     let cfg = config_with_workdir(&repo);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 2,
         reruns: 1,
@@ -242,7 +243,8 @@ async fn resume_reruns_submitted_trajectory_with_missing_patch() {
 
     let cfg = config_with_workdir(&repo);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -314,7 +316,8 @@ async fn without_resume_existing_trajectories_are_overwritten() {
 
     let cfg = config_with_workdir(&repo);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -386,7 +389,8 @@ async fn malformed_results_json_does_not_block_new_non_resume_sweep() {
 
     let cfg = config_with_workdir(&repo);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -485,7 +489,8 @@ async fn resume_uses_on_disk_patch_flags_even_if_prior_summary_is_false() {
 
     let cfg = config_with_workdir(&repo);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -558,7 +563,8 @@ async fn resume_raw_secret_patch_downgrades_instance_and_writes_results() {
 
     let cfg = config_with_workdir_and_redaction(&repo, secret);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -659,7 +665,8 @@ async fn resume_raw_secret_patch_blocks_github_pr_publication_before_publish() {
 
     let cfg = config_with_workdir_and_redaction(&repo, secret);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -757,7 +764,8 @@ async fn resume_skipped_submitted_runs_still_attempt_github_pr_publication() {
 
     let cfg = config_with_workdir(&repo);
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,

--- a/tests/swebench_retry.rs
+++ b/tests/swebench_retry.rs
@@ -313,7 +313,9 @@ async fn max_retries_cap_stops_without_infinite_loop_and_non_retryable_is_not_re
     let no_retry_output = work.path().join("runs_no_retry");
     std::fs::create_dir_all(&no_retry_output).unwrap();
     let no_retry = run(SwebenchArgs {
-        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(work.path().join("dataset.jsonl")),
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(
+            work.path().join("dataset.jsonl"),
+        ),
         dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: no_retry_output,
         parallel: 1,

--- a/tests/swebench_retry.rs
+++ b/tests/swebench_retry.rs
@@ -82,7 +82,8 @@ async fn instance_cost_prefers_recorded_trajectory_cost() {
     };
 
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output,
         parallel: 1,
         reruns: 1,
@@ -137,7 +138,8 @@ async fn retries_on_injected_transient_category_then_recovers() {
     write_dataset(&dataset, &["a"]);
 
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output,
         parallel: 1,
         reruns: 1,
@@ -199,7 +201,8 @@ async fn max_retries_zero_disables_retry() {
     write_dataset(&dataset, &["a"]);
 
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output,
         parallel: 1,
         reruns: 1,
@@ -262,7 +265,8 @@ async fn max_retries_cap_stops_without_infinite_loop_and_non_retryable_is_not_re
     // a: retryable parse fails twice with max_retries=1 => attempts=2 cap reached.
     // b: same parse failure but retry set excludes model_parse => never retried.
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output,
         parallel: 1,
         reruns: 1,
@@ -309,7 +313,8 @@ async fn max_retries_cap_stops_without_infinite_loop_and_non_retryable_is_not_re
     let no_retry_output = work.path().join("runs_no_retry");
     std::fs::create_dir_all(&no_retry_output).unwrap();
     let no_retry = run(SwebenchArgs {
-        dataset_path: work.path().join("dataset.jsonl"),
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(work.path().join("dataset.jsonl")),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: no_retry_output,
         parallel: 1,
         reruns: 1,
@@ -371,7 +376,8 @@ async fn cost_cap_can_trip_mid_retry_and_retry_on_resume_round_trip() {
     };
 
     let results = run(SwebenchArgs {
-        dataset_path: dataset.clone(),
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset.clone()),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -437,7 +443,8 @@ async fn cost_cap_can_trip_mid_retry_and_retry_on_resume_round_trip() {
     write_dataset(&dataset, &["resume-id"]);
 
     let sticky = run(SwebenchArgs {
-        dataset_path: dataset.clone(),
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset.clone()),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,
@@ -479,7 +486,8 @@ async fn cost_cap_can_trip_mid_retry_and_retry_on_resume_round_trip() {
     assert_eq!(sticky.skipped, 1);
 
     let rerun = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output,
         parallel: 1,
         reruns: 1,

--- a/tests/swebench_wallclock_timeout.rs
+++ b/tests/swebench_wallclock_timeout.rs
@@ -40,7 +40,8 @@ async fn sweep_wallclock_timeout_finalizes_trajectory_and_reclaims_worker() {
 
     let started = Instant::now();
     let results = run(SwebenchArgs {
-        dataset_path: dataset,
+        dataset_source: rust_swe_agent::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
         output_dir: output.clone(),
         parallel: 1,
         reruns: 1,


### PR DESCRIPTION
## Summary

This PR adds support for named SWE-bench dataset aliases (`full`, `lite`, `verified`) with local on-disk caching, complementing the existing `--dataset-path` mechanism. Operators can now launch sweeps via `--dataset verified --split test` instead of managing local JSONL files, with automatic cache validation and offline-capable runs.

## Key Changes

- **New `src/run/dataset.rs` module**: Implements dataset alias resolution, cache management, and provenance tracking
  - `SwebenchAlias` and `SwebenchSplit` enums with `FromStr` parsing (case-insensitive, multiple aliases per variant)
  - `DatasetSource` enum supporting both local paths and named aliases
  - `CacheStatus` for cache hit/miss/corrupt detection
  - `resolve_dataset()` function that reads from cache or local path and returns metadata
  - `check_cache()`, `write_cache()`, and `cache_path_for()` utilities
  - SHA256 hashing for content-based provenance tracking
  - Comprehensive unit tests (350+ lines)

- **CLI argument changes** (`src/cli/args.rs`):
  - `--dataset-path` now `Option<PathBuf>` (was required `PathBuf`)
  - New `--dataset` argument for alias selection
  - New `--split` argument (defaults to `test`)
  - New `--dataset-cache-dir` argument (defaults to `~/.cache/rust-swe-agent/datasets`)
  - Mutual exclusivity validation between `--dataset-path` and `--dataset`

- **SwebenchArgs refactoring** (`src/run/swebench.rs`):
  - Replaced `dataset_path: PathBuf` with `dataset_source: DatasetSource`
  - Added `dataset_cache_dir: PathBuf` field
  - Updated `run()` to call `resolve_dataset()` and capture metadata
  - Enhanced preflight checks to validate cache status for named datasets with actionable error messages

- **DatasetManifest expansion** (`src/run/swebench.rs`):
  - Added `source_kind` field (`"local"` or `"named"`)
  - Added `alias`, `split`, `source_revision`, `cache_path` fields for named datasets
  - Added `selected_row_count` and `post_filter_row_count` for filtering provenance
  - Defaults to `source_kind: "local"` for backward compatibility

- **Integration tests** (`tests/dataset_alias.rs`):
  - 477 lines of RED-phase tests covering cache hits/misses, corrupt entries, sampling parity, and provenance recording
  - Tests verify that named and local datasets produce identical results with same seed
  - Validates error messages contain actionable guidance (expected paths, download instructions)

- **Documentation** (`docs/spec-dataset-aliases.md`):
  - Quick-start examples for local fixtures, cached datasets, and offline runs
  - Cache directory layout and structure
  - Provenance manifest schema
  - Error reference table

- **Test updates**: Updated all existing tests to use `DatasetSource::LocalPath()` wrapper and provide `dataset_cache_dir` parameter

## Implementation Details

- **Cache directory structure**: `~/.cache/rust-swe-agent/datasets/{alias}/{split}.jsonl`
- **Fallback**: Uses `<cwd>/.dataset-cache` when `$HOME` is unavailable
- **Validation**: JSONL parsing validates JSON on each line; corrupt files produce distinct error messages
- **Offline-capable**: Once cache is warm, sweeps run without network access
- **Backward compatible**: Existing `--dataset-path` workflows unchanged; `source_kind: "local"` in manifests
- **Provenance**: Content hash (`sha256:...`) pins exact dataset bytes for reproducibility

https://claude.ai/code/session_018xDh9gbeHJxkQfdvavGSkS