### PR TITLE
feat: add harness-level skill activation

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -80,6 +80,7 @@ Raw secrets must **never** appear in committed config files or TOML examples.
 [environment]  # Execution environment: local shell or Docker
 [prompts]      # System and instance prompt templates
 [sweep]        # Rate-limiting for parallel sweeps
+[skills]       # Harness-level skill discovery and activation
 [redaction]    # Secret redaction policy
 [policy]       # Pre-execution command policy (safe / ask / yolo)
 ```
@@ -202,6 +203,23 @@ opt-in: when unset, no ceiling is applied.
 | `max_input_tpm` | integer \| null | `null` | Any positive integer | Cap aggregate input tokens/minute; maps to `--max-input-tpm` |
 
 CLI values always win over config file values for both fields.
+
+---
+
+## `[skills]`
+
+Harness-level agent skills are optional and disabled by default. When enabled,
+the harness scans configured paths into a private registry, resolves the
+relevant subset for each task, and injects only active skill bodies into the
+run's additional context. Inactive skill names and descriptions are not sent to
+the model.
+
+| Field | Type | Default | Valid values | Notes |
+|---|---|---|---|---|
+| `enabled` | bool | `false` | `true`, `false` | Enables skill discovery and activation for the run |
+| `auto_load` | bool | `true` | `true`, `false` | When `true`, the harness can activate skills from task/manifests; explicit `$skill-name` mentions still work when this is `false` |
+| `paths` | array of strings | `[]` | Directories or `SKILL.md` files | Paths are resolved by the harness process; `~/...` expands to the user home directory |
+| `max_active` | integer | `4` | `1`-`∞` when enabled | Hard cap on selected skills injected into a single run |
 
 ---
 

--- a/docs/plans/2026-05-10-harness-skills.md
+++ b/docs/plans/2026-05-10-harness-skills.md
@@ -1,0 +1,74 @@
+# Harness Skills Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add harness-level agent skills so the registry stays private and only selected skill bodies are injected into the agent prompt.
+
+**Architecture:** The harness scans configured skill directories, parses `SKILL.md` frontmatter into a private registry, resolves relevant skills from explicit mentions and task text, loads only selected skill bodies, and passes the active context to `DefaultAgentBuilder`. The agent never receives the complete skill registry by default.
+
+**Tech Stack:** Rust 2024, existing config overlay system, `serde`, `tempfile`, focused unit/integration tests.
+
+---
+
+### Task 1: Skill Registry
+
+**Files:**
+- Create: `src/skills.rs`
+- Modify: `src/lib.rs`
+- Test: `tests/skills.rs`
+
+**Steps:**
+1. Write failing tests for scanning `SKILL.md` files and parsing only `name` and `description` frontmatter.
+2. Implement a small frontmatter parser without adding dependencies.
+3. Add content loading that returns the full skill body for selected skills.
+
+### Task 2: Harness Resolver
+
+**Files:**
+- Modify: `src/skills.rs`
+- Test: `tests/skills.rs`
+
+**Steps:**
+1. Write failing tests for explicit `$skill-name` activation and keyword activation from `name`/`description`.
+2. Implement deterministic resolver behavior with deduplication and stable ordering.
+3. Record activation reason and SHA-256 provenance.
+
+### Task 3: Config Surface
+
+**Files:**
+- Modify: `src/config/schema.rs`
+- Modify: `src/config/mod.rs`
+- Modify: `src/config/defaults/default.toml`
+- Test: `tests/config_reference.rs`
+
+**Steps:**
+1. Write failing tests for `[skills] enabled`, `paths`, and `auto_load`.
+2. Add `SkillCfg` to root config with safe defaults.
+3. Validate configured skill paths and document defaults.
+
+### Task 4: Prompt Injection
+
+**Files:**
+- Modify: `src/agent/default.rs`
+- Modify: `src/run/mini.rs`
+- Modify: `src/run/replay.rs`
+- Modify: `src/config/defaults/default.toml`
+- Test: `tests/agent_loop.rs` or `tests/skills.rs`
+
+**Steps:**
+1. Write failing tests proving inactive skill metadata is absent from initial prompts.
+2. Write failing tests proving selected skill body is present in system prompt.
+3. Thread `active_skills` from the harness into `DefaultAgentBuilder`.
+4. Add active skill provenance to the trajectory manifest.
+
+### Task 5: Verification
+
+**Files:**
+- Affected Rust and docs files.
+
+**Steps:**
+1. Run `cargo fmt --all`.
+2. Run targeted skill tests.
+3. Run `cargo test --all-targets --all-features`.
+4. Run `cargo clippy --all-targets --all-features -- -D warnings`.
+5. Scan affected areas for `TODO`, `FIXME`, and stubs.

--- a/src/config/defaults/default.toml
+++ b/src/config/defaults/default.toml
@@ -135,6 +135,15 @@ enabled = true
 # intentionally producing a private, non-shareable artifact.
 unsafe_allow_secret_leaks = false
 
+[skills]
+# Harness-level agent skills are private by default: the harness scans the
+# configured paths, selects relevant skills, and injects only active skill
+# bodies into the run's extra context.
+enabled = false
+auto_load = true
+paths = []
+max_active = 4
+
 [prompts]
 system = '''
 You are a skilled software engineer working at a terminal. You have

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -13,7 +13,7 @@ pub mod schema;
 
 pub use schema::{
     AgentCfg, AgentKind, EnvCfg, EnvKind, McpServerCfg, ModelCfg, PromptCfg, RedactionCfg, RootCfg,
-    SweepCfg, ToolCfg, ToolHookCfg, ToolHooksCfg,
+    SkillCfg, SweepCfg, ToolCfg, ToolHookCfg, ToolHooksCfg,
 };
 
 const DEFAULT_TOML: &str = include_str!("defaults/default.toml");
@@ -61,6 +61,7 @@ impl Config {
 fn validate_root(root: &RootCfg) -> Result<(), ConfigError> {
     validate_agent_tools(root)?;
     validate_mcp_servers(root)?;
+    validate_skills(root)?;
     for pattern in &root.agent.test_command_patterns {
         Regex::new(pattern).map_err(|err| {
             ConfigError::Invalid(format!(
@@ -74,6 +75,20 @@ fn validate_root(root: &RootCfg) -> Result<(), ConfigError> {
                 "invalid redaction.custom_patterns regex {pattern:?}: {err}"
             ))
         })?;
+    }
+    Ok(())
+}
+
+fn validate_skills(root: &RootCfg) -> Result<(), ConfigError> {
+    if root.skills.enabled && root.skills.max_active == 0 {
+        return Err(ConfigError::Invalid(
+            "skills.max_active must be greater than 0 when skills.enabled=true".into(),
+        ));
+    }
+    if root.skills.paths.iter().any(|path| path.trim().is_empty()) {
+        return Err(ConfigError::Invalid(
+            "skills.paths entries cannot be empty".into(),
+        ));
     }
     Ok(())
 }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -186,6 +186,44 @@ pub struct SweepCfg {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillCfg {
+    /// Enable harness-level skill discovery and activation. Disabled by
+    /// default to preserve prompt stability unless a run opts in.
+    #[serde(default)]
+    pub enabled: bool,
+    /// When enabled, allow the harness to activate skills from task/manifests
+    /// without an explicit `$skill-name` mention.
+    #[serde(default = "default_skill_auto_load")]
+    pub auto_load: bool,
+    /// Directories or `SKILL.md` files to scan. Paths are resolved by the
+    /// harness process; `~/...` expands to the user home directory.
+    #[serde(default)]
+    pub paths: Vec<String>,
+    /// Hard cap on active skills injected into a run.
+    #[serde(default = "default_skill_max_active")]
+    pub max_active: usize,
+}
+
+impl Default for SkillCfg {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            auto_load: default_skill_auto_load(),
+            paths: Vec::new(),
+            max_active: default_skill_max_active(),
+        }
+    }
+}
+
+const fn default_skill_auto_load() -> bool {
+    true
+}
+
+const fn default_skill_max_active() -> usize {
+    4
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RedactionCfg {
     /// Enable runtime redaction before observations, trajectories, streams,
     /// exports, and shareable artifacts are persisted or emitted.
@@ -232,6 +270,8 @@ pub struct RootCfg {
     pub prompts: PromptCfg,
     #[serde(default)]
     pub sweep: SweepCfg,
+    #[serde(default)]
+    pub skills: SkillCfg,
     #[serde(default)]
     pub redaction: RedactionCfg,
     #[serde(default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod model;
 pub mod policy;
 pub mod redaction;
 pub mod run;
+pub mod skills;
 pub mod stream;
 pub mod template;
 pub mod tool;
@@ -26,7 +27,9 @@ pub use run::dataset::{
 };
 
 pub use agent::{Agent, DefaultAgent, ExitReason, InteractiveAgent, StepOutcome};
-pub use config::{Config, McpServerCfg, RedactionCfg, ToolCfg, ToolHookCfg, ToolHooksCfg};
+pub use config::{
+    Config, McpServerCfg, RedactionCfg, SkillCfg, ToolCfg, ToolHookCfg, ToolHooksCfg,
+};
 #[cfg(feature = "docker")]
 pub use env::DockerEnvironment;
 pub use env::{Environment, LocalEnvironment, RunRequest, RunResult};
@@ -41,6 +44,10 @@ pub use policy::{
     PolicyRule,
 };
 pub use redaction::{RedactionCount, RedactionSummary, Redactor};
+pub use skills::{
+    ActiveSkill, ActiveSkillManifest, ActiveSkillSet, ResolvedSkillContext, SkillActivationReason,
+    SkillManifest, SkillRegistry, SkillResolveRequest, resolve_for_task,
+};
 pub use stream::{BroadcastSink, NullSink, SseServer, StreamEvent, StreamSink};
 pub use tool::{
     BASH_TOOL_NAME, CommandTool, McpStdioServer, ToolCall, ToolDefinition, ToolInvocation,

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -163,7 +163,9 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     }
     .build_with_tool_providers(tool_providers)?;
     agent.cancellation = args.cancellation.clone();
-    record_active_skill_provenance(&mut agent, &resolved_skills.active_skills)?;
+    resolved_skills
+        .active_skills
+        .record_redacted_provenance(&mut agent.trajectory.info, &agent.redactor)?;
 
     let traj_path = args
         .output_dir
@@ -374,20 +376,6 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     if let Some(err) = verification_err {
         return Err(err);
     }
-    Ok(())
-}
-
-fn record_active_skill_provenance(
-    agent: &mut DefaultAgent,
-    active_skills: &crate::skills::ActiveSkillSet,
-) -> Result<(), Error> {
-    if active_skills.is_empty() {
-        return Ok(());
-    }
-    agent.trajectory.info.other.insert(
-        "active_skills".into(),
-        serde_json::to_value(active_skills.provenance())?,
-    );
     Ok(())
 }
 

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -118,6 +118,11 @@ pub struct MiniArgs {
 pub async fn run(args: MiniArgs) -> Result<(), Error> {
     std::fs::create_dir_all(&args.output_dir)?;
 
+    let resolved_skills = crate::skills::resolve_for_task(
+        &args.config.root.skills,
+        &args.task,
+        args.extra_context.clone(),
+    )?;
     let model = build_model(
         &args.config,
         args.deterministic_responses,
@@ -152,12 +157,13 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         model,
         env,
         task: args.task.clone(),
-        extra_context: args.extra_context.clone(),
+        extra_context: resolved_skills.merged_extra_context.clone(),
         renderer: None,
         stream: sink,
     }
     .build_with_tool_providers(tool_providers)?;
     agent.cancellation = args.cancellation.clone();
+    record_active_skill_provenance(&mut agent, &resolved_skills.active_skills)?;
 
     let traj_path = args
         .output_dir
@@ -368,6 +374,20 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     if let Some(err) = verification_err {
         return Err(err);
     }
+    Ok(())
+}
+
+fn record_active_skill_provenance(
+    agent: &mut DefaultAgent,
+    active_skills: &crate::skills::ActiveSkillSet,
+) -> Result<(), Error> {
+    if active_skills.is_empty() {
+        return Ok(());
+    }
+    agent.trajectory.info.other.insert(
+        "active_skills".into(),
+        serde_json::to_value(active_skills.provenance())?,
+    );
     Ok(())
 }
 

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -57,6 +57,7 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
         .info
         .task
         .unwrap_or_else(|| "Replayed Task".into());
+    let resolved_skills = crate::skills::resolve_for_task(&args.config.root.skills, &task, None)?;
     let traj_name = args
         .trajectory_name
         .unwrap_or_else(|| crate::run::mini::slugify(&task));
@@ -66,11 +67,17 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
         model,
         env,
         task,
-        extra_context: None,
+        extra_context: resolved_skills.merged_extra_context,
         renderer: None,
         stream: None,
     }
     .build_with_tool_providers(tool_providers)?;
+    if !resolved_skills.active_skills.is_empty() {
+        agent.trajectory.info.other.insert(
+            "active_skills".into(),
+            serde_json::to_value(resolved_skills.active_skills.provenance())?,
+        );
+    }
 
     // 4. Run the replay
     tracing::info!(?args.trajectory_path, "starting replay mode");

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -72,12 +72,9 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
         stream: None,
     }
     .build_with_tool_providers(tool_providers)?;
-    if !resolved_skills.active_skills.is_empty() {
-        agent.trajectory.info.other.insert(
-            "active_skills".into(),
-            serde_json::to_value(resolved_skills.active_skills.provenance())?,
-        );
-    }
+    resolved_skills
+        .active_skills
+        .record_redacted_provenance(&mut agent.trajectory.info, &agent.redactor)?;
 
     // 4. Run the replay
     tracing::info!(?args.trajectory_path, "starting replay mode");

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -451,9 +451,38 @@ fn ends_with_unescaped_quote(value: &str) -> bool {
 
 fn mentioned_explicitly(normalized_task: &str, manifest: &SkillManifest) -> bool {
     let normalized_name = &manifest.normalized_name;
-    normalized_task.contains(&format!("${normalized_name}"))
-        || normalized_task.contains(&format!("@{normalized_name}"))
-        || normalized_task.contains(&format!("/{normalized_name}"))
+    ["$", "@", "/"].iter().any(|marker| {
+        contains_explicit_mention(normalized_task, &format!("{marker}{normalized_name}"))
+    })
+}
+
+fn contains_explicit_mention(normalized_task: &str, needle: &str) -> bool {
+    let mut search_from = 0;
+    while let Some(offset) = normalized_task[search_from..].find(needle) {
+        let start = search_from + offset;
+        let end = start + needle.len();
+        if is_explicit_mention_start_boundary(normalized_task[..start].chars().next_back())
+            && is_explicit_mention_end_boundary(normalized_task[end..].chars().next())
+        {
+            return true;
+        }
+        search_from = end;
+    }
+    false
+}
+
+fn is_explicit_mention_start_boundary(previous: Option<char>) -> bool {
+    match previous {
+        None => true,
+        Some(ch) => ch.is_whitespace(),
+    }
+}
+
+fn is_explicit_mention_end_boundary(next: Option<char>) -> bool {
+    match next {
+        None => true,
+        Some(ch) => ch.is_whitespace(),
+    }
 }
 
 fn match_score(task_tokens: &BTreeSet<String>, manifest: &SkillManifest) -> usize {

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,0 +1,504 @@
+//! Harness-level agent skill discovery and activation.
+//!
+//! The registry is private context owned by the harness: it scans skill
+//! manifests, resolves the relevant subset for a task, and loads only those
+//! selected skill bodies into model-visible context.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsStr;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use crate::config::SkillCfg;
+use crate::error::{ConfigError, Error};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillManifest {
+    pub name: String,
+    pub description: String,
+    pub path: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SkillRegistry {
+    manifests: Vec<SkillManifest>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillActivationReason {
+    ExplicitMention,
+    AutoMatch,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActiveSkill {
+    pub name: String,
+    pub description: String,
+    pub path: PathBuf,
+    pub content: String,
+    pub sha256: String,
+    pub activation_reason: SkillActivationReason,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActiveSkillSet {
+    pub skills: Vec<ActiveSkill>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SkillResolveRequest<'a> {
+    pub task: &'a str,
+    pub auto_load: bool,
+    pub max_active: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActiveSkillManifest {
+    pub name: String,
+    pub description: String,
+    pub path: PathBuf,
+    pub sha256: String,
+    pub activation_reason: SkillActivationReason,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResolvedSkillContext {
+    pub active_skills: ActiveSkillSet,
+    pub merged_extra_context: Option<String>,
+}
+
+impl SkillRegistry {
+    pub fn scan_paths(paths: impl IntoIterator<Item = PathBuf>) -> Result<Self, Error> {
+        let mut skill_files = Vec::new();
+        for path in paths {
+            if !path.exists() {
+                continue;
+            }
+            collect_skill_files(&path, &mut skill_files)?;
+        }
+        skill_files.sort();
+
+        let mut manifests = Vec::new();
+        let mut seen_names = BTreeSet::new();
+        for path in skill_files {
+            let text = std::fs::read_to_string(&path)?;
+            let frontmatter = parse_frontmatter(&path, &text)?;
+            let manifest = SkillManifest {
+                name: required_frontmatter(&path, &frontmatter, "name")?,
+                description: required_frontmatter(&path, &frontmatter, "description")?,
+                version: frontmatter.get("version").cloned(),
+                path,
+            };
+            if !seen_names.insert(manifest.name.clone()) {
+                return Err(Error::Config(ConfigError::Invalid(format!(
+                    "duplicate skill name `{}`",
+                    manifest.name
+                ))));
+            }
+            manifests.push(manifest);
+        }
+
+        Ok(Self { manifests })
+    }
+
+    pub fn manifests(&self) -> &[SkillManifest] {
+        &self.manifests
+    }
+
+    pub fn resolve(&self, request: SkillResolveRequest<'_>) -> Result<ActiveSkillSet, Error> {
+        if request.max_active == 0 {
+            return Ok(ActiveSkillSet::default());
+        }
+
+        let mut selected = Vec::new();
+        let mut seen = BTreeSet::new();
+        let normalized_task = normalize_search_text(request.task);
+
+        for manifest in &self.manifests {
+            if mentioned_explicitly(&normalized_task, &manifest.name) {
+                selected.push(load_active_skill(
+                    manifest,
+                    SkillActivationReason::ExplicitMention,
+                )?);
+                seen.insert(manifest.name.clone());
+                if selected.len() >= request.max_active {
+                    return Ok(ActiveSkillSet { skills: selected });
+                }
+            }
+        }
+
+        if request.auto_load {
+            let mut scored = self
+                .manifests
+                .iter()
+                .filter(|manifest| !seen.contains(&manifest.name))
+                .filter_map(|manifest| {
+                    let score = match_score(&normalized_task, manifest);
+                    (score >= 2).then_some((score, manifest))
+                })
+                .collect::<Vec<_>>();
+            scored.sort_by(|(score_a, manifest_a), (score_b, manifest_b)| {
+                score_b
+                    .cmp(score_a)
+                    .then_with(|| manifest_a.name.cmp(&manifest_b.name))
+            });
+
+            for (_, manifest) in scored {
+                selected.push(load_active_skill(
+                    manifest,
+                    SkillActivationReason::AutoMatch,
+                )?);
+                if selected.len() >= request.max_active {
+                    break;
+                }
+            }
+        }
+
+        Ok(ActiveSkillSet { skills: selected })
+    }
+}
+
+impl ActiveSkillSet {
+    pub fn is_empty(&self) -> bool {
+        self.skills.is_empty()
+    }
+
+    pub fn render_context(&self) -> String {
+        if self.skills.is_empty() {
+            return String::new();
+        }
+
+        let mut rendered = String::from(
+            "Active agent skills:\nThe harness selected these instructions for this task. Follow them when relevant.\n",
+        );
+        for skill in &self.skills {
+            rendered.push_str("\n---\n");
+            rendered.push_str("Skill: ");
+            rendered.push_str(&skill.name);
+            rendered.push('\n');
+            rendered.push_str("Activation: ");
+            rendered.push_str(match skill.activation_reason {
+                SkillActivationReason::ExplicitMention => "explicit_mention",
+                SkillActivationReason::AutoMatch => "auto_match",
+            });
+            rendered.push('\n');
+            rendered.push_str("Source: ");
+            rendered.push_str(&skill.path.display().to_string());
+            rendered.push('\n');
+            rendered.push_str("SHA-256: ");
+            rendered.push_str(&skill.sha256);
+            rendered.push_str("\n\n");
+            rendered.push_str(skill.content.trim());
+            rendered.push('\n');
+        }
+        rendered
+    }
+
+    pub fn merge_extra_context(&self, extra_context: Option<String>) -> Option<String> {
+        let skill_context = self.render_context();
+        if skill_context.is_empty() {
+            return extra_context;
+        }
+        Some(match extra_context {
+            Some(extra) if !extra.trim().is_empty() => format!("{extra}\n\n{skill_context}"),
+            _ => skill_context,
+        })
+    }
+
+    pub fn provenance(&self) -> Vec<ActiveSkillManifest> {
+        self.skills
+            .iter()
+            .map(|skill| ActiveSkillManifest {
+                name: skill.name.clone(),
+                description: skill.description.clone(),
+                path: skill.path.clone(),
+                sha256: skill.sha256.clone(),
+                activation_reason: skill.activation_reason,
+            })
+            .collect()
+    }
+}
+
+pub fn resolve_for_task(
+    cfg: &SkillCfg,
+    task: &str,
+    extra_context: Option<String>,
+) -> Result<ResolvedSkillContext, Error> {
+    if !cfg.enabled || cfg.paths.is_empty() {
+        return Ok(ResolvedSkillContext {
+            active_skills: ActiveSkillSet::default(),
+            merged_extra_context: extra_context,
+        });
+    }
+
+    let paths = cfg.paths.iter().map(expand_skill_path).collect::<Vec<_>>();
+    let registry = SkillRegistry::scan_paths(paths)?;
+    let active_skills = registry.resolve(SkillResolveRequest {
+        task,
+        auto_load: cfg.auto_load,
+        max_active: cfg.max_active,
+    })?;
+    let merged_extra_context = active_skills.merge_extra_context(extra_context);
+    Ok(ResolvedSkillContext {
+        active_skills,
+        merged_extra_context,
+    })
+}
+
+fn collect_skill_files(path: &Path, files: &mut Vec<PathBuf>) -> Result<(), Error> {
+    if path.is_file() {
+        if path
+            .file_name()
+            .is_some_and(|name| name == OsStr::new("SKILL.md"))
+        {
+            files.push(path.to_path_buf());
+        }
+        return Ok(());
+    }
+    if !path.is_dir() {
+        return Ok(());
+    }
+
+    for entry in std::fs::read_dir(path)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            collect_skill_files(&entry.path(), files)?;
+        } else if file_type.is_file() && entry.file_name() == OsStr::new("SKILL.md") {
+            files.push(entry.path());
+        }
+    }
+    Ok(())
+}
+
+fn parse_frontmatter(path: &Path, text: &str) -> Result<BTreeMap<String, String>, Error> {
+    let Some(rest) = text.strip_prefix("---") else {
+        return Err(Error::Config(ConfigError::Invalid(format!(
+            "skill `{}` missing YAML frontmatter",
+            path.display()
+        ))));
+    };
+    let rest = rest
+        .strip_prefix("\r\n")
+        .or_else(|| rest.strip_prefix('\n'))
+        .ok_or_else(|| {
+            Error::Config(ConfigError::Invalid(format!(
+                "skill `{}` has malformed frontmatter start",
+                path.display()
+            )))
+        })?;
+    let Some((frontmatter, _body)) = split_frontmatter(rest) else {
+        return Err(Error::Config(ConfigError::Invalid(format!(
+            "skill `{}` missing closing frontmatter fence",
+            path.display()
+        ))));
+    };
+
+    Ok(parse_frontmatter_fields(frontmatter))
+}
+
+fn split_frontmatter(text: &str) -> Option<(&str, &str)> {
+    for marker in ["\n---\r\n", "\n---\n"] {
+        if let Some(pos) = text.find(marker) {
+            let body_start = pos + marker.len();
+            return Some((&text[..pos], &text[body_start..]));
+        }
+    }
+    if let Some(pos) = text
+        .strip_suffix("\n---")
+        .map(|_| text.len() - "\n---".len())
+    {
+        return Some((&text[..pos], ""));
+    }
+    None
+}
+
+fn parse_frontmatter_fields(frontmatter: &str) -> BTreeMap<String, String> {
+    let mut fields = BTreeMap::new();
+    let mut lines = frontmatter.lines().peekable();
+
+    while let Some(line) = lines.next() {
+        if line.trim().is_empty() || line.trim_start().starts_with('#') {
+            continue;
+        }
+        if line.chars().next().is_some_and(char::is_whitespace) {
+            continue;
+        }
+        let Some((key, raw_value)) = line.split_once(':') else {
+            continue;
+        };
+        let key = key.trim().to_owned();
+        let mut value = raw_value.trim().to_owned();
+        if value.starts_with('"') && !ends_with_unescaped_quote(&value) {
+            while let Some(next) = lines.peek() {
+                value.push('\n');
+                value.push_str(next);
+                let done = ends_with_unescaped_quote(next.trim());
+                let _ = lines.next();
+                if done {
+                    break;
+                }
+            }
+        }
+        fields.insert(key, unquote_scalar(&value));
+    }
+
+    fields
+}
+
+fn required_frontmatter(
+    path: &Path,
+    frontmatter: &BTreeMap<String, String>,
+    key: &str,
+) -> Result<String, Error> {
+    frontmatter
+        .get(key)
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .ok_or_else(|| {
+            Error::Config(ConfigError::Invalid(format!(
+                "skill `{}` missing required `{key}` frontmatter",
+                path.display()
+            )))
+        })
+}
+
+fn unquote_scalar(value: &str) -> String {
+    let value = value.trim();
+    if value.len() >= 2
+        && ((value.starts_with('"') && value.ends_with('"'))
+            || (value.starts_with('\'') && value.ends_with('\'')))
+    {
+        value[1..value.len() - 1].to_owned()
+    } else {
+        value.to_owned()
+    }
+}
+
+fn ends_with_unescaped_quote(value: &str) -> bool {
+    let mut backslashes = 0usize;
+    for ch in value.chars().rev().skip(1) {
+        if ch == '\\' {
+            backslashes += 1;
+        } else {
+            break;
+        }
+    }
+    value.ends_with('"') && backslashes % 2 == 0
+}
+
+fn mentioned_explicitly(normalized_task: &str, skill_name: &str) -> bool {
+    let normalized_name = normalize_search_text(skill_name);
+    normalized_task.contains(&format!("${normalized_name}"))
+        || normalized_task.contains(&format!("@{normalized_name}"))
+        || normalized_task.contains(&format!("/{normalized_name}"))
+}
+
+fn match_score(normalized_task: &str, manifest: &SkillManifest) -> usize {
+    let task_tokens = tokenize(normalized_task).collect::<BTreeSet<_>>();
+    let search_text = normalize_search_text(&format!("{} {}", manifest.name, manifest.description));
+    let mut matched = BTreeSet::new();
+    for token in tokenize(&search_text) {
+        if is_stopword(&token) {
+            continue;
+        }
+        if task_tokens.contains(&token) {
+            matched.insert(token);
+        }
+    }
+    matched.len()
+}
+
+fn tokenize(text: &str) -> impl Iterator<Item = String> + '_ {
+    text.split_whitespace()
+        .map(ToOwned::to_owned)
+        .filter(|token| token.len() >= 3)
+}
+
+fn normalize_search_text(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '$' || ch == '@' || ch == '/' {
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(' ');
+        }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn is_stopword(token: &str) -> bool {
+    matches!(
+        token,
+        "and"
+            | "for"
+            | "the"
+            | "this"
+            | "that"
+            | "use"
+            | "uses"
+            | "with"
+            | "work"
+            | "when"
+            | "should"
+            | "must"
+            | "all"
+            | "any"
+    )
+}
+
+fn load_active_skill(
+    manifest: &SkillManifest,
+    activation_reason: SkillActivationReason,
+) -> Result<ActiveSkill, Error> {
+    let full_text = std::fs::read_to_string(&manifest.path)?;
+    let content = skill_body(&full_text)
+        .map(str::trim)
+        .filter(|body| !body.is_empty())
+        .unwrap_or_else(|| full_text.trim())
+        .to_owned();
+    Ok(ActiveSkill {
+        name: manifest.name.clone(),
+        description: manifest.description.clone(),
+        path: manifest.path.clone(),
+        sha256: sha256_hex(full_text.as_bytes()),
+        activation_reason,
+        content,
+    })
+}
+
+fn skill_body(text: &str) -> Option<&str> {
+    let rest = text.strip_prefix("---")?;
+    let rest = rest
+        .strip_prefix("\r\n")
+        .or_else(|| rest.strip_prefix('\n'))?;
+    let (_, body) = split_frontmatter(rest)?;
+    Some(body)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
+fn expand_skill_path(path: &String) -> PathBuf {
+    if let Some(stripped) = path.strip_prefix("~/").or_else(|| path.strip_prefix("~\\")) {
+        if let Some(home) = std::env::var_os("USERPROFILE").or_else(|| std::env::var_os("HOME")) {
+            return PathBuf::from(home).join(stripped);
+        }
+    }
+    PathBuf::from(path)
+}

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -14,6 +14,8 @@ use sha2::{Digest as _, Sha256};
 
 use crate::config::SkillCfg;
 use crate::error::{ConfigError, Error};
+use crate::redaction::{Redactor, surface};
+use crate::trajectory::TrajectoryInfo;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SkillManifest {
@@ -22,6 +24,10 @@ pub struct SkillManifest {
     pub path: PathBuf,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    #[serde(skip)]
+    normalized_name: String,
+    #[serde(skip)]
+    search_tokens: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -89,9 +95,13 @@ impl SkillRegistry {
         for path in skill_files {
             let text = std::fs::read_to_string(&path)?;
             let frontmatter = parse_frontmatter(&path, &text)?;
+            let name = required_frontmatter(&path, &frontmatter, "name")?;
+            let description = required_frontmatter(&path, &frontmatter, "description")?;
             let manifest = SkillManifest {
-                name: required_frontmatter(&path, &frontmatter, "name")?,
-                description: required_frontmatter(&path, &frontmatter, "description")?,
+                normalized_name: normalize_search_text(&name),
+                search_tokens: searchable_tokens(&name, &description),
+                name,
+                description,
                 version: frontmatter.get("version").cloned(),
                 path,
             };
@@ -119,9 +129,12 @@ impl SkillRegistry {
         let mut selected = Vec::new();
         let mut seen = BTreeSet::new();
         let normalized_task = normalize_search_text(request.task);
+        let task_tokens = tokenize(&normalized_task)
+            .filter(|token| !is_stopword(token))
+            .collect::<BTreeSet<_>>();
 
         for manifest in &self.manifests {
-            if mentioned_explicitly(&normalized_task, &manifest.name) {
+            if mentioned_explicitly(&normalized_task, manifest) {
                 selected.push(load_active_skill(
                     manifest,
                     SkillActivationReason::ExplicitMention,
@@ -139,7 +152,7 @@ impl SkillRegistry {
                 .iter()
                 .filter(|manifest| !seen.contains(&manifest.name))
                 .filter_map(|manifest| {
-                    let score = match_score(&normalized_task, manifest);
+                    let score = match_score(&task_tokens, manifest);
                     (score >= 2).then_some((score, manifest))
                 })
                 .collect::<Vec<_>>();
@@ -187,12 +200,6 @@ impl ActiveSkillSet {
                 SkillActivationReason::ExplicitMention => "explicit_mention",
                 SkillActivationReason::AutoMatch => "auto_match",
             });
-            rendered.push('\n');
-            rendered.push_str("Source: ");
-            rendered.push_str(&skill.path.display().to_string());
-            rendered.push('\n');
-            rendered.push_str("SHA-256: ");
-            rendered.push_str(&skill.sha256);
             rendered.push_str("\n\n");
             rendered.push_str(skill.content.trim());
             rendered.push('\n');
@@ -222,6 +229,30 @@ impl ActiveSkillSet {
                 activation_reason: skill.activation_reason,
             })
             .collect()
+    }
+
+    pub fn redacted_provenance_value(
+        &self,
+        redactor: &Redactor,
+    ) -> Result<serde_json::Value, Error> {
+        let mut value = serde_json::to_value(self.provenance())?;
+        redactor.redact_json_value(&mut value, surface::TRAJECTORY);
+        Ok(value)
+    }
+
+    pub fn record_redacted_provenance(
+        &self,
+        info: &mut TrajectoryInfo,
+        redactor: &Redactor,
+    ) -> Result<(), Error> {
+        if self.is_empty() {
+            return Ok(());
+        }
+        info.other.insert(
+            "active_skills".into(),
+            self.redacted_provenance_value(redactor)?,
+        );
+        Ok(())
     }
 }
 
@@ -337,12 +368,13 @@ fn parse_frontmatter_fields(frontmatter: &str) -> BTreeMap<String, String> {
             continue;
         };
         let key = key.trim().to_owned();
-        let mut value = raw_value.trim().to_owned();
+        let mut value = strip_trailing_comment(raw_value.trim());
         if value.starts_with('"') && !ends_with_unescaped_quote(&value) {
             while let Some(next) = lines.peek() {
+                let next_value = strip_trailing_comment(next.trim_end());
                 value.push('\n');
-                value.push_str(next);
-                let done = ends_with_unescaped_quote(next.trim());
+                value.push_str(&next_value);
+                let done = ends_with_unescaped_quote(next_value.trim());
                 let _ = lines.next();
                 if done {
                     break;
@@ -353,6 +385,27 @@ fn parse_frontmatter_fields(frontmatter: &str) -> BTreeMap<String, String> {
     }
 
     fields
+}
+
+fn strip_trailing_comment(value: &str) -> String {
+    let mut quote = None;
+    let mut escaped = false;
+
+    for (idx, ch) in value.char_indices() {
+        match (quote, ch) {
+            (Some('"'), '\\') if !escaped => {
+                escaped = true;
+                continue;
+            }
+            (Some(active), _) if ch == active && !escaped => quote = None,
+            (None, '"' | '\'') => quote = Some(ch),
+            (None, '#') => return value[..idx].trim_end().to_owned(),
+            _ => {}
+        }
+        escaped = false;
+    }
+
+    value.trim_end().to_owned()
 }
 
 fn required_frontmatter(
@@ -396,32 +449,26 @@ fn ends_with_unescaped_quote(value: &str) -> bool {
     value.ends_with('"') && backslashes % 2 == 0
 }
 
-fn mentioned_explicitly(normalized_task: &str, skill_name: &str) -> bool {
-    let normalized_name = normalize_search_text(skill_name);
+fn mentioned_explicitly(normalized_task: &str, manifest: &SkillManifest) -> bool {
+    let normalized_name = &manifest.normalized_name;
     normalized_task.contains(&format!("${normalized_name}"))
         || normalized_task.contains(&format!("@{normalized_name}"))
         || normalized_task.contains(&format!("/{normalized_name}"))
 }
 
-fn match_score(normalized_task: &str, manifest: &SkillManifest) -> usize {
-    let task_tokens = tokenize(normalized_task).collect::<BTreeSet<_>>();
-    let search_text = normalize_search_text(&format!("{} {}", manifest.name, manifest.description));
-    let mut matched = BTreeSet::new();
-    for token in tokenize(&search_text) {
-        if is_stopword(&token) {
-            continue;
-        }
-        if task_tokens.contains(&token) {
-            matched.insert(token);
-        }
-    }
-    matched.len()
+fn match_score(task_tokens: &BTreeSet<String>, manifest: &SkillManifest) -> usize {
+    task_tokens.intersection(&manifest.search_tokens).count()
 }
 
 fn tokenize(text: &str) -> impl Iterator<Item = String> + '_ {
-    text.split_whitespace()
-        .map(ToOwned::to_owned)
-        .filter(|token| token.len() >= 3)
+    text.split_whitespace().map(ToOwned::to_owned)
+}
+
+fn searchable_tokens(name: &str, description: &str) -> BTreeSet<String> {
+    let search_text = normalize_search_text(&format!("{name} {description}"));
+    tokenize(&search_text)
+        .filter(|token| !is_stopword(token))
+        .collect()
 }
 
 fn normalize_search_text(text: &str) -> String {

--- a/tests/skills.rs
+++ b/tests/skills.rs
@@ -207,6 +207,60 @@ GO_BODY
 }
 
 #[test]
+fn explicit_mentions_require_boundary_after_skill_name() {
+    let temp = tempfile::tempdir().unwrap();
+    write_skill(
+        temp.path(),
+        "go",
+        r#"---
+name: go
+description: Use for Go code.
+---
+
+# Go
+
+GO_BODY
+"#,
+    );
+
+    let registry = SkillRegistry::scan_paths([temp.path().to_path_buf()]).unwrap();
+
+    for task in [
+        "Review /goals before planning.",
+        "Open /google in the browser.",
+        "Audit $governance settings.",
+        "Inspect @golang ownership.",
+        "Visit https://example.com/google?q=1.",
+        "Visit https://example.com/go?q=1.",
+        "Email person@go.dev for details.",
+    ] {
+        let active = registry
+            .resolve(SkillResolveRequest {
+                task,
+                auto_load: false,
+                max_active: 8,
+            })
+            .unwrap();
+        assert!(
+            active.skills.is_empty(),
+            "task `{task}` should not explicitly activate go"
+        );
+    }
+
+    for task in ["Use /go for this task.", "Use $go.", "Ask @go now."] {
+        let active = registry
+            .resolve(SkillResolveRequest {
+                task,
+                auto_load: false,
+                max_active: 8,
+            })
+            .unwrap();
+        assert_eq!(active.skills.len(), 1, "task `{task}` should activate go");
+        assert_eq!(active.skills[0].name, "go");
+    }
+}
+
+#[test]
 fn active_skill_context_appends_after_operator_extra_context() {
     let active = ActiveSkillSet {
         skills: vec![ActiveSkill {

--- a/tests/skills.rs
+++ b/tests/skills.rs
@@ -59,6 +59,36 @@ version: 1.0.0
 }
 
 #[test]
+fn frontmatter_parser_ignores_trailing_comments_outside_quotes() {
+    let temp = tempfile::tempdir().unwrap();
+    write_skill(
+        temp.path(),
+        "commented-skill",
+        r##"---
+name: commented-skill # route by this name
+description: "Use # inside quoted text" # but not this comment
+---
+
+# Commented Skill
+"##,
+    );
+
+    let registry = SkillRegistry::scan_paths([temp.path().to_path_buf()]).unwrap();
+    let manifest = &registry.manifests()[0];
+
+    assert_eq!(manifest.name, "commented-skill");
+    assert_eq!(manifest.description, "Use # inside quoted text");
+    let active = registry
+        .resolve(SkillResolveRequest {
+            task: "Use $commented-skill for this task.",
+            auto_load: false,
+            max_active: 8,
+        })
+        .unwrap();
+    assert_eq!(active.skills[0].name, "commented-skill");
+}
+
+#[test]
 fn resolver_loads_explicit_skill_without_leaking_inactive_metadata() {
     let temp = tempfile::tempdir().unwrap();
     write_skill(
@@ -147,6 +177,36 @@ SECURITY_REVIEW_BODY
 }
 
 #[test]
+fn auto_resolver_matches_short_programming_language_tokens() {
+    let temp = tempfile::tempdir().unwrap();
+    write_skill(
+        temp.path(),
+        "go",
+        r#"---
+name: go
+description: Use for Go code.
+---
+
+# Go
+
+GO_BODY
+"#,
+    );
+
+    let registry = SkillRegistry::scan_paths([temp.path().to_path_buf()]).unwrap();
+    let active = registry
+        .resolve(SkillResolveRequest {
+            task: "Fix this Go code.",
+            auto_load: true,
+            max_active: 8,
+        })
+        .unwrap();
+
+    assert_eq!(active.skills.len(), 1);
+    assert_eq!(active.skills[0].name, "go");
+}
+
+#[test]
 fn active_skill_context_appends_after_operator_extra_context() {
     let active = ActiveSkillSet {
         skills: vec![ActiveSkill {
@@ -165,6 +225,30 @@ fn active_skill_context_appends_after_operator_extra_context() {
     assert!(merged.contains("Operator context"));
     assert!(merged.contains("Active agent skills"));
     assert!(merged.contains("RUST_ROUTER_BODY"));
+}
+
+#[test]
+fn active_skill_context_omits_source_path_and_hash() {
+    let active = ActiveSkillSet {
+        skills: vec![ActiveSkill {
+            name: "rust-router".to_owned(),
+            description: "Use for Rust work.".to_owned(),
+            path: "C:/Users/markm/private/SKILL.md".into(),
+            content: "# Rust Router\n\nRUST_ROUTER_BODY".to_owned(),
+            sha256: "a".repeat(64),
+            activation_reason: SkillActivationReason::ExplicitMention,
+        }],
+    };
+
+    let context = active.render_context();
+
+    assert!(context.contains("Skill: rust-router"));
+    assert!(context.contains("Activation: explicit_mention"));
+    assert!(context.contains("RUST_ROUTER_BODY"));
+    assert!(!context.contains("C:/Users/markm/private/SKILL.md"));
+    assert!(!context.contains(&"a".repeat(64)));
+    assert!(!context.contains("SHA-256"));
+    assert!(!context.contains("Source:"));
 }
 
 #[test]
@@ -327,6 +411,66 @@ paths = ["{skill_path}"]
 
     let first_user_message = trajectory["messages"][1]["content"].as_str().unwrap();
     assert!(first_user_message.contains("SECURITY_REVIEW_BODY"));
+}
+
+#[tokio::test]
+async fn mini_run_redacts_active_skill_provenance() {
+    let temp = tempfile::tempdir().unwrap();
+    let output = tempfile::tempdir().unwrap();
+    let secret_root = temp.path().join("TOP_SECRET_ROOT");
+    write_skill(
+        &secret_root,
+        "security-review",
+        r#"---
+name: security-review
+description: Use TOP_SECRET_VALUE for security review work.
+---
+
+# Security Review
+
+SECURITY_REVIEW_BODY
+"#,
+    );
+
+    let skill_path = toml_path(&secret_root);
+    let cfg = Config::from_toml_str(&format!(
+        r#"
+[skills]
+enabled = true
+auto_load = true
+paths = ["{skill_path}"]
+
+[redaction]
+secret_literals = ["TOP_SECRET_VALUE", "TOP_SECRET_ROOT"]
+"#,
+    ))
+    .unwrap();
+
+    rust_swe_agent::run::mini::run(rust_swe_agent::run::mini::MiniArgs {
+        task: "Please perform a security review.".to_owned(),
+        extra_context: None,
+        config: cfg,
+        output_dir: output.path().to_path_buf(),
+        trajectory_name: "skill-redaction-run".to_owned(),
+        deterministic_responses: Some(vec![
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".to_owned(),
+        ]),
+        deterministic_usage_per_call: None,
+        task_timeout_secs: None,
+        cancellation: None,
+        stream_addr: None,
+        patch_capture: None,
+        verification_checks: vec![],
+        verification_timeout_secs: 60,
+    })
+    .await
+    .unwrap();
+
+    let trajectory_path = output.path().join("skill-redaction-run.traj.json");
+    let trajectory_text = fs::read_to_string(trajectory_path).unwrap();
+    assert!(!trajectory_text.contains("TOP_SECRET_VALUE"));
+    assert!(!trajectory_text.contains("TOP_SECRET_ROOT"));
+    assert!(trajectory_text.contains("[REDACTED:configured_literal:"));
 }
 
 fn write_skill(root: &Path, dirname: &str, content: &str) {

--- a/tests/skills.rs
+++ b/tests/skills.rs
@@ -1,0 +1,340 @@
+#![allow(clippy::unwrap_used)]
+
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use rust_swe_agent::agent::default::DefaultAgentBuilder;
+use rust_swe_agent::skills::{
+    ActiveSkill, ActiveSkillSet, SkillActivationReason, SkillRegistry, SkillResolveRequest,
+    resolve_for_task,
+};
+use rust_swe_agent::{
+    Agent, Config, DeterministicModel, Environment, ExitReason, LocalEnvironment,
+};
+
+#[test]
+fn registry_scans_skill_manifests_without_loading_bodies() {
+    let temp = tempfile::tempdir().unwrap();
+    write_skill(
+        temp.path(),
+        "rust-router",
+        r#"---
+name: rust-router
+description: Use for Rust questions and cargo work.
+---
+
+# Rust Router
+
+RUST_ROUTER_BODY_SHOULD_NOT_BE_IN_MANIFEST
+"#,
+    );
+    write_skill(
+        temp.path(),
+        "security-review",
+        r#"---
+name: security-review
+description: Use for security review and threat modeling.
+version: 1.0.0
+---
+
+# Security Review
+"#,
+    );
+
+    let registry = SkillRegistry::scan_paths([temp.path().to_path_buf()]).unwrap();
+    let manifests = registry.manifests();
+
+    assert_eq!(manifests.len(), 2);
+    assert_eq!(manifests[0].name, "rust-router");
+    assert_eq!(
+        manifests[0].description,
+        "Use for Rust questions and cargo work."
+    );
+    assert_eq!(manifests[1].name, "security-review");
+    assert!(
+        !format!("{manifests:?}").contains("RUST_ROUTER_BODY_SHOULD_NOT_BE_IN_MANIFEST"),
+        "manifest registry must not retain unloaded skill bodies"
+    );
+}
+
+#[test]
+fn resolver_loads_explicit_skill_without_leaking_inactive_metadata() {
+    let temp = tempfile::tempdir().unwrap();
+    write_skill(
+        temp.path(),
+        "rust-router",
+        r#"---
+name: rust-router
+description: Use for Rust questions and cargo work.
+---
+
+# Rust Router
+
+RUST_ROUTER_BODY
+"#,
+    );
+    write_skill(
+        temp.path(),
+        "secret-skill",
+        r#"---
+name: secret-skill
+description: SECRET_METADATA_DO_NOT_LEAK
+---
+
+# Secret Skill
+
+SECRET_BODY_DO_NOT_LEAK
+"#,
+    );
+
+    let registry = SkillRegistry::scan_paths([temp.path().to_path_buf()]).unwrap();
+    let active = registry
+        .resolve(SkillResolveRequest {
+            task: "Use $rust-router to fix this borrow checker issue.",
+            auto_load: false,
+            max_active: 8,
+        })
+        .unwrap();
+
+    assert_eq!(active.skills.len(), 1);
+    assert_eq!(active.skills[0].name, "rust-router");
+    assert_eq!(
+        active.skills[0].activation_reason,
+        SkillActivationReason::ExplicitMention
+    );
+    assert_eq!(active.skills[0].sha256.len(), 64);
+
+    let context = active.render_context();
+    assert!(context.contains("RUST_ROUTER_BODY"));
+    assert!(!context.contains("SECRET_METADATA_DO_NOT_LEAK"));
+    assert!(!context.contains("SECRET_BODY_DO_NOT_LEAK"));
+}
+
+#[test]
+fn auto_resolver_loads_skills_from_task_keywords() {
+    let temp = tempfile::tempdir().unwrap();
+    write_skill(
+        temp.path(),
+        "security-review",
+        r#"---
+name: security-review
+description: Use for security review and threat model work.
+---
+
+# Security Review
+
+SECURITY_REVIEW_BODY
+"#,
+    );
+
+    let registry = SkillRegistry::scan_paths([temp.path().to_path_buf()]).unwrap();
+    let active = registry
+        .resolve(SkillResolveRequest {
+            task: "Please perform a security review of the policy engine.",
+            auto_load: true,
+            max_active: 8,
+        })
+        .unwrap();
+
+    assert_eq!(active.skills.len(), 1);
+    assert_eq!(active.skills[0].name, "security-review");
+    assert_eq!(
+        active.skills[0].activation_reason,
+        SkillActivationReason::AutoMatch
+    );
+    assert!(active.render_context().contains("SECURITY_REVIEW_BODY"));
+}
+
+#[test]
+fn active_skill_context_appends_after_operator_extra_context() {
+    let active = ActiveSkillSet {
+        skills: vec![ActiveSkill {
+            name: "rust-router".to_owned(),
+            description: "Use for Rust work.".to_owned(),
+            path: "rust-router/SKILL.md".into(),
+            content: "# Rust Router\n\nRUST_ROUTER_BODY".to_owned(),
+            sha256: "0".repeat(64),
+            activation_reason: SkillActivationReason::ExplicitMention,
+        }],
+    };
+
+    let merged = active.merge_extra_context(Some("Operator context".to_owned()));
+    let merged = merged.unwrap();
+
+    assert!(merged.contains("Operator context"));
+    assert!(merged.contains("Active agent skills"));
+    assert!(merged.contains("RUST_ROUTER_BODY"));
+}
+
+#[test]
+fn config_parses_skills_section() {
+    let cfg = Config::from_toml_str(
+        r#"
+[skills]
+enabled = true
+auto_load = false
+paths = ["./.agents/skills", "./.codex/skills"]
+max_active = 3
+"#,
+    )
+    .unwrap();
+
+    assert!(cfg.root.skills.enabled);
+    assert!(!cfg.root.skills.auto_load);
+    assert_eq!(
+        cfg.root.skills.paths,
+        vec!["./.agents/skills", "./.codex/skills"]
+    );
+    assert_eq!(cfg.root.skills.max_active, 3);
+}
+
+#[tokio::test]
+async fn selected_skill_context_reaches_agent_prompt_without_inactive_manifest_leak() {
+    let temp = tempfile::tempdir().unwrap();
+    write_skill(
+        temp.path(),
+        "rust-router",
+        r#"---
+name: rust-router
+description: Use for Rust questions and cargo work.
+---
+
+# Rust Router
+
+RUST_ROUTER_BODY
+"#,
+    );
+    write_skill(
+        temp.path(),
+        "secret-skill",
+        r#"---
+name: secret-skill
+description: SECRET_METADATA_DO_NOT_LEAK
+---
+
+# Secret Skill
+
+SECRET_BODY_DO_NOT_LEAK
+"#,
+    );
+
+    let skill_path = toml_path(temp.path());
+    let cfg = Config::from_toml_str(&format!(
+        r#"
+[skills]
+enabled = true
+auto_load = false
+paths = ["{skill_path}"]
+"#,
+    ))
+    .unwrap();
+    let resolved = resolve_for_task(
+        &cfg.root.skills,
+        "Use $rust-router to fix this Rust issue.",
+        None,
+    )
+    .unwrap();
+    let model = Arc::new(DeterministicModel::new([
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".to_owned(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model: model.clone(),
+        env,
+        task: "Use $rust-router to fix this Rust issue.".to_owned(),
+        extra_context: resolved.merged_extra_context,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+    assert!(matches!(exit, ExitReason::Submitted { .. }));
+
+    let recorded = model.recorded_inputs();
+    let first_prompt = recorded[0]
+        .iter()
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(first_prompt.contains("RUST_ROUTER_BODY"));
+    assert!(!first_prompt.contains("SECRET_METADATA_DO_NOT_LEAK"));
+    assert!(!first_prompt.contains("SECRET_BODY_DO_NOT_LEAK"));
+}
+
+#[tokio::test]
+async fn mini_run_records_active_skill_provenance() {
+    let temp = tempfile::tempdir().unwrap();
+    let output = tempfile::tempdir().unwrap();
+    write_skill(
+        temp.path(),
+        "security-review",
+        r#"---
+name: security-review
+description: Use for security review and threat model work.
+---
+
+# Security Review
+
+SECURITY_REVIEW_BODY
+"#,
+    );
+
+    let skill_path = toml_path(temp.path());
+    let cfg = Config::from_toml_str(&format!(
+        r#"
+[skills]
+enabled = true
+auto_load = true
+paths = ["{skill_path}"]
+"#,
+    ))
+    .unwrap();
+
+    rust_swe_agent::run::mini::run(rust_swe_agent::run::mini::MiniArgs {
+        task: "Please perform a security review.".to_owned(),
+        extra_context: None,
+        config: cfg,
+        output_dir: output.path().to_path_buf(),
+        trajectory_name: "skill-run".to_owned(),
+        deterministic_responses: Some(vec![
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".to_owned(),
+        ]),
+        deterministic_usage_per_call: None,
+        task_timeout_secs: None,
+        cancellation: None,
+        stream_addr: None,
+        patch_capture: None,
+        verification_checks: vec![],
+        verification_timeout_secs: 60,
+    })
+    .await
+    .unwrap();
+
+    let trajectory_path = output.path().join("skill-run.traj.json");
+    let trajectory: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(trajectory_path).unwrap()).unwrap();
+    let active_skills = trajectory["info"]["active_skills"].as_array().unwrap();
+    assert_eq!(active_skills[0]["name"].as_str(), Some("security-review"));
+    assert_eq!(
+        active_skills[0]["activation_reason"].as_str(),
+        Some("auto_match")
+    );
+    assert_eq!(active_skills[0]["sha256"].as_str().unwrap().len(), 64);
+
+    let first_user_message = trajectory["messages"][1]["content"].as_str().unwrap();
+    assert!(first_user_message.contains("SECURITY_REVIEW_BODY"));
+}
+
+fn write_skill(root: &Path, dirname: &str, content: &str) {
+    let dir = root.join(dirname);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("SKILL.md"), content).unwrap();
+}
+
+fn toml_path(path: &Path) -> String {
+    path.display().to_string().replace('\\', "\\\\")
+}


### PR DESCRIPTION
Add private skill registry scanning, task-based skill resolution, active skill context injection, and trajectory provenance without exposing
  inactive skill metadata to the agent prompt.