### PR TITLE
🗺️ Atlas: [architectural change] Strongly type Template Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,8 +14,8 @@ pub enum Error {
     #[error(transparent)]
     Config(#[from] ConfigError),
 
-    #[error("template render failed: {0}")]
-    Template(String),
+    #[error(transparent)]
+    Template(#[from] minijinja::Error),
 
     #[error("trajectory io: {0}")]
     Trajectory(String),

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -40,13 +40,11 @@ impl Renderer {
     pub fn render_str<T: Serialize>(&self, tmpl: &str, ctx: &T) -> Result<String, Error> {
         self.env
             .render_str(tmpl, Value::from_serialize(ctx))
-            .map_err(|e| Error::Template(e.to_string()))
+            .map_err(Into::into)
     }
 
     pub fn render_with(&self, tmpl: &str, ctx: Value) -> Result<String, Error> {
-        self.env
-            .render_str(tmpl, ctx)
-            .map_err(|e| Error::Template(e.to_string()))
+        self.env.render_str(tmpl, ctx).map_err(Into::into)
     }
 }
 
@@ -67,7 +65,7 @@ pub fn render_simple(tmpl: &str, vars: &[(&str, &str)]) -> Result<String, Error>
     env.set_auto_escape_callback(|_| minijinja::AutoEscape::None);
     let map: BTreeMap<&str, &str> = vars.iter().copied().collect();
     env.render_str(tmpl, Value::from_serialize(&map))
-        .map_err(|e| Error::Template(e.to_string()))
+        .map_err(Into::into)
 }
 
 /// Keep `Arc<Renderer>` cheap in hot paths.

--- a/tests/exit_code_contract.rs
+++ b/tests/exit_code_contract.rs
@@ -266,7 +266,10 @@ fn github_error_maps_to_internal_error() {
 
 #[test]
 fn template_error_maps_to_internal_error() {
-    let e = Error::Template("render failed".into());
+    let e = Error::Template(minijinja::Error::new(
+        minijinja::ErrorKind::InvalidOperation,
+        "render failed",
+    ));
     assert_eq!(ExitCode::from_error(&e), ExitCode::InternalError);
 }
 
@@ -384,7 +387,13 @@ fn text_and_numeric_surfaces_agree_for_every_error_variant() {
         ),
         ("internal_error", Error::Trajectory("corrupt".into())),
         ("internal_error", Error::Github("api 500".into())),
-        ("internal_error", Error::Template("render".into())),
+        (
+            "internal_error",
+            Error::Template(minijinja::Error::new(
+                minijinja::ErrorKind::InvalidOperation,
+                "render",
+            )),
+        ),
     ];
 
     for (expected_class, e) in error_cases {


### PR DESCRIPTION
🕸️ Tangle: The codebase was losing original error context for template rendering failures by stringifying `minijinja::Error` into `Error::Template(String)`.
📐 Blueprint: Refactored `Error::Template` in `src/error.rs` to use `#[from] minijinja::Error` and `#[error(transparent)]`. Refactored `src/template/mod.rs` to use standard automatic type coercion via `map_err(Into::into)`.
🧱 Stability: Reduced error abstraction leakage and simplified upstream error handling while preserving detailed context.
🔬 Verification: Builds successfully, all related tests pass, strict separation of error handling is enforced.

---
*PR created automatically by Jules for task [396497710378134868](https://jules.google.com/task/396497710378134868) started by @madmax983*