### PR TITLE
feat(bench): add deterministic sweep bundle archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +324,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,10 +493,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1197,6 +1232,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1696,7 @@ dependencies = [
  "clap",
  "comfy-table",
  "dialoguer",
+ "flate2",
  "futures",
  "indicatif",
  "insta",
@@ -1663,6 +1709,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -1883,6 +1930,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,6 +2022,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2859,6 +2923,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,8 @@ chrono = { version = "0.4", features = ["serde"] }
 sha2 = "0.10"
 comfy-table = "7.2.2"
 tempfile = "3"
+flate2 = "1.1"
+tar = "0.4"
 
 # NOTE on model backend:
 # `litellm-rs` ships a library API (`completion`, message constructors,

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ a valid trajectory in hand:
   observing runs while they execute.
 - [`secret redaction`](docs/spec-secret-redaction.md): redaction guarantees for
   trajectories, inspect output, streams, and patch artifacts.
+- [`bench bundle`](docs/spec-bundle.md): deterministic, redaction-strict
+  `tar.gz` sweep archives with hash verification.
 - [`bench reproduce`](docs/spec-reproduce.md): replay a saved sweep from its
   manifest, detect environment drift, and write a `reproducibility.json`
   comparison artifact.

--- a/docs/artifact-contract.md
+++ b/docs/artifact-contract.md
@@ -22,6 +22,7 @@ Run artifacts use explicit top-level metadata:
 | `calibration_report` | `bench calibrate` / `calibration.json` | `artifact_kind`, `schema_version`, `forecast_path`, `results_path`, `verdict`, `comparability`, `metrics`, `per_instance` | mismatch details, warnings, future calibration diagnostics |
 | `preflight_report` | `bench doctor/swebench --format json` | `artifact_kind`, `schema_version`, `mode`, `checks` | additional check metadata |
 | `swebench_predictions_metadata` | `all_preds.metadata.json`, `all_preds.run-k.metadata.json` | `artifact_kind`, `schema_version`, `predictions_file`, `aggregate`, `row_count`, `swebench_evaluator_compatible` | `run_index`, future provenance fields |
+| `bundle_manifest` | `BUNDLE.json` inside `bench bundle` archives | `artifact_kind`, `schema_version`, `source_sweep_dir`, `source_manifest_hash`, `harness_git_sha`, `bundle_generated_at`, `instance_scope`, `files` | future integrity metadata |
 
 `all_preds*.jsonl` rows intentionally do not carry artifact metadata. They stay compatible with SWE-bench evaluators; version metadata lives in the companion metadata JSON files.
 

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -15,7 +15,7 @@ parsing human-oriented output.
 | 4    | `task_unsuccessful`      | The agent ran but did not produce a usable result: step limit reached, environment command failed, wallclock timeout, or repeated model API errors. |
 | 5    | `budget_halt`            | Cost ceiling triggered: `bench forecast --fail-over-cap` projected an over-cap run, or the sweep stopped because `--sweep-cost-limit-usd` was reached and no new tasks were dispatched. |
 | 6    | `regression_gate_failure`| `bench compare --max-regressions` or `--max-patch-size-regression` threshold was exceeded. |
-| 7    | `verification_failure`   | One or more `--verify NAME:COMMAND` checks did not pass after a `mini` run. |
+| 7    | `verification_failure`   | One or more `--verify NAME:COMMAND` checks did not pass after a `mini` run, or `bench bundle` detected a redaction retrigger / archive verification mismatch. |
 | 8    | `calibration_optimistic` | `bench calibrate --fail-on-optimistic` found actual sweep metrics above the forecast interval. |
 | 130  | `interrupted`            | Graceful SIGINT / Ctrl-C cancellation (POSIX convention: 128 + SIGINT(2)). |
 | 137  | `killed`                 | SIGKILL escalation after the graceful-cancel deadline expired (128 + SIGKILL(9)). |
@@ -62,6 +62,7 @@ coarse sweep-level result.
 | `bench tail`                    | `success`, `usage_error`, `internal_error` |
 | `bench triage`                  | `success`, `usage_error`, `internal_error` |
 | `bench frontier`                | `success`, `usage_error`, `internal_error` |
+| `bench bundle`                  | `success`, `usage_error`, `verification_failure`, `internal_error` |
 
 > **Legacy note:** `hello-world` and `replay` do not yet produce distinct
 > outcome classes beyond `success` / `internal_error`; they are interactive or

--- a/docs/spec-bundle.md
+++ b/docs/spec-bundle.md
@@ -1,0 +1,127 @@
+# `bench bundle` - Portable Sweep Archives
+
+`bench bundle` exports one completed sweep into a deterministic, redaction-strict
+`tar.gz` archive. The archive is meant for bug reports, audit handoff, and later
+`bench inspect`, `bench reproduce`, or `bench triage` use after extraction.
+
+## Synopsis
+
+```bash
+rust-swe-agent bench bundle --sweep runs/sweep --output sweep.tar.gz
+rust-swe-agent bench bundle --sweep runs/sweep --instance repo__id-123 --output one.tar.gz
+rust-swe-agent bench bundle --verify sweep.tar.gz
+```
+
+`--instance <ID>` narrows the archive to that instance's trajectory, patch if
+present, filtered `results.json`, filtered `evaluation.json` if present, and the
+sweep-level manifest. Without `--instance`, every instance listed in
+`results.json` is included.
+
+## Fixed Layout
+
+Only these paths are written:
+
+```text
+manifest.json
+results.json
+evaluation.json                 # only when present in the source sweep
+trajectories/<instance_id>.traj.json
+patches/<instance_id>.patch      # only when present for that instance
+BUNDLE.json                      # written last
+```
+
+Files outside that allow-list are ignored, including editor swap files, OS
+metadata, logs, and ad hoc notes. Extracted bundles are accepted by existing
+readers without path flags: `bench inspect --sweep <dir> --instance <id>` reads
+`trajectories/<id>.traj.json`, and patch readers accept `patches/<id>.patch`.
+
+## `BUNDLE.json`
+
+`BUNDLE.json` is a versioned artifact:
+
+```json
+{
+  "artifact_kind": "bundle_manifest",
+  "schema_version": { "major": 1, "minor": 3 },
+  "source_sweep_dir": ".",
+  "source_manifest_hash": "sha256:...",
+  "harness_git_sha": "...",
+  "bundle_generated_at": "2026-05-10T12:00:00Z",
+  "instance_scope": "full",
+  "files": [
+    { "path": "manifest.json", "sha256": "...", "bytes": 1234 }
+  ]
+}
+```
+
+The `files` list covers every other file in the archive and excludes
+`BUNDLE.json` itself. `source_manifest_hash` is computed from the normalized
+`manifest.json` bytes in the bundle.
+
+## Redaction Strict Mode
+
+Before any file is written to the archive, the bundle command re-runs the
+default export redactor over the normalized artifact bytes. It also merges
+redaction settings from the source sweep's resolved config when that config is
+available in either `results.json.manifest.config.resolved` or standalone
+`manifest.json.config.resolved`. If the redactor would mask anything, bundle
+creation aborts before replacing the output path and prints a
+`redaction:retrigger:<path>` reason.
+
+This is fail-closed defense in depth: bundle export never silently rewrites a
+leaky artifact into a different artifact.
+
+## Determinism
+
+Bundle creation pins:
+
+- tar entry order;
+- tar entry mtime, uid, gid, mode, and type;
+- gzip mtime;
+- archive layout;
+- path normalization before hashing.
+
+Two runs from identical source bytes are byte-identical when
+`bundle_generated_at` is fixed. For reproducible CI fixtures, set
+`SOURCE_DATE_EPOCH` to a Unix timestamp; otherwise the timestamp records the
+current UTC second.
+
+Absolute occurrences of the source sweep path inside emitted text artifacts are
+rewritten relative to the bundle root before hashing. Obvious Windows and Unix
+absolute path shapes are also normalized to avoid leaking local filesystem
+details from trajectories, patches, or manifests.
+
+## Extracted-Bundle Compatibility
+
+After extraction, the fixed layout works with:
+
+- `bench inspect --sweep <dir> --instance <id>`;
+- `bench triage --sweep <dir>`;
+- `bench reproduce --from <dir> --output <out> --limit 0` for manifest drift and
+  reproducibility-report smoke checks.
+
+Full `bench reproduce` still needs the original dataset to be available when
+the recorded manifest points at a local dataset path. Bundles do not include
+dataset rows because that would make the archive much larger and could
+redistribute third-party benchmark data unintentionally.
+
+## Verification
+
+`bench bundle --verify <archive>` reads `BUNDLE.json`, recomputes every listed
+file hash and byte count, and rejects unlisted files. Success prints:
+
+```text
+bundle:ok
+```
+
+Failures print one line per problem on stdout and exit non-zero:
+
+```text
+extra:<path>
+missing:<path>
+hash_mismatch:<path>
+```
+
+Hash mismatches, missing files, extra files, and redaction retriggers use the
+documented `verification_failure` outcome class. Bad invocations, missing source
+artifacts, and unsupported future bundle schemas use `usage_error`.

--- a/docs/spec-reproduce.md
+++ b/docs/spec-reproduce.md
@@ -29,7 +29,7 @@ rust-swe-agent bench reproduce \
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--allow-drift <FIELD>` | *(none)* | Whitelist a hard-drift field. May be repeated. See [Drift Policy](#drift-policy). |
-| `--limit N` | *(all)* | Replay at most N instances (partial replay). |
+| `--limit N` | *(all)* | Replay at most N instances (partial replay). `--limit 0` performs a manifest/drift smoke check and writes an empty `reproducibility.json` without launching tasks. |
 | `--filter SPEC` | *(all)* | Comma-separated instance ids, or `@path/to/ids.txt`. |
 | `--per-task-budget-usd USD` | *(from manifest)* | Override the per-task USD ceiling for the replay sweep. Recorded in the new manifest. |
 | `--skip-model-probe` | `false` | Skip the model-endpoint preflight probe. Useful for CI fixtures and dry-run modes that must not spend model credits. |
@@ -78,6 +78,10 @@ The replay sweep writes a complete, independent artifact set under `--output`:
 ```
 
 The source `--from` directory is never modified.
+
+`--limit 0` writes only `reproducibility.json` under `--output`; it is intended
+for CI checks that need to prove a saved sweep or extracted bundle is readable
+without spending model credits or requiring the original dataset.
 
 ## `reproducibility.json` Schema
 

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -53,6 +53,7 @@ pub enum ArtifactKind {
     CalibrationReport,
     PreflightReport,
     SwebenchPredictionsMetadata,
+    BundleManifest,
 }
 
 impl ArtifactKind {
@@ -66,6 +67,7 @@ impl ArtifactKind {
             Self::CalibrationReport => "calibration_report",
             Self::PreflightReport => "preflight_report",
             Self::SwebenchPredictionsMetadata => "swebench_predictions_metadata",
+            Self::BundleManifest => "bundle_manifest",
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -252,6 +252,8 @@ pub enum BenchCmd {
     Frontier(FrontierCmd),
     /// Replay a saved sweep from its manifest and report reproducibility.
     Reproduce(ReproduceCmd),
+    /// Export or verify a portable, redacted sweep archive.
+    Bundle(BundleCmd),
 }
 
 #[derive(Debug, Args)]
@@ -292,6 +294,39 @@ pub struct ReproduceCmd {
     /// and dry-run modes that don't spend model credits).
     #[arg(long, default_value_t = false)]
     pub skip_model_probe: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct BundleCmd {
+    /// Source sweep directory to archive.
+    #[arg(
+        long,
+        value_name = "DIR",
+        conflicts_with = "verify",
+        requires = "output"
+    )]
+    pub sweep: Option<PathBuf>,
+
+    /// Archive path to write (`.tar.gz`).
+    #[arg(
+        long,
+        value_name = "PATH",
+        conflicts_with = "verify",
+        requires = "sweep"
+    )]
+    pub output: Option<PathBuf>,
+
+    /// Restrict the bundle to one instance id.
+    #[arg(long, value_name = "ID", conflicts_with = "verify", requires = "sweep")]
+    pub instance: Option<String>,
+
+    /// Verify an existing bundle archive instead of creating one.
+    #[arg(
+        long,
+        value_name = "ARCHIVE",
+        conflicts_with_all = ["sweep", "output", "instance"]
+    )]
+    pub verify: Option<PathBuf>,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -96,6 +96,9 @@ pub async fn run() -> Result<(), Error> {
         Command::Bench {
             cmd: args::BenchCmd::Reproduce(r),
         } => bench_reproduce(r).await,
+        Command::Bench {
+            cmd: args::BenchCmd::Bundle(b),
+        } => bench_bundle(b),
         #[cfg(feature = "docker")]
         Command::Cleanup => cleanup_cmd().await,
         #[cfg(not(feature = "docker"))]
@@ -1057,6 +1060,20 @@ async fn bench_reproduce(r: args::ReproduceCmd) -> Result<(), Error> {
     // Compute source manifest hash for provenance.
     let source_manifest_hash = hash_manifest(&source_manifest);
 
+    if r.limit == Some(0) {
+        let report = crate::run::reproduce::build_reproducibility_report(
+            &r.from,
+            source_manifest_hash,
+            &[],
+            &[],
+            &r.output,
+        );
+        std::fs::create_dir_all(&r.output).map_err(Error::Io)?;
+        write_report(&report, &r.output)?;
+        print!("{}", render_summary(&report));
+        return Ok(());
+    }
+
     // Build the swebench args from the source manifest, applying any overrides.
     let sweep_args =
         reproduce_swebench_args(&r, &source_manifest, &source_results, &source_manifest_hash)?;
@@ -1186,7 +1203,10 @@ fn reproduce_swebench_args(
         }
         _ => {
             // Local path — use the recorded path as-is.
-            DatasetSource::LocalPath(std::path::PathBuf::from(&manifest.dataset.path))
+            DatasetSource::LocalPath(
+                bundle_reproduce_dataset_path(r, manifest, source_results)?
+                    .unwrap_or_else(|| std::path::PathBuf::from(&manifest.dataset.path)),
+            )
         }
     };
 
@@ -1255,6 +1275,43 @@ fn reproduce_swebench_args(
             r.from.display().to_string(),
         )),
     })
+}
+
+fn bundle_reproduce_dataset_path(
+    r: &args::ReproduceCmd,
+    manifest: &crate::run::swebench::ProvenanceManifest,
+    source_results: &crate::run::swebench::SweepResults,
+) -> Result<Option<std::path::PathBuf>, Error> {
+    if !r
+        .from
+        .join(crate::run::bundle::BUNDLE_MANIFEST_PATH)
+        .exists()
+    {
+        return Ok(None);
+    }
+    let recorded = std::path::PathBuf::from(&manifest.dataset.path);
+    let recorded_exists = if recorded.is_absolute() {
+        recorded.exists()
+    } else {
+        recorded.exists() || r.from.join(&recorded).exists()
+    };
+    if recorded_exists {
+        return Ok(None);
+    }
+    std::fs::create_dir_all(&r.output).map_err(Error::Io)?;
+    let path = r.output.join("bundle-reproduce.instances.jsonl");
+    let mut text = String::new();
+    for instance in &source_results.instances {
+        let row = serde_json::json!({
+            "instance_id": instance.instance_id,
+            "problem_statement": format!("bundle replay placeholder for {}", instance.instance_id),
+            "base_commit": "HEAD"
+        });
+        text.push_str(&serde_json::to_string(&row)?);
+        text.push('\n');
+    }
+    std::fs::write(&path, text).map_err(Error::Io)?;
+    Ok(Some(path))
 }
 
 fn bench_frontier(f: args::FrontierCmd) -> Result<(), Error> {
@@ -1380,6 +1437,68 @@ fn bench_triage(t: args::TriageCmd) -> Result<(), Error> {
             println!("{}", serde_json::to_string_pretty(&report)?);
             Ok(())
         }
+    }
+}
+
+fn bench_bundle(b: args::BundleCmd) -> Result<(), Error> {
+    if let Some(archive) = b.verify {
+        let report = crate::run::bundle::verify_bundle(&archive).map_err(bundle_error_to_error)?;
+        if report.problems.is_empty() {
+            println!("bundle:ok");
+            return Ok(());
+        }
+        for problem in report.problems {
+            println!("{problem}");
+        }
+        exit_with_outcome(ExitCode::VerificationFailure, "bundle verification failed");
+    }
+
+    let sweep = b.sweep.ok_or_else(|| {
+        Error::Config(crate::error::ConfigError::Invalid(
+            "bundle: --sweep is required unless --verify is used".into(),
+        ))
+    })?;
+    let output = b.output.ok_or_else(|| {
+        Error::Config(crate::error::ConfigError::Invalid(
+            "bundle: --output is required when --sweep is used".into(),
+        ))
+    })?;
+    match crate::run::bundle::create_bundle(&crate::run::bundle::BundleCreateArgs {
+        sweep_dir: sweep,
+        output_path: output,
+        instance: b.instance,
+    }) {
+        Ok(report) => {
+            println!(
+                "bundle:{} files={}",
+                report.output_path.display(),
+                report.files.len()
+            );
+            Ok(())
+        }
+        Err(crate::run::bundle::BundleError::RedactionRetrigger { path }) => {
+            println!("redaction:retrigger:{path}");
+            exit_with_outcome(
+                ExitCode::VerificationFailure,
+                "bundle redaction retriggered",
+            );
+        }
+        Err(err) => Err(bundle_error_to_error(err)),
+    }
+}
+
+fn bundle_error_to_error(err: crate::run::bundle::BundleError) -> Error {
+    match err {
+        crate::run::bundle::BundleError::MissingSource(message)
+        | crate::run::bundle::BundleError::Schema(message)
+        | crate::run::bundle::BundleError::InvalidArchive(message) => {
+            Error::Config(crate::error::ConfigError::Invalid(message))
+        }
+        crate::run::bundle::BundleError::Io(err) => Error::Io(err),
+        crate::run::bundle::BundleError::Json(err) => Error::Json(err),
+        crate::run::bundle::BundleError::RedactionRetrigger { path } => Error::Config(
+            crate::error::ConfigError::Invalid(format!("redaction:retrigger:{path}")),
+        ),
     }
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1204,7 +1204,7 @@ fn reproduce_swebench_args(
         _ => {
             // Local path — use the recorded path as-is.
             DatasetSource::LocalPath(
-                bundle_reproduce_dataset_path(r, manifest, source_results)?
+                bundle_reproduce_dataset_path(r, manifest)?
                     .unwrap_or_else(|| std::path::PathBuf::from(&manifest.dataset.path)),
             )
         }
@@ -1280,7 +1280,6 @@ fn reproduce_swebench_args(
 fn bundle_reproduce_dataset_path(
     r: &args::ReproduceCmd,
     manifest: &crate::run::swebench::ProvenanceManifest,
-    source_results: &crate::run::swebench::SweepResults,
 ) -> Result<Option<std::path::PathBuf>, Error> {
     if !r
         .from
@@ -1290,28 +1289,20 @@ fn bundle_reproduce_dataset_path(
         return Ok(None);
     }
     let recorded = std::path::PathBuf::from(&manifest.dataset.path);
-    let recorded_exists = if recorded.is_absolute() {
-        recorded.exists()
-    } else {
-        recorded.exists() || r.from.join(&recorded).exists()
-    };
-    if recorded_exists {
-        return Ok(None);
+    if !recorded.is_absolute() {
+        let bundled_relative = r.from.join(&recorded);
+        if bundled_relative.exists() {
+            return Ok(Some(bundled_relative));
+        }
     }
-    std::fs::create_dir_all(&r.output).map_err(Error::Io)?;
-    let path = r.output.join("bundle-reproduce.instances.jsonl");
-    let mut text = String::new();
-    for instance in &source_results.instances {
-        let row = serde_json::json!({
-            "instance_id": instance.instance_id,
-            "problem_statement": format!("bundle replay placeholder for {}", instance.instance_id),
-            "base_commit": "HEAD"
-        });
-        text.push_str(&serde_json::to_string(&row)?);
-        text.push('\n');
+    if recorded.exists() {
+        return Ok(Some(recorded));
     }
-    std::fs::write(&path, text).map_err(Error::Io)?;
-    Ok(Some(path))
+    Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+        "bundle reproduce requires the original local dataset `{}` for positive replays; \
+         use --limit 0 for bundle readability smoke checks or make the recorded dataset path available",
+        manifest.dataset.path
+    ))))
 }
 
 fn bench_frontier(f: args::FrontierCmd) -> Result<(), Error> {

--- a/src/run/bundle.rs
+++ b/src/run/bundle.rs
@@ -230,7 +230,7 @@ pub fn create_bundle(args: &BundleCreateArgs) -> Result<BundleCreateReport, Bund
     let mut files = vec![workspace.prepare_bytes("manifest.json", manifest_bytes)?];
 
     if args.instance.is_some() {
-        filter_results_for_scope(&mut results_value, &included_set, &args.sweep_dir);
+        filter_results_for_scope(&mut results_value, &included_set, &args.sweep_dir)?;
     }
     let results_bytes = normalized_json_bytes(&results_value, &normalizer)?;
     strict_redaction_check("results.json", &results_bytes, &redactor)?;
@@ -244,15 +244,15 @@ pub fn create_bundle(args: &BundleCreateArgs) -> Result<BundleCreateReport, Bund
 
     let mut patch_files = Vec::new();
     for instance_id in &included_ids {
-        let trajectory_sources = find_trajectory_paths_for_bundle(&args.sweep_dir, instance_id);
+        let row = result_row_for_instance(&results_value, instance_id).ok_or_else(|| {
+            BundleError::MissingSource(format!(
+                "bundle: instance `{instance_id}` not found in results.json"
+            ))
+        })?;
+        let trajectory_sources =
+            find_trajectory_paths_for_bundle(&args.sweep_dir, instance_id, row)?;
         if trajectory_sources.is_empty() {
-            if allows_missing_trajectory(&results_value, instance_id) {
-                continue;
-            }
-            return Err(BundleError::MissingSource(format!(
-                "bundle: missing trajectory for instance `{instance_id}` in {}",
-                args.sweep_dir.display()
-            )));
+            continue;
         }
         for (trajectory_src, trajectory_dest) in trajectory_sources {
             let trajectory = normalized_text_file(&trajectory_src, &normalizer)?;
@@ -458,7 +458,7 @@ fn filter_results_for_scope(
     value: &mut serde_json::Value,
     included: &BTreeSet<String>,
     sweep_dir: &Path,
-) {
+) -> Result<(), BundleError> {
     let Some(aggregates) = value
         .get_mut("instances")
         .and_then(serde_json::Value::as_array_mut)
@@ -470,16 +470,20 @@ fn filter_results_for_scope(
             });
 
             let row_aggregates = scoped_result_aggregates(instances);
-            scoped_slot_aggregates_from_run_artifacts(sweep_dir, instances, &row_aggregates)
-                .unwrap_or(row_aggregates)
+            Ok::<ScopedResultAggregates, BundleError>(
+                scoped_slot_aggregates_from_run_artifacts(sweep_dir, instances, &row_aggregates)?
+                    .unwrap_or(row_aggregates),
+            )
         })
     else {
-        return;
+        return Ok(());
     };
+    let aggregates = aggregates?;
 
     if let serde_json::Value::Object(map) = value {
         apply_scoped_result_aggregates(map, &aggregates, included);
     }
+    Ok(())
 }
 
 fn apply_scoped_result_aggregates(
@@ -618,9 +622,9 @@ fn scoped_slot_aggregates_from_run_artifacts(
     sweep_dir: &Path,
     instances: &[serde_json::Value],
     row_aggregates: &ScopedResultAggregates,
-) -> Option<ScopedResultAggregates> {
+) -> Result<Option<ScopedResultAggregates>, BundleError> {
     if !instances.iter().any(|row| effective_runs_value(row) > 1) {
-        return None;
+        return Ok(None);
     }
 
     let mut aggregates = ScopedResultAggregates {
@@ -629,11 +633,13 @@ fn scoped_slot_aggregates_from_run_artifacts(
     };
     for row in instances {
         let runs = effective_runs_value(row);
-        if runs <= 1 {
+        if runs <= 1 || is_never_started_budget_halt(row) {
             add_result_row_to_aggregates(&mut aggregates, row);
             continue;
         }
-        let instance_id = string_field(row, "instance_id")?;
+        let instance_id = string_field(row, "instance_id").ok_or_else(|| {
+            BundleError::MissingSource("bundle: results.json instance missing instance_id".into())
+        })?;
         for run_index in 1..=runs {
             let slot = run_slot_result_value_from_artifact(sweep_dir, instance_id, run_index)?;
             add_result_row_to_aggregates(&mut aggregates, &slot);
@@ -655,7 +661,7 @@ fn scoped_slot_aggregates_from_run_artifacts(
     if aggregates.model_mix.is_empty() {
         aggregates.model_mix.clone_from(&row_aggregates.model_mix);
     }
-    Some(aggregates)
+    Ok(Some(aggregates))
 }
 
 fn add_result_row_to_aggregates(aggregates: &mut ScopedResultAggregates, row: &serde_json::Value) {
@@ -668,6 +674,10 @@ fn add_outcome_counts_to_aggregates(
     aggregates: &mut ScopedResultAggregates,
     row: &serde_json::Value,
 ) {
+    if is_never_started_budget_halt(row) {
+        aggregates.budget_halted += 1;
+        return;
+    }
     let outcome = string_field(row, "outcome");
     let exit_reason = string_field(row, "exit_reason");
     let runs = effective_runs_value(row);
@@ -790,11 +800,13 @@ fn run_slot_result_value_from_artifact(
     sweep_dir: &Path,
     instance_id: &str,
     run_index: u32,
-) -> Option<serde_json::Value> {
-    let path = find_trajectory_path_for_run(sweep_dir, instance_id, run_index)?;
-    let text = std::fs::read_to_string(path).ok()?;
-    let trajectory: serde_json::Value = serde_json::from_str(&text).ok()?;
-    let info = trajectory.get("info")?;
+) -> Result<serde_json::Value, BundleError> {
+    let path = required_rerun_trajectory_path(sweep_dir, instance_id, run_index)?;
+    let text = std::fs::read_to_string(path)?;
+    let trajectory: serde_json::Value = serde_json::from_str(&text)?;
+    let info = trajectory
+        .get("info")
+        .ok_or_else(|| BundleError::Schema("trajectory missing info block".into()))?;
 
     let mut row = serde_json::Map::new();
     row.insert(
@@ -868,7 +880,7 @@ fn run_slot_result_value_from_artifact(
         row.insert("patch_present".into(), serde_json::Value::Bool(false));
         row.insert("non_empty_patch".into(), serde_json::Value::Bool(false));
     }
-    Some(serde_json::Value::Object(row))
+    Ok(serde_json::Value::Object(row))
 }
 
 fn copy_token_field(
@@ -1001,16 +1013,18 @@ fn included_instance_ids(
     }
 }
 
-fn allows_missing_trajectory(results: &serde_json::Value, instance_id: &str) -> bool {
+fn result_row_for_instance<'a>(
+    results: &'a serde_json::Value,
+    instance_id: &str,
+) -> Option<&'a serde_json::Value> {
     results
         .get("instances")
         .and_then(serde_json::Value::as_array)
         .and_then(|instances| {
-            instances.iter().find(|row| {
-                row.get("instance_id").and_then(serde_json::Value::as_str) == Some(instance_id)
-            })
+            instances
+                .iter()
+                .find(|row| string_field(row, "instance_id") == Some(instance_id))
         })
-        .is_some_and(is_never_started_budget_halt)
 }
 
 fn is_never_started_budget_halt(row: &serde_json::Value) -> bool {
@@ -1039,6 +1053,23 @@ fn validate_instance_scope(instance: Option<&str>) -> Result<(), BundleError> {
 
 fn find_trajectory_path(sweep_dir: &Path, instance_id: &str) -> Option<PathBuf> {
     find_trajectory_path_for_run(sweep_dir, instance_id, 1)
+}
+
+fn required_rerun_trajectory_path(
+    sweep_dir: &Path,
+    instance_id: &str,
+    run_index: u32,
+) -> Result<PathBuf, BundleError> {
+    let path = sweep_dir
+        .join(instance_id)
+        .join(format!("run-{run_index}.traj.json"));
+    if path.exists() {
+        return Ok(path);
+    }
+    Err(BundleError::MissingSource(format!(
+        "bundle: missing trajectory for rerun slot `{instance_id}/run-{run_index}.traj.json` in {}",
+        sweep_dir.display()
+    )))
 }
 
 fn find_trajectory_path_for_run(
@@ -1084,21 +1115,45 @@ fn find_patch_path_for_run(sweep_dir: &Path, instance_id: &str, run_index: u32) 
     .find(|path| path.exists())
 }
 
-fn find_trajectory_paths_for_bundle(sweep_dir: &Path, instance_id: &str) -> Vec<(PathBuf, String)> {
+fn find_trajectory_paths_for_bundle(
+    sweep_dir: &Path,
+    instance_id: &str,
+    row: &serde_json::Value,
+) -> Result<Vec<(PathBuf, String)>, BundleError> {
+    if is_never_started_budget_halt(row) {
+        return Ok(Vec::new());
+    }
+    let runs = effective_runs_value(row);
+    if runs > 1 {
+        let mut out = Vec::new();
+        for run_index in 1..=runs {
+            let path = required_rerun_trajectory_path(sweep_dir, instance_id, run_index)?;
+            out.push((path, format!("{instance_id}/run-{run_index}.traj.json")));
+        }
+        return Ok(out);
+    }
+
     let nested = sorted_nested_run_files(&sweep_dir.join(instance_id), ".traj.json");
     if !nested.is_empty() {
-        return nested
+        return Ok(nested
             .into_iter()
             .filter_map(|path| {
                 let file_name = path.file_name()?.to_string_lossy();
                 Some((path.clone(), format!("{instance_id}/{file_name}")))
             })
-            .collect();
+            .collect());
     }
     find_trajectory_path(sweep_dir, instance_id)
         .map(|path| (path, format!("trajectories/{instance_id}.traj.json")))
         .into_iter()
-        .collect()
+        .next()
+        .map(|entry| vec![entry])
+        .ok_or_else(|| {
+            BundleError::MissingSource(format!(
+                "bundle: missing trajectory for instance `{instance_id}` in {}",
+                sweep_dir.display()
+            ))
+        })
 }
 
 fn find_patch_paths_for_bundle(sweep_dir: &Path, instance_id: &str) -> Vec<(PathBuf, String)> {

--- a/src/run/bundle.rs
+++ b/src/run/bundle.rs
@@ -246,6 +246,9 @@ pub fn create_bundle(args: &BundleCreateArgs) -> Result<BundleCreateReport, Bund
     for instance_id in &included_ids {
         let trajectory_sources = find_trajectory_paths_for_bundle(&args.sweep_dir, instance_id);
         if trajectory_sources.is_empty() {
+            if allows_missing_trajectory(&results_value, instance_id) {
+                continue;
+            }
             return Err(BundleError::MissingSource(format!(
                 "bundle: missing trajectory for instance `{instance_id}` in {}",
                 args.sweep_dir.display()
@@ -996,6 +999,24 @@ fn included_instance_ids(
         }
         None => Ok(all.to_vec()),
     }
+}
+
+fn allows_missing_trajectory(results: &serde_json::Value, instance_id: &str) -> bool {
+    results
+        .get("instances")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|instances| {
+            instances.iter().find(|row| {
+                row.get("instance_id").and_then(serde_json::Value::as_str) == Some(instance_id)
+            })
+        })
+        .is_some_and(is_never_started_budget_halt)
+}
+
+fn is_never_started_budget_halt(row: &serde_json::Value) -> bool {
+    string_field(row, "exit_reason") == Some("budget_halt")
+        && row.get("outcome").is_none_or(serde_json::Value::is_null)
+        && !bool_field(row, "patch_present")
 }
 
 fn validate_instance_scope(instance: Option<&str>) -> Result<(), BundleError> {

--- a/src/run/bundle.rs
+++ b/src/run/bundle.rs
@@ -71,7 +71,45 @@ pub struct BundleManifest {
 #[derive(Debug, Clone)]
 struct PreparedFile {
     archive_path: String,
-    bytes: Vec<u8>,
+    source_path: PathBuf,
+    sha256: String,
+    bytes: u64,
+}
+
+struct BundleWorkspace {
+    dir: tempfile::TempDir,
+    next_id: usize,
+}
+
+impl BundleWorkspace {
+    fn new() -> Result<Self, BundleError> {
+        Ok(Self {
+            dir: tempfile::tempdir()?,
+            next_id: 0,
+        })
+    }
+
+    fn prepare_bytes(
+        &mut self,
+        archive_path: impl Into<String>,
+        bytes: Vec<u8>,
+    ) -> Result<PreparedFile, BundleError> {
+        let archive_path = archive_path.into();
+        let source_path = self
+            .dir
+            .path()
+            .join(format!("bundle-entry-{}", self.next_id));
+        self.next_id = self.next_id.saturating_add(1);
+        let sha256 = sha256_hex(&bytes);
+        let len = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+        std::fs::write(&source_path, bytes)?;
+        Ok(PreparedFile {
+            archive_path,
+            source_path,
+            sha256,
+            bytes: len,
+        })
+    }
 }
 
 struct PathNormalizer {
@@ -88,10 +126,7 @@ impl PathNormalizer {
             push_path_needles(&mut needles, &canonical.display().to_string());
         }
         Self {
-            needles: needles
-                .into_iter()
-                .filter(|value| !value.is_empty() && value != ".")
-                .collect(),
+            needles: sorted_path_needles(needles),
             windows_abs: Regex::new(r#"[A-Za-z]:(?:\\\\|\\|/)[^"'\r\n\s,}\]]+"#).ok(),
             unix_abs: Regex::new(r#"(^|[\s"'\[({:=,])/(?:[^\s/"'\]\[{}(),]+/)+[^\s/"'\]\[{}(),]+"#)
                 .ok(),
@@ -112,6 +147,44 @@ impl PathNormalizer {
             |regex| regex.replace_all(&normalized, "${1}.").into_owned(),
         )
     }
+}
+
+#[derive(Debug, Clone)]
+struct ArchiveEntryInfo {
+    sha256: Option<String>,
+    bytes: u64,
+    regular_file: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ArchiveInventory {
+    bundle_bytes: Option<Vec<u8>>,
+    entries: BTreeMap<String, ArchiveEntryInfo>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ScopedResultAggregates {
+    total: usize,
+    submitted: usize,
+    submitted_with_tests: usize,
+    skipped: usize,
+    with_patch: usize,
+    patch_empty: usize,
+    patch_apply_invalid: usize,
+    github_pr_failures: usize,
+    budget_halted: usize,
+    total_input_tokens: u64,
+    total_cache_read_tokens: u64,
+    total_cache_creation_tokens: u64,
+    total_completion_tokens: u64,
+    total_cost_usd: Option<f64>,
+    actual_cost_usd: Option<f64>,
+    retries: u64,
+    retried_instances: usize,
+    resolved_count: usize,
+    total_fallbacks: u64,
+    model_mix: BTreeMap<String, usize>,
+    failures: serde_json::Map<String, serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -150,30 +223,20 @@ pub fn create_bundle(args: &BundleCreateArgs) -> Result<BundleCreateReport, Bund
     let source_manifest_hash = format!("sha256:{}", sha256_hex(&manifest_bytes));
     strict_redaction_check("manifest.json", &manifest_bytes, &redactor)?;
 
+    let mut workspace = BundleWorkspace::new()?;
+    let mut files = vec![workspace.prepare_bytes("manifest.json", manifest_bytes)?];
+
     if args.instance.is_some() {
         filter_results_for_scope(&mut results_value, &included_set);
     }
     let results_bytes = normalized_json_bytes(&results_value, &normalizer)?;
     strict_redaction_check("results.json", &results_bytes, &redactor)?;
-
-    let mut files = vec![
-        PreparedFile {
-            archive_path: "manifest.json".into(),
-            bytes: manifest_bytes,
-        },
-        PreparedFile {
-            archive_path: "results.json".into(),
-            bytes: results_bytes,
-        },
-    ];
+    files.push(workspace.prepare_bytes("results.json", results_bytes)?);
 
     if let Some(evaluation) = load_optional_evaluation(&args.sweep_dir, &included_set, &normalizer)?
     {
         strict_redaction_check("evaluation.json", &evaluation, &redactor)?;
-        files.push(PreparedFile {
-            archive_path: "evaluation.json".into(),
-            bytes: evaluation,
-        });
+        files.push(workspace.prepare_bytes("evaluation.json", evaluation)?);
     }
 
     let mut patch_files = Vec::new();
@@ -188,19 +251,13 @@ pub fn create_bundle(args: &BundleCreateArgs) -> Result<BundleCreateReport, Bund
         let trajectory_dest = format!("trajectories/{instance_id}.traj.json");
         let trajectory = normalized_text_file(&trajectory_src, &normalizer)?;
         strict_redaction_check(&trajectory_dest, &trajectory, &redactor)?;
-        files.push(PreparedFile {
-            archive_path: trajectory_dest,
-            bytes: trajectory,
-        });
+        files.push(workspace.prepare_bytes(trajectory_dest, trajectory)?);
 
         if let Some(patch_src) = find_patch_path(&args.sweep_dir, instance_id) {
             let patch_dest = format!("patches/{instance_id}.patch");
             let patch = normalized_text_file(&patch_src, &normalizer)?;
             strict_redaction_check(&patch_dest, &patch, &redactor)?;
-            patch_files.push(PreparedFile {
-                archive_path: patch_dest,
-                bytes: patch,
-            });
+            patch_files.push(workspace.prepare_bytes(patch_dest, patch)?);
         }
     }
     files.extend(patch_files);
@@ -209,8 +266,8 @@ pub fn create_bundle(args: &BundleCreateArgs) -> Result<BundleCreateReport, Bund
         .iter()
         .map(|file| BundleFileEntry {
             path: file.archive_path.clone(),
-            sha256: sha256_hex(&file.bytes),
-            bytes: u64::try_from(file.bytes.len()).unwrap_or(u64::MAX),
+            sha256: file.sha256.clone(),
+            bytes: file.bytes,
         })
         .collect::<Vec<_>>();
 
@@ -235,9 +292,10 @@ pub fn create_bundle(args: &BundleCreateArgs) -> Result<BundleCreateReport, Bund
 }
 
 pub fn verify_bundle(archive_path: &Path) -> Result<BundleVerifyReport, BundleError> {
-    let mut actual = read_archive_files(archive_path)?;
+    let inventory = read_archive_inventory(archive_path)?;
+    let actual = inventory.entries;
     let mut problems = Vec::new();
-    let Some(bundle_bytes) = actual.remove(BUNDLE_MANIFEST_PATH) else {
+    let Some(bundle_bytes) = inventory.bundle_bytes else {
         return Ok(BundleVerifyReport {
             problems: vec![format!("missing:{BUNDLE_MANIFEST_PATH}")],
         });
@@ -264,13 +322,11 @@ pub fn verify_bundle(archive_path: &Path) -> Result<BundleVerifyReport, BundleEr
 
     for (path, entry) in &expected {
         match actual.get(path) {
-            Some(bytes) => {
-                if u64::try_from(bytes.len()).unwrap_or(u64::MAX) != entry.bytes {
-                    problems.push(format!("hash_mismatch:{path}"));
-                    continue;
-                }
-                let digest = sha256_hex(bytes);
-                if digest != entry.sha256 {
+            Some(actual_entry) => {
+                if !actual_entry.regular_file
+                    || actual_entry.bytes != entry.bytes
+                    || actual_entry.sha256.as_deref() != Some(entry.sha256.as_str())
+                {
                     problems.push(format!("hash_mismatch:{path}"));
                 }
             }
@@ -374,7 +430,7 @@ fn load_optional_evaluation(
 }
 
 fn filter_results_for_scope(value: &mut serde_json::Value, included: &BTreeSet<String>) {
-    let Some((total, submitted, skipped, with_patch, patch_empty, budget_halted, failures)) = value
+    let Some(aggregates) = value
         .get_mut("instances")
         .and_then(serde_json::Value::as_array_mut)
         .map(|instances| {
@@ -384,89 +440,269 @@ fn filter_results_for_scope(value: &mut serde_json::Value, included: &BTreeSet<S
                     .is_some_and(|id| included.contains(id))
             });
 
-            let total = instances.len();
-            let submitted = instances
-                .iter()
-                .filter(|row| string_field(row, "outcome") == Some("submitted"))
-                .count();
-            let skipped = instances
-                .iter()
-                .filter(|row| {
-                    string_field(row, "outcome") == Some("skipped")
-                        || string_field(row, "exit_reason") == Some("skipped")
-                })
-                .count();
-            let with_patch = instances
-                .iter()
-                .filter(|row| bool_field(row, "patch_present"))
-                .count();
-            let patch_empty = instances
-                .iter()
-                .filter(|row| {
-                    bool_field(row, "patch_present") && !bool_field(row, "non_empty_patch")
-                })
-                .count();
-            let budget_halted = instances
-                .iter()
-                .filter(|row| string_field(row, "exit_reason") == Some("budget_halt"))
-                .count();
-            let mut failures = serde_json::Map::new();
-            for category in instances
-                .iter()
-                .filter_map(|row| string_field(row, "failure_category"))
-            {
-                let next = failures
-                    .get(category)
-                    .and_then(serde_json::Value::as_u64)
-                    .unwrap_or_default()
-                    .saturating_add(1);
-                failures.insert(category.to_owned(), serde_json::json!(next));
-            }
-            (
-                total,
-                submitted,
-                skipped,
-                with_patch,
-                patch_empty,
-                budget_halted,
-                failures,
-            )
+            scoped_result_aggregates(instances)
         })
     else {
         return;
     };
 
     if let serde_json::Value::Object(map) = value {
-        map.insert("total".into(), serde_json::json!(total));
-        map.insert("completed".into(), serde_json::json!(total));
-        map.insert("submitted".into(), serde_json::json!(submitted));
-        map.insert("skipped".into(), serde_json::json!(skipped));
-        map.insert(
-            "errored".into(),
-            serde_json::json!(total.saturating_sub(submitted + skipped)),
+        apply_scoped_result_aggregates(map, &aggregates, included);
+    }
+}
+
+fn apply_scoped_result_aggregates(
+    map: &mut serde_json::Map<String, serde_json::Value>,
+    aggregates: &ScopedResultAggregates,
+    included: &BTreeSet<String>,
+) {
+    map.insert("total".into(), serde_json::json!(aggregates.total));
+    map.insert("completed".into(), serde_json::json!(aggregates.total));
+    map.insert("submitted".into(), serde_json::json!(aggregates.submitted));
+    map.insert(
+        "submitted_with_tests".into(),
+        serde_json::json!(aggregates.submitted_with_tests),
+    );
+    map.insert("skipped".into(), serde_json::json!(aggregates.skipped));
+    map.insert(
+        "errored".into(),
+        serde_json::json!(
+            aggregates
+                .total
+                .saturating_sub(aggregates.submitted + aggregates.skipped)
+        ),
+    );
+    map.insert(
+        "with_patch".into(),
+        serde_json::json!(aggregates.with_patch),
+    );
+    map.insert(
+        "patch_empty".into(),
+        serde_json::json!(aggregates.patch_empty),
+    );
+    map.insert(
+        "patch_apply_invalid".into(),
+        serde_json::json!(aggregates.patch_apply_invalid),
+    );
+    map.insert(
+        "github_pr_failures".into(),
+        serde_json::json!(aggregates.github_pr_failures),
+    );
+    map.insert(
+        "budget_halted".into(),
+        serde_json::json!(aggregates.budget_halted),
+    );
+    map.insert(
+        "failures_by_category".into(),
+        serde_json::Value::Object(aggregates.failures.clone()),
+    );
+    apply_scoped_cost_and_token_aggregates(map, aggregates);
+    if let Some(filter_spec) = map
+        .get_mut("filter_spec")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        filter_spec.insert("selected_count".into(), serde_json::json!(aggregates.total));
+        filter_spec.insert(
+            "instance_ids".into(),
+            serde_json::Value::Array(
+                included
+                    .iter()
+                    .map(|id| serde_json::Value::String(id.clone()))
+                    .collect(),
+            ),
         );
-        map.insert("with_patch".into(), serde_json::json!(with_patch));
-        map.insert("patch_empty".into(), serde_json::json!(patch_empty));
-        map.insert("budget_halted".into(), serde_json::json!(budget_halted));
+    }
+}
+
+fn apply_scoped_cost_and_token_aggregates(
+    map: &mut serde_json::Map<String, serde_json::Value>,
+    aggregates: &ScopedResultAggregates,
+) {
+    map.insert(
+        "total_input_tokens".into(),
+        serde_json::json!(aggregates.total_input_tokens),
+    );
+    map.insert(
+        "total_cache_read_tokens".into(),
+        serde_json::json!(aggregates.total_cache_read_tokens),
+    );
+    map.insert(
+        "total_cache_creation_tokens".into(),
+        serde_json::json!(aggregates.total_cache_creation_tokens),
+    );
+    map.insert(
+        "total_completion_tokens".into(),
+        serde_json::json!(aggregates.total_completion_tokens),
+    );
+    if let Some(cost) = aggregates.total_cost_usd {
+        map.insert("total_cost_usd".into(), serde_json::json!(cost));
+    }
+    if map.contains_key("actual_cost_usd") {
         map.insert(
-            "failures_by_category".into(),
-            serde_json::Value::Object(failures),
+            "actual_cost_usd".into(),
+            serde_json::json!(aggregates.actual_cost_usd),
         );
-        if let Some(filter_spec) = map
-            .get_mut("filter_spec")
-            .and_then(serde_json::Value::as_object_mut)
-        {
-            filter_spec.insert("selected_count".into(), serde_json::json!(total));
-            filter_spec.insert(
-                "instance_ids".into(),
-                serde_json::Value::Array(
-                    included
-                        .iter()
-                        .map(|id| serde_json::Value::String(id.clone()))
-                        .collect(),
-                ),
-            );
+    }
+    map.insert(
+        "cache_hit_rate".into(),
+        serde_json::json!(cache_hit_rate(aggregates)),
+    );
+    map.insert("retries".into(), serde_json::json!(aggregates.retries));
+    map.insert(
+        "retried_instances".into(),
+        serde_json::json!(aggregates.retried_instances),
+    );
+    map.insert("pass_at_k".into(), serde_json::json!(pass_at_k(aggregates)));
+    map.insert(
+        "total_fallbacks".into(),
+        serde_json::json!(aggregates.total_fallbacks),
+    );
+    if !aggregates.model_mix.is_empty() || map.contains_key("model_mix") {
+        map.insert("model_mix".into(), serde_json::json!(aggregates.model_mix));
+    }
+}
+
+fn scoped_result_aggregates(instances: &[serde_json::Value]) -> ScopedResultAggregates {
+    let mut aggregates = ScopedResultAggregates {
+        total: instances.len(),
+        ..ScopedResultAggregates::default()
+    };
+    for row in instances {
+        let outcome = string_field(row, "outcome");
+        let exit_reason = string_field(row, "exit_reason");
+        if outcome == Some("submitted") {
+            aggregates.submitted += 1;
+            if bool_field(row, "tests_run_before_submit") {
+                aggregates.submitted_with_tests += 1;
+            }
         }
+        if outcome == Some("skipped") || exit_reason == Some("skipped") {
+            aggregates.skipped += 1;
+        }
+        if bool_field(row, "patch_present") {
+            aggregates.with_patch += 1;
+            if !bool_field(row, "non_empty_patch") {
+                aggregates.patch_empty += 1;
+            }
+        }
+        if bool_field(row, "patch_apply_invalid")
+            || string_field(row, "failure_category") == Some("patch_apply_invalid")
+        {
+            aggregates.patch_apply_invalid += 1;
+        }
+        if row
+            .get("github_pr_error")
+            .is_some_and(|value| !value.is_null())
+        {
+            aggregates.github_pr_failures += 1;
+        }
+        if exit_reason == Some("budget_halt") {
+            aggregates.budget_halted += 1;
+        }
+        if let Some(category) = string_field(row, "failure_category") {
+            let next = aggregates
+                .failures
+                .get(category)
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or_default()
+                .saturating_add(1);
+            aggregates
+                .failures
+                .insert(category.to_owned(), serde_json::json!(next));
+        }
+
+        aggregates.total_input_tokens = aggregates
+            .total_input_tokens
+            .saturating_add(u64_field(row, "total_input_tokens").unwrap_or_default());
+        aggregates.total_cache_read_tokens = aggregates
+            .total_cache_read_tokens
+            .saturating_add(u64_field(row, "total_cache_read_tokens").unwrap_or_default());
+        aggregates.total_cache_creation_tokens = aggregates
+            .total_cache_creation_tokens
+            .saturating_add(u64_field(row, "total_cache_creation_tokens").unwrap_or_default());
+        aggregates.total_completion_tokens = aggregates
+            .total_completion_tokens
+            .saturating_add(u64_field(row, "total_completion_tokens").unwrap_or_default());
+        aggregates.total_cost_usd =
+            sum_optional_f64(aggregates.total_cost_usd, instance_cost_usd(row));
+        aggregates.actual_cost_usd =
+            sum_optional_f64(aggregates.actual_cost_usd, instance_actual_cost_usd(row));
+
+        let retries = retry_count(row);
+        aggregates.retries = aggregates.retries.saturating_add(retries);
+        if retries > 0 {
+            aggregates.retried_instances += 1;
+        }
+        if instance_resolved(row) {
+            aggregates.resolved_count += 1;
+        }
+        if let Some(fallback_count) = u64_field(row, "fallback_count") {
+            aggregates.total_fallbacks = aggregates.total_fallbacks.saturating_add(fallback_count);
+        }
+        if let Some(model) = string_field(row, "final_model") {
+            *aggregates.model_mix.entry(model.to_owned()).or_default() += 1;
+        }
+    }
+    aggregates
+}
+
+fn u64_field(value: &serde_json::Value, key: &str) -> Option<u64> {
+    value.get(key).and_then(serde_json::Value::as_u64)
+}
+
+fn f64_field(value: &serde_json::Value, key: &str) -> Option<f64> {
+    value.get(key).and_then(serde_json::Value::as_f64)
+}
+
+fn instance_cost_usd(value: &serde_json::Value) -> Option<f64> {
+    f64_field(value, "cost_usd").or_else(|| f64_field(value, "total_cost_usd"))
+}
+
+fn instance_actual_cost_usd(value: &serde_json::Value) -> Option<f64> {
+    f64_field(value, "actual_cost_usd").or_else(|| f64_field(value, "cost_usd"))
+}
+
+fn sum_optional_f64(current: Option<f64>, next: Option<f64>) -> Option<f64> {
+    match (current, next) {
+        (Some(current), Some(next)) => Some(current + next),
+        (Some(current), None) => Some(current),
+        (None, Some(next)) => Some(next),
+        (None, None) => None,
+    }
+}
+
+fn retry_count(value: &serde_json::Value) -> u64 {
+    u64_field(value, "retries")
+        .unwrap_or_else(|| u64_field(value, "attempts").unwrap_or(1).saturating_sub(1))
+}
+
+fn instance_resolved(value: &serde_json::Value) -> bool {
+    bool_field(value, "pass_at_1")
+        || u64_field(value, "resolved_count").unwrap_or_default() > 0
+        || string_field(value, "outcome") == Some("resolved")
+}
+
+fn cache_hit_rate(aggregates: &ScopedResultAggregates) -> f64 {
+    let prompt = aggregates
+        .total_input_tokens
+        .saturating_add(aggregates.total_cache_read_tokens)
+        .saturating_add(aggregates.total_cache_creation_tokens);
+    if prompt == 0 {
+        return 0.0;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    {
+        aggregates.total_cache_read_tokens as f64 / prompt as f64
+    }
+}
+
+fn pass_at_k(aggregates: &ScopedResultAggregates) -> f64 {
+    if aggregates.total == 0 {
+        return 0.0;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    {
+        aggregates.resolved_count as f64 / aggregates.total as f64
     }
 }
 
@@ -622,9 +858,6 @@ fn write_archive_atomically(
         let _ = std::fs::remove_file(&tmp);
         return Err(err);
     }
-    if output_path.exists() {
-        std::fs::remove_file(output_path)?;
-    }
     std::fs::rename(&tmp, output_path)?;
     Ok(())
 }
@@ -640,11 +873,36 @@ fn write_archive(
         .write(file, Compression::default());
     let mut builder = tar::Builder::new(encoder);
     for file in files {
-        append_tar_file(&mut builder, &file.archive_path, &file.bytes)?;
+        append_tar_file_from_path(
+            &mut builder,
+            &file.archive_path,
+            &file.source_path,
+            file.bytes,
+        )?;
     }
     append_tar_file(&mut builder, BUNDLE_MANIFEST_PATH, bundle_bytes)?;
     let encoder = builder.into_inner()?;
     encoder.finish()?;
+    Ok(())
+}
+
+fn append_tar_file_from_path<W: std::io::Write>(
+    builder: &mut tar::Builder<W>,
+    archive_path: &str,
+    source_path: &Path,
+    bytes: u64,
+) -> Result<(), BundleError> {
+    validate_archive_path(archive_path)?;
+    let mut header = tar::Header::new_gnu();
+    header.set_size(bytes);
+    header.set_mode(0o644);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_entry_type(tar::EntryType::Regular);
+    header.set_cksum();
+    let mut file = std::fs::File::open(source_path)?;
+    builder.append_data(&mut header, archive_path, &mut file)?;
     Ok(())
 }
 
@@ -675,27 +933,70 @@ fn temporary_output_path(output_path: &Path) -> PathBuf {
     output_path.with_file_name(format!(".{file_name}.{pid}.tmp"))
 }
 
-fn read_archive_files(archive_path: &Path) -> Result<BTreeMap<String, Vec<u8>>, BundleError> {
+fn read_archive_inventory(archive_path: &Path) -> Result<ArchiveInventory, BundleError> {
     let file = std::fs::File::open(archive_path)?;
     let decoder = GzDecoder::new(file);
     let mut archive = tar::Archive::new(decoder);
-    let mut out = BTreeMap::new();
+    let mut inventory = ArchiveInventory {
+        bundle_bytes: None,
+        entries: BTreeMap::new(),
+    };
     for entry in archive.entries()? {
         let mut entry = entry?;
-        if !entry.header().entry_type().is_file() {
-            continue;
-        }
         let raw_path = entry.path()?;
         let path = normalize_archive_path(&raw_path)?;
-        let mut bytes = Vec::new();
-        entry.read_to_end(&mut bytes)?;
-        if out.insert(path.clone(), bytes).is_some() {
-            return Err(BundleError::InvalidArchive(format!(
-                "bundle: duplicate archive entry {path}"
-            )));
+        if entry.header().entry_type().is_file() {
+            if path == BUNDLE_MANIFEST_PATH {
+                if inventory.bundle_bytes.is_some() {
+                    return Err(BundleError::InvalidArchive(format!(
+                        "bundle: duplicate archive entry {path}"
+                    )));
+                }
+                let mut bundle_bytes = Vec::new();
+                entry.read_to_end(&mut bundle_bytes)?;
+                inventory.bundle_bytes = Some(bundle_bytes);
+                continue;
+            }
+            let (digest, bytes) = hash_reader(&mut entry)?;
+            let info = ArchiveEntryInfo {
+                sha256: Some(digest),
+                bytes,
+                regular_file: true,
+            };
+            if inventory.entries.insert(path.clone(), info).is_some() {
+                return Err(BundleError::InvalidArchive(format!(
+                    "bundle: duplicate archive entry {path}"
+                )));
+            }
+        } else {
+            let info = ArchiveEntryInfo {
+                sha256: None,
+                bytes: 0,
+                regular_file: false,
+            };
+            if inventory.entries.insert(path.clone(), info).is_some() {
+                return Err(BundleError::InvalidArchive(format!(
+                    "bundle: duplicate archive entry {path}"
+                )));
+            }
         }
     }
-    Ok(out)
+    Ok(inventory)
+}
+
+fn hash_reader<R: std::io::Read>(reader: &mut R) -> Result<(String, u64), std::io::Error> {
+    let mut hasher = Sha256::new();
+    let mut total = 0u64;
+    let mut buf = [0u8; 8192];
+    loop {
+        let read = reader.read(&mut buf)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buf[..read]);
+        total = total.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
+    }
+    Ok((format!("{:x}", hasher.finalize()), total))
 }
 
 fn validate_archive_path(path: &str) -> Result<(), BundleError> {
@@ -776,5 +1077,36 @@ fn push_path_needles(out: &mut BTreeSet<String>, raw: &str) {
     for value in [raw.to_owned(), slash, backslash] {
         out.insert(value.clone());
         out.insert(value.replace('\\', "\\\\"));
+    }
+}
+
+fn sorted_path_needles<I>(needles: I) -> Vec<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut needles = needles
+        .into_iter()
+        .filter(|value| !value.is_empty() && value != ".")
+        .collect::<Vec<_>>();
+    needles.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
+    needles
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PathNormalizer, sorted_path_needles};
+
+    #[test]
+    fn path_normalizer_prefers_longest_needle_first() {
+        let normalizer = PathNormalizer {
+            needles: sorted_path_needles(vec!["/tmp/a".into(), "/tmp/a/b".into()]),
+            windows_abs: None,
+            unix_abs: None,
+        };
+
+        assert_eq!(
+            normalizer.normalize_text("path=/tmp/a/b/file"),
+            "path=./file"
+        );
     }
 }

--- a/src/run/bundle.rs
+++ b/src/run/bundle.rs
@@ -260,7 +260,9 @@ pub fn create_bundle(args: &BundleCreateArgs) -> Result<BundleCreateReport, Bund
             files.push(workspace.prepare_bytes(trajectory_dest, trajectory)?);
         }
 
-        for (patch_src, patch_dest) in find_patch_paths_for_bundle(&args.sweep_dir, instance_id) {
+        for (patch_src, patch_dest) in
+            find_patch_paths_for_bundle(&args.sweep_dir, instance_id, row)
+        {
             let patch = normalized_text_file(&patch_src, &normalizer)?;
             strict_redaction_check(&patch_dest, &patch, &redactor)?;
             patch_files.push(workspace.prepare_bytes(patch_dest, patch)?);
@@ -1055,6 +1057,14 @@ fn find_trajectory_path(sweep_dir: &Path, instance_id: &str) -> Option<PathBuf> 
     find_trajectory_path_for_run(sweep_dir, instance_id, 1)
 }
 
+fn find_single_run_trajectory_path(sweep_dir: &Path, instance_id: &str) -> Option<PathBuf> {
+    let nested = sweep_dir.join(instance_id).join("run-1.traj.json");
+    nested
+        .exists()
+        .then_some(nested)
+        .or_else(|| find_trajectory_path(sweep_dir, instance_id))
+}
+
 fn required_rerun_trajectory_path(
     sweep_dir: &Path,
     instance_id: &str,
@@ -1094,10 +1104,6 @@ fn find_trajectory_path_for_run(
     .find(|path| path.exists())
 }
 
-fn find_patch_path(sweep_dir: &Path, instance_id: &str) -> Option<PathBuf> {
-    find_patch_path_for_run(sweep_dir, instance_id, 1)
-}
-
 fn find_patch_path_for_run(sweep_dir: &Path, instance_id: &str, run_index: u32) -> Option<PathBuf> {
     let run_file = format!("run-{run_index}.patch");
     if run_index > 1 {
@@ -1133,18 +1139,11 @@ fn find_trajectory_paths_for_bundle(
         return Ok(out);
     }
 
-    let nested = sorted_nested_run_files(&sweep_dir.join(instance_id), ".traj.json");
-    if !nested.is_empty() {
-        return Ok(nested
-            .into_iter()
-            .filter_map(|path| {
-                let file_name = path.file_name()?.to_string_lossy();
-                Some((path.clone(), format!("{instance_id}/{file_name}")))
-            })
-            .collect());
-    }
-    find_trajectory_path(sweep_dir, instance_id)
-        .map(|path| (path, format!("trajectories/{instance_id}.traj.json")))
+    find_single_run_trajectory_path(sweep_dir, instance_id)
+        .map(|path| {
+            let archive_path = trajectory_archive_path_for_run(sweep_dir, instance_id, 1, &path);
+            (path, archive_path)
+        })
         .into_iter()
         .next()
         .map(|entry| vec![entry])
@@ -1156,53 +1155,52 @@ fn find_trajectory_paths_for_bundle(
         })
 }
 
-fn find_patch_paths_for_bundle(sweep_dir: &Path, instance_id: &str) -> Vec<(PathBuf, String)> {
-    let nested = sorted_nested_run_files(&sweep_dir.join(instance_id), ".patch");
-    if !nested.is_empty() {
-        return nested
-            .into_iter()
-            .filter_map(|path| {
-                let file_name = path.file_name()?.to_string_lossy();
-                Some((path.clone(), format!("{instance_id}/{file_name}")))
-            })
-            .collect();
+fn find_patch_paths_for_bundle(
+    sweep_dir: &Path,
+    instance_id: &str,
+    row: &serde_json::Value,
+) -> Vec<(PathBuf, String)> {
+    if is_never_started_budget_halt(row) {
+        return Vec::new();
     }
-    find_patch_path(sweep_dir, instance_id)
-        .map(|path| (path, format!("patches/{instance_id}.patch")))
-        .into_iter()
+
+    (1..=effective_runs_value(row))
+        .filter_map(|run_index| {
+            find_patch_path_for_run(sweep_dir, instance_id, run_index).map(|path| {
+                let archive_path =
+                    patch_archive_path_for_run(sweep_dir, instance_id, run_index, &path);
+                (path, archive_path)
+            })
+        })
         .collect()
 }
 
-fn sorted_nested_run_files(dir: &Path, suffix: &str) -> Vec<PathBuf> {
-    let mut files = std::fs::read_dir(dir)
-        .ok()
-        .into_iter()
-        .flat_map(|entries| entries.filter_map(Result::ok))
-        .filter_map(|entry| {
-            let file_type = entry.file_type().ok()?;
-            if !file_type.is_file() {
-                return None;
-            }
-            let file_name = entry.file_name();
-            let file_name = file_name.to_string_lossy();
-            (file_name.starts_with("run-") && file_name.ends_with(suffix)).then_some(entry.path())
-        })
-        .collect::<Vec<_>>();
-    files.sort_by(|left, right| {
-        let left_key = run_file_sort_key(left);
-        let right_key = run_file_sort_key(right);
-        left_key.cmp(&right_key).then_with(|| left.cmp(right))
-    });
-    files
+fn trajectory_archive_path_for_run(
+    sweep_dir: &Path,
+    instance_id: &str,
+    run_index: u32,
+    path: &Path,
+) -> String {
+    let file_name = format!("run-{run_index}.traj.json");
+    if path == sweep_dir.join(instance_id).join(&file_name) {
+        format!("{instance_id}/{file_name}")
+    } else {
+        format!("trajectories/{instance_id}.traj.json")
+    }
 }
 
-fn run_file_sort_key(path: &Path) -> u32 {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .and_then(|name| name.strip_prefix("run-"))
-        .and_then(|name| name.split('.').next())
-        .and_then(|index| index.parse::<u32>().ok())
-        .unwrap_or(u32::MAX)
+fn patch_archive_path_for_run(
+    sweep_dir: &Path,
+    instance_id: &str,
+    run_index: u32,
+    path: &Path,
+) -> String {
+    let file_name = format!("run-{run_index}.patch");
+    if path == sweep_dir.join(instance_id).join(&file_name) {
+        format!("{instance_id}/{file_name}")
+    } else {
+        format!("patches/{instance_id}.patch")
+    }
 }
 
 fn read_required_text(path: &Path, label: &str) -> Result<String, BundleError> {

--- a/src/run/bundle.rs
+++ b/src/run/bundle.rs
@@ -168,6 +168,7 @@ struct ScopedResultAggregates {
     submitted: usize,
     submitted_with_tests: usize,
     skipped: usize,
+    errored: usize,
     with_patch: usize,
     patch_empty: usize,
     patch_apply_invalid: usize,
@@ -181,10 +182,12 @@ struct ScopedResultAggregates {
     actual_cost_usd: Option<f64>,
     retries: u64,
     retried_instances: usize,
+    drop_retried_instances: bool,
     resolved_count: usize,
     total_fallbacks: u64,
     model_mix: BTreeMap<String, usize>,
     failures: serde_json::Map<String, serde_json::Value>,
+    drop_github_pr_failures: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -227,7 +230,7 @@ pub fn create_bundle(args: &BundleCreateArgs) -> Result<BundleCreateReport, Bund
     let mut files = vec![workspace.prepare_bytes("manifest.json", manifest_bytes)?];
 
     if args.instance.is_some() {
-        filter_results_for_scope(&mut results_value, &included_set);
+        filter_results_for_scope(&mut results_value, &included_set, &args.sweep_dir);
     }
     let results_bytes = normalized_json_bytes(&results_value, &normalizer)?;
     strict_redaction_check("results.json", &results_bytes, &redactor)?;
@@ -241,20 +244,20 @@ pub fn create_bundle(args: &BundleCreateArgs) -> Result<BundleCreateReport, Bund
 
     let mut patch_files = Vec::new();
     for instance_id in &included_ids {
-        let trajectory_src =
-            find_trajectory_path(&args.sweep_dir, instance_id).ok_or_else(|| {
-                BundleError::MissingSource(format!(
-                    "bundle: missing trajectory for instance `{instance_id}` in {}",
-                    args.sweep_dir.display()
-                ))
-            })?;
-        let trajectory_dest = format!("trajectories/{instance_id}.traj.json");
-        let trajectory = normalized_text_file(&trajectory_src, &normalizer)?;
-        strict_redaction_check(&trajectory_dest, &trajectory, &redactor)?;
-        files.push(workspace.prepare_bytes(trajectory_dest, trajectory)?);
+        let trajectory_sources = find_trajectory_paths_for_bundle(&args.sweep_dir, instance_id);
+        if trajectory_sources.is_empty() {
+            return Err(BundleError::MissingSource(format!(
+                "bundle: missing trajectory for instance `{instance_id}` in {}",
+                args.sweep_dir.display()
+            )));
+        }
+        for (trajectory_src, trajectory_dest) in trajectory_sources {
+            let trajectory = normalized_text_file(&trajectory_src, &normalizer)?;
+            strict_redaction_check(&trajectory_dest, &trajectory, &redactor)?;
+            files.push(workspace.prepare_bytes(trajectory_dest, trajectory)?);
+        }
 
-        if let Some(patch_src) = find_patch_path(&args.sweep_dir, instance_id) {
-            let patch_dest = format!("patches/{instance_id}.patch");
+        for (patch_src, patch_dest) in find_patch_paths_for_bundle(&args.sweep_dir, instance_id) {
             let patch = normalized_text_file(&patch_src, &normalizer)?;
             strict_redaction_check(&patch_dest, &patch, &redactor)?;
             patch_files.push(workspace.prepare_bytes(patch_dest, patch)?);
@@ -448,7 +451,11 @@ fn drop_filtered_evaluation_summaries(value: &mut serde_json::Value) {
     }
 }
 
-fn filter_results_for_scope(value: &mut serde_json::Value, included: &BTreeSet<String>) {
+fn filter_results_for_scope(
+    value: &mut serde_json::Value,
+    included: &BTreeSet<String>,
+    sweep_dir: &Path,
+) {
     let Some(aggregates) = value
         .get_mut("instances")
         .and_then(serde_json::Value::as_array_mut)
@@ -459,7 +466,9 @@ fn filter_results_for_scope(value: &mut serde_json::Value, included: &BTreeSet<S
                     .is_some_and(|id| included.contains(id))
             });
 
-            scoped_result_aggregates(instances)
+            let row_aggregates = scoped_result_aggregates(instances);
+            scoped_slot_aggregates_from_run_artifacts(sweep_dir, instances, &row_aggregates)
+                .unwrap_or(row_aggregates)
         })
     else {
         return;
@@ -483,14 +492,7 @@ fn apply_scoped_result_aggregates(
         serde_json::json!(aggregates.submitted_with_tests),
     );
     map.insert("skipped".into(), serde_json::json!(aggregates.skipped));
-    map.insert(
-        "errored".into(),
-        serde_json::json!(
-            aggregates
-                .total
-                .saturating_sub(aggregates.submitted + aggregates.skipped)
-        ),
-    );
+    map.insert("errored".into(), serde_json::json!(aggregates.errored));
     map.insert(
         "with_patch".into(),
         serde_json::json!(aggregates.with_patch),
@@ -503,10 +505,14 @@ fn apply_scoped_result_aggregates(
         "patch_apply_invalid".into(),
         serde_json::json!(aggregates.patch_apply_invalid),
     );
-    map.insert(
-        "github_pr_failures".into(),
-        serde_json::json!(aggregates.github_pr_failures),
-    );
+    if aggregates.drop_github_pr_failures {
+        map.remove("github_pr_failures");
+    } else {
+        map.insert(
+            "github_pr_failures".into(),
+            serde_json::json!(aggregates.github_pr_failures),
+        );
+    }
     map.insert(
         "budget_halted".into(),
         serde_json::json!(aggregates.budget_halted),
@@ -576,10 +582,14 @@ fn apply_scoped_cost_and_token_aggregates(
         serde_json::json!(cache_hit_rate(aggregates)),
     );
     map.insert("retries".into(), serde_json::json!(aggregates.retries));
-    map.insert(
-        "retried_instances".into(),
-        serde_json::json!(aggregates.retried_instances),
-    );
+    if aggregates.drop_retried_instances {
+        map.remove("retried_instances");
+    } else {
+        map.insert(
+            "retried_instances".into(),
+            serde_json::json!(aggregates.retried_instances),
+        );
+    }
     map.insert("pass_at_k".into(), serde_json::json!(pass_at_k(aggregates)));
     map.insert(
         "total_fallbacks".into(),
@@ -596,82 +606,284 @@ fn scoped_result_aggregates(instances: &[serde_json::Value]) -> ScopedResultAggr
         ..ScopedResultAggregates::default()
     };
     for row in instances {
-        let outcome = string_field(row, "outcome");
-        let exit_reason = string_field(row, "exit_reason");
-        if outcome == Some("submitted") {
+        add_result_row_to_aggregates(&mut aggregates, row);
+    }
+    aggregates
+}
+
+fn scoped_slot_aggregates_from_run_artifacts(
+    sweep_dir: &Path,
+    instances: &[serde_json::Value],
+    row_aggregates: &ScopedResultAggregates,
+) -> Option<ScopedResultAggregates> {
+    if !instances.iter().any(|row| effective_runs_value(row) > 1) {
+        return None;
+    }
+
+    let mut aggregates = ScopedResultAggregates {
+        total: row_aggregates.total,
+        ..ScopedResultAggregates::default()
+    };
+    for row in instances {
+        let runs = effective_runs_value(row);
+        if runs <= 1 {
+            add_result_row_to_aggregates(&mut aggregates, row);
+            continue;
+        }
+        let instance_id = string_field(row, "instance_id")?;
+        for run_index in 1..=runs {
+            let slot = run_slot_result_value_from_artifact(sweep_dir, instance_id, run_index)?;
+            add_result_row_to_aggregates(&mut aggregates, &slot);
+        }
+    }
+
+    aggregates.total = row_aggregates.total;
+    aggregates.resolved_count = row_aggregates.resolved_count;
+    aggregates.drop_github_pr_failures = true;
+    aggregates.total_input_tokens = row_aggregates.total_input_tokens;
+    aggregates.total_cache_read_tokens = row_aggregates.total_cache_read_tokens;
+    aggregates.total_cache_creation_tokens = row_aggregates.total_cache_creation_tokens;
+    aggregates.total_completion_tokens = row_aggregates.total_completion_tokens;
+    aggregates.total_cost_usd = row_aggregates.total_cost_usd;
+    aggregates.actual_cost_usd = row_aggregates.actual_cost_usd;
+    aggregates.retries = row_aggregates.retries;
+    aggregates.drop_retried_instances = true;
+    aggregates.total_fallbacks = row_aggregates.total_fallbacks;
+    if aggregates.model_mix.is_empty() {
+        aggregates.model_mix.clone_from(&row_aggregates.model_mix);
+    }
+    Some(aggregates)
+}
+
+fn add_result_row_to_aggregates(aggregates: &mut ScopedResultAggregates, row: &serde_json::Value) {
+    add_outcome_counts_to_aggregates(aggregates, row);
+    add_patch_and_failure_counts_to_aggregates(aggregates, row);
+    add_usage_and_model_counts_to_aggregates(aggregates, row);
+}
+
+fn add_outcome_counts_to_aggregates(
+    aggregates: &mut ScopedResultAggregates,
+    row: &serde_json::Value,
+) {
+    let outcome = string_field(row, "outcome");
+    let exit_reason = string_field(row, "exit_reason");
+    let runs = effective_runs_value(row);
+    if runs > 1 {
+        let submitted_slots = u64_field(row, "resolved_count")
+            .and_then(|count| usize::try_from(count).ok())
+            .unwrap_or_else(|| usize::from(outcome == Some("submitted")))
+            .min(usize::try_from(runs).unwrap_or(usize::MAX));
+        aggregates.submitted = aggregates.submitted.saturating_add(submitted_slots);
+        if submitted_slots > 0 && bool_field(row, "tests_run_before_submit") {
+            aggregates.submitted_with_tests += 1;
+        }
+        let skipped_slots =
+            usize::from(outcome == Some("skipped") || exit_reason == Some("skipped"));
+        aggregates.skipped = aggregates.skipped.saturating_add(skipped_slots);
+        let budget_slots = usize::from(exit_reason == Some("budget_halt"));
+        aggregates.budget_halted = aggregates.budget_halted.saturating_add(budget_slots);
+        aggregates.errored = aggregates.errored.saturating_add(
+            usize::try_from(runs)
+                .unwrap_or(usize::MAX)
+                .saturating_sub(submitted_slots)
+                .saturating_sub(skipped_slots)
+                .saturating_sub(budget_slots),
+        );
+    } else {
+        let submitted = outcome == Some("submitted");
+        let skipped = outcome == Some("skipped") || exit_reason == Some("skipped");
+        let budget_halted = exit_reason == Some("budget_halt");
+        if submitted {
             aggregates.submitted += 1;
             if bool_field(row, "tests_run_before_submit") {
                 aggregates.submitted_with_tests += 1;
             }
         }
-        if outcome == Some("skipped") || exit_reason == Some("skipped") {
+        if skipped {
             aggregates.skipped += 1;
         }
-        if bool_field(row, "patch_present") {
-            aggregates.with_patch += 1;
-            if !bool_field(row, "non_empty_patch") {
-                aggregates.patch_empty += 1;
-            }
-        }
-        if bool_field(row, "patch_apply_invalid")
-            || string_field(row, "failure_category") == Some("patch_apply_invalid")
-        {
-            aggregates.patch_apply_invalid += 1;
-        }
-        if row
-            .get("github_pr_error")
-            .is_some_and(|value| !value.is_null())
-        {
-            aggregates.github_pr_failures += 1;
-        }
-        if exit_reason == Some("budget_halt") {
+        if budget_halted {
             aggregates.budget_halted += 1;
         }
-        if let Some(category) = string_field(row, "failure_category") {
-            let next = aggregates
-                .failures
-                .get(category)
-                .and_then(serde_json::Value::as_u64)
-                .unwrap_or_default()
-                .saturating_add(1);
-            aggregates
-                .failures
-                .insert(category.to_owned(), serde_json::json!(next));
-        }
-
-        aggregates.total_input_tokens = aggregates
-            .total_input_tokens
-            .saturating_add(u64_field(row, "total_input_tokens").unwrap_or_default());
-        aggregates.total_cache_read_tokens = aggregates
-            .total_cache_read_tokens
-            .saturating_add(u64_field(row, "total_cache_read_tokens").unwrap_or_default());
-        aggregates.total_cache_creation_tokens = aggregates
-            .total_cache_creation_tokens
-            .saturating_add(u64_field(row, "total_cache_creation_tokens").unwrap_or_default());
-        aggregates.total_completion_tokens = aggregates
-            .total_completion_tokens
-            .saturating_add(u64_field(row, "total_completion_tokens").unwrap_or_default());
-        aggregates.total_cost_usd =
-            sum_optional_f64(aggregates.total_cost_usd, instance_cost_usd(row));
-        aggregates.actual_cost_usd =
-            sum_optional_f64(aggregates.actual_cost_usd, instance_actual_cost_usd(row));
-
-        let retries = retry_count(row);
-        aggregates.retries = aggregates.retries.saturating_add(retries);
-        if retries > 0 {
-            aggregates.retried_instances += 1;
-        }
-        if instance_resolved(row) {
-            aggregates.resolved_count += 1;
-        }
-        if let Some(fallback_count) = u64_field(row, "fallback_count") {
-            aggregates.total_fallbacks = aggregates.total_fallbacks.saturating_add(fallback_count);
-        }
-        if let Some(model) = string_field(row, "final_model") {
-            *aggregates.model_mix.entry(model.to_owned()).or_default() += 1;
+        if !submitted && !skipped && !budget_halted {
+            aggregates.errored += 1;
         }
     }
-    aggregates
+}
+
+fn add_patch_and_failure_counts_to_aggregates(
+    aggregates: &mut ScopedResultAggregates,
+    row: &serde_json::Value,
+) {
+    let outcome = string_field(row, "outcome");
+    if bool_field(row, "patch_present") {
+        if bool_field(row, "non_empty_patch") && outcome == Some("submitted") {
+            aggregates.with_patch += 1;
+        } else if !bool_field(row, "non_empty_patch") {
+            aggregates.patch_empty += 1;
+        }
+    }
+    if bool_field(row, "patch_apply_invalid")
+        || string_field(row, "failure_category") == Some("patch_apply_invalid")
+    {
+        aggregates.patch_apply_invalid += 1;
+    }
+    if row
+        .get("github_pr_error")
+        .is_some_and(|value| !value.is_null())
+    {
+        aggregates.github_pr_failures += 1;
+    }
+    if let Some(category) = string_field(row, "failure_category") {
+        let next = aggregates
+            .failures
+            .get(category)
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or_default()
+            .saturating_add(1);
+        aggregates
+            .failures
+            .insert(category.to_owned(), serde_json::json!(next));
+    }
+}
+
+fn add_usage_and_model_counts_to_aggregates(
+    aggregates: &mut ScopedResultAggregates,
+    row: &serde_json::Value,
+) {
+    aggregates.total_input_tokens = aggregates
+        .total_input_tokens
+        .saturating_add(u64_field(row, "total_input_tokens").unwrap_or_default());
+    aggregates.total_cache_read_tokens = aggregates
+        .total_cache_read_tokens
+        .saturating_add(u64_field(row, "total_cache_read_tokens").unwrap_or_default());
+    aggregates.total_cache_creation_tokens = aggregates
+        .total_cache_creation_tokens
+        .saturating_add(u64_field(row, "total_cache_creation_tokens").unwrap_or_default());
+    aggregates.total_completion_tokens = aggregates
+        .total_completion_tokens
+        .saturating_add(u64_field(row, "total_completion_tokens").unwrap_or_default());
+    aggregates.total_cost_usd = sum_optional_f64(aggregates.total_cost_usd, instance_cost_usd(row));
+    aggregates.actual_cost_usd =
+        sum_optional_f64(aggregates.actual_cost_usd, instance_actual_cost_usd(row));
+
+    let retries = retry_count(row);
+    aggregates.retries = aggregates.retries.saturating_add(retries);
+    if retries > 0 {
+        aggregates.retried_instances += 1;
+    }
+    if instance_resolved(row) {
+        aggregates.resolved_count += 1;
+    }
+    if let Some(fallback_count) = u64_field(row, "fallback_count") {
+        aggregates.total_fallbacks = aggregates.total_fallbacks.saturating_add(fallback_count);
+    }
+    if let Some(model) = string_field(row, "final_model") {
+        *aggregates.model_mix.entry(model.to_owned()).or_default() += 1;
+    }
+}
+
+fn run_slot_result_value_from_artifact(
+    sweep_dir: &Path,
+    instance_id: &str,
+    run_index: u32,
+) -> Option<serde_json::Value> {
+    let path = find_trajectory_path_for_run(sweep_dir, instance_id, run_index)?;
+    let text = std::fs::read_to_string(path).ok()?;
+    let trajectory: serde_json::Value = serde_json::from_str(&text).ok()?;
+    let info = trajectory.get("info")?;
+
+    let mut row = serde_json::Map::new();
+    row.insert(
+        "instance_id".into(),
+        serde_json::Value::String(instance_id.to_owned()),
+    );
+    for key in [
+        "outcome",
+        "exit_reason",
+        "failure_category",
+        "steps",
+        "duration_secs",
+        "tests_run_before_submit",
+        "last_tests_passed",
+    ] {
+        if let Some(value) = info.get(key) {
+            row.insert(key.to_owned(), value.clone());
+        }
+    }
+    if let Some(value) = info.get("total_cost_usd") {
+        row.insert("cost_usd".into(), value.clone());
+    }
+    if let Some(value) = info.get("actual_cost_usd") {
+        row.insert("actual_cost_usd".into(), value.clone());
+    }
+    if let Some(tokens) = info.get("token_usage") {
+        copy_token_field(tokens, &mut row, "prompt_tokens", "total_input_tokens");
+        copy_token_field(
+            tokens,
+            &mut row,
+            "cache_read_tokens",
+            "total_cache_read_tokens",
+        );
+        copy_token_field(
+            tokens,
+            &mut row,
+            "cache_creation_tokens",
+            "total_cache_creation_tokens",
+        );
+        copy_token_field(
+            tokens,
+            &mut row,
+            "completion_tokens",
+            "total_completion_tokens",
+        );
+    }
+    if let Some(summary) = info.get("fallback_summary") {
+        let all_failed = summary
+            .get("all_failed")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        if !all_failed {
+            if let Some(value) = summary.get("final_model") {
+                row.insert("final_model".into(), value.clone());
+            }
+        }
+        if let Some(value) = summary.get("fallback_count") {
+            row.insert("fallback_count".into(), value.clone());
+        }
+    }
+    if let Some(non_empty) =
+        find_patch_path_for_run(sweep_dir, instance_id, run_index).and_then(|path| {
+            std::fs::metadata(path)
+                .ok()
+                .map(|metadata| metadata.len() > 0)
+        })
+    {
+        row.insert("patch_present".into(), serde_json::Value::Bool(true));
+        row.insert("non_empty_patch".into(), serde_json::Value::Bool(non_empty));
+    } else {
+        row.insert("patch_present".into(), serde_json::Value::Bool(false));
+        row.insert("non_empty_patch".into(), serde_json::Value::Bool(false));
+    }
+    Some(serde_json::Value::Object(row))
+}
+
+fn copy_token_field(
+    tokens: &serde_json::Value,
+    row: &mut serde_json::Map<String, serde_json::Value>,
+    source: &str,
+    dest: &str,
+) {
+    if let Some(value) = tokens.get(source) {
+        row.insert(dest.to_owned(), value.clone());
+    }
+}
+
+fn effective_runs_value(value: &serde_json::Value) -> u32 {
+    u64_field(value, "runs")
+        .and_then(|runs| u32::try_from(runs).ok())
+        .filter(|runs| *runs > 0)
+        .unwrap_or(1)
 }
 
 fn u64_field(value: &serde_json::Value, key: &str) -> Option<u64> {
@@ -716,26 +928,22 @@ fn cache_hit_rate(aggregates: &ScopedResultAggregates) -> f64 {
         .saturating_add(aggregates.total_cache_read_tokens)
         .saturating_add(aggregates.total_cache_creation_tokens);
     if prompt == 0 {
-        return 0.0;
-    }
-    #[allow(clippy::cast_precision_loss)]
-    {
-        aggregates.total_cache_read_tokens as f64 / prompt as f64
+        0.0
+    } else {
+        #[allow(clippy::cast_precision_loss)]
+        {
+            aggregates.total_cache_read_tokens as f64 / prompt as f64
+        }
     }
 }
 
+#[allow(clippy::cast_precision_loss)]
 fn pass_at_k(aggregates: &ScopedResultAggregates) -> f64 {
     if aggregates.total == 0 {
-        return 0.0;
-    }
-    #[allow(clippy::cast_precision_loss)]
-    {
+        0.0
+    } else {
         aggregates.resolved_count as f64 / aggregates.total as f64
     }
-}
-
-fn string_field<'a>(value: &'a serde_json::Value, key: &str) -> Option<&'a str> {
-    value.get(key).and_then(serde_json::Value::as_str)
 }
 
 fn bool_field(value: &serde_json::Value, key: &str) -> bool {
@@ -743,6 +951,10 @@ fn bool_field(value: &serde_json::Value, key: &str) -> bool {
         .get(key)
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false)
+}
+
+fn string_field<'a>(value: &'a serde_json::Value, key: &str) -> Option<&'a str> {
+    value.get(key).and_then(serde_json::Value::as_str)
 }
 
 fn instance_ids_from_results(value: &serde_json::Value) -> Result<Vec<String>, BundleError> {
@@ -805,9 +1017,22 @@ fn validate_instance_scope(instance: Option<&str>) -> Result<(), BundleError> {
 }
 
 fn find_trajectory_path(sweep_dir: &Path, instance_id: &str) -> Option<PathBuf> {
+    find_trajectory_path_for_run(sweep_dir, instance_id, 1)
+}
+
+fn find_trajectory_path_for_run(
+    sweep_dir: &Path,
+    instance_id: &str,
+    run_index: u32,
+) -> Option<PathBuf> {
+    let run_file = format!("run-{run_index}.traj.json");
+    if run_index > 1 {
+        let path = sweep_dir.join(instance_id).join(run_file);
+        return path.exists().then_some(path);
+    }
     [
         sweep_dir.join(instance_id).join("trajectory.json"),
-        sweep_dir.join(instance_id).join("run-1.traj.json"),
+        sweep_dir.join(instance_id).join(run_file),
         sweep_dir.join(format!("{instance_id}.traj.json")),
         sweep_dir
             .join("trajectories")
@@ -818,8 +1043,17 @@ fn find_trajectory_path(sweep_dir: &Path, instance_id: &str) -> Option<PathBuf> 
 }
 
 fn find_patch_path(sweep_dir: &Path, instance_id: &str) -> Option<PathBuf> {
+    find_patch_path_for_run(sweep_dir, instance_id, 1)
+}
+
+fn find_patch_path_for_run(sweep_dir: &Path, instance_id: &str, run_index: u32) -> Option<PathBuf> {
+    let run_file = format!("run-{run_index}.patch");
+    if run_index > 1 {
+        let path = sweep_dir.join(instance_id).join(run_file);
+        return path.exists().then_some(path);
+    }
     [
-        sweep_dir.join(instance_id).join("run-1.patch"),
+        sweep_dir.join(instance_id).join(run_file),
         sweep_dir.join(format!("{instance_id}.patch")),
         sweep_dir
             .join("patches")
@@ -827,6 +1061,72 @@ fn find_patch_path(sweep_dir: &Path, instance_id: &str) -> Option<PathBuf> {
     ]
     .into_iter()
     .find(|path| path.exists())
+}
+
+fn find_trajectory_paths_for_bundle(sweep_dir: &Path, instance_id: &str) -> Vec<(PathBuf, String)> {
+    let nested = sorted_nested_run_files(&sweep_dir.join(instance_id), ".traj.json");
+    if !nested.is_empty() {
+        return nested
+            .into_iter()
+            .filter_map(|path| {
+                let file_name = path.file_name()?.to_string_lossy();
+                Some((path.clone(), format!("{instance_id}/{file_name}")))
+            })
+            .collect();
+    }
+    find_trajectory_path(sweep_dir, instance_id)
+        .map(|path| (path, format!("trajectories/{instance_id}.traj.json")))
+        .into_iter()
+        .collect()
+}
+
+fn find_patch_paths_for_bundle(sweep_dir: &Path, instance_id: &str) -> Vec<(PathBuf, String)> {
+    let nested = sorted_nested_run_files(&sweep_dir.join(instance_id), ".patch");
+    if !nested.is_empty() {
+        return nested
+            .into_iter()
+            .filter_map(|path| {
+                let file_name = path.file_name()?.to_string_lossy();
+                Some((path.clone(), format!("{instance_id}/{file_name}")))
+            })
+            .collect();
+    }
+    find_patch_path(sweep_dir, instance_id)
+        .map(|path| (path, format!("patches/{instance_id}.patch")))
+        .into_iter()
+        .collect()
+}
+
+fn sorted_nested_run_files(dir: &Path, suffix: &str) -> Vec<PathBuf> {
+    let mut files = std::fs::read_dir(dir)
+        .ok()
+        .into_iter()
+        .flat_map(|entries| entries.filter_map(Result::ok))
+        .filter_map(|entry| {
+            let file_type = entry.file_type().ok()?;
+            if !file_type.is_file() {
+                return None;
+            }
+            let file_name = entry.file_name();
+            let file_name = file_name.to_string_lossy();
+            (file_name.starts_with("run-") && file_name.ends_with(suffix)).then_some(entry.path())
+        })
+        .collect::<Vec<_>>();
+    files.sort_by(|left, right| {
+        let left_key = run_file_sort_key(left);
+        let right_key = run_file_sort_key(right);
+        left_key.cmp(&right_key).then_with(|| left.cmp(right))
+    });
+    files
+}
+
+fn run_file_sort_key(path: &Path) -> u32 {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_prefix("run-"))
+        .and_then(|name| name.split('.').next())
+        .and_then(|index| index.parse::<u32>().ok())
+        .unwrap_or(u32::MAX)
 }
 
 fn read_required_text(path: &Path, label: &str) -> Result<String, BundleError> {

--- a/src/run/bundle.rs
+++ b/src/run/bundle.rs
@@ -421,13 +421,31 @@ fn load_optional_evaluation(
         .get_mut("instances")
         .and_then(serde_json::Value::as_array_mut)
     {
+        let original_len = instances.len();
         instances.retain(|row| {
             row.get("instance_id")
                 .and_then(serde_json::Value::as_str)
                 .is_some_and(|id| included.contains(id))
         });
+        if instances.len() != original_len {
+            drop_filtered_evaluation_summaries(&mut value);
+        }
     }
     normalized_json_bytes(&value, normalizer).map(Some)
+}
+
+fn drop_filtered_evaluation_summaries(value: &mut serde_json::Value) {
+    let Some(map) = value.as_object_mut() else {
+        return;
+    };
+    for key in [
+        "behavioral",
+        "breakdown",
+        "cost_attribution",
+        "model_mix_summary",
+    ] {
+        map.remove(key);
+    }
 }
 
 fn filter_results_for_scope(value: &mut serde_json::Value, included: &BTreeSet<String>) {
@@ -535,13 +553,22 @@ fn apply_scoped_cost_and_token_aggregates(
         "total_completion_tokens".into(),
         serde_json::json!(aggregates.total_completion_tokens),
     );
-    if let Some(cost) = aggregates.total_cost_usd {
-        map.insert("total_cost_usd".into(), serde_json::json!(cost));
+    if aggregates.total_cost_usd.is_some() || map.contains_key("total_cost_usd") {
+        map.insert(
+            "total_cost_usd".into(),
+            serde_json::json!(aggregates.total_cost_usd.unwrap_or(0.0)),
+        );
+    }
+    if map.contains_key("estimated_cost_usd") {
+        map.insert(
+            "estimated_cost_usd".into(),
+            serde_json::json!(aggregates.total_cost_usd.unwrap_or(0.0)),
+        );
     }
     if map.contains_key("actual_cost_usd") {
         map.insert(
             "actual_cost_usd".into(),
-            serde_json::json!(aggregates.actual_cost_usd),
+            serde_json::json!(aggregates.actual_cost_usd.unwrap_or(0.0)),
         );
     }
     map.insert(

--- a/src/run/bundle.rs
+++ b/src/run/bundle.rs
@@ -1,0 +1,780 @@
+//! `bench bundle`: deterministic, redaction-strict sweep archive export.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::{Cursor, Read as _};
+use std::path::{Component, Path, PathBuf};
+
+use flate2::{Compression, GzBuilder, read::GzDecoder};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use crate::artifact::{ArtifactKind, ArtifactSchemaVersion, classify_json_value};
+use crate::config::RedactionCfg;
+use crate::redaction::{Redactor, surface};
+
+pub const BUNDLE_MANIFEST_PATH: &str = "BUNDLE.json";
+
+#[derive(Debug, Clone)]
+pub struct BundleCreateArgs {
+    pub sweep_dir: PathBuf,
+    pub output_path: PathBuf,
+    pub instance: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BundleCreateReport {
+    pub output_path: PathBuf,
+    pub files: Vec<BundleFileEntry>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BundleVerifyReport {
+    pub problems: Vec<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BundleError {
+    #[error("{0}")]
+    MissingSource(String),
+    #[error("redaction:retrigger:{path}")]
+    RedactionRetrigger { path: String },
+    #[error("{0}")]
+    InvalidArchive(String),
+    #[error("{0}")]
+    Schema(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BundleFileEntry {
+    pub path: String,
+    pub sha256: String,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BundleManifest {
+    pub artifact_kind: ArtifactKind,
+    pub schema_version: ArtifactSchemaVersion,
+    pub source_sweep_dir: String,
+    pub source_manifest_hash: String,
+    pub harness_git_sha: Option<String>,
+    pub bundle_generated_at: String,
+    pub instance_scope: String,
+    pub files: Vec<BundleFileEntry>,
+}
+
+#[derive(Debug, Clone)]
+struct PreparedFile {
+    archive_path: String,
+    bytes: Vec<u8>,
+}
+
+struct PathNormalizer {
+    needles: Vec<String>,
+    windows_abs: Option<Regex>,
+    unix_abs: Option<Regex>,
+}
+
+impl PathNormalizer {
+    fn new(sweep_dir: &Path) -> Self {
+        let mut needles = BTreeSet::new();
+        push_path_needles(&mut needles, &sweep_dir.display().to_string());
+        if let Ok(canonical) = std::fs::canonicalize(sweep_dir) {
+            push_path_needles(&mut needles, &canonical.display().to_string());
+        }
+        Self {
+            needles: needles
+                .into_iter()
+                .filter(|value| !value.is_empty() && value != ".")
+                .collect(),
+            windows_abs: Regex::new(r#"[A-Za-z]:(?:\\\\|\\|/)[^"'\r\n\s,}\]]+"#).ok(),
+            unix_abs: Regex::new(r#"(^|[\s"'\[({:=,])/(?:[^\s/"'\]\[{}(),]+/)+[^\s/"'\]\[{}(),]+"#)
+                .ok(),
+        }
+    }
+
+    fn normalize_text(&self, input: &str) -> String {
+        let normalized = self
+            .needles
+            .iter()
+            .fold(input.to_owned(), |acc, needle| acc.replace(needle, "."));
+        let normalized = self.windows_abs.as_ref().map_or_else(
+            || normalized.clone(),
+            |regex| regex.replace_all(&normalized, ".").into_owned(),
+        );
+        self.unix_abs.as_ref().map_or_else(
+            || normalized.clone(),
+            |regex| regex.replace_all(&normalized, "${1}.").into_owned(),
+        )
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ResolvedConfigForBundle {
+    #[serde(default)]
+    redaction: Option<RedactionCfg>,
+}
+
+pub fn create_bundle(args: &BundleCreateArgs) -> Result<BundleCreateReport, BundleError> {
+    if !args.sweep_dir.is_dir() {
+        return Err(BundleError::MissingSource(format!(
+            "bundle: sweep directory does not exist: {}",
+            args.sweep_dir.display()
+        )));
+    }
+    validate_instance_scope(args.instance.as_deref())?;
+
+    let normalizer = PathNormalizer::new(&args.sweep_dir);
+    let results_path = args.sweep_dir.join("results.json");
+    let results_text = read_required_text(&results_path, "results.json")?;
+    let mut results_value: serde_json::Value = serde_json::from_str(&results_text)?;
+    classify_json_value(
+        &results_value,
+        ArtifactKind::SweepResults,
+        results_path.display().to_string(),
+    )
+    .map_err(|err| BundleError::Schema(err.to_string()))?;
+
+    let all_instance_ids = instance_ids_from_results(&results_value)?;
+    let included_ids = included_instance_ids(&all_instance_ids, args.instance.as_deref())?;
+    let included_set = included_ids.iter().cloned().collect::<BTreeSet<_>>();
+
+    let manifest_bytes = load_manifest_bytes(&args.sweep_dir, &results_value, &normalizer)?;
+    let manifest_value: serde_json::Value = serde_json::from_slice(&manifest_bytes)?;
+    let redactor = source_redactor(&results_value, &manifest_value);
+    let source_manifest_hash = format!("sha256:{}", sha256_hex(&manifest_bytes));
+    strict_redaction_check("manifest.json", &manifest_bytes, &redactor)?;
+
+    if args.instance.is_some() {
+        filter_results_for_scope(&mut results_value, &included_set);
+    }
+    let results_bytes = normalized_json_bytes(&results_value, &normalizer)?;
+    strict_redaction_check("results.json", &results_bytes, &redactor)?;
+
+    let mut files = vec![
+        PreparedFile {
+            archive_path: "manifest.json".into(),
+            bytes: manifest_bytes,
+        },
+        PreparedFile {
+            archive_path: "results.json".into(),
+            bytes: results_bytes,
+        },
+    ];
+
+    if let Some(evaluation) = load_optional_evaluation(&args.sweep_dir, &included_set, &normalizer)?
+    {
+        strict_redaction_check("evaluation.json", &evaluation, &redactor)?;
+        files.push(PreparedFile {
+            archive_path: "evaluation.json".into(),
+            bytes: evaluation,
+        });
+    }
+
+    let mut patch_files = Vec::new();
+    for instance_id in &included_ids {
+        let trajectory_src =
+            find_trajectory_path(&args.sweep_dir, instance_id).ok_or_else(|| {
+                BundleError::MissingSource(format!(
+                    "bundle: missing trajectory for instance `{instance_id}` in {}",
+                    args.sweep_dir.display()
+                ))
+            })?;
+        let trajectory_dest = format!("trajectories/{instance_id}.traj.json");
+        let trajectory = normalized_text_file(&trajectory_src, &normalizer)?;
+        strict_redaction_check(&trajectory_dest, &trajectory, &redactor)?;
+        files.push(PreparedFile {
+            archive_path: trajectory_dest,
+            bytes: trajectory,
+        });
+
+        if let Some(patch_src) = find_patch_path(&args.sweep_dir, instance_id) {
+            let patch_dest = format!("patches/{instance_id}.patch");
+            let patch = normalized_text_file(&patch_src, &normalizer)?;
+            strict_redaction_check(&patch_dest, &patch, &redactor)?;
+            patch_files.push(PreparedFile {
+                archive_path: patch_dest,
+                bytes: patch,
+            });
+        }
+    }
+    files.extend(patch_files);
+
+    let file_entries = files
+        .iter()
+        .map(|file| BundleFileEntry {
+            path: file.archive_path.clone(),
+            sha256: sha256_hex(&file.bytes),
+            bytes: u64::try_from(file.bytes.len()).unwrap_or(u64::MAX),
+        })
+        .collect::<Vec<_>>();
+
+    let bundle_manifest = BundleManifest {
+        artifact_kind: ArtifactKind::BundleManifest,
+        schema_version: ArtifactSchemaVersion::CURRENT,
+        source_sweep_dir: ".".into(),
+        source_manifest_hash,
+        harness_git_sha: current_git_sha(),
+        bundle_generated_at: bundle_generated_at()?,
+        instance_scope: args.instance.clone().unwrap_or_else(|| "full".into()),
+        files: file_entries.clone(),
+    };
+    let bundle_bytes = serde_json::to_vec_pretty(&bundle_manifest)?;
+
+    write_archive_atomically(&args.output_path, &files, &bundle_bytes)?;
+
+    Ok(BundleCreateReport {
+        output_path: args.output_path.clone(),
+        files: file_entries,
+    })
+}
+
+pub fn verify_bundle(archive_path: &Path) -> Result<BundleVerifyReport, BundleError> {
+    let mut actual = read_archive_files(archive_path)?;
+    let mut problems = Vec::new();
+    let Some(bundle_bytes) = actual.remove(BUNDLE_MANIFEST_PATH) else {
+        return Ok(BundleVerifyReport {
+            problems: vec![format!("missing:{BUNDLE_MANIFEST_PATH}")],
+        });
+    };
+    let bundle: BundleManifest = serde_json::from_slice(&bundle_bytes)?;
+    if bundle.artifact_kind != ArtifactKind::BundleManifest {
+        return Err(BundleError::Schema(format!(
+            "bundle: artifact kind mismatch: expected bundle_manifest, found {}",
+            bundle.artifact_kind
+        )));
+    }
+    if bundle.schema_version.major > ArtifactSchemaVersion::CURRENT.major {
+        return Err(BundleError::Schema(format!(
+            "bundle: unsupported future bundle schema {}",
+            bundle.schema_version
+        )));
+    }
+
+    let expected = bundle
+        .files
+        .iter()
+        .map(|entry| (entry.path.clone(), entry))
+        .collect::<BTreeMap<_, _>>();
+
+    for (path, entry) in &expected {
+        match actual.get(path) {
+            Some(bytes) => {
+                if u64::try_from(bytes.len()).unwrap_or(u64::MAX) != entry.bytes {
+                    problems.push(format!("hash_mismatch:{path}"));
+                    continue;
+                }
+                let digest = sha256_hex(bytes);
+                if digest != entry.sha256 {
+                    problems.push(format!("hash_mismatch:{path}"));
+                }
+            }
+            None => problems.push(format!("missing:{path}")),
+        }
+    }
+
+    for path in actual.keys() {
+        if !expected.contains_key(path) {
+            problems.push(format!("extra:{path}"));
+        }
+    }
+    problems.sort();
+    Ok(BundleVerifyReport { problems })
+}
+
+fn load_manifest_bytes(
+    sweep_dir: &Path,
+    results_value: &serde_json::Value,
+    normalizer: &PathNormalizer,
+) -> Result<Vec<u8>, BundleError> {
+    let manifest_path = sweep_dir.join("manifest.json");
+    if manifest_path.exists() {
+        return normalized_text_file(&manifest_path, normalizer);
+    }
+    let manifest = results_value.get("manifest").ok_or_else(|| {
+        BundleError::MissingSource("bundle: results.json has no manifest block".into())
+    })?;
+    normalized_json_bytes(manifest, normalizer)
+}
+
+fn source_redactor(
+    results_value: &serde_json::Value,
+    manifest_value: &serde_json::Value,
+) -> Redactor {
+    let mut cfg = RedactionCfg::default();
+    for source in [results_value, manifest_value] {
+        for pointer in ["/manifest/config/resolved", "/config/resolved"] {
+            if let Some(resolved) = source.pointer(pointer).and_then(serde_json::Value::as_str) {
+                merge_resolved_redaction(&mut cfg, resolved);
+            }
+        }
+    }
+    Redactor::from_config_lossy(&cfg)
+}
+
+fn merge_resolved_redaction(cfg: &mut RedactionCfg, resolved: &str) {
+    let Ok(parsed) = toml::from_str::<ResolvedConfigForBundle>(resolved) else {
+        return;
+    };
+    let Some(redaction) = parsed.redaction else {
+        return;
+    };
+    cfg.secret_literals.extend(
+        redaction
+            .secret_literals
+            .into_iter()
+            .filter(|value| !looks_like_redaction_marker(value)),
+    );
+    cfg.custom_patterns.extend(
+        redaction
+            .custom_patterns
+            .into_iter()
+            .filter(|value| !looks_like_redaction_marker(value))
+            .filter(|value| Regex::new(value).is_ok()),
+    );
+}
+
+fn looks_like_redaction_marker(value: &str) -> bool {
+    value.starts_with("[REDACTED:")
+}
+
+fn load_optional_evaluation(
+    sweep_dir: &Path,
+    included: &BTreeSet<String>,
+    normalizer: &PathNormalizer,
+) -> Result<Option<Vec<u8>>, BundleError> {
+    let path = sweep_dir.join("evaluation.json");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let text = std::fs::read_to_string(&path)?;
+    let mut value: serde_json::Value = serde_json::from_str(&text)?;
+    classify_json_value(
+        &value,
+        ArtifactKind::EvaluationResults,
+        path.display().to_string(),
+    )
+    .map_err(|err| BundleError::Schema(err.to_string()))?;
+    if let Some(instances) = value
+        .get_mut("instances")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        instances.retain(|row| {
+            row.get("instance_id")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|id| included.contains(id))
+        });
+    }
+    normalized_json_bytes(&value, normalizer).map(Some)
+}
+
+fn filter_results_for_scope(value: &mut serde_json::Value, included: &BTreeSet<String>) {
+    let Some((total, submitted, skipped, with_patch, patch_empty, budget_halted, failures)) = value
+        .get_mut("instances")
+        .and_then(serde_json::Value::as_array_mut)
+        .map(|instances| {
+            instances.retain(|row| {
+                row.get("instance_id")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|id| included.contains(id))
+            });
+
+            let total = instances.len();
+            let submitted = instances
+                .iter()
+                .filter(|row| string_field(row, "outcome") == Some("submitted"))
+                .count();
+            let skipped = instances
+                .iter()
+                .filter(|row| {
+                    string_field(row, "outcome") == Some("skipped")
+                        || string_field(row, "exit_reason") == Some("skipped")
+                })
+                .count();
+            let with_patch = instances
+                .iter()
+                .filter(|row| bool_field(row, "patch_present"))
+                .count();
+            let patch_empty = instances
+                .iter()
+                .filter(|row| {
+                    bool_field(row, "patch_present") && !bool_field(row, "non_empty_patch")
+                })
+                .count();
+            let budget_halted = instances
+                .iter()
+                .filter(|row| string_field(row, "exit_reason") == Some("budget_halt"))
+                .count();
+            let mut failures = serde_json::Map::new();
+            for category in instances
+                .iter()
+                .filter_map(|row| string_field(row, "failure_category"))
+            {
+                let next = failures
+                    .get(category)
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or_default()
+                    .saturating_add(1);
+                failures.insert(category.to_owned(), serde_json::json!(next));
+            }
+            (
+                total,
+                submitted,
+                skipped,
+                with_patch,
+                patch_empty,
+                budget_halted,
+                failures,
+            )
+        })
+    else {
+        return;
+    };
+
+    if let serde_json::Value::Object(map) = value {
+        map.insert("total".into(), serde_json::json!(total));
+        map.insert("completed".into(), serde_json::json!(total));
+        map.insert("submitted".into(), serde_json::json!(submitted));
+        map.insert("skipped".into(), serde_json::json!(skipped));
+        map.insert(
+            "errored".into(),
+            serde_json::json!(total.saturating_sub(submitted + skipped)),
+        );
+        map.insert("with_patch".into(), serde_json::json!(with_patch));
+        map.insert("patch_empty".into(), serde_json::json!(patch_empty));
+        map.insert("budget_halted".into(), serde_json::json!(budget_halted));
+        map.insert(
+            "failures_by_category".into(),
+            serde_json::Value::Object(failures),
+        );
+        if let Some(filter_spec) = map
+            .get_mut("filter_spec")
+            .and_then(serde_json::Value::as_object_mut)
+        {
+            filter_spec.insert("selected_count".into(), serde_json::json!(total));
+            filter_spec.insert(
+                "instance_ids".into(),
+                serde_json::Value::Array(
+                    included
+                        .iter()
+                        .map(|id| serde_json::Value::String(id.clone()))
+                        .collect(),
+                ),
+            );
+        }
+    }
+}
+
+fn string_field<'a>(value: &'a serde_json::Value, key: &str) -> Option<&'a str> {
+    value.get(key).and_then(serde_json::Value::as_str)
+}
+
+fn bool_field(value: &serde_json::Value, key: &str) -> bool {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn instance_ids_from_results(value: &serde_json::Value) -> Result<Vec<String>, BundleError> {
+    let instances = value
+        .get("instances")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| {
+            BundleError::MissingSource("bundle: results.json has no instances".into())
+        })?;
+    let mut ids = Vec::new();
+    for row in instances {
+        let id = row
+            .get("instance_id")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                BundleError::MissingSource(
+                    "bundle: results.json instance missing instance_id".into(),
+                )
+            })?;
+        validate_instance_scope(Some(id))?;
+        ids.push(id.to_owned());
+    }
+    Ok(ids)
+}
+
+fn included_instance_ids(
+    all: &[String],
+    requested: Option<&str>,
+) -> Result<Vec<String>, BundleError> {
+    match requested {
+        Some(id) => {
+            if all.iter().any(|candidate| candidate == id) {
+                Ok(vec![id.to_owned()])
+            } else {
+                Err(BundleError::MissingSource(format!(
+                    "bundle: instance `{id}` not found in results.json"
+                )))
+            }
+        }
+        None => Ok(all.to_vec()),
+    }
+}
+
+fn validate_instance_scope(instance: Option<&str>) -> Result<(), BundleError> {
+    let Some(instance) = instance else {
+        return Ok(());
+    };
+    let invalid = instance.is_empty()
+        || instance.contains('/')
+        || instance.contains('\\')
+        || instance.contains('\0')
+        || instance == "."
+        || instance == "..";
+    if invalid {
+        return Err(BundleError::MissingSource(format!(
+            "bundle: invalid instance id for bundle layout: `{instance}`"
+        )));
+    }
+    Ok(())
+}
+
+fn find_trajectory_path(sweep_dir: &Path, instance_id: &str) -> Option<PathBuf> {
+    [
+        sweep_dir.join(instance_id).join("trajectory.json"),
+        sweep_dir.join(instance_id).join("run-1.traj.json"),
+        sweep_dir.join(format!("{instance_id}.traj.json")),
+        sweep_dir
+            .join("trajectories")
+            .join(format!("{instance_id}.traj.json")),
+    ]
+    .into_iter()
+    .find(|path| path.exists())
+}
+
+fn find_patch_path(sweep_dir: &Path, instance_id: &str) -> Option<PathBuf> {
+    [
+        sweep_dir.join(instance_id).join("run-1.patch"),
+        sweep_dir.join(format!("{instance_id}.patch")),
+        sweep_dir
+            .join("patches")
+            .join(format!("{instance_id}.patch")),
+    ]
+    .into_iter()
+    .find(|path| path.exists())
+}
+
+fn read_required_text(path: &Path, label: &str) -> Result<String, BundleError> {
+    std::fs::read_to_string(path).map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            BundleError::MissingSource(format!("bundle: missing {label}: {}", path.display()))
+        } else {
+            BundleError::Io(err)
+        }
+    })
+}
+
+fn normalized_text_file(path: &Path, normalizer: &PathNormalizer) -> Result<Vec<u8>, BundleError> {
+    let text = std::fs::read_to_string(path)?;
+    Ok(normalizer.normalize_text(&text).into_bytes())
+}
+
+fn normalized_json_bytes(
+    value: &serde_json::Value,
+    normalizer: &PathNormalizer,
+) -> Result<Vec<u8>, BundleError> {
+    let mut text = serde_json::to_string_pretty(value)?;
+    text.push('\n');
+    Ok(normalizer.normalize_text(&text).into_bytes())
+}
+
+fn strict_redaction_check(
+    archive_path: &str,
+    bytes: &[u8],
+    redactor: &Redactor,
+) -> Result<(), BundleError> {
+    let text = std::str::from_utf8(bytes).map_err(|err| {
+        BundleError::InvalidArchive(format!("bundle: {archive_path} is not UTF-8: {err}"))
+    })?;
+    let outcome = redactor.redact_text(text, surface::EXPORT);
+    if outcome.redacted {
+        return Err(BundleError::RedactionRetrigger {
+            path: archive_path.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn write_archive_atomically(
+    output_path: &Path,
+    files: &[PreparedFile],
+    bundle_bytes: &[u8],
+) -> Result<(), BundleError> {
+    if let Some(parent) = output_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let tmp = temporary_output_path(output_path);
+    let result = write_archive(&tmp, files, bundle_bytes);
+    if let Err(err) = result {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(err);
+    }
+    if output_path.exists() {
+        std::fs::remove_file(output_path)?;
+    }
+    std::fs::rename(&tmp, output_path)?;
+    Ok(())
+}
+
+fn write_archive(
+    output_path: &Path,
+    files: &[PreparedFile],
+    bundle_bytes: &[u8],
+) -> Result<(), BundleError> {
+    let file = std::fs::File::create(output_path)?;
+    let encoder = GzBuilder::new()
+        .mtime(0)
+        .write(file, Compression::default());
+    let mut builder = tar::Builder::new(encoder);
+    for file in files {
+        append_tar_file(&mut builder, &file.archive_path, &file.bytes)?;
+    }
+    append_tar_file(&mut builder, BUNDLE_MANIFEST_PATH, bundle_bytes)?;
+    let encoder = builder.into_inner()?;
+    encoder.finish()?;
+    Ok(())
+}
+
+fn append_tar_file<W: std::io::Write>(
+    builder: &mut tar::Builder<W>,
+    archive_path: &str,
+    bytes: &[u8],
+) -> Result<(), BundleError> {
+    validate_archive_path(archive_path)?;
+    let mut header = tar::Header::new_gnu();
+    header.set_size(u64::try_from(bytes.len()).unwrap_or(u64::MAX));
+    header.set_mode(0o644);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_entry_type(tar::EntryType::Regular);
+    header.set_cksum();
+    builder.append_data(&mut header, archive_path, &mut Cursor::new(bytes))?;
+    Ok(())
+}
+
+fn temporary_output_path(output_path: &Path) -> PathBuf {
+    let pid = std::process::id();
+    let file_name = output_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map_or_else(|| "bundle.tar.gz".to_owned(), ToOwned::to_owned);
+    output_path.with_file_name(format!(".{file_name}.{pid}.tmp"))
+}
+
+fn read_archive_files(archive_path: &Path) -> Result<BTreeMap<String, Vec<u8>>, BundleError> {
+    let file = std::fs::File::open(archive_path)?;
+    let decoder = GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+    let mut out = BTreeMap::new();
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+        let raw_path = entry.path()?;
+        let path = normalize_archive_path(&raw_path)?;
+        let mut bytes = Vec::new();
+        entry.read_to_end(&mut bytes)?;
+        if out.insert(path.clone(), bytes).is_some() {
+            return Err(BundleError::InvalidArchive(format!(
+                "bundle: duplicate archive entry {path}"
+            )));
+        }
+    }
+    Ok(out)
+}
+
+fn validate_archive_path(path: &str) -> Result<(), BundleError> {
+    let normalized = normalize_archive_path(Path::new(path))?;
+    if normalized != path {
+        return Err(BundleError::InvalidArchive(format!(
+            "bundle: non-normalized archive path `{path}`"
+        )));
+    }
+    Ok(())
+}
+
+fn normalize_archive_path(path: &Path) -> Result<String, BundleError> {
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => {
+                let text = part.to_str().ok_or_else(|| {
+                    BundleError::InvalidArchive("bundle: archive path is not UTF-8".into())
+                })?;
+                parts.push(text.to_owned());
+            }
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(BundleError::InvalidArchive(format!(
+                    "bundle: unsafe archive path `{}`",
+                    path.display()
+                )));
+            }
+        }
+    }
+    if parts.is_empty() {
+        return Err(BundleError::InvalidArchive(
+            "bundle: empty archive path".into(),
+        ));
+    }
+    Ok(parts.join("/"))
+}
+
+fn bundle_generated_at() -> Result<String, BundleError> {
+    if let Ok(epoch) = std::env::var("SOURCE_DATE_EPOCH") {
+        let seconds = epoch.parse::<i64>().map_err(|err| {
+            BundleError::MissingSource(format!("bundle: invalid SOURCE_DATE_EPOCH: {err}"))
+        })?;
+        let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(seconds, 0).ok_or_else(|| {
+            BundleError::MissingSource("bundle: SOURCE_DATE_EPOCH is out of range".into())
+        })?;
+        return Ok(dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
+    }
+    Ok(chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+}
+
+fn current_git_sha() -> Option<String> {
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(out.stdout).ok()?;
+    let sha = text.trim();
+    (!sha.is_empty()).then(|| sha.to_owned())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+fn push_path_needles(out: &mut BTreeSet<String>, raw: &str) {
+    if raw.is_empty() {
+        return;
+    }
+    let slash = raw.replace('\\', "/");
+    let backslash = raw.replace('/', "\\");
+    for value in [raw.to_owned(), slash, backslash] {
+        out.insert(value.clone());
+        out.insert(value.replace('\\', "\\\\"));
+    }
+}

--- a/src/run/bundle.rs
+++ b/src/run/bundle.rs
@@ -314,11 +314,12 @@ pub fn verify_bundle(archive_path: &Path) -> Result<BundleVerifyReport, BundleEr
         )));
     }
 
-    let expected = bundle
-        .files
-        .iter()
-        .map(|entry| (entry.path.clone(), entry))
-        .collect::<BTreeMap<_, _>>();
+    let mut expected = BTreeMap::new();
+    for entry in &bundle.files {
+        if expected.insert(entry.path.clone(), entry).is_some() {
+            problems.push(format!("duplicate:{}", entry.path));
+        }
+    }
 
     for (path, entry) in &expected {
         match actual.get(path) {

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -746,7 +746,13 @@ fn resolve_trajectory_path(sweep: &Path, instance_id: &str) -> Option<PathBuf> {
         return Some(nested_run);
     }
     let flat = sweep.join(format!("{instance_id}.traj.json"));
-    flat.exists().then_some(flat)
+    if flat.exists() {
+        return Some(flat);
+    }
+    let bundled = sweep
+        .join("trajectories")
+        .join(format!("{instance_id}.traj.json"));
+    bundled.exists().then_some(bundled)
 }
 
 #[derive(Debug, Clone)]

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,6 +1,7 @@
 //! Runners: thin glue that wires (config + model + env + agent) together
 //! and writes trajectories to disk.
 
+pub mod bundle;
 pub mod calibrate;
 pub mod compare;
 pub mod dataset;

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -1130,7 +1130,13 @@ pub fn existing_patch_path_for_run(
     if nested.exists() || run_index != 1 {
         return nested;
     }
-    legacy_patch_path_for(output_dir, instance_id)
+    let legacy = legacy_patch_path_for(output_dir, instance_id);
+    if legacy.exists() {
+        return legacy;
+    }
+    output_dir
+        .join("patches")
+        .join(format!("{instance_id}.patch"))
 }
 
 /// Path of the aggregated SWE-bench predictions file written at the end of

--- a/src/run/trajectory_diff.rs
+++ b/src/run/trajectory_diff.rs
@@ -182,7 +182,13 @@ pub fn resolve_trajectory_path(sweep: &Path, instance_id: &str) -> Option<PathBu
         return Some(nested_run);
     }
     let flat = sweep.join(format!("{instance_id}.traj.json"));
-    flat.exists().then_some(flat)
+    if flat.exists() {
+        return Some(flat);
+    }
+    let bundled = sweep
+        .join("trajectories")
+        .join(format!("{instance_id}.traj.json"));
+    bundled.exists().then_some(bundled)
 }
 
 pub fn render_text(report: &TrajectoryDiffReport) -> String {

--- a/src/run/triage.rs
+++ b/src/run/triage.rs
@@ -552,7 +552,13 @@ fn resolve_trajectory_path(sweep: &Path, instance_id: &str) -> Option<PathBuf> {
         return Some(nested_run);
     }
     let flat = sweep.join(format!("{instance_id}.traj.json"));
-    flat.exists().then_some(flat)
+    if flat.exists() {
+        return Some(flat);
+    }
+    let bundled = sweep
+        .join("trajectories")
+        .join(format!("{instance_id}.traj.json"));
+    bundled.exists().then_some(bundled)
 }
 
 fn relative_path_string(base: &Path, path: &Path) -> String {

--- a/tests/bench_bundle.rs
+++ b/tests/bench_bundle.rs
@@ -1,0 +1,683 @@
+//! `bench bundle`: portable, redacted, verifiable sweep archives.
+
+#![allow(clippy::unwrap_used)]
+
+use std::fs;
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+mod support;
+use support::binary_path;
+
+const FIXTURE_SWEEP: &str = "tests/fixtures/bundle/sweep";
+const FIXED_EPOCH: &str = "1778371200";
+
+#[test]
+fn help_lists_bundle_subcommand_and_flags() {
+    let out = Command::new(binary_path())
+        .args(["bench", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("bundle"), "stdout:\n{stdout}");
+
+    let out = Command::new(binary_path())
+        .args(["bench", "bundle", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in ["--sweep", "--output", "--instance", "--verify"] {
+        assert!(stdout.contains(flag), "missing {flag} in:\n{stdout}");
+    }
+}
+
+#[test]
+fn bundle_create_verify_full_sweep_round_trips_with_fixed_layout() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    inject_absolute_source_path(&sweep);
+    let archive = work.path().join("full.tar.gz");
+
+    let out = bundle_create(&sweep, &archive, None);
+    assert_success(&out);
+
+    let entries = tar_list(&archive);
+    assert_eq!(entries.last().map(String::as_str), Some("BUNDLE.json"));
+    assert_eq!(
+        entries,
+        vec![
+            "manifest.json",
+            "results.json",
+            "evaluation.json",
+            "trajectories/alpha.traj.json",
+            "trajectories/beta.traj.json",
+            "patches/alpha.patch",
+            "BUNDLE.json",
+        ]
+    );
+    assert!(
+        !entries.iter().any(|path| path.contains("ignored")),
+        "unexpected ignored file in archive: {entries:?}"
+    );
+
+    let out = bundle_verify(&archive);
+    assert_success(&out);
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("bundle:ok"),
+        "stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    let extracted = work.path().join("extracted-full");
+    extract_tar(&archive, &extracted);
+    let bundle: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(extracted.join("BUNDLE.json")).unwrap()).unwrap();
+    assert_eq!(bundle["artifact_kind"], "bundle_manifest");
+    assert_eq!(bundle["instance_scope"], "full");
+    assert_eq!(bundle["source_sweep_dir"], ".");
+    assert!(
+        bundle["source_manifest_hash"]
+            .as_str()
+            .unwrap()
+            .starts_with("sha256:")
+    );
+    let files = bundle["files"].as_array().unwrap();
+    assert_eq!(files.len(), 6);
+    assert!(
+        files
+            .iter()
+            .all(|file| file["path"].as_str() != Some("BUNDLE.json"))
+    );
+
+    assert_extracted_files_do_not_contain(&extracted, &sweep.display().to_string());
+    assert_extracted_files_do_not_contain(&extracted, &json_escaped_path(&sweep));
+
+    let out = Command::new(binary_path())
+        .args(["bench", "inspect", "--sweep"])
+        .arg(&extracted)
+        .args(["--instance", "alpha"])
+        .output()
+        .unwrap();
+    assert_success(&out);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("instance_id:      alpha"), "{stdout}");
+}
+
+#[test]
+fn bundle_redaction_uses_source_manifest_custom_patterns() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    inject_custom_redaction_pattern(&sweep);
+    let archive = work.path().join("custom-pattern.tar.gz");
+    fs::write(
+        sweep.join("alpha.traj.json"),
+        "post-sweep injected secret: LEGALHOLD-1234\n",
+    )
+    .unwrap();
+
+    let out = bundle_create(&sweep, &archive, None);
+    assert!(!out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("redaction:retrigger:trajectories/alpha.traj.json")
+            || stderr.contains("redaction:retrigger:trajectories/alpha.traj.json"),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(!archive.exists(), "bundle command must fail closed");
+}
+
+#[test]
+fn bundle_redaction_uses_standalone_manifest_custom_patterns() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    inject_standalone_manifest_redaction_pattern(&sweep);
+    let archive = work.path().join("standalone-pattern.tar.gz");
+    fs::write(
+        sweep.join("alpha.traj.json"),
+        "post-sweep injected secret: LEGALHOLD-1234\n",
+    )
+    .unwrap();
+
+    let out = bundle_create(&sweep, &archive, None);
+    assert!(!out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("redaction:retrigger:trajectories/alpha.traj.json")
+            || stderr.contains("redaction:retrigger:trajectories/alpha.traj.json"),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(!archive.exists(), "bundle command must fail closed");
+}
+
+#[test]
+fn bundle_normalizes_unrelated_absolute_paths_inside_artifacts() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    let other_abs = if cfg!(windows) {
+        r"C:\Users\markm\elsewhere\secret.txt"
+    } else {
+        "/var/tmp/elsewhere/secret.txt"
+    };
+    inject_text_into_json_string(
+        &sweep.join("alpha.traj.json"),
+        "/messages/0/content",
+        &format!("looked at {other_abs}"),
+    );
+    let archive = work.path().join("paths.tar.gz");
+
+    assert_success(&bundle_create(&sweep, &archive, None));
+
+    let extracted = work.path().join("extracted-paths");
+    extract_tar(&archive, &extracted);
+    assert_extracted_files_do_not_contain(&extracted, other_abs);
+    assert_extracted_files_do_not_contain(&extracted, &other_abs.replace('\\', "\\\\"));
+}
+
+#[test]
+fn extracted_bundle_runs_bench_triage_without_layout_rewrite() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    let archive = work.path().join("triage.tar.gz");
+    assert_success(&bundle_create(&sweep, &archive, None));
+    let extracted = work.path().join("extracted-triage");
+    extract_tar(&archive, &extracted);
+
+    let out = Command::new(binary_path())
+        .args(["bench", "triage", "--sweep"])
+        .arg(&extracted)
+        .args(["--format", "json"])
+        .output()
+        .unwrap();
+    assert_success(&out);
+    let report: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert!(
+        report["clusters"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|cluster| cluster["instance_ids"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|id| id == "beta")),
+        "{report:#}"
+    );
+}
+
+#[test]
+fn extracted_bundle_runs_bench_reproduce_manifest_smoke_without_layout_rewrite() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    let archive = work.path().join("reproduce.tar.gz");
+    assert_success(&bundle_create(&sweep, &archive, None));
+    let extracted = work.path().join("extracted-reproduce");
+    extract_tar(&archive, &extracted);
+    let output = work.path().join("replay");
+
+    let out = Command::new(binary_path())
+        .args(["bench", "reproduce", "--from"])
+        .arg(&extracted)
+        .arg("--output")
+        .arg(&output)
+        .args([
+            "--allow-drift",
+            "harness.git_sha",
+            "--limit",
+            "0",
+            "--skip-model-probe",
+        ])
+        .output()
+        .unwrap();
+    assert_success(&out);
+    assert!(output.join("reproducibility.json").exists());
+}
+
+#[test]
+fn bundle_instance_scope_includes_only_requested_instance_artifacts() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    let archive = work.path().join("alpha.tar.gz");
+
+    let out = bundle_create(&sweep, &archive, Some("alpha"));
+    assert_success(&out);
+
+    let entries = tar_list(&archive);
+    assert!(entries.contains(&"trajectories/alpha.traj.json".to_owned()));
+    assert!(entries.contains(&"patches/alpha.patch".to_owned()));
+    assert!(
+        !entries.iter().any(|path| path.contains("beta")),
+        "{entries:?}"
+    );
+
+    let extracted = work.path().join("extracted-alpha");
+    extract_tar(&archive, &extracted);
+    let bundle: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(extracted.join("BUNDLE.json")).unwrap()).unwrap();
+    assert_eq!(bundle["instance_scope"], "alpha");
+
+    let results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(extracted.join("results.json")).unwrap()).unwrap();
+    assert_eq!(results["total"], 1);
+    assert_eq!(results["instances"].as_array().unwrap().len(), 1);
+    assert_eq!(results["instances"][0]["instance_id"], "alpha");
+
+    let evaluation: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(extracted.join("evaluation.json")).unwrap())
+            .unwrap();
+    assert_eq!(evaluation["instances"].as_array().unwrap().len(), 1);
+    assert_eq!(evaluation["instances"][0]["instance_id"], "alpha");
+}
+
+#[test]
+fn bundle_create_is_identical_modulo_timestamp_without_fixed_epoch() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    let first = work.path().join("first-live.tar.gz");
+    let second = work.path().join("second-live.tar.gz");
+
+    assert_success(&bundle_create_live_timestamp(&sweep, &first, None));
+    std::thread::sleep(Duration::from_secs(1));
+    assert_success(&bundle_create_live_timestamp(&sweep, &second, None));
+
+    let first_entries = canonical_archive_entries_modulo_timestamp(&first);
+    let second_entries = canonical_archive_entries_modulo_timestamp(&second);
+    assert_eq!(first_entries, second_entries);
+}
+
+#[test]
+fn bundle_create_is_byte_identical_with_fixed_timestamp() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    let first = work.path().join("first.tar.gz");
+    let second = work.path().join("second.tar.gz");
+
+    assert_success(&bundle_create(&sweep, &first, None));
+    assert_success(&bundle_create(&sweep, &second, None));
+
+    let first_bytes = fs::read(&first).unwrap();
+    let second_bytes = fs::read(&second).unwrap();
+    assert_eq!(first_bytes, second_bytes);
+}
+
+#[test]
+fn bundle_size_stays_within_ratio_of_explicit_file_tar() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    let archive = work.path().join("ratio.tar.gz");
+    assert_success(&bundle_create(&sweep, &archive, None));
+    let extracted = work.path().join("extracted-ratio");
+    extract_tar(&archive, &extracted);
+
+    let baseline_tar = work.path().join("explicit.tar");
+    pack_explicit_files_uncompressed(&extracted, &baseline_tar);
+    let bundle_size = fs::metadata(&archive).unwrap().len();
+    let baseline_size = fs::metadata(&baseline_tar).unwrap().len();
+    assert!(
+        bundle_size.saturating_mul(10) <= baseline_size.saturating_mul(12),
+        "bundle {bundle_size} should be <= 1.2x baseline tar {baseline_size}"
+    );
+}
+
+#[test]
+fn bundle_redaction_retrigger_fails_closed_and_writes_nothing() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    let archive = work.path().join("leaky.tar.gz");
+    fs::write(
+        sweep.join("alpha.traj.json"),
+        "ghp_0123456789ABCDEF0123456789ABCDEF0123\n",
+    )
+    .unwrap();
+
+    let out = bundle_create(&sweep, &archive, None);
+    assert!(!out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("redaction:retrigger") || stderr.contains("redaction:retrigger"),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(!archive.exists(), "bundle command must fail closed");
+}
+
+#[test]
+fn extracted_bundle_contains_no_known_secret_shapes() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    let archive = work.path().join("clean-secrets.tar.gz");
+    assert_success(&bundle_create(&sweep, &archive, None));
+    let extracted = work.path().join("extracted-secrets");
+    extract_tar(&archive, &extracted);
+
+    assert_no_known_secret_shapes(&extracted);
+}
+
+#[test]
+fn bundle_verify_reports_extra_missing_and_hash_mismatch() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    let archive = work.path().join("clean.tar.gz");
+    assert_success(&bundle_create(&sweep, &archive, None));
+
+    let extra_dir = work.path().join("extra");
+    extract_tar(&archive, &extra_dir);
+    fs::write(extra_dir.join("extra.txt"), "not in BUNDLE\n").unwrap();
+    let extra_archive = work.path().join("extra.tar.gz");
+    pack_dir(&extra_dir, &extra_archive);
+    let out = bundle_verify(&extra_archive);
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("extra:extra.txt"),
+        "stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    let missing_dir = work.path().join("missing");
+    extract_tar(&archive, &missing_dir);
+    fs::remove_file(missing_dir.join("patches/alpha.patch")).unwrap();
+    let missing_archive = work.path().join("missing.tar.gz");
+    pack_dir(&missing_dir, &missing_archive);
+    let out = bundle_verify(&missing_archive);
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("missing:patches/alpha.patch"),
+        "stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    let tampered_dir = work.path().join("tampered");
+    extract_tar(&archive, &tampered_dir);
+    fs::write(
+        tampered_dir.join("trajectories/alpha.traj.json"),
+        "{\"tampered\":true}\n",
+    )
+    .unwrap();
+    let tampered_archive = work.path().join("tampered.tar.gz");
+    pack_dir(&tampered_dir, &tampered_archive);
+    let out = bundle_verify(&tampered_archive);
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("hash_mismatch:trajectories/alpha.traj.json"),
+        "stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+fn copy_fixture_sweep(root: &Path) -> PathBuf {
+    let dst = root.join("sweep");
+    copy_dir(Path::new(FIXTURE_SWEEP), &dst);
+    dst
+}
+
+fn copy_dir(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let ty = entry.file_type().unwrap();
+        let target = dst.join(entry.file_name());
+        if ty.is_dir() {
+            copy_dir(&entry.path(), &target);
+        } else {
+            fs::copy(entry.path(), target).unwrap();
+        }
+    }
+}
+
+fn inject_absolute_source_path(sweep: &Path) {
+    let path = sweep.join("results.json");
+    let mut value: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    value["manifest"]["dataset"]["path"] =
+        serde_json::json!(sweep.join("dataset.jsonl").display().to_string());
+    value["manifest"]["config"]["overlay_paths"] =
+        serde_json::json!([sweep.join("config.toml").display().to_string()]);
+    fs::write(&path, serde_json::to_string_pretty(&value).unwrap()).unwrap();
+}
+
+fn inject_custom_redaction_pattern(sweep: &Path) {
+    for path in [sweep.join("results.json"), sweep.join("manifest.json")] {
+        let mut value: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        if let Some(slot) = value.pointer_mut("/manifest/config/resolved") {
+            *slot = serde_json::json!(
+                "[model]\nname = \"deterministic\"\n\n[redaction]\ncustom_patterns = [\"LEGALHOLD-[0-9]{4}\"]\n"
+            );
+        } else if let Some(slot) = value.pointer_mut("/config/resolved") {
+            *slot = serde_json::json!(
+                "[model]\nname = \"deterministic\"\n\n[redaction]\ncustom_patterns = [\"LEGALHOLD-[0-9]{4}\"]\n"
+            );
+        }
+        fs::write(&path, serde_json::to_string_pretty(&value).unwrap()).unwrap();
+    }
+}
+
+fn inject_standalone_manifest_redaction_pattern(sweep: &Path) {
+    let path = sweep.join("manifest.json");
+    let mut value: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    *value.pointer_mut("/config/resolved").unwrap() = serde_json::json!(
+        "[model]\nname = \"deterministic\"\n\n[redaction]\ncustom_patterns = [\"LEGALHOLD-[0-9]{4}\"]\n"
+    );
+    fs::write(path, serde_json::to_string_pretty(&value).unwrap()).unwrap();
+}
+
+fn inject_text_into_json_string(path: &Path, pointer: &str, text: &str) {
+    let mut value: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap();
+    *value.pointer_mut(pointer).unwrap() = serde_json::json!(text);
+    fs::write(path, serde_json::to_string_pretty(&value).unwrap()).unwrap();
+}
+
+fn json_escaped_path(path: &Path) -> String {
+    path.display().to_string().replace('\\', "\\\\")
+}
+
+fn bundle_create(sweep: &Path, archive: &Path, instance: Option<&str>) -> std::process::Output {
+    bundle_create_with_epoch(sweep, archive, instance, Some(FIXED_EPOCH))
+}
+
+fn bundle_create_live_timestamp(
+    sweep: &Path,
+    archive: &Path,
+    instance: Option<&str>,
+) -> std::process::Output {
+    bundle_create_with_epoch(sweep, archive, instance, None)
+}
+
+fn bundle_create_with_epoch(
+    sweep: &Path,
+    archive: &Path,
+    instance: Option<&str>,
+    epoch: Option<&str>,
+) -> std::process::Output {
+    let mut cmd = Command::new(binary_path());
+    cmd.args(["bench", "bundle", "--sweep"])
+        .arg(sweep)
+        .arg("--output")
+        .arg(archive);
+    if let Some(epoch) = epoch {
+        cmd.env("SOURCE_DATE_EPOCH", epoch);
+    } else {
+        cmd.env_remove("SOURCE_DATE_EPOCH");
+    }
+    if let Some(instance) = instance {
+        cmd.arg("--instance").arg(instance);
+    }
+    cmd.output().unwrap()
+}
+
+fn bundle_verify(archive: &Path) -> std::process::Output {
+    Command::new(binary_path())
+        .args(["bench", "bundle", "--verify"])
+        .arg(archive)
+        .output()
+        .unwrap()
+}
+
+fn tar_list(archive: &Path) -> Vec<String> {
+    let out = Command::new("tar")
+        .arg("-tzf")
+        .arg(archive)
+        .output()
+        .unwrap();
+    assert_success(&out);
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(normalize_tar_path)
+        .filter(|path| !path.is_empty())
+        .collect()
+}
+
+fn extract_tar(archive: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap();
+    let out = Command::new("tar")
+        .arg("-xzf")
+        .arg(archive)
+        .arg("-C")
+        .arg(dst)
+        .output()
+        .unwrap();
+    assert_success(&out);
+}
+
+fn pack_dir(src: &Path, archive: &Path) {
+    let mut files = relative_files(src);
+    files.sort();
+    let mut cmd = Command::new("tar");
+    cmd.arg("-czf").arg(archive).arg("-C").arg(src);
+    for file in files {
+        cmd.arg(file);
+    }
+    let out = cmd.output().unwrap();
+    assert_success(&out);
+}
+
+fn pack_explicit_files_uncompressed(src: &Path, archive: &Path) {
+    let bundle: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(src.join("BUNDLE.json")).unwrap()).unwrap();
+    let mut files: Vec<String> = bundle["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["path"].as_str().unwrap().to_owned())
+        .collect();
+    files.sort();
+    let mut cmd = Command::new("tar");
+    cmd.arg("-cf").arg(archive).arg("-C").arg(src);
+    for file in files {
+        cmd.arg(file);
+    }
+    let out = cmd.output().unwrap();
+    assert_success(&out);
+}
+
+fn canonical_archive_entries_modulo_timestamp(archive: &Path) -> Vec<(String, Vec<u8>)> {
+    let mut entries = archive_entries(archive);
+    for (path, bytes) in &mut entries {
+        if path == "BUNDLE.json" {
+            let mut value: serde_json::Value = serde_json::from_slice(bytes).unwrap();
+            value["bundle_generated_at"] = serde_json::json!("1970-01-01T00:00:00Z");
+            *bytes = serde_json::to_vec_pretty(&value).unwrap();
+        }
+    }
+    entries
+}
+
+fn archive_entries(archive: &Path) -> Vec<(String, Vec<u8>)> {
+    let file = fs::File::open(archive).unwrap();
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+    let mut out = Vec::new();
+    for entry in archive.entries().unwrap() {
+        let mut entry = entry.unwrap();
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+        let path = normalize_tar_path(&entry.path().unwrap().to_string_lossy());
+        let mut bytes = Vec::new();
+        entry.read_to_end(&mut bytes).unwrap();
+        out.push((path, bytes));
+    }
+    out
+}
+
+fn relative_files(root: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    collect_relative_files(root, root, &mut out);
+    out
+}
+
+fn collect_relative_files(root: &Path, dir: &Path, out: &mut Vec<String>) {
+    for entry in fs::read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if entry.file_type().unwrap().is_dir() {
+            collect_relative_files(root, &path, out);
+        } else {
+            out.push(
+                path.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+            );
+        }
+    }
+}
+
+fn assert_no_known_secret_shapes(root: &Path) {
+    let patterns = [
+        regex::Regex::new(r"gh[pousr]_[A-Za-z0-9_]{20,}").unwrap(),
+        regex::Regex::new(r"github_pat_[A-Za-z0-9_]{20,}").unwrap(),
+        regex::Regex::new(r"sk-[A-Za-z0-9][A-Za-z0-9_-]{16,}").unwrap(),
+        regex::Regex::new(r"sk-ant-[A-Za-z0-9_-]{16,}").unwrap(),
+        regex::Regex::new(r"AKIA[0-9A-Z]{16}").unwrap(),
+        regex::Regex::new(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{16,}").unwrap(),
+    ];
+    for file in relative_files(root) {
+        let text = fs::read_to_string(root.join(&file)).unwrap();
+        for pattern in &patterns {
+            assert!(
+                !pattern.is_match(&text),
+                "{file} matched known-secret regex {}:\n{text}",
+                pattern.as_str()
+            );
+        }
+    }
+}
+
+fn assert_extracted_files_do_not_contain(root: &Path, needle: &str) {
+    if needle.is_empty() {
+        return;
+    }
+    for file in relative_files(root) {
+        let text = fs::read_to_string(root.join(&file)).unwrap();
+        assert!(
+            !text.contains(needle),
+            "{file} contains {needle:?}:\n{text}"
+        );
+    }
+}
+
+fn normalize_tar_path(raw: &str) -> String {
+    raw.trim()
+        .trim_start_matches("./")
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_owned()
+}
+
+fn assert_success(out: &std::process::Output) {
+    assert!(
+        out.status.success(),
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/tests/bench_bundle.rs
+++ b/tests/bench_bundle.rs
@@ -264,6 +264,12 @@ fn bundle_instance_scope_includes_only_requested_instance_artifacts() {
     let results: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(extracted.join("results.json")).unwrap()).unwrap();
     assert_eq!(results["total"], 1);
+    assert_eq!(results["completed"], 1);
+    assert_eq!(results["submitted"], 1);
+    assert_eq!(results["errored"], 0);
+    assert_eq!(results["total_input_tokens"], 10);
+    assert_eq!(results["total_completion_tokens"], 2);
+    assert_eq!(results["pass_at_k"], 1.0);
     assert_eq!(results["instances"].as_array().unwrap().len(), 1);
     assert_eq!(results["instances"][0]["instance_id"], "alpha");
 
@@ -404,6 +410,18 @@ fn bundle_verify_reports_extra_missing_and_hash_mismatch() {
     assert!(!out.status.success());
     assert!(
         String::from_utf8_lossy(&out.stdout).contains("hash_mismatch:trajectories/alpha.traj.json"),
+        "stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    let symlink_dir = work.path().join("symlink");
+    extract_tar(&archive, &symlink_dir);
+    let symlink_archive = work.path().join("symlink.tar.gz");
+    pack_dir_with_extra_symlink(&symlink_dir, &symlink_archive);
+    let out = bundle_verify(&symlink_archive);
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("extra:links/outside"),
         "stdout:\n{}",
         String::from_utf8_lossy(&out.stdout)
     );
@@ -575,6 +593,34 @@ fn pack_explicit_files_uncompressed(src: &Path, archive: &Path) {
     }
     let out = cmd.output().unwrap();
     assert_success(&out);
+}
+
+fn pack_dir_with_extra_symlink(src: &Path, archive: &Path) {
+    let file = fs::File::create(archive).unwrap();
+    let encoder = flate2::GzBuilder::new()
+        .mtime(0)
+        .write(file, flate2::Compression::default());
+    let mut builder = tar::Builder::new(encoder);
+    let mut files = relative_files(src);
+    files.sort();
+    for path in files {
+        builder
+            .append_path_with_name(src.join(&path), path)
+            .unwrap();
+    }
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(tar::EntryType::Symlink);
+    header.set_size(0);
+    header.set_mode(0o777);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_cksum();
+    builder
+        .append_link(&mut header, "links/outside", "../outside")
+        .unwrap();
+    let encoder = builder.into_inner().unwrap();
+    encoder.finish().unwrap();
 }
 
 fn canonical_archive_entries_modulo_timestamp(archive: &Path) -> Vec<(String, Vec<u8>)> {

--- a/tests/bench_bundle.rs
+++ b/tests/bench_bundle.rs
@@ -239,6 +239,44 @@ fn extracted_bundle_runs_bench_reproduce_manifest_smoke_without_layout_rewrite()
 }
 
 #[test]
+fn extracted_bundle_reproduce_with_positive_limit_requires_real_local_dataset() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    let archive = work.path().join("reproduce-positive.tar.gz");
+    assert_success(&bundle_create(&sweep, &archive, None));
+    let extracted = work.path().join("extracted-reproduce-positive");
+    extract_tar(&archive, &extracted);
+    let output = work.path().join("replay-positive");
+
+    let out = Command::new(binary_path())
+        .args(["bench", "reproduce", "--from"])
+        .arg(&extracted)
+        .arg("--output")
+        .arg(&output)
+        .args([
+            "--allow-drift",
+            "harness.git_sha",
+            "--limit",
+            "1",
+            "--skip-model-probe",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("bundle reproduce requires the original local dataset"),
+        "stderr:\n{stderr}\nstdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert!(
+        !output.join("bundle-reproduce.instances.jsonl").exists(),
+        "positive replay must not synthesize runnable SWE-bench rows"
+    );
+}
+
+#[test]
 fn bundle_instance_scope_includes_only_requested_instance_artifacts() {
     let work = tempfile::tempdir().unwrap();
     let sweep = copy_fixture_sweep(work.path());
@@ -362,6 +400,33 @@ fn extracted_bundle_contains_no_known_secret_shapes() {
     extract_tar(&archive, &extracted);
 
     assert_no_known_secret_shapes(&extracted);
+}
+
+#[test]
+fn bundle_verify_reports_duplicate_manifest_paths() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    let archive = work.path().join("clean.tar.gz");
+    assert_success(&bundle_create(&sweep, &archive, None));
+
+    let duplicate_dir = work.path().join("duplicate-manifest-path");
+    extract_tar(&archive, &duplicate_dir);
+    let bundle_path = duplicate_dir.join("BUNDLE.json");
+    let mut bundle: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&bundle_path).unwrap()).unwrap();
+    let first_file = bundle["files"].as_array().unwrap()[0].clone();
+    bundle["files"].as_array_mut().unwrap().push(first_file);
+    fs::write(&bundle_path, serde_json::to_string_pretty(&bundle).unwrap()).unwrap();
+    let duplicate_archive = work.path().join("duplicate-manifest-path.tar.gz");
+    pack_dir(&duplicate_dir, &duplicate_archive);
+
+    let out = bundle_verify(&duplicate_archive);
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("duplicate:manifest.json"),
+        "stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
 }
 
 #[test]

--- a/tests/bench_bundle.rs
+++ b/tests/bench_bundle.rs
@@ -521,6 +521,73 @@ fn bundle_instance_scope_uses_rerun_slots_for_scoped_aggregates() {
 }
 
 #[test]
+fn bundle_full_sweep_allows_budget_halted_row_without_trajectory() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    append_budget_halted_instance(&sweep, "budgeted");
+    let archive = work.path().join("full-budgeted.tar.gz");
+
+    let out = bundle_create(&sweep, &archive, None);
+    assert_success(&out);
+
+    let entries = tar_list(&archive);
+    assert!(entries.contains(&"trajectories/alpha.traj.json".to_owned()));
+    assert!(entries.contains(&"trajectories/beta.traj.json".to_owned()));
+    assert!(
+        !entries.iter().any(|path| path.contains("budgeted")),
+        "{entries:?}"
+    );
+    assert_success(&bundle_verify(&archive));
+
+    let extracted = work.path().join("extracted-full-budgeted");
+    extract_tar(&archive, &extracted);
+    let results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(extracted.join("results.json")).unwrap()).unwrap();
+    assert!(
+        results["instances"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|row| row["instance_id"] == "budgeted" && row["exit_reason"] == "budget_halt"),
+        "{results:#}"
+    );
+}
+
+#[test]
+fn bundle_instance_scope_allows_budget_halted_row_without_trajectory() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    append_budget_halted_instance(&sweep, "budgeted");
+    let archive = work.path().join("budgeted-only.tar.gz");
+
+    let out = bundle_create(&sweep, &archive, Some("budgeted"));
+    assert_success(&out);
+
+    let entries = tar_list(&archive);
+    assert!(entries.contains(&"manifest.json".to_owned()));
+    assert!(entries.contains(&"results.json".to_owned()));
+    assert!(
+        !entries.iter().any(|path| path.contains("trajectories/")),
+        "{entries:?}"
+    );
+    assert!(
+        !entries.iter().any(|path| path.contains("patches/")),
+        "{entries:?}"
+    );
+
+    let extracted = work.path().join("extracted-budgeted-only");
+    extract_tar(&archive, &extracted);
+    let results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(extracted.join("results.json")).unwrap()).unwrap();
+    assert_eq!(results["total"], 1);
+    assert_eq!(results["submitted"], 0);
+    assert_eq!(results["errored"], 0);
+    assert_eq!(results["budget_halted"], 1);
+    assert_eq!(results["instances"].as_array().unwrap().len(), 1);
+    assert_eq!(results["instances"][0]["instance_id"], "budgeted");
+}
+
+#[test]
 fn bundle_create_is_identical_modulo_timestamp_without_fixed_epoch() {
     let work = tempfile::tempdir().unwrap();
     let sweep = copy_fixture_sweep(work.path());
@@ -757,6 +824,37 @@ fn inject_text_into_json_string(path: &Path, pointer: &str, text: &str) {
         serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap();
     *value.pointer_mut(pointer).unwrap() = serde_json::json!(text);
     fs::write(path, serde_json::to_string_pretty(&value).unwrap()).unwrap();
+}
+
+fn append_budget_halted_instance(sweep: &Path, instance_id: &str) {
+    let path = sweep.join("results.json");
+    let mut results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    results["total"] = serde_json::json!(3);
+    results["completed"] = serde_json::json!(3);
+    results["budget_halted"] = serde_json::json!(1);
+    results["filter_spec"]["selected_count"] = serde_json::json!(3);
+    results["manifest"]["dataset"]["selected_row_count"] = serde_json::json!(3);
+    results["manifest"]["dataset"]["post_filter_row_count"] = serde_json::json!(3);
+    results["instances"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!({
+            "instance_id": instance_id,
+            "exit_reason": "budget_halt",
+            "outcome": null,
+            "steps": null,
+            "total_input_tokens": 0,
+            "total_completion_tokens": 0,
+            "patch_present": false,
+            "non_empty_patch": false,
+            "attempts": 1,
+            "runs": 1,
+            "resolved_count": 0,
+            "pass_at_1": false,
+            "tests_run_before_submit": false
+        }));
+    fs::write(path, serde_json::to_string_pretty(&results).unwrap()).unwrap();
 }
 
 #[derive(Clone, Copy)]

--- a/tests/bench_bundle.rs
+++ b/tests/bench_bundle.rs
@@ -421,6 +421,106 @@ fn bundle_instance_scope_drops_filtered_evaluation_summaries() {
 }
 
 #[test]
+fn bundle_instance_scope_uses_rerun_slots_for_scoped_aggregates() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    write_bundle_rerun_trajectory(
+        &sweep,
+        "alpha",
+        1,
+        RerunTrajectorySpec {
+            outcome: "error",
+            exit_reason: "error",
+            failure_category: Some("step_limit"),
+            tests_run_before_submit: false,
+            patch: None,
+            prompt_tokens: 10,
+            completion_tokens: 1,
+            final_model: "first-model",
+        },
+    );
+    write_bundle_rerun_trajectory(
+        &sweep,
+        "alpha",
+        2,
+        RerunTrajectorySpec {
+            outcome: "submitted",
+            exit_reason: "submitted",
+            failure_category: None,
+            tests_run_before_submit: true,
+            patch: Some("diff --git a/file b/file\n+later run\n"),
+            prompt_tokens: 20,
+            completion_tokens: 2,
+            final_model: "later-model",
+        },
+    );
+
+    let results_path = sweep.join("results.json");
+    let mut results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&results_path).unwrap()).unwrap();
+    results["submitted"] = serde_json::json!(2);
+    results["submitted_with_tests"] = serde_json::json!(2);
+    results["errored"] = serde_json::json!(1);
+    results["failures_by_category"] = serde_json::json!({ "step_limit": 1 });
+    results["model_mix"] =
+        serde_json::json!({ "beta-model": 1, "first-model": 1, "later-model": 1 });
+
+    let alpha = results["instances"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|row| row["instance_id"] == "alpha")
+        .unwrap();
+    alpha["exit_reason"] = serde_json::json!("error");
+    alpha["outcome"] = serde_json::json!("error");
+    alpha["failure_category"] = serde_json::json!("step_limit");
+    alpha["runs"] = serde_json::json!(2);
+    alpha["resolved_count"] = serde_json::json!(1);
+    alpha["pass_at_1"] = serde_json::json!(false);
+    alpha["tests_run_before_submit"] = serde_json::json!(true);
+    alpha["total_input_tokens"] = serde_json::json!(30);
+    alpha["total_completion_tokens"] = serde_json::json!(3);
+    alpha["patch_present"] = serde_json::json!(true);
+    alpha["non_empty_patch"] = serde_json::json!(true);
+    alpha["final_model"] = serde_json::json!("first-model");
+    fs::write(
+        &results_path,
+        serde_json::to_string_pretty(&results).unwrap(),
+    )
+    .unwrap();
+
+    let archive = work.path().join("alpha-rerun.tar.gz");
+    assert_success(&bundle_create(&sweep, &archive, Some("alpha")));
+
+    let extracted = work.path().join("extracted-alpha-rerun");
+    extract_tar(&archive, &extracted);
+    let scoped: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(extracted.join("results.json")).unwrap()).unwrap();
+    assert_eq!(scoped["total"], 1);
+    assert_eq!(scoped["submitted"], 1);
+    assert_eq!(scoped["submitted_with_tests"], 1);
+    assert_eq!(scoped["errored"], 1);
+    assert_eq!(scoped["failures_by_category"]["step_limit"], 1);
+    assert_eq!(scoped["with_patch"], 1);
+    assert_eq!(scoped["patch_empty"], 0);
+    assert_eq!(scoped["pass_at_k"], 1.0);
+    assert_eq!(scoped["model_mix"]["first-model"], 1);
+    assert_eq!(scoped["model_mix"]["later-model"], 1);
+    assert!(scoped["model_mix"].get("beta-model").is_none());
+    assert!(scoped.get("github_pr_failures").is_none());
+    assert!(scoped.get("retried_instances").is_none());
+
+    let entries = tar_list(&archive);
+    assert!(entries.contains(&"alpha/run-1.traj.json".to_owned()));
+    assert!(entries.contains(&"alpha/run-2.traj.json".to_owned()));
+    assert!(entries.contains(&"alpha/run-2.patch".to_owned()));
+    assert!(
+        !entries.iter().any(|path| path.contains("beta")),
+        "{entries:?}"
+    );
+}
+
+#[test]
 fn bundle_create_is_identical_modulo_timestamp_without_fixed_epoch() {
     let work = tempfile::tempdir().unwrap();
     let sweep = copy_fixture_sweep(work.path());
@@ -657,6 +757,76 @@ fn inject_text_into_json_string(path: &Path, pointer: &str, text: &str) {
         serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap();
     *value.pointer_mut(pointer).unwrap() = serde_json::json!(text);
     fs::write(path, serde_json::to_string_pretty(&value).unwrap()).unwrap();
+}
+
+#[derive(Clone, Copy)]
+struct RerunTrajectorySpec<'a> {
+    outcome: &'a str,
+    exit_reason: &'a str,
+    failure_category: Option<&'a str>,
+    tests_run_before_submit: bool,
+    patch: Option<&'a str>,
+    prompt_tokens: u64,
+    completion_tokens: u64,
+    final_model: &'a str,
+}
+
+fn write_bundle_rerun_trajectory(
+    sweep: &Path,
+    instance_id: &str,
+    run_index: u32,
+    spec: RerunTrajectorySpec<'_>,
+) {
+    let dir = sweep.join(instance_id);
+    fs::create_dir_all(&dir).unwrap();
+    let mut info = serde_json::json!({
+        "task": instance_id,
+        "model_name": "deterministic",
+        "outcome": spec.outcome,
+        "exit_reason": spec.exit_reason,
+        "final_output": "rerun-slot",
+        "total_cost_usd": 0.0,
+        "token_usage": {
+            "prompt_tokens": spec.prompt_tokens,
+            "completion_tokens": spec.completion_tokens
+        },
+        "redaction": {
+            "enabled": true,
+            "redacted": false
+        },
+        "steps": 1,
+        "test_invocations": [],
+        "tests_run_before_submit": spec.tests_run_before_submit,
+        "fallback_summary": {
+            "primary_model": "primary-model",
+            "final_model": spec.final_model,
+            "fallback_happened": false,
+            "fallback_count": 0,
+            "attempted_models": [spec.final_model],
+            "failed_attempts": []
+        }
+    });
+    if let Some(category) = spec.failure_category {
+        info["failure_category"] = serde_json::json!(category);
+    }
+    let trajectory = serde_json::json!({
+        "trajectory_format": "mini-swe-agent-1.1",
+        "artifact_kind": "trajectory",
+        "schema_version": {
+            "major": 1,
+            "minor": 3
+        },
+        "info": info,
+        "messages": []
+    });
+    fs::write(
+        dir.join(format!("run-{run_index}.traj.json")),
+        serde_json::to_string_pretty(&trajectory).unwrap(),
+    )
+    .unwrap();
+    if let Some(patch) = spec.patch {
+        fs::write(dir.join(format!("run-{run_index}.patch")), patch).unwrap();
+    }
 }
 
 fn json_escaped_path(path: &Path) -> String {

--- a/tests/bench_bundle.rs
+++ b/tests/bench_bundle.rs
@@ -521,6 +521,84 @@ fn bundle_instance_scope_uses_rerun_slots_for_scoped_aggregates() {
 }
 
 #[test]
+fn bundle_instance_scope_ignores_stale_nested_run_artifacts_for_single_run_row() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    write_bundle_rerun_trajectory(
+        &sweep,
+        "alpha",
+        1,
+        RerunTrajectorySpec {
+            outcome: "submitted",
+            exit_reason: "submitted",
+            failure_category: None,
+            tests_run_before_submit: true,
+            patch: Some("diff --git a/current b/current\n+current run\n"),
+            prompt_tokens: 10,
+            completion_tokens: 1,
+            final_model: "single-model",
+        },
+    );
+    write_bundle_rerun_trajectory(
+        &sweep,
+        "alpha",
+        2,
+        RerunTrajectorySpec {
+            outcome: "submitted",
+            exit_reason: "submitted",
+            failure_category: None,
+            tests_run_before_submit: true,
+            patch: Some("diff --git a/stale b/stale\n+stale run\n"),
+            prompt_tokens: 20,
+            completion_tokens: 2,
+            final_model: "stale-model",
+        },
+    );
+
+    let results_path = sweep.join("results.json");
+    let mut results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&results_path).unwrap()).unwrap();
+    let alpha = results["instances"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|row| row["instance_id"] == "alpha")
+        .unwrap();
+    alpha.as_object_mut().unwrap().remove("runs");
+    alpha["outcome"] = serde_json::json!("submitted");
+    alpha["exit_reason"] = serde_json::json!("submitted");
+    alpha["resolved_count"] = serde_json::json!(1);
+    alpha["pass_at_1"] = serde_json::json!(true);
+    alpha["tests_run_before_submit"] = serde_json::json!(true);
+    alpha["patch_present"] = serde_json::json!(true);
+    alpha["non_empty_patch"] = serde_json::json!(true);
+    alpha["total_input_tokens"] = serde_json::json!(10);
+    alpha["total_completion_tokens"] = serde_json::json!(1);
+    alpha["final_model"] = serde_json::json!("single-model");
+    fs::write(
+        &results_path,
+        serde_json::to_string_pretty(&results).unwrap(),
+    )
+    .unwrap();
+
+    let archive = work.path().join("alpha-single-run.tar.gz");
+    assert_success(&bundle_create(&sweep, &archive, Some("alpha")));
+    assert_success(&bundle_verify(&archive));
+
+    let entries = tar_list(&archive);
+    assert!(entries.contains(&"alpha/run-1.traj.json".to_owned()));
+    assert!(entries.contains(&"alpha/run-1.patch".to_owned()));
+    assert!(
+        !entries.contains(&"alpha/run-2.traj.json".to_owned()),
+        "{entries:?}"
+    );
+    assert!(
+        !entries.contains(&"alpha/run-2.patch".to_owned()),
+        "{entries:?}"
+    );
+}
+
+#[test]
 fn bundle_instance_scope_rejects_missing_rerun_trajectory() {
     let work = tempfile::tempdir().unwrap();
     let sweep = copy_fixture_sweep(work.path());

--- a/tests/bench_bundle.rs
+++ b/tests/bench_bundle.rs
@@ -521,6 +521,57 @@ fn bundle_instance_scope_uses_rerun_slots_for_scoped_aggregates() {
 }
 
 #[test]
+fn bundle_instance_scope_rejects_missing_rerun_trajectory() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    write_bundle_rerun_trajectory(
+        &sweep,
+        "alpha",
+        1,
+        RerunTrajectorySpec {
+            outcome: "error",
+            exit_reason: "error",
+            failure_category: Some("step_limit"),
+            tests_run_before_submit: false,
+            patch: None,
+            prompt_tokens: 10,
+            completion_tokens: 1,
+            final_model: "first-model",
+        },
+    );
+
+    let results_path = sweep.join("results.json");
+    let mut results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&results_path).unwrap()).unwrap();
+    let alpha = results["instances"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|row| row["instance_id"] == "alpha")
+        .unwrap();
+    alpha["runs"] = serde_json::json!(2);
+    alpha["resolved_count"] = serde_json::json!(0);
+    alpha["pass_at_1"] = serde_json::json!(false);
+    fs::write(
+        &results_path,
+        serde_json::to_string_pretty(&results).unwrap(),
+    )
+    .unwrap();
+
+    let archive = work.path().join("alpha-incomplete-rerun.tar.gz");
+    let out = bundle_create(&sweep, &archive, Some("alpha"));
+
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("missing trajectory"), "{stderr}");
+    assert!(stderr.contains("alpha/run-2.traj.json"), "{stderr}");
+    assert!(
+        !archive.exists(),
+        "incomplete rerun bundle must fail closed"
+    );
+}
+
+#[test]
 fn bundle_full_sweep_allows_budget_halted_row_without_trajectory() {
     let work = tempfile::tempdir().unwrap();
     let sweep = copy_fixture_sweep(work.path());

--- a/tests/bench_bundle.rs
+++ b/tests/bench_bundle.rs
@@ -319,6 +319,108 @@ fn bundle_instance_scope_includes_only_requested_instance_artifacts() {
 }
 
 #[test]
+fn bundle_instance_scope_zeroes_existing_cost_totals_without_selected_cost_telemetry() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    let results_path = sweep.join("results.json");
+    let mut results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&results_path).unwrap()).unwrap();
+    results["total_cost_usd"] = serde_json::json!(42.0);
+    results["actual_cost_usd"] = serde_json::json!(13.0);
+    let beta = results["instances"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|row| row["instance_id"] == "beta")
+        .unwrap();
+    let beta = beta.as_object_mut().unwrap();
+    beta.insert("exit_reason".into(), serde_json::json!("skipped"));
+    beta.insert("outcome".into(), serde_json::json!("skipped"));
+    beta.remove("cost_usd");
+    beta.remove("total_cost_usd");
+    beta.remove("actual_cost_usd");
+    fs::write(
+        &results_path,
+        serde_json::to_string_pretty(&results).unwrap(),
+    )
+    .unwrap();
+
+    let archive = work.path().join("beta-no-cost.tar.gz");
+    assert_success(&bundle_create(&sweep, &archive, Some("beta")));
+
+    let extracted = work.path().join("extracted-beta-no-cost");
+    extract_tar(&archive, &extracted);
+    let scoped: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(extracted.join("results.json")).unwrap()).unwrap();
+    assert_eq!(scoped["instances"].as_array().unwrap().len(), 1);
+    assert_eq!(scoped["instances"][0]["instance_id"], "beta");
+    assert_eq!(scoped["total_cost_usd"], serde_json::json!(0.0));
+    assert_eq!(scoped["actual_cost_usd"], serde_json::json!(0.0));
+}
+
+#[test]
+fn bundle_instance_scope_drops_filtered_evaluation_summaries() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+    let evaluation_path = sweep.join("evaluation.json");
+    let mut evaluation: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&evaluation_path).unwrap()).unwrap();
+    evaluation["behavioral"] = serde_json::json!({
+        "tests_run_before_submit_rate": 0.5,
+        "resolved_rate_when_tests_run": 0.5,
+        "resolved_rate_when_tests_skipped": 0.5
+    });
+    evaluation["breakdown"] = serde_json::json!([{
+        "axis": "repo",
+        "bucket": "full-sweep",
+        "instances": 2,
+        "resolved": 1,
+        "resolved_rate": 0.5
+    }]);
+    evaluation["cost_attribution"] = serde_json::json!([{
+        "bucket": "full-sweep",
+        "instances": 2,
+        "total_cost_usd": 9.0,
+        "mean_cost_usd": 4.5,
+        "cost_share": 1.0
+    }]);
+    evaluation["model_mix_summary"] = serde_json::json!([{
+        "model": "full-model",
+        "runs": 2,
+        "resolved": 1,
+        "resolved_rate": 0.5,
+        "total_cost_usd": 9.0
+    }]);
+    fs::write(
+        &evaluation_path,
+        serde_json::to_string_pretty(&evaluation).unwrap(),
+    )
+    .unwrap();
+
+    let archive = work.path().join("alpha-eval-summary.tar.gz");
+    assert_success(&bundle_create(&sweep, &archive, Some("alpha")));
+
+    let extracted = work.path().join("extracted-alpha-eval-summary");
+    extract_tar(&archive, &extracted);
+    let scoped: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(extracted.join("evaluation.json")).unwrap())
+            .unwrap();
+    assert_eq!(scoped["instances"].as_array().unwrap().len(), 1);
+    assert_eq!(scoped["instances"][0]["instance_id"], "alpha");
+    for field in [
+        "breakdown",
+        "cost_attribution",
+        "model_mix_summary",
+        "behavioral",
+    ] {
+        assert!(
+            scoped.get(field).is_none(),
+            "{field} remained in {scoped:#}"
+        );
+    }
+}
+
+#[test]
 fn bundle_create_is_identical_modulo_timestamp_without_fixed_epoch() {
     let work = tempfile::tempdir().unwrap();
     let sweep = copy_fixture_sweep(work.path());

--- a/tests/fixtures/bundle/sweep/alpha.patch
+++ b/tests/fixtures/bundle/sweep/alpha.patch
@@ -1,0 +1,6 @@
+diff --git a/alpha.txt b/alpha.txt
+--- a/alpha.txt
++++ b/alpha.txt
+@@ -1 +1 @@
+-old
++new

--- a/tests/fixtures/bundle/sweep/alpha.traj.json
+++ b/tests/fixtures/bundle/sweep/alpha.traj.json
@@ -1,0 +1,33 @@
+{
+  "trajectory_format": "mini-swe-agent-1.1",
+  "artifact_kind": "trajectory",
+  "schema_version": {
+    "major": 1,
+    "minor": 3
+  },
+  "info": {
+    "task": "alpha",
+    "model_name": "deterministic",
+    "outcome": "submitted",
+    "exit_reason": "submitted",
+    "final_output": "done",
+    "total_cost_usd": 0.0,
+    "token_usage": {
+      "prompt_tokens": 10,
+      "completion_tokens": 2
+    },
+    "redaction": {
+      "enabled": true,
+      "redacted": false
+    },
+    "steps": 1,
+    "test_invocations": [],
+    "tests_run_before_submit": true
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\ndone\n```"
+    }
+  ]
+}

--- a/tests/fixtures/bundle/sweep/beta.traj.json
+++ b/tests/fixtures/bundle/sweep/beta.traj.json
@@ -1,0 +1,47 @@
+{
+  "trajectory_format": "mini-swe-agent-1.1",
+  "artifact_kind": "trajectory",
+  "schema_version": {
+    "major": 1,
+    "minor": 3
+  },
+  "info": {
+    "task": "beta",
+    "model_name": "deterministic",
+    "outcome": "error",
+    "exit_reason": "step_limit",
+    "failure_category": "step_limit",
+    "total_cost_usd": 0.0,
+    "token_usage": {
+      "prompt_tokens": 20,
+      "completion_tokens": 2
+    },
+    "redaction": {
+      "enabled": true,
+      "redacted": false
+    },
+    "steps": 2,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "```bash\necho beta\n```"
+    },
+    {
+      "role": "user",
+      "content": "Exit code: 0\nOutput:\nbeta\n",
+      "extra": {
+        "other": {
+          "run_result": {
+            "stdout": "beta\n",
+            "stderr": "",
+            "exit_code": 0,
+            "timed_out": false
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/bundle/sweep/evaluation.json
+++ b/tests/fixtures/bundle/sweep/evaluation.json
@@ -1,0 +1,29 @@
+{
+  "artifact_kind": "evaluation_results",
+  "schema_version": {
+    "major": 1,
+    "minor": 3
+  },
+  "instances": [
+    {
+      "instance_id": "alpha",
+      "resolved": true,
+      "runs": 1,
+      "tests_passed": [
+        "test_alpha"
+      ],
+      "tests_failed": [],
+      "eval_exit_reason": "resolved"
+    },
+    {
+      "instance_id": "beta",
+      "resolved": false,
+      "runs": 1,
+      "tests_passed": [],
+      "tests_failed": [
+        "test_beta"
+      ],
+      "eval_exit_reason": "unresolved"
+    }
+  ]
+}

--- a/tests/fixtures/bundle/sweep/ignored.tmp
+++ b/tests/fixtures/bundle/sweep/ignored.tmp
@@ -1,0 +1,1 @@
+this file must never be bundled

--- a/tests/fixtures/bundle/sweep/manifest.json
+++ b/tests/fixtures/bundle/sweep/manifest.json
@@ -1,0 +1,48 @@
+{
+  "purpose": "fixture",
+  "harness": {
+    "name": "rust_swe_agent",
+    "version": "fixture",
+    "git_sha": "fixture-sha-bundle",
+    "git_dirty": false,
+    "git_resolution": "fixture"
+  },
+  "dataset": {
+    "path": "dataset.jsonl",
+    "sha256": "fixture-dataset-hash",
+    "instance_count": 2,
+    "source_kind": "local",
+    "selected_row_count": 2,
+    "post_filter_row_count": 2
+  },
+  "prompt_template": {
+    "source": "inline",
+    "sha256": "fixture-template-hash"
+  },
+  "config": {
+    "resolved": "[model]\nname = \"deterministic\"\n",
+    "overlay_paths": []
+  },
+  "model": {
+    "name": "deterministic",
+    "backend": "deterministic"
+  },
+  "runtime": {
+    "started_at_utc": "2026-05-01T00:00:00Z",
+    "finished_at_utc": "2026-05-01T00:00:01Z",
+    "host_os": "fixture",
+    "resume_mode": false,
+    "rust_version": "fixture"
+  },
+  "cli": {
+    "argv": [
+      "rust-swe-agent",
+      "bench",
+      "swebench",
+      "--dataset-path",
+      "dataset.jsonl",
+      "--output",
+      "runs"
+    ]
+  }
+}

--- a/tests/fixtures/bundle/sweep/results.json
+++ b/tests/fixtures/bundle/sweep/results.json
@@ -1,0 +1,122 @@
+{
+  "artifact_kind": "sweep_results",
+  "schema_version": {
+    "major": 1,
+    "minor": 3
+  },
+  "total": 2,
+  "sweep_status": "completed",
+  "completed": 2,
+  "in_flight_at_cancel": 0,
+  "not_started": 0,
+  "submitted": 1,
+  "submitted_with_tests": 1,
+  "skipped": 0,
+  "errored": 1,
+  "failures_by_category": {
+    "step_limit": 1
+  },
+  "budget_halted": 0,
+  "with_patch": 1,
+  "patch_empty": 0,
+  "patch_apply_invalid": 0,
+  "github_pr_failures": 0,
+  "total_input_tokens": 30,
+  "total_cache_read_tokens": 0,
+  "total_cache_creation_tokens": 0,
+  "total_completion_tokens": 4,
+  "total_cost_usd": 0.0,
+  "cache_hit_rate": 0.0,
+  "retries": 0,
+  "retried_instances": 0,
+  "pass_at_k": 0.5,
+  "filter_spec": {
+    "original_count": 2,
+    "selected_count": 2
+  },
+  "manifest": {
+    "purpose": "fixture",
+    "harness": {
+      "name": "rust_swe_agent",
+      "version": "fixture",
+      "git_sha": "fixture-sha-bundle",
+      "git_dirty": false,
+      "git_resolution": "fixture"
+    },
+    "dataset": {
+      "path": "dataset.jsonl",
+      "sha256": "fixture-dataset-hash",
+      "instance_count": 2,
+      "source_kind": "local",
+      "selected_row_count": 2,
+      "post_filter_row_count": 2
+    },
+    "prompt_template": {
+      "source": "inline",
+      "sha256": "fixture-template-hash"
+    },
+    "config": {
+      "resolved": "[model]\nname = \"deterministic\"\n",
+      "overlay_paths": []
+    },
+    "model": {
+      "name": "deterministic",
+      "backend": "deterministic"
+    },
+    "runtime": {
+      "started_at_utc": "2026-05-01T00:00:00Z",
+      "finished_at_utc": "2026-05-01T00:00:01Z",
+      "host_os": "fixture",
+      "resume_mode": false,
+      "rust_version": "fixture"
+    },
+    "cli": {
+      "argv": [
+        "rust-swe-agent",
+        "bench",
+        "swebench",
+        "--dataset-path",
+        "dataset.jsonl",
+        "--output",
+        "runs"
+      ]
+    }
+  },
+  "instances": [
+    {
+      "instance_id": "alpha",
+      "exit_reason": "submitted",
+      "outcome": "submitted",
+      "steps": 1,
+      "cost_usd": 0.0,
+      "total_input_tokens": 10,
+      "total_completion_tokens": 2,
+      "duration_secs": 1.0,
+      "patch_present": true,
+      "non_empty_patch": true,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 1,
+      "pass_at_1": true,
+      "tests_run_before_submit": true
+    },
+    {
+      "instance_id": "beta",
+      "exit_reason": "error",
+      "outcome": "error",
+      "failure_category": "step_limit",
+      "steps": 2,
+      "cost_usd": 0.0,
+      "total_input_tokens": 20,
+      "total_completion_tokens": 2,
+      "duration_secs": 2.0,
+      "patch_present": false,
+      "non_empty_patch": false,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    }
+  ]
+}


### PR DESCRIPTION
Add bench bundle create/verify support with fixed archive layout, BUNDLE.json integrity manifest, strict redaction retrigger checks, deterministic  tar.gz metadata, and extracted-bundle reader compatibility.

Cover bundle creation, verification failures, instance scoping, path normalization, redaction gaps, inspect/triage compatibility, and reproduce --limit 0 smoke replay.