### PR TITLE
feat(bench): add forecast calibration reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,28 @@ After credentials are set and you are ready to spend a small calibration
 budget, run `forecast` before a full sweep:
 
 ```bash
-cargo run --quiet -- --log info bench forecast --dataset-path ./data/swebench.jsonl --output runs/forecast --limit 5 --calibration-n 2 --sweep-cost-limit-usd 1.00
+cargo run --quiet -- --log info bench forecast --dataset-path ./data/swebench.jsonl --output runs/forecast --limit 5 --calibration-n 2 --sweep-cost-limit-usd 1.00 --format json > runs/forecast.json
 ```
+
+### 4. Close The Calibration Loop
+
+For paid sweeps, treat the operator loop as `doctor` -> `forecast` ->
+`swebench` -> `calibrate`. The forecast keeps the first spend bounded; the
+calibration report tells you whether that forecast was trustworthy after the
+real sweep completes.
+
+```bash
+cargo run --quiet -- --log error bench doctor --dataset-path ./data/swebench.jsonl --output runs/doctor --limit 5 --skip-model-probe
+cargo run --quiet -- --log info bench forecast --dataset-path ./data/swebench.jsonl --output runs/forecast --limit 5 --calibration-n 2 --sweep-cost-limit-usd 1.00 --format json > runs/forecast.json
+cargo run --quiet -- --log info bench swebench --dataset-path ./data/swebench.jsonl --output runs/sweep --limit 5 --sweep-cost-limit-usd 1.00
+cargo run --quiet -- --log error bench calibrate --forecast runs/forecast.json --results runs/sweep/results.json --output runs/sweep/calibration.json --fail-on-optimistic
+```
+
+`bench calibrate` prints a compact summary, writes a versioned
+`calibration_report`, classifies each metric as `within_interval`,
+`over_upper`, or `under_lower`, and exits with `calibration_optimistic` when
+`--fail-on-optimistic` is set and actuals overshot the forecast. The budget
+seance gets a receipt.
 
 ## Live-Model Quickstart
 
@@ -122,7 +142,9 @@ cargo run --quiet -- --log error bench inspect --sweep runs/live-quickstart --in
 
 For a real SWE-bench sweep, run `bench doctor` first, then `bench forecast`
 with a cost cap, then `bench swebench` only after the forecast clears your
-budget. This avoids beginning with a multi-instance spendfest. Tiny mercy.
+budget, and finally `bench calibrate` against the completed `results.json`.
+This avoids beginning with a multi-instance spendfest and leaves a durable
+calibration record. Tiny mercy.
 
 ## Troubleshooting
 

--- a/docs/artifact-contract.md
+++ b/docs/artifact-contract.md
@@ -5,7 +5,7 @@ Run artifacts use explicit top-level metadata:
 ```json
 {
   "artifact_kind": "sweep_results",
-  "schema_version": { "major": 1, "minor": 1 }
+  "schema_version": { "major": 1, "minor": 3 }
 }
 ```
 
@@ -18,7 +18,8 @@ Run artifacts use explicit top-level metadata:
 | `trajectory` | `*.traj.json`, `<instance>/run-k.traj.json` | `trajectory_format`, `artifact_kind`, `schema_version`, `info`, `messages` | `actual_cost_usd`, `actual_cost_source`, `baseline_cost_usd`, `baseline_cost_model`, active `toolset`, `verification_status` (`verified`/`unverified`/`verification_failed`), `verification_results` (array of per-check evidence), extra `info` fields, message `extra` fields |
 | `sweep_results` | `results.json` | `artifact_kind`, `schema_version`, `total`, `submitted`, `skipped`, `errored`, `failures_by_category`, `instances` | `actual_cost_usd`, `actual_cost_source`, `baseline_cost_usd`, `baseline_cost_model`, manifest, filter spec, token, retry, rate-limit, cancellation fields |
 | `evaluation_results` | `evaluation.json` | `artifact_kind`, `schema_version`, `instances` | behavioral metrics, breakdown rows, cost attribution |
-| `forecast_report` | `bench forecast --format json` | `artifact_kind`, `schema_version`, `calibration`, `per_instance`, `forecast`, `resolution_rate`, `threshold` | additional forecast diagnostics |
+| `forecast_report` | `bench forecast --format json` | `artifact_kind`, `schema_version`, `calibration`, `per_instance`, `forecast`, `resolution_rate`, `threshold` | `forecast.target_instance_ids` for exact calibration comparability, additional forecast diagnostics |
+| `calibration_report` | `bench calibrate` / `calibration.json` | `artifact_kind`, `schema_version`, `forecast_path`, `results_path`, `verdict`, `comparability`, `metrics`, `per_instance` | mismatch details, warnings, future calibration diagnostics |
 | `preflight_report` | `bench doctor/swebench --format json` | `artifact_kind`, `schema_version`, `mode`, `checks` | additional check metadata |
 | `swebench_predictions_metadata` | `all_preds.metadata.json`, `all_preds.run-k.metadata.json` | `artifact_kind`, `schema_version`, `predictions_file`, `aggregate`, `row_count`, `swebench_evaluator_compatible` | `run_index`, future provenance fields |
 
@@ -33,7 +34,7 @@ Cost fields are split deliberately:
 
 ## Reader Policy
 
-`bench inspect`, `bench tail`, `bench compare`, `bench evaluate`, and trajectory diff loading classify artifacts before reporting metrics.
+`bench inspect`, `bench tail`, `bench compare`, `bench evaluate`, `bench calibrate`, and trajectory diff loading classify artifacts before reporting metrics.
 
 Compatibility classes:
 

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -16,6 +16,7 @@ parsing human-oriented output.
 | 5    | `budget_halt`            | Cost ceiling triggered: `bench forecast --fail-over-cap` projected an over-cap run, or the sweep stopped because `--sweep-cost-limit-usd` was reached and no new tasks were dispatched. |
 | 6    | `regression_gate_failure`| `bench compare --max-regressions` or `--max-patch-size-regression` threshold was exceeded. |
 | 7    | `verification_failure`   | One or more `--verify NAME:COMMAND` checks did not pass after a `mini` run. |
+| 8    | `calibration_optimistic` | `bench calibrate --fail-on-optimistic` found actual sweep metrics above the forecast interval. |
 | 130  | `interrupted`            | Graceful SIGINT / Ctrl-C cancellation (POSIX convention: 128 + SIGINT(2)). |
 | 137  | `killed`                 | SIGKILL escalation after the graceful-cancel deadline expired (128 + SIGKILL(9)). |
 
@@ -53,6 +54,7 @@ coarse sweep-level result.
 | `mini`                          | `success`, `usage_error`, `preflight_failure`, `task_unsuccessful`, `verification_failure`, `internal_error` |
 | `bench swebench`                | `success`, `usage_error`, `preflight_failure`, `budget_halt`, `internal_error`, `interrupted`, `killed` |
 | `bench forecast`                | `success`, `usage_error`, `budget_halt`, `internal_error`, `interrupted` |
+| `bench calibrate`               | `success`, `usage_error`, `calibration_optimistic`, `internal_error` |
 | `bench doctor`                  | `success`, `usage_error`, `preflight_failure`, `internal_error` |
 | `bench compare`                 | `success`, `usage_error`, `regression_gate_failure`, `internal_error` |
 | `bench evaluate`                | `success`, `usage_error`, `internal_error` |
@@ -111,6 +113,20 @@ rust-swe-agent bench forecast --dataset lite --output /tmp/forecast \
 exit_code=$?
 if [ $exit_code -eq 5 ]; then
   echo "Forecast exceeds cost cap — increase cap or reduce dataset"
+  exit 1
+fi
+```
+
+### Gating optimistic calibration
+
+```bash
+rust-swe-agent bench calibrate \
+  --forecast runs/forecast.json \
+  --results runs/sweep/results.json \
+  --fail-on-optimistic
+exit_code=$?
+if [ $exit_code -eq 8 ]; then
+  echo "Forecast was optimistic - increase calibration or budget before the next run"
   exit 1
 fi
 ```

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -20,7 +20,7 @@ pub struct ArtifactSchemaVersion {
 }
 
 impl ArtifactSchemaVersion {
-    pub const CURRENT: Self = Self { major: 1, minor: 2 };
+    pub const CURRENT: Self = Self { major: 1, minor: 3 };
     pub const LEGACY_PRE_VERSIONING: Self = Self { major: 0, minor: 0 };
 
     #[must_use]
@@ -50,6 +50,7 @@ pub enum ArtifactKind {
     SweepResults,
     EvaluationResults,
     ForecastReport,
+    CalibrationReport,
     PreflightReport,
     SwebenchPredictionsMetadata,
 }
@@ -62,6 +63,7 @@ impl ArtifactKind {
             Self::SweepResults => "sweep_results",
             Self::EvaluationResults => "evaluation_results",
             Self::ForecastReport => "forecast_report",
+            Self::CalibrationReport => "calibration_report",
             Self::PreflightReport => "preflight_report",
             Self::SwebenchPredictionsMetadata => "swebench_predictions_metadata",
         }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -378,7 +378,7 @@ pub struct SwebenchCmd {
     #[arg(long, alias = "output-dir")]
     pub output: PathBuf,
 
-    #[arg(long, default_value_t = 4)]
+    #[arg(long, default_value_t = crate::run::swebench::DEFAULT_PARALLEL)]
     pub parallel: usize,
 
     /// Run each selected SWE-bench instance N independent times.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -233,6 +233,8 @@ pub enum BenchCmd {
     Swebench(SwebenchCmd),
     /// Forecast sweep cost from a reproducible calibration slice.
     Forecast(SwebenchCmd),
+    /// Compare a forecast artifact against completed sweep results.
+    Calibrate(CalibrateCmd),
     /// Validate sweep inputs without launching tasks.
     Doctor(SwebenchCmd),
     /// Diff two completed sweep runs by instance id; surfaces regressions
@@ -246,6 +248,31 @@ pub enum BenchCmd {
     Tail(TailCmd),
     /// Pareto frontier across multiple sweep runs: ASCII chart + JSON dataset.
     Frontier(FrontierCmd),
+}
+
+#[derive(Debug, Args)]
+pub struct CalibrateCmd {
+    /// Forecast JSON artifact emitted by `bench forecast --format json`.
+    #[arg(long)]
+    pub forecast: PathBuf,
+
+    /// Completed sweep `results.json` artifact emitted by `bench swebench`.
+    #[arg(long)]
+    pub results: PathBuf,
+
+    /// Path to write the versioned calibration JSON artifact.
+    /// Defaults to `calibration.json` next to `--results`.
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+
+    /// Output format for stdout: `text` (default) or `json`.
+    /// The JSON artifact is written to `--output` in both modes.
+    #[arg(long, default_value = "text")]
+    pub format: String,
+
+    /// Exit non-zero with `calibration_optimistic` when the verdict is optimistic.
+    #[arg(long, default_value_t = false)]
+    pub fail_on_optimistic: bool,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -70,6 +70,9 @@ pub async fn run() -> Result<(), Error> {
             cmd: args::BenchCmd::Forecast(s),
         } => Box::pin(bench_forecast(s)).await,
         Command::Bench {
+            cmd: args::BenchCmd::Calibrate(c),
+        } => bench_calibrate(c),
+        Command::Bench {
             cmd: args::BenchCmd::Doctor(s),
         } => bench_doctor(s).await,
         Command::Bench {
@@ -409,6 +412,46 @@ fn print_forecast_report(
             "unknown --format `{other}` (expected `text` or `json`)"
         )))),
     }
+}
+
+fn bench_calibrate(c: args::CalibrateCmd) -> Result<(), Error> {
+    let report = crate::run::calibrate::compute(&crate::run::calibrate::CalibrationArgs {
+        forecast_path: c.forecast.clone(),
+        results_path: c.results.clone(),
+    })?;
+    let json = crate::run::calibrate::to_json(&report)?;
+    let output_path = c.output.unwrap_or_else(|| {
+        c.results.parent().map_or_else(
+            || std::path::PathBuf::from("calibration.json"),
+            |parent| parent.join("calibration.json"),
+        )
+    });
+    if let Some(parent) = output_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    std::fs::write(&output_path, &json)?;
+
+    match c.format.as_str() {
+        "text" => print!("{}", crate::run::calibrate::render_text(&report)),
+        "json" => println!("{json}"),
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "unknown --format `{other}` (expected `text` or `json`)"
+            ))));
+        }
+    }
+
+    if c.fail_on_optimistic
+        && report.verdict == crate::run::calibrate::CalibrationVerdict::Optimistic
+    {
+        exit_with_outcome(
+            ExitCode::CalibrationOptimistic,
+            "calibration verdict is optimistic",
+        );
+    }
+    Ok(())
 }
 
 fn swebench_config_from_cmd(s: &args::SwebenchCmd) -> Result<Config, Error> {

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -44,6 +44,9 @@ pub enum ExitCode {
     RegressionGateFailure = 6,
     /// 7 — verification failure (one or more `--verify` checks did not pass).
     VerificationFailure = 7,
+    /// 8 - calibration gate failure (`bench calibrate --fail-on-optimistic`
+    /// found actuals above the forecast interval).
+    CalibrationOptimistic = 8,
     /// 130 — user interruption (graceful SIGINT / Ctrl-C; 128 + SIGINT(2)).
     Interrupted = 130,
     /// 137 — forced kill (SIGKILL escalation after graceful-cancel deadline; 128 + SIGKILL(9)).
@@ -72,6 +75,7 @@ impl ExitCode {
             Self::BudgetHalt => "budget_halt",
             Self::RegressionGateFailure => "regression_gate_failure",
             Self::VerificationFailure => "verification_failure",
+            Self::CalibrationOptimistic => "calibration_optimistic",
             Self::Interrupted => "interrupted",
             Self::Killed => "killed",
         }

--- a/src/run/calibrate.rs
+++ b/src/run/calibrate.rs
@@ -520,9 +520,9 @@ fn build_mismatches(
         );
     }
 
-    if let Some(actual_parallel) = actual_manifest.and_then(parallel_from_manifest) {
+    if let Some(actual_manifest) = actual_manifest {
         let forecast_parallel = forecast.forecast.parallel.to_string();
-        let actual_parallel = actual_parallel.to_string();
+        let actual_parallel = parallel_from_manifest(actual_manifest).to_string();
         compare_field(
             &mut mismatches,
             "parallel",
@@ -616,21 +616,21 @@ fn compare_optional_field(
     }
 }
 
-fn parallel_from_manifest(manifest: &ProvenanceManifest) -> Option<usize> {
+fn parallel_from_manifest(manifest: &ProvenanceManifest) -> usize {
     let argv = &manifest.cli.argv;
     for (idx, arg) in argv.iter().enumerate() {
         if let Some(value) = arg.strip_prefix("--parallel=") {
             if let Ok(parallel) = value.parse() {
-                return Some(parallel);
+                return parallel;
             }
         }
         if (arg == "--parallel" || arg == "-p") && idx + 1 < argv.len() {
             if let Ok(parallel) = argv[idx + 1].parse() {
-                return Some(parallel);
+                return parallel;
             }
         }
     }
-    None
+    swebench::DEFAULT_PARALLEL
 }
 
 fn calibration_verdict(
@@ -718,16 +718,9 @@ fn actual_resolution_rate(results: &SweepResults) -> f64 {
         let resolved = results
             .instances
             .iter()
-            .map(swebench::resolved_count)
-            .fold(0u32, u32::saturating_add);
-        let runs = results
-            .instances
-            .iter()
-            .map(swebench::effective_runs)
-            .fold(0u32, u32::saturating_add);
-        if runs > 0 {
-            return f64::from(resolved) / f64::from(runs);
-        }
+            .filter(|row| swebench::pass_at_1(row))
+            .count();
+        return as_f64_usize(resolved) / as_f64_usize(results.instances.len());
     }
     results.pass_at_k
 }

--- a/src/run/calibrate.rs
+++ b/src/run/calibrate.rs
@@ -1,0 +1,820 @@
+//! `bench calibrate`: compare a forecast artifact against a completed sweep.
+//!
+//! This is deliberately read-only over existing artifacts. The forecast is the
+//! promise; the sweep results are the bill. No model calls, no runner state,
+//! no fresh astrology.
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::artifact::{ArtifactCompatibility, ArtifactKind, classify_json_value};
+use crate::error::{ConfigError, Error};
+use crate::run::forecast::{ForecastReport, IntervalEstimate, QuantileSummary};
+use crate::run::swebench::{self, ProvenanceManifest, SweepResults};
+
+/// Inputs for a calibration comparison.
+#[derive(Debug, Clone)]
+pub struct CalibrationArgs {
+    pub forecast_path: PathBuf,
+    pub results_path: PathBuf,
+}
+
+/// Durable forecast-vs-actual report.
+#[derive(Debug, Clone, Serialize)]
+pub struct CalibrationReport {
+    pub forecast_path: String,
+    pub results_path: String,
+    pub forecast_artifact: String,
+    pub results_artifact: String,
+    pub verdict: CalibrationVerdict,
+    pub comparability: CalibrationComparability,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mismatches: Vec<CalibrationMismatch>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+    pub forecast_target_n: usize,
+    pub actual_instance_count: usize,
+    pub metrics: CalibrationMetrics,
+    pub per_instance: PerInstanceCalibration,
+}
+
+/// Overall sweep calibration result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CalibrationVerdict {
+    WellCalibrated,
+    Optimistic,
+    Pessimistic,
+    NotComparable,
+}
+
+impl CalibrationVerdict {
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::WellCalibrated => "well_calibrated",
+            Self::Optimistic => "optimistic",
+            Self::Pessimistic => "pessimistic",
+            Self::NotComparable => "not_comparable",
+        }
+    }
+}
+
+/// Whether forecast and actual artifacts appear to describe the same sweep.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CalibrationComparability {
+    Matched,
+    Mismatched,
+}
+
+/// Forecast/result provenance difference that makes the comparison suspect.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CalibrationMismatch {
+    pub field: String,
+    pub forecast: String,
+    pub actual: String,
+}
+
+/// Scalar aggregate metrics whose forecast uses a confidence interval.
+#[derive(Debug, Clone, Serialize)]
+pub struct CalibrationMetrics {
+    pub total_usd: ScalarCalibration,
+    pub total_input_tokens: ScalarCalibration,
+    pub total_output_tokens: ScalarCalibration,
+    pub wall_clock_seconds: ScalarCalibration,
+    pub resolution_rate: ScalarCalibration,
+}
+
+impl CalibrationMetrics {
+    fn statuses(&self) -> impl Iterator<Item = CalibrationMetricStatus> + '_ {
+        [
+            self.total_usd.status,
+            self.total_input_tokens.status,
+            self.total_output_tokens.status,
+            self.wall_clock_seconds.status,
+            self.resolution_rate.status,
+        ]
+        .into_iter()
+    }
+}
+
+/// Per-instance distribution diagnostics from the forecast's p10/median/p90
+/// summaries compared with the actual sweep's observed p10/median/p90.
+#[derive(Debug, Clone, Serialize)]
+pub struct PerInstanceCalibration {
+    pub input_tokens: DistributionCalibration,
+    pub output_tokens: DistributionCalibration,
+    pub usd_cost: DistributionCalibration,
+    pub step_count: DistributionCalibration,
+    pub wall_clock_seconds: DistributionCalibration,
+}
+
+impl PerInstanceCalibration {
+    fn statuses(&self) -> impl Iterator<Item = CalibrationMetricStatus> + '_ {
+        [
+            self.input_tokens.status,
+            self.output_tokens.status,
+            self.usd_cost.status,
+            self.step_count.status,
+            self.wall_clock_seconds.status,
+        ]
+        .into_iter()
+    }
+}
+
+/// Classification against the forecast interval.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CalibrationMetricStatus {
+    WithinInterval,
+    OverUpper,
+    UnderLower,
+}
+
+impl CalibrationMetricStatus {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::WithinInterval => "within_interval",
+            Self::OverUpper => "over_upper",
+            Self::UnderLower => "under_lower",
+        }
+    }
+}
+
+/// Scalar forecast-vs-actual comparison.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScalarCalibration {
+    pub forecast: IntervalEstimate,
+    pub actual: f64,
+    pub status: CalibrationMetricStatus,
+    pub absolute_error: f64,
+    pub relative_error: Option<f64>,
+}
+
+impl ScalarCalibration {
+    fn new(forecast: IntervalEstimate, actual: f64) -> Self {
+        Self {
+            forecast,
+            actual,
+            status: classify_interval(forecast, actual),
+            absolute_error: (actual - forecast.point).abs(),
+            relative_error: relative_error(forecast.point, actual),
+        }
+    }
+}
+
+/// Distribution forecast-vs-actual comparison.
+#[derive(Debug, Clone, Serialize)]
+pub struct DistributionCalibration {
+    pub forecast: QuantileSummary,
+    pub actual: QuantileSummary,
+    pub status: CalibrationMetricStatus,
+    pub absolute_error: f64,
+    pub relative_error: Option<f64>,
+}
+
+impl DistributionCalibration {
+    fn new(forecast: QuantileSummary, actual: QuantileSummary) -> Self {
+        let interval = IntervalEstimate {
+            point: forecast.median,
+            lower: forecast.p10,
+            upper: forecast.p90,
+        };
+        Self {
+            forecast,
+            actual,
+            status: classify_interval(interval, actual.median),
+            absolute_error: (actual.median - forecast.median).abs(),
+            relative_error: relative_error(forecast.median, actual.median),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LoadedForecast {
+    report: ForecastReport,
+    artifact: ArtifactCompatibility,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct LoadedResults {
+    results: SweepResults,
+    artifact: ArtifactCompatibility,
+    warnings: Vec<String>,
+}
+
+/// Compute a calibration report from an existing forecast JSON artifact and a
+/// completed sweep `results.json` artifact.
+pub fn compute(args: &CalibrationArgs) -> Result<CalibrationReport, Error> {
+    let forecast = load_forecast(&args.forecast_path)?;
+    let actual = load_results(&args.results_path, "sweep results")?;
+    if actual.results.sweep_status != swebench::SWEEP_STATUS_COMPLETED {
+        return Err(Error::Config(ConfigError::Invalid(format!(
+            "calibration requires completed sweep results, got sweep_status={}",
+            actual.results.sweep_status
+        ))));
+    }
+
+    let mut warnings = Vec::new();
+    warnings.extend(forecast.warnings.clone());
+    warnings.extend(actual.warnings.clone());
+
+    let calibration = load_forecast_calibration_results(&args.forecast_path, &forecast.report)?;
+    let calibration_manifest = if let Some(loaded) = calibration {
+        warnings.extend(loaded.warnings);
+        loaded.results.manifest
+    } else {
+        warnings.push(format!(
+            "forecast calibration results unavailable at {}; dataset/model comparability not fully checked",
+            calibration_results_path(&args.forecast_path, &forecast.report).display()
+        ));
+        None
+    };
+
+    let mismatches = build_mismatches(
+        &forecast.report,
+        calibration_manifest.as_ref(),
+        actual.results.manifest.as_ref(),
+        &actual.results,
+    );
+    let metrics = build_metrics(&forecast.report, &actual.results);
+    let per_instance = build_per_instance(&forecast.report, &actual.results);
+    let comparability = if mismatches.is_empty() {
+        CalibrationComparability::Matched
+    } else {
+        CalibrationComparability::Mismatched
+    };
+    let verdict = calibration_verdict(comparability, &metrics, &per_instance);
+
+    Ok(CalibrationReport {
+        forecast_path: args.forecast_path.display().to_string(),
+        results_path: args.results_path.display().to_string(),
+        forecast_artifact: forecast.artifact.identity_label(),
+        results_artifact: actual.artifact.identity_label(),
+        verdict,
+        comparability,
+        mismatches,
+        warnings,
+        forecast_target_n: forecast.report.forecast.target_n,
+        actual_instance_count: actual.results.instances.len(),
+        metrics,
+        per_instance,
+    })
+}
+
+/// Serialize a calibration report as a versioned JSON artifact.
+pub fn to_json(report: &CalibrationReport) -> Result<String, Error> {
+    crate::artifact::to_string_pretty(ArtifactKind::CalibrationReport, report).map_err(Error::from)
+}
+
+/// Render a compact operator-facing calibration summary.
+#[must_use]
+pub fn render_text(report: &CalibrationReport) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "\n=== bench calibrate ===");
+    let _ = writeln!(out, "Forecast:           {}", report.forecast_path);
+    let _ = writeln!(out, "Results:            {}", report.results_path);
+    let _ = writeln!(out, "Verdict:            {}", report.verdict.label());
+    let _ = writeln!(
+        out,
+        "Comparability:      {}",
+        match report.comparability {
+            CalibrationComparability::Matched => "matched",
+            CalibrationComparability::Mismatched => "mismatched",
+        }
+    );
+    let _ = writeln!(
+        out,
+        "Instances:          forecast target {} / actual {}",
+        report.forecast_target_n, report.actual_instance_count
+    );
+    write_scalar_line(&mut out, "Total USD", "$", &report.metrics.total_usd);
+    write_scalar_line(
+        &mut out,
+        "Input tokens",
+        "",
+        &report.metrics.total_input_tokens,
+    );
+    write_scalar_line(
+        &mut out,
+        "Output tokens",
+        "",
+        &report.metrics.total_output_tokens,
+    );
+    write_scalar_line(
+        &mut out,
+        "Wall-clock sec",
+        "",
+        &report.metrics.wall_clock_seconds,
+    );
+    write_scalar_line(
+        &mut out,
+        "Resolution rate",
+        "",
+        &report.metrics.resolution_rate,
+    );
+    if !report.mismatches.is_empty() {
+        out.push_str("Mismatches:\n");
+        for mismatch in &report.mismatches {
+            let _ = writeln!(
+                out,
+                "  {}: forecast={} actual={}",
+                mismatch.field, mismatch.forecast, mismatch.actual
+            );
+        }
+    }
+    for warning in &report.warnings {
+        let _ = writeln!(out, "warning: {warning}");
+    }
+    out
+}
+
+fn load_forecast(path: &Path) -> Result<LoadedForecast, Error> {
+    let value = read_json_artifact(path, "forecast")?;
+    let artifact = classify_json_value(
+        &value,
+        ArtifactKind::ForecastReport,
+        path.display().to_string(),
+    )
+    .map_err(|err| Error::Trajectory(err.to_string()))?;
+    let warnings = artifact.warnings.clone();
+    let report: ForecastReport = serde_json::from_value(value)?;
+    Ok(LoadedForecast {
+        report,
+        artifact,
+        warnings,
+    })
+}
+
+fn load_results(path: &Path, label: &str) -> Result<LoadedResults, Error> {
+    let value = read_json_artifact(path, label)?;
+    let artifact = classify_json_value(
+        &value,
+        ArtifactKind::SweepResults,
+        path.display().to_string(),
+    )
+    .map_err(|err| Error::Trajectory(err.to_string()))?;
+    let warnings = artifact.warnings.clone();
+    let results: SweepResults = serde_json::from_value(value)?;
+    Ok(LoadedResults {
+        results,
+        artifact,
+        warnings,
+    })
+}
+
+fn read_json_artifact(path: &Path, label: &str) -> Result<serde_json::Value, Error> {
+    if !path.is_file() {
+        return Err(Error::Config(ConfigError::Invalid(format!(
+            "{label} artifact not found: {}",
+            path.display()
+        ))));
+    }
+    let text = std::fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&text)?)
+}
+
+fn load_forecast_calibration_results(
+    forecast_path: &Path,
+    report: &ForecastReport,
+) -> Result<Option<LoadedResults>, Error> {
+    let path = calibration_results_path(forecast_path, report);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    load_results(&path, "forecast calibration").map(Some)
+}
+
+fn calibration_results_path(forecast_path: &Path, report: &ForecastReport) -> PathBuf {
+    let output_dir = PathBuf::from(&report.calibration.output_dir);
+    let base = if output_dir.is_absolute() {
+        output_dir
+    } else {
+        forecast_path
+            .parent()
+            .map_or_else(|| output_dir.clone(), |parent| parent.join(&output_dir))
+    };
+    base.join("results.json")
+}
+
+fn build_metrics(forecast: &ForecastReport, actual: &SweepResults) -> CalibrationMetrics {
+    CalibrationMetrics {
+        total_usd: ScalarCalibration::new(
+            forecast.forecast.total_cost_usd,
+            actual
+                .actual_cost_total_usd()
+                .unwrap_or(actual.estimated_cost_usd),
+        ),
+        total_input_tokens: ScalarCalibration::new(
+            forecast.forecast.total_input_tokens,
+            as_f64_u64(actual.total_prompt_tokens),
+        ),
+        total_output_tokens: ScalarCalibration::new(
+            forecast.forecast.total_output_tokens,
+            as_f64_u64(actual.total_completion_tokens),
+        ),
+        wall_clock_seconds: ScalarCalibration::new(
+            forecast.forecast.wall_clock_seconds,
+            actual_wall_clock_seconds(actual, forecast.forecast.parallel),
+        ),
+        resolution_rate: ScalarCalibration::new(
+            resolution_interval(forecast),
+            actual_resolution_rate(actual),
+        ),
+    }
+}
+
+fn build_per_instance(forecast: &ForecastReport, actual: &SweepResults) -> PerInstanceCalibration {
+    let model_name = actual.manifest.as_ref().map(|m| m.model.name.as_str());
+    PerInstanceCalibration {
+        input_tokens: DistributionCalibration::new(
+            forecast.per_instance.input_tokens,
+            quantiles(
+                &actual
+                    .instances
+                    .iter()
+                    .map(|row| row.prompt_tokens.map_or(0.0, as_f64_u64))
+                    .collect::<Vec<_>>(),
+            ),
+        ),
+        output_tokens: DistributionCalibration::new(
+            forecast.per_instance.output_tokens,
+            quantiles(
+                &actual
+                    .instances
+                    .iter()
+                    .map(|row| row.completion_tokens.map_or(0.0, as_f64_u64))
+                    .collect::<Vec<_>>(),
+            ),
+        ),
+        usd_cost: DistributionCalibration::new(
+            forecast.per_instance.usd_cost,
+            quantiles(
+                &actual
+                    .instances
+                    .iter()
+                    .map(|row| row.effective_cost_usd(model_name).unwrap_or_default())
+                    .collect::<Vec<_>>(),
+            ),
+        ),
+        step_count: DistributionCalibration::new(
+            forecast.per_instance.step_count,
+            quantiles(
+                &actual
+                    .instances
+                    .iter()
+                    .map(|row| row.steps.map_or(0.0, f64::from))
+                    .collect::<Vec<_>>(),
+            ),
+        ),
+        wall_clock_seconds: DistributionCalibration::new(
+            forecast.per_instance.wall_clock_seconds,
+            quantiles(
+                &actual
+                    .instances
+                    .iter()
+                    .map(|row| row.duration_secs.unwrap_or_default())
+                    .collect::<Vec<_>>(),
+            ),
+        ),
+    }
+}
+
+fn build_mismatches(
+    forecast: &ForecastReport,
+    calibration_manifest: Option<&ProvenanceManifest>,
+    actual_manifest: Option<&ProvenanceManifest>,
+    actual: &SweepResults,
+) -> Vec<CalibrationMismatch> {
+    let mut mismatches = Vec::new();
+    if let (Some(forecast_manifest), Some(actual_manifest)) =
+        (calibration_manifest, actual_manifest)
+    {
+        compare_field(
+            &mut mismatches,
+            "dataset.sha256",
+            &forecast_manifest.dataset.sha256,
+            &actual_manifest.dataset.sha256,
+        );
+        compare_optional_field(
+            &mut mismatches,
+            "dataset.alias",
+            forecast_manifest.dataset.alias.as_deref(),
+            actual_manifest.dataset.alias.as_deref(),
+        );
+        compare_optional_field(
+            &mut mismatches,
+            "dataset.split",
+            forecast_manifest.dataset.split.as_deref(),
+            actual_manifest.dataset.split.as_deref(),
+        );
+        compare_field(
+            &mut mismatches,
+            "model.name",
+            &forecast_manifest.model.name,
+            &actual_manifest.model.name,
+        );
+    }
+
+    if let Some(actual_parallel) = actual_manifest.and_then(parallel_from_manifest) {
+        let forecast_parallel = forecast.forecast.parallel.to_string();
+        let actual_parallel = actual_parallel.to_string();
+        compare_field(
+            &mut mismatches,
+            "parallel",
+            &forecast_parallel,
+            &actual_parallel,
+        );
+    }
+
+    let forecast_count = forecast.forecast.target_n.to_string();
+    let actual_count = actual.instances.len().to_string();
+    compare_field(
+        &mut mismatches,
+        "instance_count",
+        &forecast_count,
+        &actual_count,
+    );
+
+    let actual_ids: BTreeSet<_> = actual
+        .instances
+        .iter()
+        .map(|row| row.instance_id.as_str())
+        .collect();
+    if forecast.forecast.target_instance_ids.is_empty() {
+        let missing_calibration_ids: Vec<_> = forecast
+            .calibration
+            .instance_ids
+            .iter()
+            .filter(|id| !actual_ids.contains(id.as_str()))
+            .cloned()
+            .collect();
+        if !missing_calibration_ids.is_empty() {
+            mismatches.push(CalibrationMismatch {
+                field: "instance_set".into(),
+                forecast: format!(
+                    "calibration subset included {}",
+                    forecast.calibration.instance_ids.join(",")
+                ),
+                actual: format!("missing {}", missing_calibration_ids.join(",")),
+            });
+        }
+    } else {
+        let forecast_ids: BTreeSet<_> = forecast
+            .forecast
+            .target_instance_ids
+            .iter()
+            .map(String::as_str)
+            .collect();
+        if forecast_ids != actual_ids {
+            mismatches.push(CalibrationMismatch {
+                field: "instance_set".into(),
+                forecast: sorted_join(forecast_ids),
+                actual: sorted_join(actual_ids),
+            });
+        }
+    }
+
+    mismatches
+}
+
+fn sorted_join(values: BTreeSet<&str>) -> String {
+    values.into_iter().collect::<Vec<_>>().join(",")
+}
+
+fn compare_field(
+    mismatches: &mut Vec<CalibrationMismatch>,
+    field: &str,
+    forecast: &str,
+    actual: &str,
+) {
+    if forecast != actual {
+        mismatches.push(CalibrationMismatch {
+            field: field.into(),
+            forecast: forecast.into(),
+            actual: actual.into(),
+        });
+    }
+}
+
+fn compare_optional_field(
+    mismatches: &mut Vec<CalibrationMismatch>,
+    field: &str,
+    forecast: Option<&str>,
+    actual: Option<&str>,
+) {
+    if forecast != actual {
+        mismatches.push(CalibrationMismatch {
+            field: field.into(),
+            forecast: forecast.unwrap_or("<none>").into(),
+            actual: actual.unwrap_or("<none>").into(),
+        });
+    }
+}
+
+fn parallel_from_manifest(manifest: &ProvenanceManifest) -> Option<usize> {
+    let argv = &manifest.cli.argv;
+    argv.windows(2).find_map(|pair| {
+        if pair[0] == "--parallel" {
+            pair[1].parse().ok()
+        } else {
+            None
+        }
+    })
+}
+
+fn calibration_verdict(
+    comparability: CalibrationComparability,
+    metrics: &CalibrationMetrics,
+    per_instance: &PerInstanceCalibration,
+) -> CalibrationVerdict {
+    if comparability == CalibrationComparability::Mismatched {
+        return CalibrationVerdict::NotComparable;
+    }
+    let statuses: Vec<_> = metrics.statuses().chain(per_instance.statuses()).collect();
+    if statuses.contains(&CalibrationMetricStatus::OverUpper) {
+        CalibrationVerdict::Optimistic
+    } else if statuses.contains(&CalibrationMetricStatus::UnderLower) {
+        CalibrationVerdict::Pessimistic
+    } else {
+        CalibrationVerdict::WellCalibrated
+    }
+}
+
+fn classify_interval(interval: IntervalEstimate, actual: f64) -> CalibrationMetricStatus {
+    const EPSILON: f64 = 1e-9;
+    if actual > interval.upper + EPSILON {
+        CalibrationMetricStatus::OverUpper
+    } else if actual < interval.lower - EPSILON {
+        CalibrationMetricStatus::UnderLower
+    } else {
+        CalibrationMetricStatus::WithinInterval
+    }
+}
+
+fn relative_error(point: f64, actual: f64) -> Option<f64> {
+    if point.abs() <= f64::EPSILON {
+        if actual.abs() <= f64::EPSILON {
+            Some(0.0)
+        } else {
+            None
+        }
+    } else {
+        Some((actual - point) / point)
+    }
+}
+
+fn resolution_interval(forecast: &ForecastReport) -> IntervalEstimate {
+    let point = forecast.resolution_rate.point.clamp(0.0, 1.0);
+    let n = forecast.resolution_rate.total;
+    if n == 0 {
+        return IntervalEstimate {
+            point,
+            lower: point,
+            upper: point,
+        };
+    }
+    let z = z_for_confidence(forecast.forecast.confidence_pct);
+    let margin = z * ((point * (1.0 - point)) / as_f64_usize(n)).sqrt();
+    IntervalEstimate {
+        point,
+        lower: (point - margin).max(0.0),
+        upper: (point + margin).min(1.0),
+    }
+}
+
+fn z_for_confidence(confidence_pct: f64) -> f64 {
+    if confidence_pct <= 80.0 {
+        1.281_551_565_544_600_4
+    } else if confidence_pct <= 90.0 {
+        1.644_853_626_951_472_2
+    } else if confidence_pct <= 95.0 {
+        1.959_963_984_540_054
+    } else if confidence_pct <= 99.0 {
+        2.575_829_303_548_900_4
+    } else {
+        3.0
+    }
+}
+
+fn actual_resolution_rate(results: &SweepResults) -> f64 {
+    if !results.instances.is_empty() {
+        let resolved = results
+            .instances
+            .iter()
+            .map(swebench::resolved_count)
+            .fold(0u32, u32::saturating_add);
+        let runs = results
+            .instances
+            .iter()
+            .map(swebench::effective_runs)
+            .fold(0u32, u32::saturating_add);
+        if runs > 0 {
+            return f64::from(resolved) / f64::from(runs);
+        }
+    }
+    results.pass_at_k
+}
+
+fn actual_wall_clock_seconds(results: &SweepResults, forecast_parallel: usize) -> f64 {
+    if let Some(seconds) = manifest_wall_clock_seconds(results.manifest.as_ref()) {
+        return seconds;
+    }
+    let total_duration = results
+        .instances
+        .iter()
+        .filter_map(|row| row.duration_secs)
+        .sum::<f64>();
+    total_duration / as_f64_usize(forecast_parallel.max(1))
+}
+
+fn manifest_wall_clock_seconds(manifest: Option<&ProvenanceManifest>) -> Option<f64> {
+    let manifest = manifest?;
+    let started = chrono::DateTime::parse_from_rfc3339(&manifest.runtime.started_at_utc).ok()?;
+    let finished =
+        chrono::DateTime::parse_from_rfc3339(manifest.runtime.finished_at_utc.as_ref()?).ok()?;
+    let millis = finished.signed_duration_since(started).num_milliseconds();
+    #[allow(clippy::cast_precision_loss)]
+    {
+        Some((millis.max(0) as f64) / 1000.0)
+    }
+}
+
+fn quantiles(values: &[f64]) -> QuantileSummary {
+    if values.is_empty() {
+        return QuantileSummary {
+            p10: 0.0,
+            median: 0.0,
+            p90: 0.0,
+        };
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    QuantileSummary {
+        p10: quantile_sorted(&sorted, 0.10),
+        median: quantile_sorted(&sorted, 0.50),
+        p90: quantile_sorted(&sorted, 0.90),
+    }
+}
+
+fn quantile_sorted(sorted: &[f64], q: f64) -> f64 {
+    if sorted.len() == 1 {
+        return sorted[0];
+    }
+    let span = as_f64_usize(sorted.len() - 1);
+    let pos = q.clamp(0.0, 1.0) * span;
+    let lo = floor_to_usize(pos);
+    let hi = ceil_to_usize(pos);
+    if lo == hi {
+        sorted[lo]
+    } else {
+        let weight = pos - as_f64_usize(lo);
+        sorted[lo].mul_add(1.0 - weight, sorted[hi] * weight)
+    }
+}
+
+fn write_scalar_line(out: &mut String, label: &str, prefix: &str, metric: &ScalarCalibration) {
+    let rel = metric.relative_error.map_or_else(
+        || "n/a".to_owned(),
+        |value| format!("{:+.2}%", value * 100.0),
+    );
+    let _ = writeln!(
+        out,
+        "  {label:<16} actual {prefix}{:.4} vs forecast {prefix}{:.4} [{prefix}{:.4}, {prefix}{:.4}] => {} (abs {:.4}, rel {rel})",
+        metric.actual,
+        metric.forecast.point,
+        metric.forecast.lower,
+        metric.forecast.upper,
+        metric.status.label(),
+        metric.absolute_error
+    );
+}
+
+fn as_f64_u64(value: u64) -> f64 {
+    #[allow(clippy::cast_precision_loss)]
+    {
+        value as f64
+    }
+}
+
+fn as_f64_usize(value: usize) -> f64 {
+    #[allow(clippy::cast_precision_loss)]
+    {
+        value as f64
+    }
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn floor_to_usize(value: f64) -> usize {
+    value.floor() as usize
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn ceil_to_usize(value: f64) -> usize {
+    value.ceil() as usize
+}

--- a/src/run/calibrate.rs
+++ b/src/run/calibrate.rs
@@ -392,14 +392,13 @@ fn load_forecast_calibration_results(
 
 fn calibration_results_path(forecast_path: &Path, report: &ForecastReport) -> PathBuf {
     let output_dir = PathBuf::from(&report.calibration.output_dir);
-    let base = if output_dir.is_absolute() {
-        output_dir
-    } else {
-        forecast_path
-            .parent()
-            .map_or_else(|| output_dir.clone(), |parent| parent.join(&output_dir))
-    };
-    base.join("results.json")
+    let cwd_relative = output_dir.join("results.json");
+    if output_dir.is_absolute() || cwd_relative.is_file() {
+        return cwd_relative;
+    }
+    forecast_path.parent().map_or(cwd_relative, |parent| {
+        parent.join(output_dir).join("results.json")
+    })
 }
 
 fn build_metrics(forecast: &ForecastReport, actual: &SweepResults) -> CalibrationMetrics {
@@ -619,13 +618,19 @@ fn compare_optional_field(
 
 fn parallel_from_manifest(manifest: &ProvenanceManifest) -> Option<usize> {
     let argv = &manifest.cli.argv;
-    argv.windows(2).find_map(|pair| {
-        if pair[0] == "--parallel" {
-            pair[1].parse().ok()
-        } else {
-            None
+    for (idx, arg) in argv.iter().enumerate() {
+        if let Some(value) = arg.strip_prefix("--parallel=") {
+            if let Ok(parallel) = value.parse() {
+                return Some(parallel);
+            }
         }
-    })
+        if (arg == "--parallel" || arg == "-p") && idx + 1 < argv.len() {
+            if let Ok(parallel) = argv[idx + 1].parse() {
+                return Some(parallel);
+            }
+        }
+    }
+    None
 }
 
 fn calibration_verdict(
@@ -671,20 +676,26 @@ fn relative_error(point: f64, actual: f64) -> Option<f64> {
 
 fn resolution_interval(forecast: &ForecastReport) -> IntervalEstimate {
     let point = forecast.resolution_rate.point.clamp(0.0, 1.0);
-    let n = forecast.resolution_rate.total;
-    if n == 0 {
+    let total = forecast.resolution_rate.total;
+    if total == 0 {
         return IntervalEstimate {
             point,
             lower: point,
             upper: point,
         };
     }
+    let successes = forecast.resolution_rate.resolved.min(total);
+    let n = as_f64_usize(total);
+    let p_hat = as_f64_usize(successes) / n;
     let z = z_for_confidence(forecast.forecast.confidence_pct);
-    let margin = z * ((point * (1.0 - point)) / as_f64_usize(n)).sqrt();
+    let z2 = z * z;
+    let denominator = 1.0 + z2 / n;
+    let center = (p_hat + z2 / (2.0 * n)) / denominator;
+    let margin = z * (p_hat.mul_add(1.0 - p_hat, z2 / (4.0 * n)) / n).sqrt() / denominator;
     IntervalEstimate {
         point,
-        lower: (point - margin).max(0.0),
-        upper: (point + margin).min(1.0),
+        lower: (center - margin).max(0.0),
+        upper: (center + margin).min(1.0),
     }
 }
 

--- a/src/run/dataset.rs
+++ b/src/run/dataset.rs
@@ -629,7 +629,10 @@ mod tests {
         assert!(msg.contains("verified"), "{msg}");
         assert!(msg.contains("test"), "{msg}");
         // error message must name the expected cache path
-        assert!(msg.contains("verified/test.jsonl"), "{msg}");
+        assert!(
+            msg.replace('\\', "/").contains("verified/test.jsonl"),
+            "{msg}"
+        );
     }
 
     #[test]

--- a/src/run/forecast.rs
+++ b/src/run/forecast.rs
@@ -103,6 +103,11 @@ pub struct QuantileSummary {
 pub struct ForecastTotals {
     /// Number of instances being forecast.
     pub target_n: usize,
+    /// Exact target instance ids when the forecast maps to a concrete planned
+    /// sweep set. Empty for legacy reports or synthetic `--target-n` forecasts
+    /// that do not correspond to the filtered dataset.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub target_instance_ids: Vec<String>,
     /// Parallel worker count used for wall-clock extrapolation.
     pub parallel: usize,
     /// Confidence level percentage used for intervals.
@@ -187,17 +192,26 @@ pub async fn run(args: ForecastArgs) -> Result<ForecastOutcome, Error> {
     let dry_run = args.sweep.dry_run;
     let original_output = args.sweep.output_dir.clone();
     let calibration_dir = original_output.join("forecast");
+    let planned = planned_instances(&args.sweep)?;
     let target_n = match args.target_n {
         Some(n) => {
             validate_positive("target-n", n)?;
             n
         }
-        None => target_count(&args.sweep)?,
+        None => planned.len(),
+    };
+    let target_instance_ids = if target_n == planned.len() {
+        planned
+            .iter()
+            .map(|inst| inst.instance_id.clone())
+            .collect()
+    } else {
+        Vec::new()
     };
     let limit = args.sweep.cost_limit_usd;
     let parallel = args.sweep.parallel.max(1);
     let calibration_instance_ids =
-        calibration_instance_ids(&args.sweep, args.calibration_n, args.seed)?;
+        calibration_instance_ids(planned, args.calibration_n, args.seed)?;
 
     let mut sweep = args.sweep;
     sweep.output_dir.clone_from(&calibration_dir);
@@ -238,6 +252,7 @@ pub async fn run(args: ForecastArgs) -> Result<ForecastOutcome, Error> {
         limit,
     )?;
     report.calibration.output_dir = calibration_dir.display().to_string();
+    report.forecast.target_instance_ids = target_instance_ids;
     Ok(ForecastOutcome::Report(Box::new(report)))
 }
 
@@ -310,6 +325,7 @@ pub fn forecast_from_results(
         },
         forecast: ForecastTotals {
             target_n,
+            target_instance_ids: Vec::new(),
             parallel,
             confidence_pct,
             total_cost_usd: total_interval(&usd_cost, target_n, 1.0, confidence_pct),
@@ -432,16 +448,11 @@ pub fn render_text(report: &ForecastReport) -> String {
     out
 }
 
-fn target_count(args: &swebench::SwebenchArgs) -> Result<usize, Error> {
-    Ok(planned_instances(args)?.len())
-}
-
 fn calibration_instance_ids(
-    args: &swebench::SwebenchArgs,
+    planned: Vec<swebench::SweBenchInstance>,
     calibration_n: usize,
     seed: u64,
 ) -> Result<Vec<String>, Error> {
-    let planned = planned_instances(args)?;
     let (calibration, _) = swebench::apply_subset(
         planned,
         &swebench::ApplySubsetParams {

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,6 +1,7 @@
 //! Runners: thin glue that wires (config + model + env + agent) together
 //! and writes trajectories to disk.
 
+pub mod calibrate;
 pub mod compare;
 pub mod dataset;
 pub mod evaluate;

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -28,7 +28,7 @@ pub use crate::cost::{
     ANTHROPIC_CACHE_CREATION_MULTIPLIER, ANTHROPIC_CACHE_READ_MULTIPLIER, BASELINE_COST_MODEL,
     CostSource, SONNET_INPUT_USD_PER_MTOK, SONNET_OUTPUT_USD_PER_MTOK, estimate_cost_usd,
 };
-use crate::error::{ConfigError, EnvError, Error};
+use crate::error::{EnvError, Error};
 use crate::model::{Model, ModelUsage};
 use crate::redaction::{Redactor, surface};
 use crate::trajectory::{FailureCategory, TokenUsage, Trajectory, exit_reason, outcome};
@@ -2174,7 +2174,7 @@ async fn run_preflight(args: &SwebenchArgs) -> Result<Vec<CheckResult>, Error> {
             }
             #[cfg(not(feature = "docker"))]
             {
-                return Err(Error::Config(ConfigError::Invalid(
+                return Err(Error::Config(crate::error::ConfigError::Invalid(
                     "environment.kind=docker requires the binary to be built with the `docker` feature"
                         .into(),
                 )));
@@ -6032,7 +6032,7 @@ instance = "inst"
         assert_eq!(v["artifact_kind"], "preflight_report");
         assert_eq!(
             v["schema_version"],
-            serde_json::json!({"major": 1, "minor": 2})
+            serde_json::json!({"major": 1, "minor": 3})
         );
         assert!(v.get("mode").is_some());
         assert!(v.get("checks").is_some());

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -43,6 +43,7 @@ pub const SWEEP_STATUS_CANCELLING: &str = "cancelling";
 pub const SWEEP_STATUS_CANCELLED: &str = "cancelled";
 pub const CANCEL_EXIT_CODE_GRACEFUL: i32 = 130;
 pub const CANCEL_EXIT_CODE_ESCALATED: i32 = 137;
+pub const DEFAULT_PARALLEL: usize = 4;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct TokenBreakdown {

--- a/tests/artifact_schema.rs
+++ b/tests/artifact_schema.rs
@@ -21,10 +21,10 @@ mod support;
 use support::binary_path;
 
 #[test]
-fn artifact_schema_current_minor_bumped_for_evaluator_provenance() {
+fn artifact_schema_current_minor_bumped_for_calibration_report() {
     assert_eq!(
         ArtifactSchemaVersion::CURRENT,
-        ArtifactSchemaVersion::new(1, 2)
+        ArtifactSchemaVersion::new(1, 3)
     );
 }
 
@@ -32,7 +32,7 @@ fn artifact_schema_current_minor_bumped_for_evaluator_provenance() {
 fn artifact_classifier_marks_exact_current_version_supported_current() {
     let payload = serde_json::json!({
         "artifact_kind": "sweep_results",
-        "schema_version": {"major": 1, "minor": 2},
+        "schema_version": {"major": 1, "minor": 3},
         "total": 0,
         "instances": []
     });
@@ -92,7 +92,7 @@ fn artifact_classifier_rejects_unsupported_future_major_versions() {
 fn artifact_classifier_rejects_kind_mismatch() {
     let payload = serde_json::json!({
         "artifact_kind": "evaluation_results",
-        "schema_version": {"major": 1, "minor": 2},
+        "schema_version": {"major": 1, "minor": 3},
         "instances": []
     });
 
@@ -142,7 +142,7 @@ fn trajectory_serialization_includes_artifact_header() {
     assert_eq!(value["artifact_kind"], "trajectory");
     assert_eq!(
         value["schema_version"],
-        serde_json::json!({"major": 1, "minor": 2})
+        serde_json::json!({"major": 1, "minor": 3})
     );
 }
 
@@ -170,7 +170,7 @@ async fn swebench_run_writes_versioned_results_and_prediction_metadata() {
     assert_eq!(results["artifact_kind"], "sweep_results");
     assert_eq!(
         results["schema_version"],
-        serde_json::json!({"major": 1, "minor": 2})
+        serde_json::json!({"major": 1, "minor": 3})
     );
 
     let predictions = std::fs::read_to_string(output.join("all_preds.jsonl")).unwrap();
@@ -194,7 +194,7 @@ async fn swebench_run_writes_versioned_results_and_prediction_metadata() {
     assert_eq!(metadata["artifact_kind"], "swebench_predictions_metadata");
     assert_eq!(
         metadata["schema_version"],
-        serde_json::json!({"major": 1, "minor": 2})
+        serde_json::json!({"major": 1, "minor": 3})
     );
     assert_eq!(metadata["predictions_file"], "all_preds.jsonl");
     assert_eq!(metadata["row_count"], 1);
@@ -237,7 +237,7 @@ async fn evaluate_run_writes_versioned_evaluation_json() {
     assert_eq!(eval["artifact_kind"], "evaluation_results");
     assert_eq!(
         eval["schema_version"],
-        serde_json::json!({"major": 1, "minor": 2})
+        serde_json::json!({"major": 1, "minor": 3})
     );
 }
 
@@ -252,7 +252,7 @@ fn forecast_json_includes_artifact_header() {
     assert_eq!(value["artifact_kind"], "forecast_report");
     assert_eq!(
         value["schema_version"],
-        serde_json::json!({"major": 1, "minor": 2})
+        serde_json::json!({"major": 1, "minor": 3})
     );
 }
 
@@ -287,7 +287,7 @@ async fn forecast_run_keeps_calibration_results_versioned_after_manifest_mark() 
     assert_eq!(calibration_results["artifact_kind"], "sweep_results");
     assert_eq!(
         calibration_results["schema_version"],
-        serde_json::json!({"major": 1, "minor": 2})
+        serde_json::json!({"major": 1, "minor": 3})
     );
 }
 
@@ -535,7 +535,7 @@ async fn current_contract_fixtures_match_emitted_artifact_top_level_fields() {
 
     let preflight = serde_json::json!({
         "artifact_kind": "preflight_report",
-        "schema_version": {"major": 1, "minor": 2},
+        "schema_version": {"major": 1, "minor": 3},
         "mode": "doctor",
         "checks": [{
             "status": "ok",
@@ -598,6 +598,11 @@ fn checked_in_fixtures_cover_legacy_current_and_future_artifact_contracts() {
         (
             "current/forecast.json",
             ArtifactKind::ForecastReport,
+            CompatibilityClass::SupportedCurrent,
+        ),
+        (
+            "current/calibration.json",
+            ArtifactKind::CalibrationReport,
             CompatibilityClass::SupportedCurrent,
         ),
         (

--- a/tests/bench_calibrate.rs
+++ b/tests/bench_calibrate.rs
@@ -115,6 +115,7 @@ fn actual_below_lower_interval_is_pessimistic() {
             wall_clock_secs: 50.0,
             resolved: 1,
             total: 4,
+            ..ResultsCase::default()
         },
         ManifestCase::default(),
         ManifestCase::default(),
@@ -301,6 +302,40 @@ fn parallel_mismatch_is_detected_from_equals_and_short_manifest_forms() {
 }
 
 #[test]
+fn absent_parallel_arg_defaults_to_cli_parallel_for_comparison() {
+    let work = tempfile::tempdir().unwrap();
+    let (forecast_path, results_path) = write_pair(
+        work.path(),
+        ForecastCase {
+            parallel: 8,
+            ..ForecastCase::default()
+        },
+        ResultsCase::default(),
+        ManifestCase::default(),
+        ManifestCase {
+            parallel: 4,
+            parallel_arg_style: ParallelArgStyle::Absent,
+            ..ManifestCase::default()
+        },
+    );
+
+    let report = compute(&CalibrationArgs {
+        forecast_path,
+        results_path,
+    })
+    .unwrap();
+
+    assert_eq!(report.verdict, CalibrationVerdict::NotComparable);
+    let mismatch = report
+        .mismatches
+        .iter()
+        .find(|mismatch| mismatch.field == "parallel")
+        .unwrap_or_else(|| panic!("{:#?}", report.mismatches));
+    assert_eq!(mismatch.forecast, "8");
+    assert_eq!(mismatch.actual, "4");
+}
+
+#[test]
 fn exact_target_instance_set_mismatch_is_flagged_even_when_counts_match() {
     let work = tempfile::tempdir().unwrap();
     let (forecast_path, results_path) = write_pair(
@@ -329,6 +364,52 @@ fn exact_target_instance_set_mismatch_is_flagged_even_when_counts_match() {
         "{:#?}",
         report.mismatches
     );
+}
+
+#[test]
+fn actual_resolution_rate_uses_pass_at_1_semantics_for_rerun_rows() {
+    let work = tempfile::tempdir().unwrap();
+    let (forecast_path, results_path) = write_pair(
+        work.path(),
+        ForecastCase {
+            total_cost_usd: interval(5.0, 4.0, 6.0),
+            input_tokens: interval(500.0, 400.0, 600.0),
+            output_tokens: interval(50.0, 40.0, 60.0),
+            wall_clock_secs: interval(50.0, 40.0, 60.0),
+            resolution_point: 0.0,
+            resolution_resolved: 0,
+            resolution_total: 2,
+            target_n: 2,
+            target_instance_ids: vec!["a".into(), "b".into()],
+            ..ForecastCase::default()
+        },
+        ResultsCase {
+            total_cost_usd: 5.0,
+            input_tokens: 500,
+            output_tokens: 50,
+            wall_clock_secs: 50.0,
+            resolved: 0,
+            total: 2,
+            runs: 2,
+            resolved_count: Some(1),
+            pass_at_1: Some(false),
+        },
+        ManifestCase::default(),
+        ManifestCase::default(),
+    );
+
+    let report = compute(&CalibrationArgs {
+        forecast_path,
+        results_path,
+    })
+    .unwrap();
+
+    assert_eq!(report.metrics.resolution_rate.actual, 0.0);
+    assert_eq!(
+        report.metrics.resolution_rate.status,
+        CalibrationMetricStatus::WithinInterval
+    );
+    assert_eq!(report.verdict, CalibrationVerdict::WellCalibrated);
 }
 
 #[test]
@@ -557,6 +638,9 @@ struct ResultsCase {
     wall_clock_secs: f64,
     resolved: usize,
     total: usize,
+    runs: u32,
+    resolved_count: Option<u32>,
+    pass_at_1: Option<bool>,
 }
 
 impl Default for ResultsCase {
@@ -568,6 +652,9 @@ impl Default for ResultsCase {
             wall_clock_secs: 105.0,
             resolved: 2,
             total: 4,
+            runs: 1,
+            resolved_count: None,
+            pass_at_1: None,
         }
     }
 }
@@ -593,6 +680,7 @@ impl Default for ManifestCase {
 
 #[derive(Debug, Clone, Copy)]
 enum ParallelArgStyle {
+    Absent,
     LongSeparated,
     LongEquals,
     ShortSeparated,
@@ -601,6 +689,7 @@ enum ParallelArgStyle {
 impl ParallelArgStyle {
     fn argv(self, parallel: usize) -> Vec<String> {
         match self {
+            Self::Absent => vec!["rust-swe-agent".into(), "bench".into(), "swebench".into()],
             Self::LongSeparated => vec![
                 "rust-swe-agent".into(),
                 "bench".into(),
@@ -739,12 +828,16 @@ fn sweep_results(
             } else {
                 case.total_cost_usd / case.total as f64
             };
-            instance(
+            let mut row = instance(
                 id,
                 submitted,
                 per_instance_cost,
                 case.wall_clock_secs / case.total.max(1) as f64,
-            )
+            );
+            row.runs = case.runs;
+            row.resolved_count = case.resolved_count.unwrap_or_else(|| u32::from(submitted));
+            row.pass_at_1 = case.pass_at_1.unwrap_or(submitted);
+            row
         })
         .collect();
     SweepResults {

--- a/tests/bench_calibrate.rs
+++ b/tests/bench_calibrate.rs
@@ -1,0 +1,730 @@
+//! `bench calibrate`: forecast-vs-actual calibration reports.
+
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::float_cmp,
+    clippy::needless_pass_by_value,
+    clippy::too_many_lines,
+    clippy::unwrap_used
+)]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use rust_swe_agent::artifact::ArtifactKind;
+use rust_swe_agent::run::calibrate::{
+    CalibrationArgs, CalibrationMetricStatus, CalibrationVerdict, compute, render_text, to_json,
+};
+use rust_swe_agent::run::forecast::{
+    CalibrationSummary, ForecastReport, ForecastTotals, IntervalEstimate, PerInstanceSummary,
+    QuantileSummary, ResolutionRateSignal, ThresholdCheck, ThresholdStatus,
+};
+use rust_swe_agent::run::swebench::{
+    CliManifest, ConfigManifest, DatasetManifest, FilterSpec, HarnessManifest, InstanceResult,
+    ModelManifest, ProvenanceManifest, RuntimeManifest, SweepResults,
+};
+use rust_swe_agent::trajectory::{FailureCategory, outcome};
+
+mod support;
+use support::binary_path;
+
+#[test]
+fn actuals_inside_intervals_are_well_calibrated() {
+    let work = tempfile::tempdir().unwrap();
+    let (forecast_path, results_path) = write_pair(
+        work.path(),
+        ForecastCase::default(),
+        ResultsCase::default(),
+        ManifestCase::default(),
+        ManifestCase::default(),
+    );
+
+    let report = compute(&CalibrationArgs {
+        forecast_path,
+        results_path,
+    })
+    .unwrap();
+
+    assert_eq!(report.verdict, CalibrationVerdict::WellCalibrated);
+    assert_eq!(
+        report.metrics.total_usd.status,
+        CalibrationMetricStatus::WithinInterval
+    );
+    assert_eq!(
+        report.metrics.total_input_tokens.status,
+        CalibrationMetricStatus::WithinInterval
+    );
+    assert_eq!(
+        report.metrics.total_output_tokens.status,
+        CalibrationMetricStatus::WithinInterval
+    );
+    assert_eq!(
+        report.metrics.wall_clock_seconds.status,
+        CalibrationMetricStatus::WithinInterval
+    );
+    assert_eq!(
+        report.metrics.resolution_rate.status,
+        CalibrationMetricStatus::WithinInterval
+    );
+    assert!(report.mismatches.is_empty(), "{:#?}", report.mismatches);
+    assert!(render_text(&report).contains("Verdict:            well_calibrated"));
+}
+
+#[test]
+fn actual_above_upper_interval_is_optimistic_with_signed_relative_error() {
+    let work = tempfile::tempdir().unwrap();
+    let (forecast_path, results_path) = write_pair(
+        work.path(),
+        ForecastCase::default(),
+        ResultsCase {
+            total_cost_usd: 15.0,
+            ..ResultsCase::default()
+        },
+        ManifestCase::default(),
+        ManifestCase::default(),
+    );
+
+    let report = compute(&CalibrationArgs {
+        forecast_path,
+        results_path,
+    })
+    .unwrap();
+
+    assert_eq!(report.verdict, CalibrationVerdict::Optimistic);
+    assert_eq!(
+        report.metrics.total_usd.status,
+        CalibrationMetricStatus::OverUpper
+    );
+    assert_eq!(report.metrics.total_usd.absolute_error, 5.0);
+    assert_eq!(report.metrics.total_usd.relative_error, Some(0.5));
+}
+
+#[test]
+fn actual_below_lower_interval_is_pessimistic() {
+    let work = tempfile::tempdir().unwrap();
+    let (forecast_path, results_path) = write_pair(
+        work.path(),
+        ForecastCase::default(),
+        ResultsCase {
+            total_cost_usd: 5.0,
+            input_tokens: 500,
+            output_tokens: 50,
+            wall_clock_secs: 50.0,
+            resolved: 1,
+            total: 4,
+        },
+        ManifestCase::default(),
+        ManifestCase::default(),
+    );
+
+    let report = compute(&CalibrationArgs {
+        forecast_path,
+        results_path,
+    })
+    .unwrap();
+
+    assert_eq!(report.verdict, CalibrationVerdict::Pessimistic);
+    assert_eq!(
+        report.metrics.total_usd.status,
+        CalibrationMetricStatus::UnderLower
+    );
+    assert_eq!(
+        report.metrics.total_input_tokens.status,
+        CalibrationMetricStatus::UnderLower
+    );
+    assert_eq!(
+        report.metrics.wall_clock_seconds.status,
+        CalibrationMetricStatus::UnderLower
+    );
+}
+
+#[test]
+fn dataset_model_parallel_and_instance_mismatches_are_flagged() {
+    let work = tempfile::tempdir().unwrap();
+    let (forecast_path, results_path) = write_pair(
+        work.path(),
+        ForecastCase::default(),
+        ResultsCase {
+            total: 3,
+            ..ResultsCase::default()
+        },
+        ManifestCase::default(),
+        ManifestCase {
+            dataset_sha256: "sha256:other".into(),
+            model: "other-model".into(),
+            parallel: 8,
+        },
+    );
+
+    let report = compute(&CalibrationArgs {
+        forecast_path,
+        results_path,
+    })
+    .unwrap();
+
+    assert_eq!(report.verdict, CalibrationVerdict::NotComparable);
+    let fields: Vec<_> = report.mismatches.iter().map(|m| m.field.as_str()).collect();
+    assert!(
+        fields.contains(&"dataset.sha256"),
+        "{:#?}",
+        report.mismatches
+    );
+    assert!(fields.contains(&"model.name"), "{:#?}", report.mismatches);
+    assert!(fields.contains(&"parallel"), "{:#?}", report.mismatches);
+    assert!(
+        fields.contains(&"instance_count"),
+        "{:#?}",
+        report.mismatches
+    );
+}
+
+#[test]
+fn exact_target_instance_set_mismatch_is_flagged_even_when_counts_match() {
+    let work = tempfile::tempdir().unwrap();
+    let (forecast_path, results_path) = write_pair(
+        work.path(),
+        ForecastCase {
+            target_instance_ids: vec!["w".into(), "x".into(), "y".into(), "z".into()],
+            ..ForecastCase::default()
+        },
+        ResultsCase::default(),
+        ManifestCase::default(),
+        ManifestCase::default(),
+    );
+
+    let report = compute(&CalibrationArgs {
+        forecast_path,
+        results_path,
+    })
+    .unwrap();
+
+    assert_eq!(report.verdict, CalibrationVerdict::NotComparable);
+    assert!(
+        report
+            .mismatches
+            .iter()
+            .any(|mismatch| mismatch.field == "instance_set"),
+        "{:#?}",
+        report.mismatches
+    );
+}
+
+#[test]
+fn calibration_json_shape_is_stable() {
+    let work = tempfile::tempdir().unwrap();
+    let (forecast_path, results_path) = write_pair(
+        work.path(),
+        ForecastCase::default(),
+        ResultsCase::default(),
+        ManifestCase::default(),
+        ManifestCase::default(),
+    );
+    let report = compute(&CalibrationArgs {
+        forecast_path,
+        results_path,
+    })
+    .unwrap();
+
+    let actual: serde_json::Value = serde_json::from_str(&to_json(&report).unwrap()).unwrap();
+    let fixture: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests")
+                .join("fixtures")
+                .join("artifact_schema")
+                .join("current")
+                .join("calibration.json"),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(json_shape(&actual), json_shape(&fixture));
+    assert_eq!(actual["artifact_kind"], "calibration_report");
+}
+
+#[test]
+fn cli_exposes_calibrate_and_writes_json_artifact() {
+    let work = tempfile::tempdir().unwrap();
+    let output = work.path().join("calibration.json");
+    let (forecast_path, results_path) = write_pair(
+        work.path(),
+        ForecastCase::default(),
+        ResultsCase::default(),
+        ManifestCase::default(),
+        ManifestCase::default(),
+    );
+
+    let help = Command::new(binary_path())
+        .args(["bench", "--help"])
+        .output()
+        .unwrap();
+    assert!(help.status.success());
+    assert!(
+        String::from_utf8(help.stdout)
+            .unwrap()
+            .contains("calibrate"),
+        "bench help should list calibrate"
+    );
+
+    let run = Command::new(binary_path())
+        .args([
+            "bench",
+            "calibrate",
+            "--forecast",
+            forecast_path.to_str().unwrap(),
+            "--results",
+            results_path.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        run.status.success(),
+        "calibrate failed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8(run.stdout).unwrap();
+    assert!(stdout.contains("=== bench calibrate ==="), "{stdout}");
+    assert!(
+        output.exists(),
+        "expected JSON artifact at {}",
+        output.display()
+    );
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(output).unwrap()).unwrap();
+    assert_eq!(json["verdict"], "well_calibrated");
+}
+
+#[test]
+fn cli_missing_input_path_is_usage_error() {
+    let work = tempfile::tempdir().unwrap();
+    let run = Command::new(binary_path())
+        .args([
+            "bench",
+            "calibrate",
+            "--forecast",
+            work.path().join("missing-forecast.json").to_str().unwrap(),
+            "--results",
+            work.path().join("missing-results.json").to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!run.status.success());
+    assert_eq!(run.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(stderr.contains("outcome_class: usage_error"), "{stderr}");
+    assert!(stderr.contains("forecast artifact not found"), "{stderr}");
+}
+
+#[test]
+fn cli_can_gate_on_optimistic_verdict_with_stable_outcome_class() {
+    let work = tempfile::tempdir().unwrap();
+    let (forecast_path, results_path) = write_pair(
+        work.path(),
+        ForecastCase::default(),
+        ResultsCase {
+            total_cost_usd: 15.0,
+            ..ResultsCase::default()
+        },
+        ManifestCase::default(),
+        ManifestCase::default(),
+    );
+
+    let run = Command::new(binary_path())
+        .args([
+            "bench",
+            "calibrate",
+            "--forecast",
+            forecast_path.to_str().unwrap(),
+            "--results",
+            results_path.to_str().unwrap(),
+            "--fail-on-optimistic",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!run.status.success());
+    assert_eq!(run.status.code(), Some(8));
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        stderr.contains("outcome_class: calibration_optimistic"),
+        "{stderr}"
+    );
+}
+
+#[derive(Debug, Clone)]
+struct ForecastCase {
+    total_cost_usd: IntervalEstimate,
+    input_tokens: IntervalEstimate,
+    output_tokens: IntervalEstimate,
+    wall_clock_secs: IntervalEstimate,
+    resolution_point: f64,
+    calibration_ids: Vec<String>,
+    target_n: usize,
+    target_instance_ids: Vec<String>,
+    parallel: usize,
+}
+
+impl Default for ForecastCase {
+    fn default() -> Self {
+        Self {
+            total_cost_usd: interval(10.0, 8.0, 12.0),
+            input_tokens: interval(1000.0, 800.0, 1200.0),
+            output_tokens: interval(100.0, 80.0, 120.0),
+            wall_clock_secs: interval(100.0, 80.0, 120.0),
+            resolution_point: 0.5,
+            calibration_ids: vec!["a".into(), "b".into()],
+            target_n: 4,
+            target_instance_ids: vec!["a".into(), "b".into(), "c".into(), "d".into()],
+            parallel: 4,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResultsCase {
+    total_cost_usd: f64,
+    input_tokens: u64,
+    output_tokens: u64,
+    wall_clock_secs: f64,
+    resolved: usize,
+    total: usize,
+}
+
+impl Default for ResultsCase {
+    fn default() -> Self {
+        Self {
+            total_cost_usd: 10.5,
+            input_tokens: 1050,
+            output_tokens: 105,
+            wall_clock_secs: 105.0,
+            resolved: 2,
+            total: 4,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ManifestCase {
+    dataset_sha256: String,
+    model: String,
+    parallel: usize,
+}
+
+impl Default for ManifestCase {
+    fn default() -> Self {
+        Self {
+            dataset_sha256: "sha256:dataset".into(),
+            model: "fixture-model".into(),
+            parallel: 4,
+        }
+    }
+}
+
+fn write_pair(
+    dir: &Path,
+    forecast: ForecastCase,
+    results: ResultsCase,
+    forecast_manifest: ManifestCase,
+    results_manifest: ManifestCase,
+) -> (PathBuf, PathBuf) {
+    let calibration_dir = dir.join("forecast");
+    std::fs::create_dir_all(&calibration_dir).unwrap();
+    let forecast_path = dir.join("forecast.json");
+    let results_path = dir.join("results.json");
+
+    let forecast_report = forecast_report(&forecast, &calibration_dir);
+    std::fs::write(
+        &forecast_path,
+        rust_swe_agent::run::forecast::to_json(&forecast_report).unwrap(),
+    )
+    .unwrap();
+
+    let calibration_results = sweep_results(
+        ResultsCase {
+            total: forecast.calibration_ids.len(),
+            resolved: forecast.calibration_ids.len(),
+            ..ResultsCase::default()
+        },
+        forecast_manifest,
+        &forecast.calibration_ids,
+    );
+    std::fs::write(
+        calibration_dir.join("results.json"),
+        rust_swe_agent::artifact::to_string_pretty(
+            ArtifactKind::SweepResults,
+            &calibration_results,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+
+    let actual_ids = match results.total {
+        0 => Vec::new(),
+        1 => vec!["a".to_owned()],
+        2 => vec!["a".to_owned(), "b".to_owned()],
+        3 => vec!["a".to_owned(), "b".to_owned(), "c".to_owned()],
+        _ => vec![
+            "a".to_owned(),
+            "b".to_owned(),
+            "c".to_owned(),
+            "d".to_owned(),
+        ],
+    };
+    let actual = sweep_results(results, results_manifest, &actual_ids);
+    std::fs::write(
+        &results_path,
+        rust_swe_agent::artifact::to_string_pretty(ArtifactKind::SweepResults, &actual).unwrap(),
+    )
+    .unwrap();
+
+    (forecast_path, results_path)
+}
+
+fn forecast_report(case: &ForecastCase, calibration_dir: &Path) -> ForecastReport {
+    ForecastReport {
+        calibration: CalibrationSummary {
+            n: case.calibration_ids.len(),
+            seed: 42,
+            output_dir: calibration_dir.display().to_string(),
+            instance_ids: case.calibration_ids.clone(),
+        },
+        per_instance: PerInstanceSummary {
+            input_tokens: quantiles(200.0, 250.0, 300.0),
+            output_tokens: quantiles(20.0, 25.0, 30.0),
+            usd_cost: quantiles(2.0, 2.5, 3.0),
+            step_count: quantiles(1.0, 2.0, 3.0),
+            wall_clock_seconds: quantiles(20.0, 25.0, 30.0),
+        },
+        forecast: ForecastTotals {
+            target_n: case.target_n,
+            target_instance_ids: case.target_instance_ids.clone(),
+            parallel: case.parallel,
+            confidence_pct: 80.0,
+            total_cost_usd: case.total_cost_usd,
+            total_input_tokens: case.input_tokens,
+            total_output_tokens: case.output_tokens,
+            wall_clock_seconds: case.wall_clock_secs,
+        },
+        resolution_rate: ResolutionRateSignal {
+            resolved: 1,
+            total: 2,
+            point: case.resolution_point,
+            disclaimer: "fixture".into(),
+        },
+        threshold: ThresholdCheck {
+            limit_usd: None,
+            status: ThresholdStatus::NotConfigured,
+            message: "no sweep cost limit configured".into(),
+        },
+    }
+}
+
+fn sweep_results(
+    case: ResultsCase,
+    manifest: ManifestCase,
+    instance_ids: &[String],
+) -> SweepResults {
+    let instances: Vec<_> = instance_ids
+        .iter()
+        .enumerate()
+        .map(|(idx, id)| {
+            let submitted = idx < case.resolved;
+            let per_instance_cost = if case.total == 0 {
+                0.0
+            } else {
+                case.total_cost_usd / case.total as f64
+            };
+            instance(
+                id,
+                submitted,
+                per_instance_cost,
+                case.wall_clock_secs / case.total.max(1) as f64,
+            )
+        })
+        .collect();
+    SweepResults {
+        total: case.total,
+        sweep_status: rust_swe_agent::run::swebench::SWEEP_STATUS_COMPLETED.into(),
+        cancelled_at: None,
+        cancel_deadline_at: None,
+        cancel_exit_code: None,
+        completed: case.total,
+        in_flight_at_cancel: 0,
+        not_started: 0,
+        submitted: case.resolved,
+        submitted_with_tests: 0,
+        skipped: 0,
+        errored: case.total.saturating_sub(case.resolved),
+        failures_by_category: BTreeMap::new(),
+        budget_halted: 0,
+        with_patch: case.resolved,
+        patch_empty: 0,
+        patch_apply_invalid: 0,
+        github_pr_failures: 0,
+        total_prompt_tokens: case.input_tokens,
+        total_cache_read_tokens: 0,
+        total_cache_creation_tokens: 0,
+        total_completion_tokens: case.output_tokens,
+        estimated_cost_usd: case.total_cost_usd,
+        actual_cost_usd: Some(case.total_cost_usd),
+        actual_cost_source: None,
+        baseline_cost_usd: None,
+        baseline_cost_model: None,
+        cache_hit_rate: 0.0,
+        retries: 0,
+        retried_instances: 0,
+        pass_at_k: if case.total == 0 {
+            0.0
+        } else {
+            case.resolved as f64 / case.total as f64
+        },
+        filter_spec: FilterSpec {
+            original_count: case.total,
+            selected_count: case.total,
+            instance_ids: Some(instance_ids.to_vec()),
+            ..FilterSpec::default()
+        },
+        manifest: Some(manifest_for(manifest, case.total, case.wall_clock_secs)),
+        cost_limit_usd: None,
+        instances,
+        rate_limit_events: None,
+        total_fallbacks: 0,
+        model_mix: BTreeMap::new(),
+    }
+}
+
+fn instance(id: &str, submitted: bool, cost_usd: f64, duration_secs: f64) -> InstanceResult {
+    InstanceResult {
+        instance_id: id.into(),
+        exit_reason: if submitted { "submitted" } else { "error" }.into(),
+        outcome: Some(if submitted {
+            outcome::SUBMITTED.into()
+        } else {
+            outcome::ERROR.into()
+        }),
+        failure_category: (!submitted).then_some(FailureCategory::Unknown),
+        steps: Some(1),
+        cost_usd: Some(cost_usd),
+        prompt_tokens: Some(250),
+        cache_read_tokens: Some(0),
+        cache_creation_tokens: Some(0),
+        completion_tokens: Some(25),
+        duration_secs: Some(duration_secs),
+        error: None,
+        github_pr_error: None,
+        patch_present: submitted,
+        non_empty_patch: false,
+        attempts: 1,
+        retry_reasons: Vec::new(),
+        runs: 1,
+        resolved_count: u32::from(submitted),
+        pass_at_1: submitted,
+        tests_run_before_submit: false,
+        last_tests_passed: None,
+        fallback_count: None,
+        final_model: None,
+    }
+}
+
+fn manifest_for(case: ManifestCase, total: usize, wall_clock_secs: f64) -> ProvenanceManifest {
+    ProvenanceManifest {
+        purpose: None,
+        harness: HarnessManifest {
+            name: "rust_swe_agent".into(),
+            version: "test".into(),
+            git_sha: None,
+            git_dirty: None,
+            git_resolution: "test".into(),
+        },
+        dataset: DatasetManifest {
+            path: "dataset.jsonl".into(),
+            sha256: case.dataset_sha256,
+            instance_count: total,
+            filter_spec: Some(FilterSpec {
+                original_count: total,
+                selected_count: total,
+                ..FilterSpec::default()
+            }),
+            source_kind: "local".into(),
+            source_revision: Some("sha256:dataset".into()),
+            selected_row_count: total,
+            post_filter_row_count: total,
+            ..DatasetManifest::default()
+        },
+        prompt_template: rust_swe_agent::run::swebench::PromptTemplateManifest {
+            source: "inline".into(),
+            path: None,
+            sha256: "prompt".into(),
+        },
+        config: ConfigManifest {
+            resolved: "test".into(),
+            overlay_paths: Vec::new(),
+        },
+        model: ModelManifest {
+            name: case.model,
+            backend: "deterministic".into(),
+            backend_version: None,
+            base_url: None,
+        },
+        runtime: RuntimeManifest {
+            started_at_utc: "2026-05-01T00:00:00Z".into(),
+            finished_at_utc: Some(format!(
+                "2026-05-01T00:{:02}:{:02}Z",
+                (wall_clock_secs / 60.0).floor() as u64,
+                (wall_clock_secs % 60.0).round() as u64
+            )),
+            host_os: "test".into(),
+            resume_mode: false,
+            rust_version: None,
+        },
+        cli: CliManifest {
+            argv: vec![
+                "rust-swe-agent".into(),
+                "bench".into(),
+                "swebench".into(),
+                "--parallel".into(),
+                case.parallel.to_string(),
+            ],
+        },
+    }
+}
+
+fn interval(point: f64, lower: f64, upper: f64) -> IntervalEstimate {
+    IntervalEstimate {
+        point,
+        lower,
+        upper,
+    }
+}
+
+fn quantiles(p10: f64, median: f64, p90: f64) -> QuantileSummary {
+    QuantileSummary { p10, median, p90 }
+}
+
+fn json_shape(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Null => serde_json::json!("null"),
+        serde_json::Value::Bool(_) => serde_json::json!("bool"),
+        serde_json::Value::Number(_) => serde_json::json!("number"),
+        serde_json::Value::String(_) => serde_json::json!("string"),
+        serde_json::Value::Array(items) => items.first().map_or_else(
+            || serde_json::json!([]),
+            |first| serde_json::json!([json_shape(first)]),
+        ),
+        serde_json::Value::Object(object) => {
+            let mut shape = serde_json::Map::new();
+            for (key, nested) in object {
+                shape.insert(key.clone(), json_shape(nested));
+            }
+            serde_json::Value::Object(shape)
+        }
+    }
+}

--- a/tests/bench_calibrate.rs
+++ b/tests/bench_calibrate.rs
@@ -156,6 +156,7 @@ fn dataset_model_parallel_and_instance_mismatches_are_flagged() {
             dataset_sha256: "sha256:other".into(),
             model: "other-model".into(),
             parallel: 8,
+            ..ManifestCase::default()
         },
     );
 
@@ -179,6 +180,124 @@ fn dataset_model_parallel_and_instance_mismatches_are_flagged() {
         "{:#?}",
         report.mismatches
     );
+}
+
+#[test]
+fn relative_calibration_output_dir_is_resolved_from_current_cwd_first() {
+    let cwd = std::env::current_dir().unwrap();
+    let work = tempfile::tempdir_in(cwd.join("target")).unwrap();
+    let rel_work = work.path().strip_prefix(&cwd).unwrap();
+    let runs_dir = rel_work.join("runs");
+    let forecast_path = runs_dir.join("forecast.json");
+    let results_path = runs_dir.join("results.json");
+    let calibration_dir = runs_dir.join("forecast").join("forecast");
+
+    std::fs::create_dir_all(cwd.join(&calibration_dir)).unwrap();
+
+    let forecast_report = forecast_report(&ForecastCase::default(), &calibration_dir);
+    std::fs::write(
+        cwd.join(&forecast_path),
+        rust_swe_agent::run::forecast::to_json(&forecast_report).unwrap(),
+    )
+    .unwrap();
+
+    let calibration_results = sweep_results(
+        ResultsCase {
+            total: 2,
+            resolved: 2,
+            ..ResultsCase::default()
+        },
+        ManifestCase::default(),
+        &["a".to_owned(), "b".to_owned()],
+    );
+    std::fs::write(
+        cwd.join(&calibration_dir).join("results.json"),
+        rust_swe_agent::artifact::to_string_pretty(
+            ArtifactKind::SweepResults,
+            &calibration_results,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+
+    let actual = sweep_results(
+        ResultsCase::default(),
+        ManifestCase {
+            model: "other-model".into(),
+            ..ManifestCase::default()
+        },
+        &[
+            "a".to_owned(),
+            "b".to_owned(),
+            "c".to_owned(),
+            "d".to_owned(),
+        ],
+    );
+    std::fs::write(
+        cwd.join(&results_path),
+        rust_swe_agent::artifact::to_string_pretty(ArtifactKind::SweepResults, &actual).unwrap(),
+    )
+    .unwrap();
+
+    let report = compute(&CalibrationArgs {
+        forecast_path,
+        results_path,
+    })
+    .unwrap();
+
+    assert!(
+        report
+            .mismatches
+            .iter()
+            .any(|mismatch| mismatch.field == "model.name"),
+        "{:#?}",
+        report.mismatches
+    );
+    assert!(
+        report
+            .warnings
+            .iter()
+            .all(|warning| !warning.contains("forecast calibration results unavailable")),
+        "{:#?}",
+        report.warnings
+    );
+}
+
+#[test]
+fn parallel_mismatch_is_detected_from_equals_and_short_manifest_forms() {
+    for parallel_arg_style in [
+        ParallelArgStyle::LongEquals,
+        ParallelArgStyle::ShortSeparated,
+    ] {
+        let work = tempfile::tempdir().unwrap();
+        let (forecast_path, results_path) = write_pair(
+            work.path(),
+            ForecastCase::default(),
+            ResultsCase::default(),
+            ManifestCase::default(),
+            ManifestCase {
+                parallel: 8,
+                parallel_arg_style,
+                ..ManifestCase::default()
+            },
+        );
+
+        let report = compute(&CalibrationArgs {
+            forecast_path,
+            results_path,
+        })
+        .unwrap();
+
+        assert_eq!(report.verdict, CalibrationVerdict::NotComparable);
+        assert!(
+            report
+                .mismatches
+                .iter()
+                .any(|mismatch| mismatch.field == "parallel"),
+            "{parallel_arg_style:?}: {:#?}",
+            report.mismatches
+        );
+    }
 }
 
 #[test]
@@ -210,6 +329,44 @@ fn exact_target_instance_set_mismatch_is_flagged_even_when_counts_match() {
         "{:#?}",
         report.mismatches
     );
+}
+
+#[test]
+fn small_n_zero_resolution_signal_uses_nonzero_interval() {
+    let work = tempfile::tempdir().unwrap();
+    let (forecast_path, results_path) = write_pair(
+        work.path(),
+        ForecastCase {
+            resolution_point: 0.0,
+            resolution_resolved: 0,
+            resolution_total: 2,
+            ..ForecastCase::default()
+        },
+        ResultsCase {
+            resolved: 1,
+            total: 4,
+            ..ResultsCase::default()
+        },
+        ManifestCase::default(),
+        ManifestCase::default(),
+    );
+
+    let report = compute(&CalibrationArgs {
+        forecast_path,
+        results_path,
+    })
+    .unwrap();
+
+    assert_eq!(
+        report.metrics.resolution_rate.status,
+        CalibrationMetricStatus::WithinInterval
+    );
+    assert!(
+        report.metrics.resolution_rate.forecast.upper > 0.2,
+        "{:#?}",
+        report.metrics.resolution_rate
+    );
+    assert_eq!(report.verdict, CalibrationVerdict::WellCalibrated);
 }
 
 #[test]
@@ -366,6 +523,8 @@ struct ForecastCase {
     output_tokens: IntervalEstimate,
     wall_clock_secs: IntervalEstimate,
     resolution_point: f64,
+    resolution_resolved: usize,
+    resolution_total: usize,
     calibration_ids: Vec<String>,
     target_n: usize,
     target_instance_ids: Vec<String>,
@@ -380,6 +539,8 @@ impl Default for ForecastCase {
             output_tokens: interval(100.0, 80.0, 120.0),
             wall_clock_secs: interval(100.0, 80.0, 120.0),
             resolution_point: 0.5,
+            resolution_resolved: 1,
+            resolution_total: 2,
             calibration_ids: vec!["a".into(), "b".into()],
             target_n: 4,
             target_instance_ids: vec!["a".into(), "b".into(), "c".into(), "d".into()],
@@ -416,6 +577,7 @@ struct ManifestCase {
     dataset_sha256: String,
     model: String,
     parallel: usize,
+    parallel_arg_style: ParallelArgStyle,
 }
 
 impl Default for ManifestCase {
@@ -424,6 +586,41 @@ impl Default for ManifestCase {
             dataset_sha256: "sha256:dataset".into(),
             model: "fixture-model".into(),
             parallel: 4,
+            parallel_arg_style: ParallelArgStyle::LongSeparated,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ParallelArgStyle {
+    LongSeparated,
+    LongEquals,
+    ShortSeparated,
+}
+
+impl ParallelArgStyle {
+    fn argv(self, parallel: usize) -> Vec<String> {
+        match self {
+            Self::LongSeparated => vec![
+                "rust-swe-agent".into(),
+                "bench".into(),
+                "swebench".into(),
+                "--parallel".into(),
+                parallel.to_string(),
+            ],
+            Self::LongEquals => vec![
+                "rust-swe-agent".into(),
+                "bench".into(),
+                "swebench".into(),
+                format!("--parallel={parallel}"),
+            ],
+            Self::ShortSeparated => vec![
+                "rust-swe-agent".into(),
+                "bench".into(),
+                "swebench".into(),
+                "-p".into(),
+                parallel.to_string(),
+            ],
         }
     }
 }
@@ -514,8 +711,8 @@ fn forecast_report(case: &ForecastCase, calibration_dir: &Path) -> ForecastRepor
             wall_clock_seconds: case.wall_clock_secs,
         },
         resolution_rate: ResolutionRateSignal {
-            resolved: 1,
-            total: 2,
+            resolved: case.resolution_resolved,
+            total: case.resolution_total,
             point: case.resolution_point,
             disclaimer: "fixture".into(),
         },
@@ -686,13 +883,7 @@ fn manifest_for(case: ManifestCase, total: usize, wall_clock_secs: f64) -> Prove
             rust_version: None,
         },
         cli: CliManifest {
-            argv: vec![
-                "rust-swe-agent".into(),
-                "bench".into(),
-                "swebench".into(),
-                "--parallel".into(),
-                case.parallel.to_string(),
-            ],
+            argv: case.parallel_arg_style.argv(case.parallel),
         },
     }
 }

--- a/tests/bench_forecast.rs
+++ b/tests/bench_forecast.rs
@@ -1028,6 +1028,7 @@ async fn calibration_sampling_stays_within_planned_limit() {
     let report = expect_forecast_report(outcome);
 
     assert_eq!(report.forecast.target_n, 1);
+    assert_eq!(report.forecast.target_instance_ids, ["a"]);
     assert_eq!(report.calibration.instance_ids, ["a"]);
 }
 

--- a/tests/dataset_alias.rs
+++ b/tests/dataset_alias.rs
@@ -140,7 +140,7 @@ async fn named_alias_cache_miss_errors_before_any_task_launches() {
     assert!(msg.contains("lite"), "error must name alias: {msg}");
     assert!(msg.contains("test"), "error must name split: {msg}");
     assert!(
-        msg.contains("lite/test.jsonl"),
+        msg.replace('\\', "/").contains("lite/test.jsonl"),
         "error must name cache path: {msg}"
     );
 }

--- a/tests/fixtures/artifact_schema/current/all_preds.metadata.json
+++ b/tests/fixtures/artifact_schema/current/all_preds.metadata.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "swebench_predictions_metadata",
-  "schema_version": {"major": 1, "minor": 2},
+  "schema_version": {"major": 1, "minor": 3},
   "predictions_file": "all_preds.jsonl",
   "aggregate": true,
   "row_count": 1,

--- a/tests/fixtures/artifact_schema/current/calibration.json
+++ b/tests/fixtures/artifact_schema/current/calibration.json
@@ -1,0 +1,86 @@
+{
+  "artifact_kind": "calibration_report",
+  "schema_version": {"major": 1, "minor": 3},
+  "forecast_path": "forecast.json",
+  "results_path": "results.json",
+  "forecast_artifact": "forecast_report@1.3",
+  "results_artifact": "sweep_results@1.3",
+  "verdict": "well_calibrated",
+  "comparability": "matched",
+  "forecast_target_n": 4,
+  "actual_instance_count": 4,
+  "metrics": {
+    "total_usd": {
+      "forecast": {"point": 10.0, "lower": 8.0, "upper": 12.0},
+      "actual": 10.5,
+      "status": "within_interval",
+      "absolute_error": 0.5,
+      "relative_error": 0.05
+    },
+    "total_input_tokens": {
+      "forecast": {"point": 1000.0, "lower": 800.0, "upper": 1200.0},
+      "actual": 1050.0,
+      "status": "within_interval",
+      "absolute_error": 50.0,
+      "relative_error": 0.05
+    },
+    "total_output_tokens": {
+      "forecast": {"point": 100.0, "lower": 80.0, "upper": 120.0},
+      "actual": 105.0,
+      "status": "within_interval",
+      "absolute_error": 5.0,
+      "relative_error": 0.05
+    },
+    "wall_clock_seconds": {
+      "forecast": {"point": 100.0, "lower": 80.0, "upper": 120.0},
+      "actual": 105.0,
+      "status": "within_interval",
+      "absolute_error": 5.0,
+      "relative_error": 0.05
+    },
+    "resolution_rate": {
+      "forecast": {"point": 0.5, "lower": 0.0, "upper": 1.0},
+      "actual": 0.5,
+      "status": "within_interval",
+      "absolute_error": 0.0,
+      "relative_error": 0.0
+    }
+  },
+  "per_instance": {
+    "input_tokens": {
+      "forecast": {"p10": 200.0, "median": 250.0, "p90": 300.0},
+      "actual": {"p10": 250.0, "median": 250.0, "p90": 250.0},
+      "status": "within_interval",
+      "absolute_error": 0.0,
+      "relative_error": 0.0
+    },
+    "output_tokens": {
+      "forecast": {"p10": 20.0, "median": 25.0, "p90": 30.0},
+      "actual": {"p10": 25.0, "median": 25.0, "p90": 25.0},
+      "status": "within_interval",
+      "absolute_error": 0.0,
+      "relative_error": 0.0
+    },
+    "usd_cost": {
+      "forecast": {"p10": 2.0, "median": 2.5, "p90": 3.0},
+      "actual": {"p10": 2.625, "median": 2.625, "p90": 2.625},
+      "status": "within_interval",
+      "absolute_error": 0.125,
+      "relative_error": 0.05
+    },
+    "step_count": {
+      "forecast": {"p10": 1.0, "median": 2.0, "p90": 3.0},
+      "actual": {"p10": 1.0, "median": 1.0, "p90": 1.0},
+      "status": "within_interval",
+      "absolute_error": 1.0,
+      "relative_error": -0.5
+    },
+    "wall_clock_seconds": {
+      "forecast": {"p10": 20.0, "median": 25.0, "p90": 30.0},
+      "actual": {"p10": 26.25, "median": 26.25, "p90": 26.25},
+      "status": "within_interval",
+      "absolute_error": 1.25,
+      "relative_error": 0.05
+    }
+  }
+}

--- a/tests/fixtures/artifact_schema/current/evaluation.json
+++ b/tests/fixtures/artifact_schema/current/evaluation.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "evaluation_results",
-  "schema_version": {"major": 1, "minor": 2},
+  "schema_version": {"major": 1, "minor": 3},
   "instances": [
     {
       "instance_id": "task-a",

--- a/tests/fixtures/artifact_schema/current/forecast.json
+++ b/tests/fixtures/artifact_schema/current/forecast.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "forecast_report",
-  "schema_version": {"major": 1, "minor": 2},
+  "schema_version": {"major": 1, "minor": 3},
   "calibration": {
     "n": 1,
     "seed": 42,

--- a/tests/fixtures/artifact_schema/current/preflight.json
+++ b/tests/fixtures/artifact_schema/current/preflight.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "preflight_report",
-  "schema_version": {"major": 1, "minor": 2},
+  "schema_version": {"major": 1, "minor": 3},
   "mode": "doctor",
   "checks": [
     {

--- a/tests/fixtures/artifact_schema/current/results.json
+++ b/tests/fixtures/artifact_schema/current/results.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "sweep_results",
-  "schema_version": {"major": 1, "minor": 2},
+  "schema_version": {"major": 1, "minor": 3},
   "total": 1,
   "sweep_status": "completed",
   "completed": 1,

--- a/tests/fixtures/artifact_schema/current/sweep/evaluation.json
+++ b/tests/fixtures/artifact_schema/current/sweep/evaluation.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "evaluation_results",
-  "schema_version": {"major": 1, "minor": 2},
+  "schema_version": {"major": 1, "minor": 3},
   "instances": [
     {
       "instance_id": "task-a",

--- a/tests/fixtures/artifact_schema/current/sweep/results.json
+++ b/tests/fixtures/artifact_schema/current/sweep/results.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "sweep_results",
-  "schema_version": {"major": 1, "minor": 2},
+  "schema_version": {"major": 1, "minor": 3},
   "total": 1,
   "sweep_status": "completed",
   "completed": 1,

--- a/tests/fixtures/artifact_schema/current/sweep/task-a.traj.json
+++ b/tests/fixtures/artifact_schema/current/sweep/task-a.traj.json
@@ -1,7 +1,7 @@
 {
   "trajectory_format": "mini-swe-agent-1.1",
   "artifact_kind": "trajectory",
-  "schema_version": {"major": 1, "minor": 2},
+  "schema_version": {"major": 1, "minor": 3},
   "info": {
     "task": "task-a",
     "model_name": "fixture-model",

--- a/tests/fixtures/artifact_schema/current/trajectory.traj.json
+++ b/tests/fixtures/artifact_schema/current/trajectory.traj.json
@@ -1,7 +1,7 @@
 {
   "trajectory_format": "mini-swe-agent-1.1",
   "artifact_kind": "trajectory",
-  "schema_version": {"major": 1, "minor": 2},
+  "schema_version": {"major": 1, "minor": 3},
   "info": {
     "task": "task-a",
     "model_name": "fixture-model",


### PR DESCRIPTION
  Add `bench calibrate` to compare forecast artifacts against completed sweep
  results, emit versioned calibration reports, classify interval accuracy, and
  support an optimistic-gate exit code.

  Also record forecast target instance IDs so calibration can detect exact
  instance-set mismatches instead of trusting matching counts. Update artifact
  schema fixtures, exit-code docs, README workflow docs, and regression coverage