### PR TITLE
Implement stable CLI exit-code contract with outcome classes

### DIFF
--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -1,0 +1,151 @@
+# CLI Exit-Code Contract
+
+`rust-swe-agent` emits a stable, documented process exit code for every
+terminal outcome so CI and orchestration scripts can react correctly without
+parsing human-oriented output.
+
+## Outcome Classes
+
+| Code | Outcome Class            | When emitted |
+|-----:|--------------------------|--------------|
+| 0    | `success`                | Command completed with no errors; all checks passed. Also covers no-op success (e.g. `bench doctor` with every preflight check green). |
+| 1    | `internal_error`         | Unexpected failure: I/O error, JSON parse failure, unclassified panic. Treat as infrastructure broken, not a domain result. |
+| 2    | `usage_error`            | Bad flag, missing required argument, unknown enum value, or invalid config file. Fix the invocation before retrying. |
+| 3    | `preflight_failure`      | Dependency unavailable at sweep start: Docker not installed, Docker daemon unreachable, container failed to start, or model endpoint probe failed. |
+| 4    | `task_unsuccessful`      | The agent ran but did not produce a usable result: step limit reached, environment command failed, wallclock timeout, or repeated model API errors. |
+| 5    | `budget_halt`            | Cost ceiling triggered: `bench forecast --fail-over-cap` projected an over-cap run, or the sweep stopped because `--sweep-cost-limit-usd` was reached and no new tasks were dispatched. |
+| 6    | `regression_gate_failure`| `bench compare --max-regressions` or `--max-patch-size-regression` threshold was exceeded. |
+| 7    | `verification_failure`   | One or more `--verify NAME:COMMAND` checks did not pass after a `mini` run. |
+| 130  | `interrupted`            | Graceful SIGINT / Ctrl-C cancellation (POSIX convention: 128 + SIGINT(2)). |
+| 137  | `killed`                 | SIGKILL escalation after the graceful-cancel deadline expired (128 + SIGKILL(9)). |
+
+## Human-Readable Output
+
+On any non-zero exit, the CLI writes two lines to **stderr** before command-specific
+detail:
+
+```
+outcome_class: <class>
+error: <message>
+```
+
+Example for a failed `--verify` check:
+
+```
+outcome_class: verification_failure
+error: verification failed: 1 of 2 check(s) did not pass
+```
+
+## Machine-Readable Output
+
+Commands that accept `--format json` write the outcome class to **stderr** using
+the same two-line format above. JSON consumers can parse the `outcome_class`
+line without inspecting the integer exit code.
+
+For sweep commands the per-instance `failure_category` field in trajectory
+JSON files carries fine-grained information; the process exit code gives the
+coarse sweep-level result.
+
+## Per-Command Outcome Class Table
+
+| Command                         | Possible outcome classes |
+|---------------------------------|--------------------------|
+| `mini`                          | `success`, `usage_error`, `preflight_failure`, `task_unsuccessful`, `verification_failure`, `internal_error`, `interrupted` |
+| `bench swebench`                | `success`, `usage_error`, `preflight_failure`, `budget_halt`, `internal_error`, `interrupted`, `killed` |
+| `bench forecast`                | `success`, `usage_error`, `budget_halt`, `internal_error`, `interrupted` |
+| `bench doctor`                  | `success`, `usage_error`, `preflight_failure`, `internal_error` |
+| `bench compare`                 | `success`, `usage_error`, `regression_gate_failure`, `internal_error` |
+| `bench evaluate`                | `success`, `usage_error`, `internal_error` |
+| `bench inspect`                 | `success`, `usage_error`, `internal_error` |
+| `bench tail`                    | `success`, `usage_error`, `internal_error` |
+| `bench frontier`                | `success`, `usage_error`, `internal_error` |
+
+> **Legacy note:** `hello-world` and `replay` do not yet produce distinct
+> outcome classes beyond `success` / `internal_error`; they are interactive or
+> debugging surfaces not intended for CI automation.
+>
+> **Future surfaces:** `doctor` (standalone) and verification surfaces must
+> extend this table before merging.
+
+## Shell Examples
+
+### Routing outcomes in CI
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+rust-swe-agent bench compare \
+  --baseline runs/before \
+  --candidate runs/after \
+  --max-regressions 0
+exit_code=$?
+
+case $exit_code in
+  0)   echo "Gate passed — no regressions" ;;
+  6)   echo "Regression gate FAILED — review bench compare output" ; exit 1 ;;
+  2)   echo "Config error — fix the invocation" ; exit 1 ;;
+  1)   echo "Infrastructure failure — retry or escalate" ; exit 1 ;;
+  *)   echo "Unexpected exit code $exit_code" ; exit 1 ;;
+esac
+```
+
+### Handling preflight / config failure
+
+```bash
+rust-swe-agent bench swebench --dataset lite --output runs/
+exit_code=$?
+if [ $exit_code -eq 3 ]; then
+  echo "Preflight failed — is Docker running?"
+  exit 1
+fi
+```
+
+### Handling budget halt
+
+```bash
+rust-swe-agent bench forecast --dataset lite --output /tmp/forecast \
+  --fail-over-cap --sweep-cost-limit-usd 50
+exit_code=$?
+if [ $exit_code -eq 5 ]; then
+  echo "Forecast exceeds cost cap — increase cap or reduce dataset"
+  exit 1
+fi
+```
+
+### Handling interrupted sweep
+
+```bash
+# A Ctrl-C during a sweep exits 130; treat as a known outcome, not error
+rust-swe-agent bench swebench --dataset lite --output runs/ || true
+exit_code=$?
+if [ $exit_code -eq 130 ] || [ $exit_code -eq 137 ]; then
+  echo "Sweep was cancelled — partial results in runs/"
+fi
+```
+
+### Handling verification failure
+
+```bash
+rust-swe-agent mini --task "Fix the bug" \
+  --verify "unit-tests:cargo test -q" \
+  --verify "lint:cargo clippy -- -D warnings"
+exit_code=$?
+if [ $exit_code -eq 7 ]; then
+  echo "Verification failed — agent output did not pass checks"
+  exit 1
+fi
+```
+
+## Compatibility Policy
+
+- **Assigned codes are stable.** Renumbering a published outcome class is a
+  **breaking change** and requires a major version bump.
+- **New outcome classes** may be introduced with previously-unused numbers in a
+  minor release. Scripts must treat an unknown non-zero code as `internal_error`
+  (code 1).
+- **Outcome class strings** (e.g. `regression_gate_failure`) are stable and
+  follow the same breaking-change rule as integer codes.
+- **`success` is always 0.** No other outcome class will ever use 0.
+- **130 and 137** are reserved for signal-based termination and will not be
+  reused for domain outcomes.

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -73,13 +73,15 @@ coarse sweep-level result.
 
 ```bash
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
+# Run in a conditional so the exit status is captured even under `set -e`.
 rust-swe-agent bench compare \
   --baseline runs/before \
   --candidate runs/after \
-  --max-regressions 0
-exit_code=$?
+  --max-regressions 0 \
+  || exit_code=$?
+exit_code=${exit_code:-0}
 
 case $exit_code in
   0)   echo "Gate passed — no regressions" ;;
@@ -116,8 +118,9 @@ fi
 ### Handling interrupted sweep
 
 ```bash
-# A Ctrl-C during a sweep exits 130; treat as a known outcome, not error
-rust-swe-agent bench swebench --dataset lite --output runs/ || true
+# A Ctrl-C during a sweep exits 130; treat as a known outcome, not error.
+# Capture exit status before || true masks it.
+rust-swe-agent bench swebench --dataset lite --output runs/
 exit_code=$?
 if [ $exit_code -eq 130 ] || [ $exit_code -eq 137 ]; then
   echo "Sweep was cancelled — partial results in runs/"

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -50,7 +50,7 @@ coarse sweep-level result.
 
 | Command                         | Possible outcome classes |
 |---------------------------------|--------------------------|
-| `mini`                          | `success`, `usage_error`, `preflight_failure`, `task_unsuccessful`, `verification_failure`, `internal_error`, `interrupted` |
+| `mini`                          | `success`, `usage_error`, `preflight_failure`, `task_unsuccessful`, `verification_failure`, `internal_error` |
 | `bench swebench`                | `success`, `usage_error`, `preflight_failure`, `budget_halt`, `internal_error`, `interrupted`, `killed` |
 | `bench forecast`                | `success`, `usage_error`, `budget_halt`, `internal_error`, `interrupted` |
 | `bench doctor`                  | `success`, `usage_error`, `preflight_failure`, `internal_error` |

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -51,6 +51,7 @@ pub async fn run() -> Result<(), Error> {
         let _ = e.print();
         if e.exit_code() != 0 {
             eprintln!("outcome_class: {}", ExitCode::UsageError.outcome_class());
+            eprintln!("error: {e}");
         }
         std::process::exit(e.exit_code());
     });

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -45,7 +45,15 @@ pub enum Command {
 }
 
 pub async fn run() -> Result<(), Error> {
-    let cli = Cli::parse();
+    let cli = Cli::try_parse().unwrap_or_else(|e| {
+        // Print clap's formatted error or help text, then add the outcome label
+        // for non-zero exits (exit 0 means --help / --version, not an error).
+        let _ = e.print();
+        if e.exit_code() != 0 {
+            eprintln!("outcome_class: {}", ExitCode::UsageError.outcome_class());
+        }
+        std::process::exit(e.exit_code());
+    });
     init_logging(&cli.log);
 
     match cli.command {
@@ -341,7 +349,12 @@ fn cancellation_exit_code(results: &crate::run::swebench::SweepResults) -> Optio
 
 fn exit_if_cancelled_sweep(results: &crate::run::swebench::SweepResults) {
     if let Some(code) = cancellation_exit_code(results) {
-        std::process::exit(code);
+        let outcome = if code == crate::run::swebench::CANCEL_EXIT_CODE_GRACEFUL {
+            ExitCode::Interrupted
+        } else {
+            ExitCode::Killed
+        };
+        exit_with_outcome(outcome, "sweep was cancelled");
     }
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -219,7 +219,11 @@ async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
         match run_forecast_from_cmd(sweep_cmd.clone()).await? {
             crate::run::forecast::ForecastOutcome::Report(report) => {
                 print_forecast_report(&report, &sweep_cmd.format)?;
-                crate::run::forecast::validate_fail_over_cap(&report, sweep_cmd.fail_over_cap)?;
+                if let Err(e) =
+                    crate::run::forecast::validate_fail_over_cap(&report, sweep_cmd.fail_over_cap)
+                {
+                    exit_with_outcome(ExitCode::BudgetHalt, &e.to_string());
+                }
                 if !crate::run::forecast::forecast_gate_allows_sweep(
                     &report,
                     crate::run::forecast::ForecastGate { yes: sweep_cmd.yes },
@@ -267,6 +271,15 @@ async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
     );
     print!("{}", results.summary_table());
     exit_if_cancelled_sweep(&results);
+    if results.budget_halted > 0 && results.cost_limit_usd.is_some() {
+        exit_with_outcome(
+            ExitCode::BudgetHalt,
+            &format!(
+                "sweep stopped early: {} task(s) were not dispatched because the sweep cost limit was reached",
+                results.budget_halted
+            ),
+        );
+    }
     let github_pr_failures = github_pr_failure_count(&results);
     if github_pr_failures > 0 {
         return Err(Error::Github(format!(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,6 +7,7 @@ use clap::{Parser, Subcommand};
 
 use crate::config::Config;
 use crate::error::Error;
+use crate::exit_code::ExitCode;
 
 pub mod args;
 
@@ -293,7 +294,12 @@ async fn bench_forecast(s: args::SwebenchCmd) -> Result<(), Error> {
     match run_forecast_from_cmd(s).await? {
         crate::run::forecast::ForecastOutcome::Report(report) => {
             print_forecast_report(&report, &output_format)?;
-            crate::run::forecast::validate_fail_over_cap(&report, fail_over_cap)
+            if let Err(e) =
+                crate::run::forecast::validate_fail_over_cap(&report, fail_over_cap)
+            {
+                exit_with_outcome(ExitCode::BudgetHalt, &e.to_string());
+            }
+            Ok(())
         }
         crate::run::forecast::ForecastOutcome::DryRun(results)
         | crate::run::forecast::ForecastOutcome::Cancelled(results) => {
@@ -302,6 +308,16 @@ async fn bench_forecast(s: args::SwebenchCmd) -> Result<(), Error> {
             Ok(())
         }
     }
+}
+
+/// Print a stable `outcome_class` label followed by the error detail, then exit.
+///
+/// Used for outcomes that are driven by explicit CLI logic (regression gate,
+/// budget-halt forecast, tail abort) rather than propagated `Error` variants.
+fn exit_with_outcome(code: ExitCode, detail: &str) -> ! {
+    eprintln!("outcome_class: {}", code.outcome_class());
+    eprintln!("error: {detail}");
+    std::process::exit(code.as_i32());
 }
 
 fn cancellation_exit_code(results: &crate::run::swebench::SweepResults) -> Option<i32> {
@@ -724,7 +740,14 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
                 ci_upper = report.resolved_delta_ci95.upper,
                 "compare: regression count exceeds --max-regressions threshold"
             );
-            std::process::exit(1);
+            exit_with_outcome(
+                ExitCode::RegressionGateFailure,
+                &format!(
+                    "compare: {} regression(s) exceed --max-regressions={}",
+                    report.regression_count(),
+                    max
+                ),
+            );
         }
     }
     if let Some(max) = c.max_patch_size_regression {
@@ -735,7 +758,12 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
                 candidate_mean_lines_changed = report.candidate_mean_lines_changed,
                 "compare: patch size regression exceeds --max-patch-size-regression threshold"
             );
-            std::process::exit(1);
+            exit_with_outcome(
+                ExitCode::RegressionGateFailure,
+                &format!(
+                    "compare: patch size regression exceeds --max-patch-size-regression={max}%"
+                ),
+            );
         }
     }
     Ok(())
@@ -1034,8 +1062,7 @@ async fn bench_tail(t: args::TailCmd) -> Result<(), Error> {
         stdout.flush()?;
 
         if let Some(reason) = snapshot.abort_reason {
-            eprintln!("bench tail: {reason}");
-            std::process::exit(1);
+            exit_with_outcome(ExitCode::InternalError, &format!("bench tail: {reason}"));
         }
         if t.once || snapshot.is_complete {
             return Ok(());

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -337,6 +337,9 @@ async fn bench_forecast(s: args::SwebenchCmd) -> Result<(), Error> {
 fn exit_with_outcome(code: ExitCode, detail: &str) -> ! {
     eprintln!("outcome_class: {}", code.outcome_class());
     eprintln!("error: {detail}");
+    // Flush stdout so piped consumers receive any buffered report output
+    // before the process terminates (process::exit bypasses Drop).
+    let _ = std::io::Write::flush(&mut std::io::stdout());
     std::process::exit(code.as_i32());
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -307,9 +307,7 @@ async fn bench_forecast(s: args::SwebenchCmd) -> Result<(), Error> {
     match run_forecast_from_cmd(s).await? {
         crate::run::forecast::ForecastOutcome::Report(report) => {
             print_forecast_report(&report, &output_format)?;
-            if let Err(e) =
-                crate::run::forecast::validate_fail_over_cap(&report, fail_over_cap)
-            {
+            if let Err(e) = crate::run::forecast::validate_fail_over_cap(&report, fail_over_cap) {
                 exit_with_outcome(ExitCode::BudgetHalt, &e.to_string());
             }
             Ok(())

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -1,0 +1,168 @@
+//! Stable CLI exit-code contract.
+//!
+//! Each variant corresponds to a documented outcome class. The `outcome_class()`
+//! string is written to stderr on failure (human-readable label) and may appear
+//! in JSON output (machine-readable) so automation can route failures without
+//! parsing prose.
+//!
+//! ## Compatibility policy
+//!
+//! Assigned codes are **stable**. Renumbering a published outcome class is a
+//! breaking change and requires a major version bump. New outcome classes may
+//! be added with previously-unused numbers in a minor release; consumers must
+//! treat an unknown code as `internal_error`.
+//!
+//! See `docs/exit-codes.md` for the full contract including per-command tables
+//! and shell examples.
+
+use crate::error::{EnvError, Error};
+
+/// Stable numeric process exit code for each terminal outcome class.
+///
+/// The integer discriminant is guaranteed stable across releases.
+/// New variants may be added in minor releases with previously-unused numbers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitCode {
+    /// 0 — success, or no-op success (e.g. `bench doctor` with all checks passing).
+    Success = 0,
+    /// 1 — unexpected internal error (I/O failure, JSON parse, unclassified panic).
+    InternalError = 1,
+    /// 2 — usage or configuration error (bad flag, unknown value, missing required arg,
+    /// invalid config file).
+    UsageError = 2,
+    /// 3 — preflight or dependency failure (Docker not installed, model endpoint
+    /// unreachable, container start failed).
+    PreflightFailure = 3,
+    /// 4 — agent task unsuccessful (step limit reached, environment setup failed,
+    /// repeated model API errors, wallclock timeout).
+    TaskUnsuccessful = 4,
+    /// 5 — budget or cost halt (`bench forecast --fail-over-cap` projected an
+    /// over-cap run, or the sweep stopped because `--sweep-cost-limit-usd` was hit).
+    BudgetHalt = 5,
+    /// 6 — regression gate failure (`bench compare --max-regressions` or
+    /// `--max-patch-size-regression` threshold exceeded).
+    RegressionGateFailure = 6,
+    /// 7 — verification failure (one or more `--verify` checks did not pass).
+    VerificationFailure = 7,
+    /// 130 — user interruption (graceful SIGINT / Ctrl-C; 128 + SIGINT(2)).
+    Interrupted = 130,
+    /// 137 — forced kill (SIGKILL escalation after graceful-cancel deadline; 128 + SIGKILL(9)).
+    Killed = 137,
+}
+
+impl ExitCode {
+    /// Return the raw integer exit code.
+    #[must_use]
+    pub fn as_i32(self) -> i32 {
+        self as i32
+    }
+
+    /// Stable outcome class label for machine-readable and human-readable output.
+    ///
+    /// The returned string is guaranteed stable for the lifetime of this variant;
+    /// it uses only lowercase ASCII letters and underscores.
+    #[must_use]
+    pub fn outcome_class(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::InternalError => "internal_error",
+            Self::UsageError => "usage_error",
+            Self::PreflightFailure => "preflight_failure",
+            Self::TaskUnsuccessful => "task_unsuccessful",
+            Self::BudgetHalt => "budget_halt",
+            Self::RegressionGateFailure => "regression_gate_failure",
+            Self::VerificationFailure => "verification_failure",
+            Self::Interrupted => "interrupted",
+            Self::Killed => "killed",
+        }
+    }
+
+    /// Best-effort mapping from a runtime `Error` to the appropriate outcome class.
+    ///
+    /// A small number of outcomes (regression gate, sweep cancellation, budget-halt
+    /// forecast) are driven by explicit `process::exit` calls in the CLI layer and
+    /// do not go through this function. See `docs/exit-codes.md` for the full table.
+    #[must_use]
+    pub fn from_error(e: &Error) -> Self {
+        match e {
+            Error::Config(_) => Self::UsageError,
+            Error::VerificationFailed(..) => Self::VerificationFailure,
+            Error::Env(env_e) => Self::from_env_error(env_e),
+            Error::Model(_) => Self::TaskUnsuccessful,
+            Error::Template(_)
+            | Error::Trajectory(_)
+            | Error::Github(_)
+            | Error::Io(_)
+            | Error::Json(_) => Self::InternalError,
+        }
+    }
+
+    fn from_env_error(e: &EnvError) -> Self {
+        match e {
+            EnvError::DockerNotInstalled
+            | EnvError::DockerDaemonUnreachable(_)
+            | EnvError::ContainerStartFailed(_) => Self::PreflightFailure,
+            EnvError::CommandFailed(_)
+            | EnvError::Timeout(_)
+            | EnvError::UnexpectedExit(_)
+            | EnvError::Io(_) => Self::TaskUnsuccessful,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::{ConfigError, EnvError, ModelError};
+
+    #[test]
+    fn from_error_config_is_usage_error() {
+        assert_eq!(
+            ExitCode::from_error(&Error::Config(ConfigError::Invalid("x".into()))),
+            ExitCode::UsageError
+        );
+    }
+
+    #[test]
+    fn from_error_verification_failed_is_verification_failure() {
+        assert_eq!(
+            ExitCode::from_error(&Error::VerificationFailed(1, 2)),
+            ExitCode::VerificationFailure
+        );
+    }
+
+    #[test]
+    fn from_error_docker_not_installed_is_preflight_failure() {
+        assert_eq!(
+            ExitCode::from_error(&Error::Env(EnvError::DockerNotInstalled)),
+            ExitCode::PreflightFailure
+        );
+    }
+
+    #[test]
+    fn from_error_command_failed_is_task_unsuccessful() {
+        assert_eq!(
+            ExitCode::from_error(&Error::Env(EnvError::CommandFailed("exit 1".into()))),
+            ExitCode::TaskUnsuccessful
+        );
+    }
+
+    #[test]
+    fn from_error_model_is_task_unsuccessful() {
+        assert_eq!(
+            ExitCode::from_error(&Error::Model(ModelError::Request("t/o".into()))),
+            ExitCode::TaskUnsuccessful
+        );
+    }
+
+    #[test]
+    fn from_error_io_is_internal_error() {
+        assert_eq!(
+            ExitCode::from_error(&Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "disk full"
+            ))),
+            ExitCode::InternalError
+        );
+    }
+}

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -158,10 +158,7 @@ mod tests {
     #[test]
     fn from_error_io_is_internal_error() {
         assert_eq!(
-            ExitCode::from_error(&Error::Io(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "disk full"
-            ))),
+            ExitCode::from_error(&Error::Io(std::io::Error::other("disk full"))),
             ExitCode::InternalError
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod cost;
 pub mod env;
 pub mod error;
+pub mod exit_code;
 pub mod ids;
 pub mod model;
 pub mod policy;
@@ -30,6 +31,7 @@ pub use config::{Config, McpServerCfg, RedactionCfg, ToolCfg, ToolHookCfg, ToolH
 pub use env::DockerEnvironment;
 pub use env::{Environment, LocalEnvironment, RunRequest, RunResult};
 pub use error::{ConfigError, EnvError, Error, ModelError};
+pub use exit_code::ExitCode;
 pub use model::{
     AnthropicBackend, CacheHint, DeterministicModel, FallbackAttemptRecord, FallbackModel,
     LitellmBackend, Message, MessageExtra, Model, ModelResponse, ModelUsage, QueryOpts, Role,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,14 @@
-use rust_swe_agent::cli;
+use rust_swe_agent::exit_code::ExitCode;
 
 #[tokio::main]
-async fn main() -> Result<(), rust_swe_agent::Error> {
-    Box::pin(cli::run()).await
+async fn main() {
+    match Box::pin(rust_swe_agent::cli::run()).await {
+        Ok(()) => {}
+        Err(e) => {
+            let code = ExitCode::from_error(&e);
+            eprintln!("outcome_class: {}", code.outcome_class());
+            eprintln!("error: {e}");
+            std::process::exit(code.as_i32());
+        }
+    }
 }

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -28,7 +28,7 @@ pub use crate::cost::{
     ANTHROPIC_CACHE_CREATION_MULTIPLIER, ANTHROPIC_CACHE_READ_MULTIPLIER, BASELINE_COST_MODEL,
     CostSource, SONNET_INPUT_USD_PER_MTOK, SONNET_OUTPUT_USD_PER_MTOK, estimate_cost_usd,
 };
-use crate::error::{ConfigError, EnvError, Error, ModelError};
+use crate::error::{ConfigError, EnvError, Error};
 use crate::model::{Model, ModelUsage};
 use crate::redaction::{Redactor, surface};
 use crate::trajectory::{FailureCategory, TokenUsage, Trajectory, exit_reason, outcome};
@@ -2194,8 +2194,16 @@ async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
         let budget = remaining.min(per_check);
         let _ = tokio::time::timeout(budget, backend.query(&msgs, &opts))
             .await
-            .map_err(|_| Error::Model(ModelError::Request("model probe timed out".into())))?
-            .map_err(|e| Error::Model(ModelError::Request(format!("model probe failed: {e}"))))?;
+            .map_err(|_| {
+                Error::Env(EnvError::DockerDaemonUnreachable(
+                    "preflight: model probe timed out".into(),
+                ))
+            })?
+            .map_err(|e| {
+                Error::Env(EnvError::DockerDaemonUnreachable(format!(
+                    "preflight: model probe failed: {e}"
+                )))
+            })?;
         checks.push(CheckResult {
             status: CheckStatus::Ok,
             name: "model.probe",

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -28,7 +28,7 @@ pub use crate::cost::{
     ANTHROPIC_CACHE_CREATION_MULTIPLIER, ANTHROPIC_CACHE_READ_MULTIPLIER, BASELINE_COST_MODEL,
     CostSource, SONNET_INPUT_USD_PER_MTOK, SONNET_OUTPUT_USD_PER_MTOK, estimate_cost_usd,
 };
-use crate::error::Error;
+use crate::error::{ConfigError, EnvError, Error, ModelError};
 use crate::model::{Model, ModelUsage};
 use crate::redaction::{Redactor, surface};
 use crate::trajectory::{FailureCategory, TokenUsage, Trajectory, exit_reason, outcome};
@@ -2141,7 +2141,9 @@ async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
                 .status
                 .success();
                 if !ok {
-                    return Err(Error::Trajectory(format!("required binary missing: {bin}")));
+                    return Err(Error::Env(EnvError::DockerDaemonUnreachable(format!(
+                        "preflight: required binary missing: {bin}"
+                    ))));
                 }
             }
             checks.push(CheckResult {
@@ -2159,7 +2161,11 @@ async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
                 let budget = remaining.min(per_check);
                 tokio::time::timeout(budget, crate::env::docker::preflight())
                     .await
-                    .map_err(|_| Error::Trajectory("docker preflight timed out".into()))??;
+                    .map_err(|_| {
+                        Error::Env(EnvError::DockerDaemonUnreachable(
+                            "docker preflight timed out".into(),
+                        ))
+                    })??;
                 checks.push(CheckResult {
                     status: CheckStatus::Ok,
                     name: "env.docker",
@@ -2168,9 +2174,10 @@ async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
             }
             #[cfg(not(feature = "docker"))]
             {
-                return Err(Error::Trajectory(
-                    "environment.kind=docker requires binary built with `docker` feature".into(),
-                ));
+                return Err(Error::Config(ConfigError::Invalid(
+                    "environment.kind=docker requires the binary to be built with the `docker` feature"
+                        .into(),
+                )));
             }
         }
     }
@@ -2187,8 +2194,8 @@ async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
         let budget = remaining.min(per_check);
         let _ = tokio::time::timeout(budget, backend.query(&msgs, &opts))
             .await
-            .map_err(|_| Error::Trajectory("model probe timed out".into()))?
-            .map_err(|e| Error::Trajectory(format!("model probe failed: {e}")))?;
+            .map_err(|_| Error::Model(ModelError::Request("model probe timed out".into())))?
+            .map_err(|e| Error::Model(ModelError::Request(format!("model probe failed: {e}"))))?;
         checks.push(CheckResult {
             status: CheckStatus::Ok,
             name: "model.probe",
@@ -2309,7 +2316,11 @@ where
     let h = tokio::task::spawn_blocking(f);
     let out = tokio::time::timeout(budget, h)
         .await
-        .map_err(|_| Error::Trajectory(format!("{name}: timeout exceeded")))?
+        .map_err(|_| {
+            Error::Env(EnvError::DockerDaemonUnreachable(format!(
+                "preflight: {name}: timeout exceeded"
+            )))
+        })?
         .map_err(|e| Error::Trajectory(format!("{name}: join error: {e}")))?
         .map_err(|e| Error::Trajectory(format!("{name}: {e}")))?;
     ensure_total_deadline(deadline)?;
@@ -2318,7 +2329,9 @@ where
 
 fn ensure_total_deadline(deadline: Instant) -> Result<(), Error> {
     if Instant::now() > deadline {
-        return Err(Error::Trajectory("preflight total timeout exceeded".into()));
+        return Err(Error::Env(EnvError::DockerDaemonUnreachable(
+            "preflight total timeout exceeded".into(),
+        )));
     }
     Ok(())
 }

--- a/tests/exit_code_contract.rs
+++ b/tests/exit_code_contract.rs
@@ -474,13 +474,13 @@ fn preflight_probe_errors_map_to_preflight_failure() {
 }
 
 /// Model probe failures (run_preflight's model availability check) map to
-/// TaskUnsuccessful (4) — better than InternalError (1) and the closest
-/// existing variant for a model API failure before sweep start.
+/// PreflightFailure (3) — the probe happens before the sweep starts, so it
+/// is a preflight condition, not a task execution failure.
 #[test]
-fn model_probe_failure_maps_to_task_unsuccessful() {
-    let e = Error::Model(ModelError::Request(
-        "model probe failed: 401 unauthorized".into(),
+fn model_probe_failure_maps_to_preflight_failure() {
+    let e = Error::Env(EnvError::DockerDaemonUnreachable(
+        "preflight: model probe failed: 401 unauthorized".into(),
     ));
-    assert_eq!(ExitCode::from_error(&e), ExitCode::TaskUnsuccessful);
-    assert_eq!(ExitCode::from_error(&e).as_i32(), 4);
+    assert_eq!(ExitCode::from_error(&e), ExitCode::PreflightFailure);
+    assert_eq!(ExitCode::from_error(&e).as_i32(), 3);
 }

--- a/tests/exit_code_contract.rs
+++ b/tests/exit_code_contract.rs
@@ -450,3 +450,37 @@ fn regression_gate_is_distinct_from_internal_error() {
         "regression_gate_failure"
     );
 }
+
+/// Preflight probe errors use EnvError::DockerDaemonUnreachable so they route
+/// to PreflightFailure (3) rather than InternalError (1). Verify the mapping
+/// works for the messages written by run_preflight in swebench.rs.
+#[test]
+fn preflight_probe_errors_map_to_preflight_failure() {
+    let cases = [
+        "preflight: required binary missing: bash",
+        "docker preflight timed out",
+        "preflight: dataset.read: timeout exceeded",
+        "preflight total timeout exceeded",
+    ];
+    for msg in cases {
+        let e = Error::Env(EnvError::DockerDaemonUnreachable(msg.into()));
+        assert_eq!(
+            ExitCode::from_error(&e),
+            ExitCode::PreflightFailure,
+            "message {msg:?} should map to PreflightFailure"
+        );
+        assert_eq!(ExitCode::from_error(&e).as_i32(), 3);
+    }
+}
+
+/// Model probe failures (run_preflight's model availability check) map to
+/// TaskUnsuccessful (4) — better than InternalError (1) and the closest
+/// existing variant for a model API failure before sweep start.
+#[test]
+fn model_probe_failure_maps_to_task_unsuccessful() {
+    let e = Error::Model(ModelError::Request(
+        "model probe failed: 401 unauthorized".into(),
+    ));
+    assert_eq!(ExitCode::from_error(&e), ExitCode::TaskUnsuccessful);
+    assert_eq!(ExitCode::from_error(&e).as_i32(), 4);
+}

--- a/tests/exit_code_contract.rs
+++ b/tests/exit_code_contract.rs
@@ -80,12 +80,18 @@ fn outcome_class_usage_error() {
 
 #[test]
 fn outcome_class_preflight_failure() {
-    assert_eq!(ExitCode::PreflightFailure.outcome_class(), "preflight_failure");
+    assert_eq!(
+        ExitCode::PreflightFailure.outcome_class(),
+        "preflight_failure"
+    );
 }
 
 #[test]
 fn outcome_class_task_unsuccessful() {
-    assert_eq!(ExitCode::TaskUnsuccessful.outcome_class(), "task_unsuccessful");
+    assert_eq!(
+        ExitCode::TaskUnsuccessful.outcome_class(),
+        "task_unsuccessful"
+    );
 }
 
 #[test]
@@ -160,7 +166,11 @@ fn all_variants_have_unique_outcome_classes() {
     let mut sorted = classes.clone();
     sorted.sort_unstable();
     sorted.dedup();
-    assert_eq!(classes.len(), sorted.len(), "duplicate outcome classes detected");
+    assert_eq!(
+        classes.len(),
+        sorted.len(),
+        "duplicate outcome classes detected"
+    );
 }
 
 // ── from_error mappings ───────────────────────────────────────────────────────
@@ -227,7 +237,10 @@ fn env_timeout_maps_to_task_unsuccessful() {
 
 #[test]
 fn io_error_maps_to_internal_error() {
-    let e = Error::Io(std::io::Error::new(std::io::ErrorKind::NotFound, "file gone"));
+    let e = Error::Io(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "file gone",
+    ));
     assert_eq!(ExitCode::from_error(&e), ExitCode::InternalError);
 }
 
@@ -281,8 +294,14 @@ fn outcome_class_strings_are_valid_snake_case_identifiers() {
             s.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
             "outcome_class {s:?} contains non-snake-case characters"
         );
-        assert!(!s.starts_with('_'), "outcome_class {s:?} starts with underscore");
-        assert!(!s.ends_with('_'), "outcome_class {s:?} ends with underscore");
+        assert!(
+            !s.starts_with('_'),
+            "outcome_class {s:?} starts with underscore"
+        );
+        assert!(
+            !s.ends_with('_'),
+            "outcome_class {s:?} ends with underscore"
+        );
     }
 }
 
@@ -309,8 +328,8 @@ fn only_success_is_zero() {
 /// Interruption codes match POSIX signal convention (128 + signal number).
 #[test]
 fn interrupted_and_killed_follow_posix_signal_convention() {
-    assert_eq!(ExitCode::Interrupted.as_i32(), 128 + 2);  // SIGINT = 2
-    assert_eq!(ExitCode::Killed.as_i32(), 128 + 9);        // SIGKILL = 9
+    assert_eq!(ExitCode::Interrupted.as_i32(), 128 + 2); // SIGINT = 2
+    assert_eq!(ExitCode::Killed.as_i32(), 128 + 9); // SIGKILL = 9
 }
 
 /// Constants exported by swebench match the ExitCode values so sweep
@@ -330,9 +349,15 @@ fn sweep_cancel_codes_align_with_exit_code_contract() {
 #[test]
 fn text_and_numeric_surfaces_agree_for_every_error_variant() {
     let error_cases: Vec<(&str, Error)> = vec![
-        ("usage_error", Error::Config(ConfigError::Invalid("x".into()))),
+        (
+            "usage_error",
+            Error::Config(ConfigError::Invalid("x".into())),
+        ),
         ("verification_failure", Error::VerificationFailed(1, 2)),
-        ("preflight_failure", Error::Env(EnvError::DockerNotInstalled)),
+        (
+            "preflight_failure",
+            Error::Env(EnvError::DockerNotInstalled),
+        ),
         (
             "preflight_failure",
             Error::Env(EnvError::DockerDaemonUnreachable("down".into())),

--- a/tests/exit_code_contract.rs
+++ b/tests/exit_code_contract.rs
@@ -1,0 +1,323 @@
+//! Stable CLI exit-code contract — TDD tests for issue #98.
+//!
+//! RED phase: tests compile but assertions / types do not yet exist.
+//! GREEN phase: implement `src/exit_code.rs` and wire it into `main.rs`.
+//! REFACTOR phase: docs/exit-codes.md documents the contract.
+
+#![allow(clippy::unwrap_used)]
+
+use rust_swe_agent::error::{ConfigError, EnvError, Error, ModelError};
+use rust_swe_agent::exit_code::ExitCode;
+
+// ── integer code values ───────────────────────────────────────────────────────
+
+#[test]
+fn success_code_is_zero() {
+    assert_eq!(ExitCode::Success.as_i32(), 0);
+}
+
+#[test]
+fn internal_error_code_is_one() {
+    assert_eq!(ExitCode::InternalError.as_i32(), 1);
+}
+
+#[test]
+fn usage_error_code_is_two() {
+    assert_eq!(ExitCode::UsageError.as_i32(), 2);
+}
+
+#[test]
+fn preflight_failure_code_is_three() {
+    assert_eq!(ExitCode::PreflightFailure.as_i32(), 3);
+}
+
+#[test]
+fn task_unsuccessful_code_is_four() {
+    assert_eq!(ExitCode::TaskUnsuccessful.as_i32(), 4);
+}
+
+#[test]
+fn budget_halt_code_is_five() {
+    assert_eq!(ExitCode::BudgetHalt.as_i32(), 5);
+}
+
+#[test]
+fn regression_gate_failure_code_is_six() {
+    assert_eq!(ExitCode::RegressionGateFailure.as_i32(), 6);
+}
+
+#[test]
+fn verification_failure_code_is_seven() {
+    assert_eq!(ExitCode::VerificationFailure.as_i32(), 7);
+}
+
+#[test]
+fn interrupted_code_is_130() {
+    assert_eq!(ExitCode::Interrupted.as_i32(), 130);
+}
+
+#[test]
+fn killed_code_is_137() {
+    assert_eq!(ExitCode::Killed.as_i32(), 137);
+}
+
+// ── outcome_class strings ─────────────────────────────────────────────────────
+
+#[test]
+fn outcome_class_success() {
+    assert_eq!(ExitCode::Success.outcome_class(), "success");
+}
+
+#[test]
+fn outcome_class_internal_error() {
+    assert_eq!(ExitCode::InternalError.outcome_class(), "internal_error");
+}
+
+#[test]
+fn outcome_class_usage_error() {
+    assert_eq!(ExitCode::UsageError.outcome_class(), "usage_error");
+}
+
+#[test]
+fn outcome_class_preflight_failure() {
+    assert_eq!(ExitCode::PreflightFailure.outcome_class(), "preflight_failure");
+}
+
+#[test]
+fn outcome_class_task_unsuccessful() {
+    assert_eq!(ExitCode::TaskUnsuccessful.outcome_class(), "task_unsuccessful");
+}
+
+#[test]
+fn outcome_class_budget_halt() {
+    assert_eq!(ExitCode::BudgetHalt.outcome_class(), "budget_halt");
+}
+
+#[test]
+fn outcome_class_regression_gate_failure() {
+    assert_eq!(
+        ExitCode::RegressionGateFailure.outcome_class(),
+        "regression_gate_failure"
+    );
+}
+
+#[test]
+fn outcome_class_verification_failure() {
+    assert_eq!(
+        ExitCode::VerificationFailure.outcome_class(),
+        "verification_failure"
+    );
+}
+
+#[test]
+fn outcome_class_interrupted() {
+    assert_eq!(ExitCode::Interrupted.outcome_class(), "interrupted");
+}
+
+#[test]
+fn outcome_class_killed() {
+    assert_eq!(ExitCode::Killed.outcome_class(), "killed");
+}
+
+// ── outcome_class and as_i32 agree (no variant maps two different ways) ───────
+
+#[test]
+fn all_variants_have_unique_codes() {
+    let variants = [
+        ExitCode::Success,
+        ExitCode::InternalError,
+        ExitCode::UsageError,
+        ExitCode::PreflightFailure,
+        ExitCode::TaskUnsuccessful,
+        ExitCode::BudgetHalt,
+        ExitCode::RegressionGateFailure,
+        ExitCode::VerificationFailure,
+        ExitCode::Interrupted,
+        ExitCode::Killed,
+    ];
+    let codes: Vec<i32> = variants.iter().map(|v| v.as_i32()).collect();
+    let mut sorted = codes.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(codes.len(), sorted.len(), "duplicate exit codes detected");
+}
+
+#[test]
+fn all_variants_have_unique_outcome_classes() {
+    let variants = [
+        ExitCode::Success,
+        ExitCode::InternalError,
+        ExitCode::UsageError,
+        ExitCode::PreflightFailure,
+        ExitCode::TaskUnsuccessful,
+        ExitCode::BudgetHalt,
+        ExitCode::RegressionGateFailure,
+        ExitCode::VerificationFailure,
+        ExitCode::Interrupted,
+        ExitCode::Killed,
+    ];
+    let classes: Vec<&str> = variants.iter().map(|v| v.outcome_class()).collect();
+    let mut sorted = classes.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(classes.len(), sorted.len(), "duplicate outcome classes detected");
+}
+
+// ── from_error mappings ───────────────────────────────────────────────────────
+
+#[test]
+fn config_error_maps_to_usage_error() {
+    let e = Error::Config(ConfigError::Invalid("bad flag".into()));
+    assert_eq!(ExitCode::from_error(&e), ExitCode::UsageError);
+}
+
+#[test]
+fn config_not_found_maps_to_usage_error() {
+    let e = Error::Config(ConfigError::NotFound("cfg.toml".into()));
+    assert_eq!(ExitCode::from_error(&e), ExitCode::UsageError);
+}
+
+#[test]
+fn verification_failed_maps_to_verification_failure() {
+    let e = Error::VerificationFailed(1, 3);
+    assert_eq!(ExitCode::from_error(&e), ExitCode::VerificationFailure);
+}
+
+#[test]
+fn model_api_error_maps_to_task_unsuccessful() {
+    let e = Error::Model(ModelError::Request("timeout".into()));
+    assert_eq!(ExitCode::from_error(&e), ExitCode::TaskUnsuccessful);
+}
+
+#[test]
+fn model_malformed_maps_to_task_unsuccessful() {
+    let e = Error::Model(ModelError::Malformed("no json".into()));
+    assert_eq!(ExitCode::from_error(&e), ExitCode::TaskUnsuccessful);
+}
+
+#[test]
+fn docker_not_installed_maps_to_preflight_failure() {
+    let e = Error::Env(EnvError::DockerNotInstalled);
+    assert_eq!(ExitCode::from_error(&e), ExitCode::PreflightFailure);
+}
+
+#[test]
+fn docker_daemon_unreachable_maps_to_preflight_failure() {
+    let e = Error::Env(EnvError::DockerDaemonUnreachable("socket closed".into()));
+    assert_eq!(ExitCode::from_error(&e), ExitCode::PreflightFailure);
+}
+
+#[test]
+fn container_start_failed_maps_to_preflight_failure() {
+    let e = Error::Env(EnvError::ContainerStartFailed("oom".into()));
+    assert_eq!(ExitCode::from_error(&e), ExitCode::PreflightFailure);
+}
+
+#[test]
+fn env_command_failed_maps_to_task_unsuccessful() {
+    let e = Error::Env(EnvError::CommandFailed("exit 1".into()));
+    assert_eq!(ExitCode::from_error(&e), ExitCode::TaskUnsuccessful);
+}
+
+#[test]
+fn env_timeout_maps_to_task_unsuccessful() {
+    let e = Error::Env(EnvError::Timeout(std::time::Duration::from_secs(60)));
+    assert_eq!(ExitCode::from_error(&e), ExitCode::TaskUnsuccessful);
+}
+
+#[test]
+fn io_error_maps_to_internal_error() {
+    let e = Error::Io(std::io::Error::new(std::io::ErrorKind::NotFound, "file gone"));
+    assert_eq!(ExitCode::from_error(&e), ExitCode::InternalError);
+}
+
+#[test]
+fn json_error_maps_to_internal_error() {
+    let e: Error = serde_json::from_str::<serde_json::Value>("not json")
+        .unwrap_err()
+        .into();
+    assert_eq!(ExitCode::from_error(&e), ExitCode::InternalError);
+}
+
+#[test]
+fn trajectory_error_maps_to_internal_error() {
+    let e = Error::Trajectory("corrupt file".into());
+    assert_eq!(ExitCode::from_error(&e), ExitCode::InternalError);
+}
+
+#[test]
+fn github_error_maps_to_internal_error() {
+    let e = Error::Github("api 500".into());
+    assert_eq!(ExitCode::from_error(&e), ExitCode::InternalError);
+}
+
+#[test]
+fn template_error_maps_to_internal_error() {
+    let e = Error::Template("render failed".into());
+    assert_eq!(ExitCode::from_error(&e), ExitCode::InternalError);
+}
+
+// ── cross-surface consistency ─────────────────────────────────────────────────
+
+/// Every outcome_class string is non-empty and uses only snake_case characters.
+#[test]
+fn outcome_class_strings_are_valid_snake_case_identifiers() {
+    let variants = [
+        ExitCode::Success,
+        ExitCode::InternalError,
+        ExitCode::UsageError,
+        ExitCode::PreflightFailure,
+        ExitCode::TaskUnsuccessful,
+        ExitCode::BudgetHalt,
+        ExitCode::RegressionGateFailure,
+        ExitCode::VerificationFailure,
+        ExitCode::Interrupted,
+        ExitCode::Killed,
+    ];
+    for v in variants {
+        let s = v.outcome_class();
+        assert!(!s.is_empty(), "outcome_class for {v:?} is empty");
+        assert!(
+            s.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+            "outcome_class {s:?} contains non-snake-case characters"
+        );
+        assert!(!s.starts_with('_'), "outcome_class {s:?} starts with underscore");
+        assert!(!s.ends_with('_'), "outcome_class {s:?} ends with underscore");
+    }
+}
+
+/// `success` must always be zero; all failure classes must be non-zero.
+#[test]
+fn only_success_is_zero() {
+    let failure_variants = [
+        ExitCode::InternalError,
+        ExitCode::UsageError,
+        ExitCode::PreflightFailure,
+        ExitCode::TaskUnsuccessful,
+        ExitCode::BudgetHalt,
+        ExitCode::RegressionGateFailure,
+        ExitCode::VerificationFailure,
+        ExitCode::Interrupted,
+        ExitCode::Killed,
+    ];
+    assert_eq!(ExitCode::Success.as_i32(), 0);
+    for v in failure_variants {
+        assert_ne!(v.as_i32(), 0, "{v:?} must not exit 0");
+    }
+}
+
+/// Interruption codes match POSIX signal convention (128 + signal number).
+#[test]
+fn interrupted_and_killed_follow_posix_signal_convention() {
+    assert_eq!(ExitCode::Interrupted.as_i32(), 128 + 2);  // SIGINT = 2
+    assert_eq!(ExitCode::Killed.as_i32(), 128 + 9);        // SIGKILL = 9
+}
+
+/// Constants exported by swebench match the ExitCode values so sweep
+/// cancellation produces a documented outcome class.
+#[test]
+fn sweep_cancel_codes_align_with_exit_code_contract() {
+    use rust_swe_agent::run::swebench::{CANCEL_EXIT_CODE_ESCALATED, CANCEL_EXIT_CODE_GRACEFUL};
+    assert_eq!(CANCEL_EXIT_CODE_GRACEFUL, ExitCode::Interrupted.as_i32());
+    assert_eq!(CANCEL_EXIT_CODE_ESCALATED, ExitCode::Killed.as_i32());
+}

--- a/tests/exit_code_contract.rs
+++ b/tests/exit_code_contract.rs
@@ -321,3 +321,107 @@ fn sweep_cancel_codes_align_with_exit_code_contract() {
     assert_eq!(CANCEL_EXIT_CODE_GRACEFUL, ExitCode::Interrupted.as_i32());
     assert_eq!(CANCEL_EXIT_CODE_ESCALATED, ExitCode::Killed.as_i32());
 }
+
+// ── cross-surface: text label agrees with exit code ───────────────────────────
+
+/// For every Error variant, the outcome_class() string from from_error()
+/// and the integer from as_i32() describe the same outcome. This verifies
+/// the text and numeric surfaces agree rather than diverging.
+#[test]
+fn text_and_numeric_surfaces_agree_for_every_error_variant() {
+    let error_cases: Vec<(&str, Error)> = vec![
+        ("usage_error", Error::Config(ConfigError::Invalid("x".into()))),
+        ("verification_failure", Error::VerificationFailed(1, 2)),
+        ("preflight_failure", Error::Env(EnvError::DockerNotInstalled)),
+        (
+            "preflight_failure",
+            Error::Env(EnvError::DockerDaemonUnreachable("down".into())),
+        ),
+        (
+            "preflight_failure",
+            Error::Env(EnvError::ContainerStartFailed("oom".into())),
+        ),
+        (
+            "task_unsuccessful",
+            Error::Env(EnvError::CommandFailed("exit 1".into())),
+        ),
+        (
+            "task_unsuccessful",
+            Error::Env(EnvError::Timeout(std::time::Duration::from_secs(60))),
+        ),
+        (
+            "task_unsuccessful",
+            Error::Model(ModelError::Request("t/o".into())),
+        ),
+        (
+            "task_unsuccessful",
+            Error::Model(ModelError::Malformed("bad".into())),
+        ),
+        ("internal_error", Error::Trajectory("corrupt".into())),
+        ("internal_error", Error::Github("api 500".into())),
+        ("internal_error", Error::Template("render".into())),
+    ];
+
+    for (expected_class, e) in error_cases {
+        let code = ExitCode::from_error(&e);
+        assert_eq!(
+            code.outcome_class(),
+            expected_class,
+            "outcome_class mismatch for {:?}: expected {expected_class}, got {}",
+            e,
+            code.outcome_class()
+        );
+        assert_ne!(
+            code.as_i32(),
+            0,
+            "failure outcome {expected_class} must not exit 0"
+        );
+        // Text surface (outcome_class string) and numeric surface (as_i32)
+        // must describe the same variant — verified by re-deriving class from code.
+        let expected_code = match expected_class {
+            "usage_error" => 2,
+            "verification_failure" => 7,
+            "preflight_failure" => 3,
+            "task_unsuccessful" => 4,
+            "internal_error" => 1,
+            "budget_halt" => 5,
+            "regression_gate_failure" => 6,
+            other => panic!("unexpected class {other} in test table"),
+        };
+        assert_eq!(
+            code.as_i32(),
+            expected_code,
+            "numeric code for {expected_class} should be {expected_code}"
+        );
+    }
+}
+
+/// The budget-halt outcome class (5) is distinct from the usage-error class (2)
+/// so that `bench swebench --sweep-cost-limit-usd` and
+/// `bench forecast --fail-over-cap` can be distinguished from bad invocations.
+#[test]
+fn budget_halt_is_distinct_from_usage_error() {
+    assert_ne!(ExitCode::BudgetHalt.as_i32(), ExitCode::UsageError.as_i32());
+    assert_ne!(
+        ExitCode::BudgetHalt.outcome_class(),
+        ExitCode::UsageError.outcome_class()
+    );
+    assert_eq!(ExitCode::BudgetHalt.as_i32(), 5);
+    assert_eq!(ExitCode::BudgetHalt.outcome_class(), "budget_halt");
+}
+
+/// The regression-gate outcome class (6) is distinct from internal error (1)
+/// so that `bench compare --max-regressions` failures can be distinguished
+/// from infrastructure failures.
+#[test]
+fn regression_gate_is_distinct_from_internal_error() {
+    assert_ne!(
+        ExitCode::RegressionGateFailure.as_i32(),
+        ExitCode::InternalError.as_i32()
+    );
+    assert_eq!(ExitCode::RegressionGateFailure.as_i32(), 6);
+    assert_eq!(
+        ExitCode::RegressionGateFailure.outcome_class(),
+        "regression_gate_failure"
+    );
+}


### PR DESCRIPTION
## Summary

Introduces a stable, documented exit-code contract for the CLI with distinct outcome classes for different failure modes. This allows CI and orchestration scripts to react correctly to different outcomes without parsing human-oriented output.

## Key Changes

- **New `src/exit_code.rs` module** defining the `ExitCode` enum with 10 stable outcome classes:
  - `Success` (0), `InternalError` (1), `UsageError` (2), `PreflightFailure` (3), `TaskUnsuccessful` (4)
  - `BudgetHalt` (5), `RegressionGateFailure` (6), `VerificationFailure` (7)
  - `Interrupted` (130), `Killed` (137) — following POSIX signal convention (128 + signal number)

- **Outcome class mapping** from `Error` variants via `ExitCode::from_error()`:
  - Config errors → `UsageError`
  - Verification failures → `VerificationFailure`
  - Docker/environment preflight issues → `PreflightFailure`
  - Model API and command execution failures → `TaskUnsuccessful`
  - I/O, JSON, and infrastructure errors → `InternalError`

- **Updated `src/main.rs`** to catch errors and emit stable output:
  - Prints `outcome_class: <class>` and `error: <message>` to stderr
  - Exits with the mapped exit code instead of propagating `Result`

- **Updated `src/cli/mod.rs`** to handle explicit CLI-driven outcomes:
  - Budget halt (forecast validation, sweep cost limit reached) → exit code 5
  - Added `exit_with_outcome()` helper for outcomes not driven by `Error` propagation
  - Integrated with existing cancellation and regression-gate logic

- **Comprehensive test suite** in `tests/exit_code_contract.rs`:
  - 40+ tests verifying integer codes, outcome class strings, uniqueness, and error mappings
  - Cross-surface consistency checks (text and numeric surfaces agree)
  - POSIX signal convention validation
  - Alignment with swebench cancellation constants

- **Documentation** in `docs/exit-codes.md`:
  - Outcome class table with descriptions
  - Per-command outcome class availability
  - Shell examples for CI routing, preflight handling, budget halt, interruption, and verification
  - Stability and compatibility policy

## Notable Implementation Details

- Exit codes are stable and breaking-change protected; new classes may be added in minor releases with previously-unused numbers
- Outcome class strings use only lowercase ASCII and underscores (snake_case)
- Budget halt (5) is distinct from usage error (2) to differentiate cost-ceiling triggers from bad invocations
- Regression gate failure (6) is distinct from internal error (1) to distinguish domain failures from infrastructure issues
- Graceful cancellation (SIGINT) exits 130; escalated kill (SIGKILL) exits 137

https://claude.ai/code/session_014oryJTacVwWr94PPfvGFHP