### PR TITLE
🔒 Warden: Limit command output buffering to prevent memory exhaustion DoS

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -332,15 +332,26 @@ where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut chunk = [0u8; 8192];
+    let mut total_read = 0;
+    const MAX_OUTPUT: usize = 10 * 1024 * 1024;
     loop {
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {
             return Ok(());
         }
+        let space_left = MAX_OUTPUT.saturating_sub(total_read);
+        if space_left == 0 {
+            return Ok(());
+        }
+        let take = std::cmp::min(n, space_left);
         buffer
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .extend_from_slice(&chunk[..n]);
+            .extend_from_slice(&chunk[..take]);
+        total_read += take;
+        if take < n {
+            return Ok(());
+        }
     }
 }
 

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -331,9 +331,9 @@ async fn read_pipe_to_buffer<R>(mut pipe: R, buffer: Arc<Mutex<Vec<u8>>>) -> Res
 where
     R: tokio::io::AsyncRead + Unpin,
 {
+    const MAX_OUTPUT: usize = 10 * 1024 * 1024;
     let mut chunk = [0u8; 8192];
     let mut total_read = 0;
-    const MAX_OUTPUT: usize = 10 * 1024 * 1024;
     loop {
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {

--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -236,9 +236,9 @@ async fn read_pipe_to_buffer<R>(mut pipe: R, buffer: Arc<Mutex<Vec<u8>>>) -> Res
 where
     R: tokio::io::AsyncRead + Unpin,
 {
+    const MAX_OUTPUT: usize = 10 * 1024 * 1024;
     let mut chunk = [0u8; 8192];
     let mut total_read = 0;
-    const MAX_OUTPUT: usize = 10 * 1024 * 1024;
     loop {
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {

--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -237,15 +237,26 @@ where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut chunk = [0u8; 8192];
+    let mut total_read = 0;
+    const MAX_OUTPUT: usize = 10 * 1024 * 1024;
     loop {
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {
             return Ok(());
         }
+        let space_left = MAX_OUTPUT.saturating_sub(total_read);
+        if space_left == 0 {
+            return Ok(());
+        }
+        let take = std::cmp::min(n, space_left);
         buffer
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .extend_from_slice(&chunk[..n]);
+            .extend_from_slice(&chunk[..take]);
+        total_read += take;
+        if take < n {
+            return Ok(());
+        }
     }
 }
 


### PR DESCRIPTION
🦠 Threat: A malicious or runaway child process (e.g. via `docker exec` or local execution) could write an infinite stream of data to stdout or stderr. The `read_pipe_to_buffer` function previously read this output unboundedly into a `Vec<u8>`, which could lead to an Out-Of-Memory (OOM) Denial-of-Service (DoS) condition for the `rust_swe_agent` process.
🛡️ Defense: Implemented capped readers by tracking `total_read` in `read_pipe_to_buffer` and stopping or truncating the read once `10 * 1024 * 1024` (10 MB) of data has been collected from a single pipe.
💥 Severity: High - could panic server via memory exhaustion.
🧪 Verification: Checked existing tests, ran `cargo test`, and manually verified the cap logic inside the loop correctly limits unbounded buffers without altering happy path execution.

---
*PR created automatically by Jules for task [11993314360021820058](https://jules.google.com/task/11993314360021820058) started by @madmax983*