### PR TITLE
feat(bench): add unresolved failure triage command

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ a valid trajectory in hand:
   and failure mix for running SWE-bench sweeps.
 - [`bench evaluate`](docs/spec-evaluation.md): evaluator output, rerun metrics,
   pass@k, and compare regression gates.
+- [`bench triage`](docs/spec-triage.md): deterministic unresolved-failure
+  clustering, ranked stdout tables, and the `triage.json` schema.
 - [`agent scriptability`](docs/spec-scriptability.md): invocation-time MCP
   servers plus `PreToolUse` and `PostToolUse` hooks for A/B testing agent
   toolsets without rebuilding Rust.

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -60,6 +60,7 @@ coarse sweep-level result.
 | `bench evaluate`                | `success`, `usage_error`, `internal_error` |
 | `bench inspect`                 | `success`, `usage_error`, `internal_error` |
 | `bench tail`                    | `success`, `usage_error`, `internal_error` |
+| `bench triage`                  | `success`, `usage_error`, `internal_error` |
 | `bench frontier`                | `success`, `usage_error`, `internal_error` |
 
 > **Legacy note:** `hello-world` and `replay` do not yet produce distinct

--- a/docs/spec-triage.md
+++ b/docs/spec-triage.md
@@ -1,0 +1,171 @@
+# `bench triage` Spec
+
+`bench triage` is a read-only post-processor for completed SWE-bench sweeps.
+It consumes the artifacts already written by `bench swebench` and
+`bench evaluate`, groups unresolved failures by deterministic terminal
+signature, writes `triage.json`, and prints the highest-leverage clusters.
+
+It never re-runs instances and never calls a model provider.
+
+## CLI
+
+```bash
+rust-swe-agent bench triage --sweep runs/sweep
+```
+
+Options:
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--sweep <dir>` | required | Sweep directory containing `results.json`, `evaluation.json`, and trajectories. |
+| `--bucket <failure_category>` | unset | Restrict output and `triage.json` to one bucket, for example `model_parse`. |
+| `--min-cluster-size <k>` | `1` | Hide clusters smaller than `k`. Use `2` to remove singleton noise. |
+| `--top <n>` | `10` | Number of ranked clusters printed in text mode. |
+| `--format text\|json` | `text` | Text table or full JSON report on stdout. `triage.json` is written in both modes. |
+
+Exit behavior:
+
+- `0`: triage completed, even if there are no unresolved failures.
+- Non-zero: missing or unreadable artifacts, unsupported future artifact schema,
+  malformed JSON, or invalid CLI flags.
+- If `evaluation.json` is absent, the error points the operator at
+  `bench evaluate --sweep <dir>`.
+
+## Inputs
+
+The command reads:
+
+- `<sweep>/results.json` for instance IDs, failure categories, and per-instance
+  cost.
+- `<sweep>/evaluation.json` for the resolved/unresolved decision.
+- Per-instance trajectories at one of:
+  - `<sweep>/<instance_id>.traj.json`
+  - `<sweep>/<instance_id>/trajectory.json`
+  - `<sweep>/<instance_id>/run-1.traj.json`
+
+The candidate set is the union of:
+
+- rows where `evaluation.json` says `resolved: false`
+- rows in `results.json` whose outcome is `error` or whose
+  `failure_category` is present
+
+This keeps evaluator omissions from hiding harness/runtime failures. Duplicate
+instance IDs are de-duplicated before clustering.
+
+## Signature Function
+
+Each unresolved instance produces one pure `FailureSignature` from four fields:
+
+1. `failure_category`
+2. The last assistant message tail, capped at the final 500 Unicode scalar
+   values.
+3. The last bash exit code, or `none` when no bash result is present.
+4. The last non-empty stderr line from the last bash result.
+
+Text fields are normalized before hashing:
+
+- Lowercase the text.
+- Split on whitespace and rejoin with single spaces.
+- Replace tokens that look like filesystem paths with `<path>`.
+- Replace ASCII number runs, including simple decimals, with `<num>`.
+
+Examples:
+
+| Raw | Normalized |
+| --- | --- |
+| `Error at /tmp/run-77/src/main.py line 42` | `error at <path> line <num>` |
+| `C:\tmp\task-202\src\main.py:44` | `<path>` |
+| `value=999` | `value=<num>` |
+| `python:3.11` | `python:<num>` |
+
+The stable hash is the first 16 lowercase hex characters of SHA-256 over the
+normalized key:
+
+```text
+failure_category=<bucket>
+assistant_tail=<normalized assistant tail>
+bash_exit_code=<code or none>
+stderr_line=<normalized stderr line>
+```
+
+Two failures collide only when all four normalized fields match.
+
+## Output Schema
+
+`bench triage` writes `<sweep>/triage.json`:
+
+```json
+{
+  "sweep": "<dir>",
+  "generated_at": "<utc-iso8601>",
+  "clusters": [
+    {
+      "cluster_id": "<stable-hash>",
+      "failure_category": "<bucket>",
+      "signature_summary": "<one-line>",
+      "instance_count": 2,
+      "total_cost_usd": 3.5,
+      "exemplar_instance_id": "<id>",
+      "exemplar_trajectory_path": "<rel-path>",
+      "instance_ids": ["<id>"]
+    }
+  ],
+  "totals": {
+    "clusters": 1,
+    "instances": 2,
+    "unclustered_instances": 1,
+    "unresolved_cost_usd": 8.5
+  }
+}
+```
+
+`generated_at` is the only intentionally time-varying field. Cluster IDs,
+ordering, summaries, exemplars, and totals are deterministic for the same
+input artifacts and flags.
+
+`totals.instances` counts instances in emitted clusters.
+`totals.unclustered_instances` counts candidate instances hidden by
+`--min-cluster-size`. `totals.unresolved_cost_usd` includes all candidates after
+`--bucket` filtering, including clusters hidden by `--min-cluster-size`, so the
+text table's cost share denominator remains the unresolved cost under review.
+
+## Ranking
+
+Clusters are sorted by:
+
+1. `instance_count * total_cost_usd` descending.
+2. `total_cost_usd` descending.
+3. `failure_category` ascending.
+4. `signature_summary` ascending.
+5. `cluster_id` ascending.
+
+The text table prints the top `N` clusters across the whole sweep using that
+same order. The `% unresolved cost` column is
+`cluster.total_cost_usd / totals.unresolved_cost_usd * 100`.
+
+## Worked Fixture
+
+The checked-in fixture at `tests/fixtures/triage/sweep` contains:
+
+- Three failure buckets: `model_parse`, `env_setup`, and `step_limit`.
+- A `model_parse` cluster with two instances whose raw paths and numbers differ
+  but normalize to the same signature.
+- A `model_parse` singleton plus one singleton in each other bucket.
+- One resolved instance that must not appear in triage output.
+
+Run it without mutating the fixture by copying it first:
+
+```bash
+cp -R tests/fixtures/triage/sweep /tmp/rust-swe-triage-fixture
+rust-swe-agent bench triage --sweep /tmp/rust-swe-triage-fixture --top 3
+```
+
+Expected top three clusters:
+
+| Rank | Bucket | Count | Cost | Exemplar |
+| ---: | --- | ---: | ---: | --- |
+| 1 | `model_parse` | 2 | `3.5000` | `model-a-1` |
+| 2 | `env_setup` | 1 | `6.0000` | `env-1` |
+| 3 | `model_parse` | 1 | `5.0000` | `model-b-1` |
+
+Rank 1 wins because `2 * 3.5 = 7.0`, which outranks `1 * 6.0 = 6.0`.

--- a/docs/spec-triage.md
+++ b/docs/spec-triage.md
@@ -46,8 +46,10 @@ The command reads:
 The candidate set is the union of:
 
 - rows where `evaluation.json` says `resolved: false`
-- rows in `results.json` whose outcome is `error` or whose
-  `failure_category` is present
+- still-unresolved rows in `results.json` whose outcome is `error` or whose
+  `failure_category` is present; pass@k aggregate rows with
+  `resolved_count > 0` are excluded even when they preserve the run-1
+  failure category for pass@1 compatibility
 
 This keeps evaluator omissions from hiding harness/runtime failures. Duplicate
 instance IDs are de-duplicated before clustering.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -246,6 +246,8 @@ pub enum BenchCmd {
     Inspect(InspectCmd),
     /// Tail live aggregate progress for a running sweep directory.
     Tail(TailCmd),
+    /// Cluster unresolved sweep failures into ranked actionable groups.
+    Triage(TriageCmd),
     /// Pareto frontier across multiple sweep runs: ASCII chart + JSON dataset.
     Frontier(FrontierCmd),
     /// Replay a saved sweep from its manifest and report reproducibility.
@@ -699,6 +701,31 @@ pub struct TailCmd {
     /// Print one snapshot and exit.
     #[arg(long, default_value_t = false)]
     pub once: bool,
+
+    /// Output format: `text` (default) or `json`.
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
+#[derive(Debug, Args)]
+pub struct TriageCmd {
+    /// Completed sweep directory produced by `bench swebench` and scored by
+    /// `bench evaluate`.
+    #[arg(long)]
+    pub sweep: PathBuf,
+
+    /// Restrict clusters to one failure category bucket, such as
+    /// `model_parse` or `env_setup`.
+    #[arg(long)]
+    pub bucket: Option<String>,
+
+    /// Hide clusters smaller than this size.
+    #[arg(long, default_value_t = 1)]
+    pub min_cluster_size: usize,
+
+    /// Number of ranked clusters to print in text mode.
+    #[arg(long, default_value_t = 10)]
+    pub top: usize,
 
     /// Output format: `text` (default) or `json`.
     #[arg(long, default_value = "text")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -88,6 +88,9 @@ pub async fn run() -> Result<(), Error> {
             cmd: args::BenchCmd::Tail(t),
         } => bench_tail(t).await,
         Command::Bench {
+            cmd: args::BenchCmd::Triage(t),
+        } => bench_triage(t),
+        Command::Bench {
             cmd: args::BenchCmd::Frontier(f),
         } => bench_frontier(f),
         Command::Bench {
@@ -231,7 +234,7 @@ async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
     let mut sweep_cmd = s;
     validate_swebench_github_pr_args(&sweep_cmd.github_pr)?;
     if sweep_cmd.forecast_first {
-        match run_forecast_from_cmd(sweep_cmd.clone()).await? {
+        match Box::pin(run_forecast_from_cmd(sweep_cmd.clone())).await? {
             crate::run::forecast::ForecastOutcome::Report(report) => {
                 print_forecast_report(&report, &sweep_cmd.format)?;
                 if let Err(e) =
@@ -319,7 +322,7 @@ async fn bench_doctor(mut s: args::SwebenchCmd) -> Result<(), Error> {
 async fn bench_forecast(s: args::SwebenchCmd) -> Result<(), Error> {
     let output_format = s.format.clone();
     let fail_over_cap = s.fail_over_cap;
-    match run_forecast_from_cmd(s).await? {
+    match Box::pin(run_forecast_from_cmd(s)).await? {
         crate::run::forecast::ForecastOutcome::Report(report) => {
             print_forecast_report(&report, &output_format)?;
             if let Err(e) = crate::run::forecast::validate_fail_over_cap(&report, fail_over_cap) {
@@ -1352,8 +1355,42 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
     Ok(())
 }
 
+fn bench_triage(t: args::TriageCmd) -> Result<(), Error> {
+    let format = match t.format.as_str() {
+        "text" => TriageFormat::Text,
+        "json" => TriageFormat::Json,
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "unknown --format `{other}` (expected `text` or `json`)"
+            ))));
+        }
+    };
+    let report = crate::run::triage::run(&crate::run::triage::TriageArgs {
+        sweep_dir: t.sweep,
+        bucket: t.bucket,
+        min_cluster_size: t.min_cluster_size,
+        top: t.top,
+    })?;
+    match format {
+        TriageFormat::Text => {
+            print!("{}", crate::run::triage::render_text(&report, t.top));
+            Ok(())
+        }
+        TriageFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            Ok(())
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TailFormat {
+    Text,
+    Json,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TriageFormat {
     Text,
     Json,
 }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -18,3 +18,4 @@ pub mod reproduce;
 pub mod swebench;
 pub mod tail;
 pub mod trajectory_diff;
+pub mod triage;

--- a/src/run/triage.rs
+++ b/src/run/triage.rs
@@ -11,7 +11,7 @@ use crate::artifact::{ArtifactKind, classify_json_value};
 use crate::env::RunResult;
 use crate::error::Error;
 use crate::run::compare::{load_evaluation_results_checked, load_sweep};
-use crate::run::swebench::InstanceResult;
+use crate::run::swebench::{InstanceResult, resolved_count};
 use crate::trajectory::{FailureCategory, Trajectory};
 
 const ASSISTANT_TAIL_CHARS: usize = 500;
@@ -131,18 +131,37 @@ struct ClusterMember {
 #[derive(Debug, Clone)]
 struct ClusterAccumulator {
     signature: FailureSignature,
+    signature_summary: String,
+    cluster_id: String,
     members: Vec<ClusterMember>,
+    total_cost_usd: f64,
+    score: f64,
 }
 
 impl ClusterAccumulator {
-    fn total_cost_usd(&self) -> f64 {
-        self.members.iter().map(|member| member.cost_usd).sum()
+    fn new(signature: FailureSignature) -> Self {
+        let signature_summary = signature.summary();
+        let cluster_id = signature.cluster_id();
+        Self {
+            signature,
+            signature_summary,
+            cluster_id,
+            members: Vec::new(),
+            total_cost_usd: 0.0,
+            score: 0.0,
+        }
     }
 
-    fn score(&self) -> f64 {
+    fn push_member(&mut self, member: ClusterMember) {
+        self.total_cost_usd += member.cost_usd;
+        self.members.push(member);
+        self.score = Self::score_for(self.members.len(), self.total_cost_usd);
+    }
+
+    fn score_for(member_count: usize, total_cost_usd: f64) -> f64 {
         #[allow(clippy::cast_precision_loss)]
         {
-            self.members.len() as f64 * self.total_cost_usd()
+            member_count as f64 * total_cost_usd
         }
     }
 }
@@ -326,7 +345,7 @@ fn build_report(args: &TriageArgs) -> Result<TriageReport, Error> {
         .sum::<usize>();
     let total_candidate_cost_usd = accumulators
         .values()
-        .map(ClusterAccumulator::total_cost_usd)
+        .map(|cluster| cluster.total_cost_usd)
         .sum::<f64>();
     let mut cluster_accs: Vec<ClusterAccumulator> = accumulators
         .into_values()
@@ -426,19 +445,16 @@ fn build_accumulators(
         };
         accumulators
             .entry(key)
-            .or_insert_with(|| ClusterAccumulator {
-                signature,
-                members: Vec::new(),
-            })
-            .members
-            .push(member);
+            .or_insert_with(|| ClusterAccumulator::new(signature))
+            .push_member(member);
     }
     Ok(accumulators)
 }
 
 fn instance_is_errored(instance: &InstanceResult) -> bool {
-    instance.outcome.as_deref() == Some(crate::trajectory::outcome::ERROR)
-        || instance.failure_category.is_some()
+    resolved_count(instance) == 0
+        && (instance.outcome.as_deref() == Some(crate::trajectory::outcome::ERROR)
+            || instance.failure_category.is_some())
 }
 
 fn compare_cluster_accumulators(
@@ -446,20 +462,16 @@ fn compare_cluster_accumulators(
     right: &ClusterAccumulator,
 ) -> std::cmp::Ordering {
     right
-        .score()
-        .total_cmp(&left.score())
-        .then_with(|| right.total_cost_usd().total_cmp(&left.total_cost_usd()))
+        .score
+        .total_cmp(&left.score)
+        .then_with(|| right.total_cost_usd.total_cmp(&left.total_cost_usd))
         .then_with(|| {
             left.signature
                 .failure_category
                 .cmp(&right.signature.failure_category)
         })
-        .then_with(|| left.signature.summary().cmp(&right.signature.summary()))
-        .then_with(|| {
-            left.signature
-                .cluster_id()
-                .cmp(&right.signature.cluster_id())
-        })
+        .then_with(|| left.signature_summary.cmp(&right.signature_summary))
+        .then_with(|| left.cluster_id.cmp(&right.cluster_id))
 }
 
 fn cluster_from_accumulator(acc: &ClusterAccumulator) -> TriageCluster {
@@ -472,11 +484,11 @@ fn cluster_from_accumulator(acc: &ClusterAccumulator) -> TriageCluster {
         Clone::clone,
     );
     TriageCluster {
-        cluster_id: acc.signature.cluster_id(),
+        cluster_id: acc.cluster_id.clone(),
         failure_category: acc.signature.failure_category.clone(),
-        signature_summary: acc.signature.summary(),
+        signature_summary: acc.signature_summary.clone(),
         instance_count: acc.members.len(),
-        total_cost_usd: acc.total_cost_usd(),
+        total_cost_usd: acc.total_cost_usd,
         exemplar_instance_id: exemplar.instance_id,
         exemplar_trajectory_path: exemplar.trajectory_path,
         instance_ids: acc

--- a/src/run/triage.rs
+++ b/src/run/triage.rs
@@ -1,0 +1,605 @@
+//! `bench triage`: deterministic clustering for unresolved sweep failures.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use crate::artifact::{ArtifactKind, classify_json_value};
+use crate::env::RunResult;
+use crate::error::Error;
+use crate::run::compare::{load_evaluation_results_checked, load_sweep};
+use crate::run::swebench::InstanceResult;
+use crate::trajectory::{FailureCategory, Trajectory};
+
+const ASSISTANT_TAIL_CHARS: usize = 500;
+const SUMMARY_MAX_CHARS: usize = 160;
+const CLUSTER_ID_HEX_CHARS: usize = 16;
+
+#[derive(Debug, Clone)]
+pub struct TriageArgs {
+    pub sweep_dir: PathBuf,
+    pub bucket: Option<String>,
+    pub min_cluster_size: usize,
+    pub top: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriageReport {
+    pub sweep: String,
+    pub generated_at: String,
+    pub clusters: Vec<TriageCluster>,
+    pub totals: TriageTotals,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriageCluster {
+    pub cluster_id: String,
+    pub failure_category: String,
+    pub signature_summary: String,
+    pub instance_count: usize,
+    pub total_cost_usd: f64,
+    pub exemplar_instance_id: String,
+    pub exemplar_trajectory_path: String,
+    pub instance_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct TriageTotals {
+    pub clusters: usize,
+    pub instances: usize,
+    pub unclustered_instances: usize,
+    pub unresolved_cost_usd: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FailureSignature {
+    failure_category: String,
+    assistant_tail: String,
+    bash_exit_code: Option<i32>,
+    stderr_line: String,
+}
+
+impl FailureSignature {
+    #[must_use]
+    pub fn from_parts(
+        failure_category: &str,
+        assistant_message: &str,
+        bash_exit_code: Option<i32>,
+        stderr_line: &str,
+    ) -> Self {
+        Self {
+            failure_category: failure_category.to_owned(),
+            assistant_tail: normalize_signature_text(&message_tail(
+                assistant_message,
+                ASSISTANT_TAIL_CHARS,
+            )),
+            bash_exit_code,
+            stderr_line: normalize_signature_text(stderr_line),
+        }
+    }
+
+    #[must_use]
+    pub fn stable_key(&self) -> String {
+        format!(
+            "failure_category={}\nassistant_tail={}\nbash_exit_code={}\nstderr_line={}",
+            self.failure_category,
+            self.assistant_tail,
+            self.bash_exit_code
+                .map_or_else(|| "none".to_owned(), |code| code.to_string()),
+            self.stderr_line
+        )
+    }
+
+    #[must_use]
+    pub fn cluster_id(&self) -> String {
+        let digest = Sha256::digest(self.stable_key().as_bytes());
+        let mut out = String::with_capacity(CLUSTER_ID_HEX_CHARS);
+        for byte in digest {
+            let _ = write!(out, "{byte:02x}");
+            if out.len() >= CLUSTER_ID_HEX_CHARS {
+                break;
+            }
+        }
+        out
+    }
+
+    #[must_use]
+    pub fn summary(&self) -> String {
+        truncate_chars(
+            &format!(
+                "assistant=\"{}\" exit={} stderr=\"{}\"",
+                self.assistant_tail,
+                self.bash_exit_code
+                    .map_or_else(|| "none".to_owned(), |code| code.to_string()),
+                self.stderr_line
+            ),
+            SUMMARY_MAX_CHARS,
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ClusterMember {
+    instance_id: String,
+    trajectory_path: String,
+    cost_usd: f64,
+}
+
+#[derive(Debug, Clone)]
+struct ClusterAccumulator {
+    signature: FailureSignature,
+    members: Vec<ClusterMember>,
+}
+
+impl ClusterAccumulator {
+    fn total_cost_usd(&self) -> f64 {
+        self.members.iter().map(|member| member.cost_usd).sum()
+    }
+
+    fn score(&self) -> f64 {
+        #[allow(clippy::cast_precision_loss)]
+        {
+            self.members.len() as f64 * self.total_cost_usd()
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TerminalSignals {
+    assistant_message: String,
+    bash_exit_code: Option<i32>,
+    stderr_line: String,
+}
+
+/// Normalize one textual signature component.
+///
+/// The normalizer lowercases, collapses whitespace, replaces tokens that look
+/// like filesystem paths with `<path>`, and replaces ASCII digit runs (including
+/// simple decimals) with `<num>`.
+#[must_use]
+pub fn normalize_signature_text(raw: &str) -> String {
+    raw.to_lowercase()
+        .split_whitespace()
+        .map(normalize_signature_token)
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn normalize_signature_token(token: &str) -> String {
+    let core = token.trim_matches(is_wrapping_punctuation);
+    if looks_like_path(core) {
+        return "<path>".into();
+    }
+    replace_numbers(token)
+}
+
+fn is_wrapping_punctuation(ch: char) -> bool {
+    matches!(
+        ch,
+        '"' | '\'' | '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>' | ',' | ';'
+    )
+}
+
+fn looks_like_path(token: &str) -> bool {
+    if token.is_empty() {
+        return false;
+    }
+    if token.starts_with('/')
+        || token.starts_with('\\')
+        || token.starts_with("./")
+        || token.starts_with("../")
+        || token.starts_with(".\\")
+        || token.starts_with("..\\")
+    {
+        return true;
+    }
+
+    let bytes = token.as_bytes();
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'\\' | b'/')
+    {
+        return true;
+    }
+
+    token.contains('/') || token.contains('\\')
+}
+
+fn replace_numbers(token: &str) -> String {
+    let mut out = String::with_capacity(token.len());
+    let mut chars = token.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch.is_ascii_digit() {
+            out.push_str("<num>");
+            consume_number_tail(&mut chars);
+            continue;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn consume_number_tail<I>(chars: &mut std::iter::Peekable<I>)
+where
+    I: Iterator<Item = char>,
+{
+    while let Some(next) = chars.peek().copied() {
+        if next.is_ascii_digit() {
+            let _ = chars.next();
+            continue;
+        }
+        if next == '.' {
+            let _ = chars.next();
+            continue;
+        }
+        break;
+    }
+}
+
+pub fn run(args: &TriageArgs) -> Result<TriageReport, Error> {
+    if args.min_cluster_size == 0 {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(
+            "triage: --min-cluster-size must be at least 1".into(),
+        )));
+    }
+
+    let mut report = build_report(args)?;
+    report.generated_at = utc_now_iso8601();
+    let output_path = args.sweep_dir.join("triage.json");
+    let file = std::fs::File::create(output_path)?;
+    serde_json::to_writer_pretty(file, &report)?;
+    Ok(report)
+}
+
+pub fn render_text(report: &TriageReport, top: usize) -> String {
+    use comfy_table::Table;
+    use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+    use comfy_table::presets::UTF8_FULL;
+
+    let mut out = String::new();
+    out.push_str("\n=== bench triage ===\n");
+    let _ = writeln!(out, "Sweep: {}", report.sweep);
+    let _ = writeln!(
+        out,
+        "Clusters: {}  instances: {}  unresolved_cost_usd: {:.4}",
+        report.totals.clusters, report.totals.instances, report.totals.unresolved_cost_usd
+    );
+    out.push('\n');
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec![
+            "rank",
+            "failure_category",
+            "instance_count",
+            "total_usd",
+            "% unresolved cost",
+            "exemplar_instance_id",
+            "signature_summary",
+        ]);
+
+    for (idx, cluster) in report.clusters.iter().take(top).enumerate() {
+        let share = if report.totals.unresolved_cost_usd > 0.0 {
+            100.0 * cluster.total_cost_usd / report.totals.unresolved_cost_usd
+        } else {
+            0.0
+        };
+        table.add_row(vec![
+            (idx + 1).to_string(),
+            cluster.failure_category.clone(),
+            cluster.instance_count.to_string(),
+            format!("{:.4}", cluster.total_cost_usd),
+            format!("{share:.1}"),
+            cluster.exemplar_instance_id.clone(),
+            truncate_chars(&cluster.signature_summary, 96),
+        ]);
+    }
+
+    out.push_str(&table.to_string());
+    out.push('\n');
+    out
+}
+
+fn build_report(args: &TriageArgs) -> Result<TriageReport, Error> {
+    let sweep = load_sweep(&args.sweep_dir)?;
+    let evaluation = load_evaluation_results_checked(&args.sweep_dir)?.ok_or_else(|| {
+        Error::Trajectory(format!(
+            "bench triage: missing evaluation.json in {}; run `bench evaluate --sweep {}` first",
+            args.sweep_dir.display(),
+            args.sweep_dir.display()
+        ))
+    })?;
+
+    let candidate_ids = candidate_instance_ids(evaluation.results, &sweep.instances);
+    let accumulators = build_accumulators(args, &sweep.instances, candidate_ids)?;
+
+    let total_candidate_instances = accumulators
+        .values()
+        .map(|cluster| cluster.members.len())
+        .sum::<usize>();
+    let total_candidate_cost_usd = accumulators
+        .values()
+        .map(ClusterAccumulator::total_cost_usd)
+        .sum::<f64>();
+    let mut cluster_accs: Vec<ClusterAccumulator> = accumulators
+        .into_values()
+        .filter(|cluster| cluster.members.len() >= args.min_cluster_size)
+        .collect();
+    for cluster in &mut cluster_accs {
+        cluster
+            .members
+            .sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
+    }
+    cluster_accs.sort_by(compare_cluster_accumulators);
+
+    let clusters: Vec<TriageCluster> = cluster_accs.iter().map(cluster_from_accumulator).collect();
+    let clustered_instances = clusters
+        .iter()
+        .map(|cluster| cluster.instance_count)
+        .sum::<usize>();
+    let totals = TriageTotals {
+        clusters: clusters.len(),
+        instances: clustered_instances,
+        unclustered_instances: total_candidate_instances.saturating_sub(clustered_instances),
+        unresolved_cost_usd: total_candidate_cost_usd,
+    };
+
+    Ok(TriageReport {
+        sweep: args.sweep_dir.display().to_string(),
+        generated_at: String::new(),
+        clusters,
+        totals,
+    })
+}
+
+fn candidate_instance_ids(
+    evaluation: crate::run::evaluate::EvaluationResults,
+    instances: &HashMap<String, InstanceResult>,
+) -> BTreeSet<String> {
+    let mut candidate_ids: BTreeSet<String> = evaluation
+        .instances
+        .into_iter()
+        .filter(|row| !row.resolved)
+        .map(|row| row.instance_id)
+        .collect();
+    candidate_ids.extend(
+        instances
+            .values()
+            .filter(|instance| instance_is_errored(instance))
+            .map(|instance| instance.instance_id.clone()),
+    );
+    candidate_ids
+}
+
+fn build_accumulators(
+    args: &TriageArgs,
+    instances: &HashMap<String, InstanceResult>,
+    candidate_ids: BTreeSet<String>,
+) -> Result<BTreeMap<String, ClusterAccumulator>, Error> {
+    let mut accumulators: BTreeMap<String, ClusterAccumulator> = BTreeMap::new();
+    for instance_id in candidate_ids {
+        let instance = instances.get(&instance_id).ok_or_else(|| {
+            Error::Trajectory(format!(
+                "bench triage: evaluation.json references `{instance_id}` but results.json has no matching instance"
+            ))
+        })?;
+        let trajectory_path =
+            resolve_trajectory_path(&args.sweep_dir, &instance_id).ok_or_else(|| {
+                Error::Trajectory(format!(
+                    "bench triage: trajectory not found for unresolved instance `{instance_id}`"
+                ))
+            })?;
+        let trajectory = load_trajectory(&trajectory_path)?;
+        let failure_category = instance
+            .failure_category
+            .or(trajectory.info.failure_category)
+            .unwrap_or(FailureCategory::Unknown);
+        let category_label = failure_label(failure_category).to_owned();
+        if args
+            .bucket
+            .as_deref()
+            .is_some_and(|bucket| bucket != category_label)
+        {
+            continue;
+        }
+
+        let signals = terminal_signals(&trajectory);
+        let signature = FailureSignature::from_parts(
+            &category_label,
+            &signals.assistant_message,
+            signals.bash_exit_code,
+            &signals.stderr_line,
+        );
+        let key = signature.stable_key();
+        let rel_path = relative_path_string(&args.sweep_dir, &trajectory_path);
+        let member = ClusterMember {
+            instance_id,
+            trajectory_path: rel_path,
+            cost_usd: instance.actual_cost_usd().unwrap_or(0.0),
+        };
+        accumulators
+            .entry(key)
+            .or_insert_with(|| ClusterAccumulator {
+                signature,
+                members: Vec::new(),
+            })
+            .members
+            .push(member);
+    }
+    Ok(accumulators)
+}
+
+fn instance_is_errored(instance: &InstanceResult) -> bool {
+    instance.outcome.as_deref() == Some(crate::trajectory::outcome::ERROR)
+        || instance.failure_category.is_some()
+}
+
+fn compare_cluster_accumulators(
+    left: &ClusterAccumulator,
+    right: &ClusterAccumulator,
+) -> std::cmp::Ordering {
+    right
+        .score()
+        .total_cmp(&left.score())
+        .then_with(|| right.total_cost_usd().total_cmp(&left.total_cost_usd()))
+        .then_with(|| {
+            left.signature
+                .failure_category
+                .cmp(&right.signature.failure_category)
+        })
+        .then_with(|| left.signature.summary().cmp(&right.signature.summary()))
+        .then_with(|| {
+            left.signature
+                .cluster_id()
+                .cmp(&right.signature.cluster_id())
+        })
+}
+
+fn cluster_from_accumulator(acc: &ClusterAccumulator) -> TriageCluster {
+    let exemplar = acc.members.first().map_or_else(
+        || ClusterMember {
+            instance_id: String::new(),
+            trajectory_path: String::new(),
+            cost_usd: 0.0,
+        },
+        Clone::clone,
+    );
+    TriageCluster {
+        cluster_id: acc.signature.cluster_id(),
+        failure_category: acc.signature.failure_category.clone(),
+        signature_summary: acc.signature.summary(),
+        instance_count: acc.members.len(),
+        total_cost_usd: acc.total_cost_usd(),
+        exemplar_instance_id: exemplar.instance_id,
+        exemplar_trajectory_path: exemplar.trajectory_path,
+        instance_ids: acc
+            .members
+            .iter()
+            .map(|member| member.instance_id.clone())
+            .collect(),
+    }
+}
+
+fn load_trajectory(path: &Path) -> Result<Trajectory, Error> {
+    let text = std::fs::read_to_string(path)?;
+    let value: serde_json::Value = serde_json::from_str(&text)?;
+    classify_json_value(&value, ArtifactKind::Trajectory, path.display().to_string())
+        .map_err(|err| Error::Trajectory(err.to_string()))?;
+    serde_json::from_value(value).map_err(Into::into)
+}
+
+fn terminal_signals(trajectory: &Trajectory) -> TerminalSignals {
+    let assistant_message = trajectory
+        .messages
+        .iter()
+        .rev()
+        .find(|message| message.role == "assistant")
+        .map_or_else(String::new, |message| message.content.clone());
+    let last_run = trajectory.messages.iter().rev().find_map(|message| {
+        if message.role != "user" {
+            return None;
+        }
+        message
+            .extra
+            .other
+            .get("run_result")
+            .and_then(|value| serde_json::from_value::<RunResult>(value.clone()).ok())
+    });
+    let (bash_exit_code, stderr_line) = last_run.map_or((None, String::new()), |run| {
+        (
+            Some(run.exit_code),
+            run.stderr
+                .lines()
+                .rev()
+                .find(|line| !line.trim().is_empty())
+                .unwrap_or_default()
+                .to_owned(),
+        )
+    });
+    TerminalSignals {
+        assistant_message,
+        bash_exit_code,
+        stderr_line,
+    }
+}
+
+fn resolve_trajectory_path(sweep: &Path, instance_id: &str) -> Option<PathBuf> {
+    let nested = sweep.join(instance_id).join("trajectory.json");
+    if nested.exists() {
+        return Some(nested);
+    }
+    let nested_run = sweep.join(instance_id).join("run-1.traj.json");
+    if nested_run.exists() {
+        return Some(nested_run);
+    }
+    let flat = sweep.join(format!("{instance_id}.traj.json"));
+    flat.exists().then_some(flat)
+}
+
+fn relative_path_string(base: &Path, path: &Path) -> String {
+    path.strip_prefix(base)
+        .map_or_else(|_| path_to_forward_slashes(path), path_to_forward_slashes)
+}
+
+fn path_to_forward_slashes(path: &Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn failure_label(c: FailureCategory) -> &'static str {
+    match c {
+        FailureCategory::EnvSetup => "env_setup",
+        FailureCategory::ModelApi => "model_api",
+        FailureCategory::ModelParse => "model_parse",
+        FailureCategory::StepLimit => "step_limit",
+        FailureCategory::CostLimit => "cost_limit",
+        FailureCategory::BudgetExhausted => "budget_exhausted",
+        FailureCategory::WallclockTimeout => "wallclock_timeout",
+        FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
+        FailureCategory::PatchEmpty => "patch_empty",
+        FailureCategory::SecretLeakDetected => "secret_leak_detected",
+        FailureCategory::Unknown => "unknown",
+    }
+}
+
+fn message_tail(message: &str, max_chars: usize) -> String {
+    let len = message.chars().count();
+    if len <= max_chars {
+        return message.to_owned();
+    }
+    message.chars().skip(len - max_chars).collect()
+}
+
+fn truncate_chars(s: &str, max_chars: usize) -> String {
+    let mut iter = s.chars();
+    let mut out: String = iter.by_ref().take(max_chars).collect();
+    if iter.next().is_some() {
+        out.push_str("...");
+    }
+    out
+}
+
+fn utc_now_iso8601() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_tail_limits_by_chars() {
+        assert_eq!(message_tail("abcdef", 3), "def");
+        assert_eq!(message_tail("abc", 3), "abc");
+    }
+}

--- a/tests/bench_triage.rs
+++ b/tests/bench_triage.rs
@@ -1,0 +1,353 @@
+//! `bench triage`: cluster unresolved sweep failures into ranked signatures.
+
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+use serde_json::json;
+
+use rust_swe_agent::run::triage::{FailureSignature, normalize_signature_text};
+
+mod support;
+use support::binary_path;
+
+#[test]
+fn signature_normalization_replaces_numbers_paths_and_whitespace() {
+    let normalized = normalize_signature_text(
+        "  ERROR at C:\\tmp\\run-42\\src\\lib.rs:101\n\tthen /tmp/swe/run-77/main.py value=999  ",
+    );
+
+    assert_eq!(normalized, "error at <path> then <path> value=<num>");
+
+    let left = FailureSignature::from_parts(
+        "model_parse",
+        "Parser failed in /tmp/swe/task-101/src/main.py line 33",
+        Some(2),
+        "SyntaxError: unexpected token 404 in /tmp/swe/task-101/src/main.py",
+    );
+    let right = FailureSignature::from_parts(
+        "model_parse",
+        " parser FAILED in C:\\tmp\\task-202\\src\\main.py line 44 ",
+        Some(2),
+        "syntaxerror: unexpected token 505 in C:\\tmp\\task-202\\src\\main.py",
+    );
+
+    assert_eq!(left.stable_key(), right.stable_key());
+    assert_eq!(left.cluster_id(), right.cluster_id());
+}
+
+#[test]
+fn cli_clusters_unresolved_failures_and_writes_ranked_triage_json() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_triage_fixture_sweep(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "triage",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--top",
+            "3",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench triage failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("=== bench triage ==="), "{stdout}");
+    assert!(stdout.contains("model_parse"), "{stdout}");
+    assert!(stdout.contains("model-a-1"), "{stdout}");
+    assert!(stdout.contains("env-1"), "{stdout}");
+
+    let model_rank = stdout.find("model-a-1").unwrap();
+    let env_rank = stdout.find("env-1").unwrap();
+    let singleton_rank = stdout.find("model-b-1").unwrap();
+    assert!(
+        model_rank < env_rank && env_rank < singleton_rank,
+        "clusters should rank by instance_count * total_cost_usd:\n{stdout}"
+    );
+
+    let report_path = sweep.path().join("triage.json");
+    assert!(report_path.exists(), "triage.json should be written");
+    let report: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&report_path).unwrap()).unwrap();
+
+    assert_eq!(report["totals"]["clusters"], 4);
+    assert_eq!(report["totals"]["instances"], 5);
+    assert_eq!(report["totals"]["unclustered_instances"], 0);
+    assert_eq!(report["totals"]["unresolved_cost_usd"], json!(15.5));
+
+    let clusters = report["clusters"].as_array().unwrap();
+    assert_eq!(clusters.len(), 4);
+    assert_eq!(clusters[0]["failure_category"], "model_parse");
+    assert_eq!(clusters[0]["instance_count"], 2);
+    assert_eq!(clusters[0]["total_cost_usd"], json!(3.5));
+    assert_eq!(clusters[0]["exemplar_instance_id"], "model-a-1");
+    assert_eq!(
+        clusters[0]["exemplar_trajectory_path"],
+        "model-a-1.traj.json"
+    );
+    assert_eq!(
+        clusters[0]["instance_ids"],
+        json!(["model-a-1", "model-a-2"])
+    );
+    assert!(
+        clusters[0]["cluster_id"].as_str().unwrap().len() >= 12,
+        "stable hash should be operator-friendly but collision-resistant enough"
+    );
+}
+
+#[test]
+fn cli_json_format_honors_bucket_and_min_cluster_size_filters() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_triage_fixture_sweep(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "triage",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--bucket",
+            "model_parse",
+            "--min-cluster-size",
+            "2",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench triage failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let clusters = report["clusters"].as_array().unwrap();
+    assert_eq!(clusters.len(), 1);
+    assert_eq!(clusters[0]["failure_category"], "model_parse");
+    assert_eq!(clusters[0]["instance_count"], 2);
+    assert_eq!(report["totals"]["instances"], 2);
+    assert_eq!(report["totals"]["unclustered_instances"], 1);
+    assert_eq!(report["totals"]["unresolved_cost_usd"], json!(8.5));
+}
+
+#[test]
+fn triage_json_is_deterministic_except_generated_at() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_triage_fixture_sweep(sweep.path());
+
+    let first = run_triage_json(sweep.path());
+    let first_file = std::fs::read_to_string(sweep.path().join("triage.json")).unwrap();
+
+    std::thread::sleep(Duration::from_secs(1));
+
+    let second = run_triage_json(sweep.path());
+    let second_file = std::fs::read_to_string(sweep.path().join("triage.json")).unwrap();
+
+    assert_eq!(
+        redact_generated_at(&first),
+        redact_generated_at(&second),
+        "stdout JSON should be deterministic except generated_at"
+    );
+    assert_eq!(
+        redact_generated_at_text(&first_file),
+        redact_generated_at_text(&second_file),
+        "triage.json bytes should be deterministic except generated_at"
+    );
+}
+
+#[test]
+fn cli_includes_errored_results_rows_missing_from_evaluation_json() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_triage_fixture_sweep(sweep.path());
+    inject_results_only_errored_instance(sweep.path());
+
+    let report = run_triage_json(sweep.path());
+    let clusters = report["clusters"].as_array().unwrap();
+    let Some(result_only) = clusters.iter().find(|cluster| {
+        cluster["instance_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|id| id == "eval-missing-error")
+    }) else {
+        panic!("errored result row missing from evaluation.json should still be triaged");
+    };
+
+    assert_eq!(result_only["failure_category"], "model_api");
+    assert_eq!(report["totals"]["instances"], 6);
+    assert_eq!(report["totals"]["unresolved_cost_usd"], json!(19.5));
+}
+
+#[test]
+fn cli_errors_when_evaluation_json_is_missing() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_triage_fixture_sweep(sweep.path());
+    std::fs::remove_file(sweep.path().join("evaluation.json")).unwrap();
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "triage",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "triage should require evaluation.json"
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("bench evaluate"),
+        "error should point operators at bench evaluate, got:\n{stderr}"
+    );
+}
+
+fn copy_triage_fixture_sweep(dir: &Path) {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/triage/sweep");
+    copy_dir(&fixture, dir);
+}
+
+fn copy_dir(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        let target = dst.join(entry.file_name());
+        if path.is_dir() {
+            copy_dir(&path, &target);
+        } else {
+            std::fs::copy(&path, &target).unwrap();
+        }
+    }
+}
+
+fn run_triage_json(sweep: &Path) -> serde_json::Value {
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "triage",
+            "--sweep",
+            sweep.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "bench triage failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+fn redact_generated_at(value: &serde_json::Value) -> serde_json::Value {
+    let mut redacted = value.clone();
+    redacted["generated_at"] = json!("<generated_at>");
+    redacted
+}
+
+fn redact_generated_at_text(text: &str) -> String {
+    text.lines()
+        .map(|line| {
+            if line.trim_start().starts_with("\"generated_at\":") {
+                let indent_len = line.len() - line.trim_start().len();
+                format!(
+                    "{}\"generated_at\": \"<generated_at>\",",
+                    " ".repeat(indent_len)
+                )
+            } else {
+                line.to_owned()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn inject_results_only_errored_instance(sweep: &Path) {
+    let results_path = sweep.join("results.json");
+    let mut results: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&results_path).unwrap()).unwrap();
+    results["total"] = json!(7);
+    results["errored"] = json!(6);
+    results["total_cost_usd"] = json!(28.5);
+    results["instances"].as_array_mut().unwrap().push(json!({
+        "instance_id": "eval-missing-error",
+        "exit_reason": "error",
+        "outcome": "error",
+        "failure_category": "model_api",
+        "cost_usd": 4.0,
+        "attempts": 1,
+        "runs": 1,
+        "resolved_count": 0,
+        "pass_at_1": false,
+        "tests_run_before_submit": false
+    }));
+    std::fs::write(
+        results_path,
+        serde_json::to_string_pretty(&results).unwrap(),
+    )
+    .unwrap();
+
+    std::fs::write(
+        sweep.join("eval-missing-error.traj.json"),
+        serde_json::to_string_pretty(&json!({
+            "trajectory_format": "mini-swe-agent-1.1",
+            "artifact_kind": "trajectory",
+            "schema_version": {"major": 1, "minor": 3},
+            "info": {
+                "task": "eval-missing-error",
+                "model_name": "fixture-model",
+                "outcome": "error",
+                "failure_category": "model_api",
+                "total_cost_usd": 4.0,
+                "steps": 2,
+                "test_invocations": [],
+                "tests_run_before_submit": false
+            },
+            "messages": [
+                {"role": "assistant", "content": "Provider returned retry-after 30"},
+                {
+                    "role": "user",
+                    "content": "observation",
+                    "extra": {
+                        "run_result": {
+                            "stdout": "",
+                            "stderr": "provider returned HTTP 429 retry-after 30",
+                            "exit_code": 1,
+                            "timed_out": false
+                        }
+                    }
+                }
+            ]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+}

--- a/tests/bench_triage.rs
+++ b/tests/bench_triage.rs
@@ -197,6 +197,28 @@ fn cli_includes_errored_results_rows_missing_from_evaluation_json() {
 }
 
 #[test]
+fn cli_excludes_resolved_rerun_aggregates_from_results_fallback_candidates() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_triage_fixture_sweep(sweep.path());
+    inject_resolved_rerun_aggregate_with_run1_failure(sweep.path());
+
+    let report = run_triage_json(sweep.path());
+    let clusters = report["clusters"].as_array().unwrap();
+    assert!(
+        clusters.iter().all(|cluster| {
+            cluster["instance_ids"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|id| id != "resolved-rerun")
+        }),
+        "resolved rerun aggregate should not be triaged: {report:#}"
+    );
+    assert_eq!(report["totals"]["instances"], 5);
+    assert_eq!(report["totals"]["unresolved_cost_usd"], json!(15.5));
+}
+
+#[test]
 fn cli_errors_when_evaluation_json_is_missing() {
     let sweep = tempfile::tempdir().unwrap();
     copy_triage_fixture_sweep(sweep.path());
@@ -340,6 +362,88 @@ fn inject_results_only_errored_instance(sweep: &Path) {
                         "run_result": {
                             "stdout": "",
                             "stderr": "provider returned HTTP 429 retry-after 30",
+                            "exit_code": 1,
+                            "timed_out": false
+                        }
+                    }
+                }
+            ]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+}
+
+fn inject_resolved_rerun_aggregate_with_run1_failure(sweep: &Path) {
+    let results_path = sweep.join("results.json");
+    let mut results: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&results_path).unwrap()).unwrap();
+    results["total"] = json!(7);
+    results["errored"] = json!(6);
+    results["resolved"] = json!(2);
+    results["total_cost_usd"] = json!(31.5);
+    results["instances"].as_array_mut().unwrap().push(json!({
+        "instance_id": "resolved-rerun",
+        "exit_reason": "error",
+        "outcome": "error",
+        "failure_category": "model_api",
+        "cost_usd": 7.0,
+        "attempts": 3,
+        "runs": 3,
+        "resolved_count": 1,
+        "pass_at_1": false,
+        "tests_run_before_submit": true
+    }));
+    std::fs::write(
+        results_path,
+        serde_json::to_string_pretty(&results).unwrap(),
+    )
+    .unwrap();
+
+    let evaluation_path = sweep.join("evaluation.json");
+    let mut evaluation: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&evaluation_path).unwrap()).unwrap();
+    evaluation["instances"].as_array_mut().unwrap().push(json!({
+        "instance_id": "resolved-rerun",
+        "resolved": true,
+        "runs": 3,
+        "resolved_count": 1,
+        "pass_at_1": false,
+        "tests_passed": [],
+        "tests_failed": [],
+        "eval_exit_reason": "resolved"
+    }));
+    std::fs::write(
+        evaluation_path,
+        serde_json::to_string_pretty(&evaluation).unwrap(),
+    )
+    .unwrap();
+
+    std::fs::write(
+        sweep.join("resolved-rerun.traj.json"),
+        serde_json::to_string_pretty(&json!({
+            "trajectory_format": "mini-swe-agent-1.1",
+            "artifact_kind": "trajectory",
+            "schema_version": {"major": 1, "minor": 3},
+            "info": {
+                "task": "resolved-rerun",
+                "model_name": "fixture-model",
+                "outcome": "error",
+                "failure_category": "model_api",
+                "total_cost_usd": 7.0,
+                "steps": 2,
+                "test_invocations": [],
+                "tests_run_before_submit": true
+            },
+            "messages": [
+                {"role": "assistant", "content": "Run 1 hit provider failure, later run solved it"},
+                {
+                    "role": "user",
+                    "content": "observation",
+                    "extra": {
+                        "run_result": {
+                            "stdout": "",
+                            "stderr": "provider failure on run 1",
                             "exit_code": 1,
                             "timed_out": false
                         }

--- a/tests/fixtures/triage/sweep/env-1.traj.json
+++ b/tests/fixtures/triage/sweep/env-1.traj.json
@@ -1,0 +1,36 @@
+{
+  "trajectory_format": "mini-swe-agent-1.1",
+  "artifact_kind": "trajectory",
+  "schema_version": {
+    "major": 1,
+    "minor": 3
+  },
+  "info": {
+    "task": "env-1",
+    "model_name": "fixture-model",
+    "outcome": "error",
+    "failure_category": "env_setup",
+    "total_cost_usd": 6.0,
+    "steps": 2,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Docker image pull failed for python:3.11"
+    },
+    {
+      "role": "user",
+      "content": "observation",
+      "extra": {
+        "run_result": {
+          "stdout": "",
+          "stderr": "daemon unavailable while pulling image python:3.11",
+          "exit_code": 125,
+          "timed_out": false
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/triage/sweep/evaluation.json
+++ b/tests/fixtures/triage/sweep/evaluation.json
@@ -1,0 +1,74 @@
+{
+  "artifact_kind": "evaluation_results",
+  "schema_version": {
+    "major": 1,
+    "minor": 3
+  },
+  "instances": [
+    {
+      "instance_id": "model-a-1",
+      "resolved": false,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_passed": [],
+      "tests_failed": [],
+      "eval_exit_reason": "unresolved"
+    },
+    {
+      "instance_id": "model-a-2",
+      "resolved": false,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_passed": [],
+      "tests_failed": [],
+      "eval_exit_reason": "unresolved"
+    },
+    {
+      "instance_id": "model-b-1",
+      "resolved": false,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_passed": [],
+      "tests_failed": [],
+      "eval_exit_reason": "unresolved"
+    },
+    {
+      "instance_id": "env-1",
+      "resolved": false,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_passed": [],
+      "tests_failed": [],
+      "eval_exit_reason": "unresolved"
+    },
+    {
+      "instance_id": "step-1",
+      "resolved": false,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_passed": [],
+      "tests_failed": [],
+      "eval_exit_reason": "unresolved"
+    },
+    {
+      "instance_id": "resolved-1",
+      "resolved": true,
+      "runs": 1,
+      "resolved_count": 1,
+      "pass_at_1": true,
+      "tests_passed": [],
+      "tests_failed": [],
+      "eval_exit_reason": "resolved"
+    }
+  ],
+  "behavioral": {
+    "tests_run_before_submit_rate": 0.0,
+    "resolved_rate_when_tests_run": 0.0,
+    "resolved_rate_when_tests_skipped": 0.0
+  }
+}

--- a/tests/fixtures/triage/sweep/model-a-1.traj.json
+++ b/tests/fixtures/triage/sweep/model-a-1.traj.json
@@ -1,0 +1,36 @@
+{
+  "trajectory_format": "mini-swe-agent-1.1",
+  "artifact_kind": "trajectory",
+  "schema_version": {
+    "major": 1,
+    "minor": 3
+  },
+  "info": {
+    "task": "model-a-1",
+    "model_name": "fixture-model",
+    "outcome": "error",
+    "failure_category": "model_parse",
+    "total_cost_usd": 2.0,
+    "steps": 2,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Parser failed in /tmp/swe/task-101/src/main.py line 33"
+    },
+    {
+      "role": "user",
+      "content": "observation",
+      "extra": {
+        "run_result": {
+          "stdout": "",
+          "stderr": "SyntaxError: unexpected token 404 in /tmp/swe/task-101/src/main.py",
+          "exit_code": 2,
+          "timed_out": false
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/triage/sweep/model-a-2.traj.json
+++ b/tests/fixtures/triage/sweep/model-a-2.traj.json
@@ -1,0 +1,36 @@
+{
+  "trajectory_format": "mini-swe-agent-1.1",
+  "artifact_kind": "trajectory",
+  "schema_version": {
+    "major": 1,
+    "minor": 3
+  },
+  "info": {
+    "task": "model-a-2",
+    "model_name": "fixture-model",
+    "outcome": "error",
+    "failure_category": "model_parse",
+    "total_cost_usd": 1.5,
+    "steps": 2,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": " parser FAILED in C:\\tmp\\task-202\\src\\main.py line 44 "
+    },
+    {
+      "role": "user",
+      "content": "observation",
+      "extra": {
+        "run_result": {
+          "stdout": "",
+          "stderr": "syntaxerror: unexpected token 505 in C:\\tmp\\task-202\\src\\main.py",
+          "exit_code": 2,
+          "timed_out": false
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/triage/sweep/model-b-1.traj.json
+++ b/tests/fixtures/triage/sweep/model-b-1.traj.json
@@ -1,0 +1,36 @@
+{
+  "trajectory_format": "mini-swe-agent-1.1",
+  "artifact_kind": "trajectory",
+  "schema_version": {
+    "major": 1,
+    "minor": 3
+  },
+  "info": {
+    "task": "model-b-1",
+    "model_name": "fixture-model",
+    "outcome": "error",
+    "failure_category": "model_parse",
+    "total_cost_usd": 5.0,
+    "steps": 2,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Could not decode JSON response from the model"
+    },
+    {
+      "role": "user",
+      "content": "observation",
+      "extra": {
+        "run_result": {
+          "stdout": "",
+          "stderr": "invalid json: expected object",
+          "exit_code": 1,
+          "timed_out": false
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/triage/sweep/resolved-1.traj.json
+++ b/tests/fixtures/triage/sweep/resolved-1.traj.json
@@ -1,0 +1,35 @@
+{
+  "trajectory_format": "mini-swe-agent-1.1",
+  "artifact_kind": "trajectory",
+  "schema_version": {
+    "major": 1,
+    "minor": 3
+  },
+  "info": {
+    "task": "resolved-1",
+    "model_name": "fixture-model",
+    "outcome": "submitted",
+    "total_cost_usd": 9.0,
+    "steps": 2,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Submitted a patch"
+    },
+    {
+      "role": "user",
+      "content": "observation",
+      "extra": {
+        "run_result": {
+          "stdout": "",
+          "stderr": "",
+          "exit_code": 0,
+          "timed_out": false
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/triage/sweep/results.json
+++ b/tests/fixtures/triage/sweep/results.json
@@ -1,0 +1,87 @@
+{
+  "artifact_kind": "sweep_results",
+  "schema_version": {
+    "major": 1,
+    "minor": 3
+  },
+  "total": 6,
+  "submitted": 1,
+  "skipped": 0,
+  "errored": 5,
+  "total_cost_usd": 24.5,
+  "instances": [
+    {
+      "instance_id": "model-a-1",
+      "exit_reason": "error",
+      "outcome": "error",
+      "failure_category": "model_parse",
+      "cost_usd": 2.0,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    },
+    {
+      "instance_id": "model-a-2",
+      "exit_reason": "error",
+      "outcome": "error",
+      "failure_category": "model_parse",
+      "cost_usd": 1.5,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    },
+    {
+      "instance_id": "model-b-1",
+      "exit_reason": "error",
+      "outcome": "error",
+      "failure_category": "model_parse",
+      "cost_usd": 5.0,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    },
+    {
+      "instance_id": "env-1",
+      "exit_reason": "error",
+      "outcome": "error",
+      "failure_category": "env_setup",
+      "cost_usd": 6.0,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    },
+    {
+      "instance_id": "step-1",
+      "exit_reason": "error",
+      "outcome": "error",
+      "failure_category": "step_limit",
+      "cost_usd": 1.0,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    },
+    {
+      "instance_id": "resolved-1",
+      "exit_reason": "submitted",
+      "outcome": "submitted",
+      "cost_usd": 9.0,
+      "patch_present": true,
+      "non_empty_patch": true,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 1,
+      "pass_at_1": true,
+      "tests_run_before_submit": false
+    }
+  ]
+}

--- a/tests/fixtures/triage/sweep/step-1.traj.json
+++ b/tests/fixtures/triage/sweep/step-1.traj.json
@@ -1,0 +1,36 @@
+{
+  "trajectory_format": "mini-swe-agent-1.1",
+  "artifact_kind": "trajectory",
+  "schema_version": {
+    "major": 1,
+    "minor": 3
+  },
+  "info": {
+    "task": "step-1",
+    "model_name": "fixture-model",
+    "outcome": "error",
+    "failure_category": "step_limit",
+    "total_cost_usd": 1.0,
+    "steps": 2,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "I need one more edit before submission"
+    },
+    {
+      "role": "user",
+      "content": "observation",
+      "extra": {
+        "run_result": {
+          "stdout": "",
+          "stderr": "",
+          "exit_code": 0,
+          "timed_out": false
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/triage/sweep/triage.json
+++ b/tests/fixtures/triage/sweep/triage.json
@@ -1,0 +1,61 @@
+{
+  "sweep": "tests/fixtures/triage/sweep",
+  "generated_at": "2026-05-10T21:46:34Z",
+  "clusters": [
+    {
+      "cluster_id": "1957f5c29ed47b20",
+      "failure_category": "model_parse",
+      "signature_summary": "assistant=\"parser failed in <path> line <num>\" exit=2 stderr=\"syntaxerror: unexpected token <num> in <path>\"",
+      "instance_count": 2,
+      "total_cost_usd": 3.5,
+      "exemplar_instance_id": "model-a-1",
+      "exemplar_trajectory_path": "model-a-1.traj.json",
+      "instance_ids": [
+        "model-a-1",
+        "model-a-2"
+      ]
+    },
+    {
+      "cluster_id": "1e259b28a1bf788d",
+      "failure_category": "env_setup",
+      "signature_summary": "assistant=\"docker image pull failed for python:<num>\" exit=125 stderr=\"daemon unavailable while pulling image python:<num>\"",
+      "instance_count": 1,
+      "total_cost_usd": 6.0,
+      "exemplar_instance_id": "env-1",
+      "exemplar_trajectory_path": "env-1.traj.json",
+      "instance_ids": [
+        "env-1"
+      ]
+    },
+    {
+      "cluster_id": "a65b80aa79e09f90",
+      "failure_category": "model_parse",
+      "signature_summary": "assistant=\"could not decode json response from the model\" exit=1 stderr=\"invalid json: expected object\"",
+      "instance_count": 1,
+      "total_cost_usd": 5.0,
+      "exemplar_instance_id": "model-b-1",
+      "exemplar_trajectory_path": "model-b-1.traj.json",
+      "instance_ids": [
+        "model-b-1"
+      ]
+    },
+    {
+      "cluster_id": "95c283b4b80d88ca",
+      "failure_category": "step_limit",
+      "signature_summary": "assistant=\"i need one more edit before submission\" exit=0 stderr=\"\"",
+      "instance_count": 1,
+      "total_cost_usd": 1.0,
+      "exemplar_instance_id": "step-1",
+      "exemplar_trajectory_path": "step-1.traj.json",
+      "instance_ids": [
+        "step-1"
+      ]
+    }
+  ],
+  "totals": {
+    "clusters": 4,
+    "instances": 5,
+    "unclustered_instances": 0,
+    "unresolved_cost_usd": 15.5
+  }
+}


### PR DESCRIPTION
  Add bench triage for deterministic clustering of unresolved SWE-bench
  failures, including JSON/human output, filtering, persisted triage reports,
  and documentation.

  Cover acceptance criteria with fixture-backed CLI tests, including
  deterministic output, min-cluster unclustered counts, and errored results
  rows missing from evaluation.json.