### PR TITLE
Add fingerprint-based prompt drift detection to replay mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,6 +1663,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "similar",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ litellm-rs = { version = "0.4.16", default-features = false }
 # Misc
 chrono = { version = "0.4", features = ["serde"] }
 sha2 = "0.10"
+similar = "2"
 comfy-table = "7.2.2"
 tempfile = "3"
 

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -16,7 +16,9 @@ parsing human-oriented output.
 | 5    | `budget_halt`            | Cost ceiling triggered: `bench forecast --fail-over-cap` projected an over-cap run, or the sweep stopped because `--sweep-cost-limit-usd` was reached and no new tasks were dispatched. |
 | 6    | `regression_gate_failure`| `bench compare --max-regressions` or `--max-patch-size-regression` threshold was exceeded. |
 | 7    | `verification_failure`   | One or more `--verify NAME:COMMAND` checks did not pass after a `mini` run. |
-| 8    | `calibration_optimistic` | `bench calibrate --fail-on-optimistic` found actual sweep metrics above the forecast interval. |
+| 8    | `calibration_optimistic`     | `bench calibrate --fail-on-optimistic` found actual sweep metrics above the forecast interval. |
+| 9    | `replay_prompt_drift`        | `bench replay` detected that at least one input fingerprint does not match the cassette. |
+| 10   | `replay_response_exhausted`  | `bench replay` ran out of scripted responses before the agent finished (structural drift). |
 | 130  | `interrupted`            | Graceful SIGINT / Ctrl-C cancellation (POSIX convention: 128 + SIGINT(2)). |
 | 137  | `killed`                 | SIGKILL escalation after the graceful-cancel deadline expired (128 + SIGKILL(9)). |
 
@@ -52,6 +54,7 @@ coarse sweep-level result.
 | Command                         | Possible outcome classes |
 |---------------------------------|--------------------------|
 | `mini`                          | `success`, `usage_error`, `preflight_failure`, `task_unsuccessful`, `verification_failure`, `internal_error` |
+| `replay`                        | `success`, `usage_error`, `replay_prompt_drift`, `replay_response_exhausted`, `task_unsuccessful`, `internal_error` |
 | `bench swebench`                | `success`, `usage_error`, `preflight_failure`, `budget_halt`, `internal_error`, `interrupted`, `killed` |
 | `bench forecast`                | `success`, `usage_error`, `budget_halt`, `internal_error`, `interrupted` |
 | `bench calibrate`               | `success`, `usage_error`, `calibration_optimistic`, `internal_error` |
@@ -63,9 +66,8 @@ coarse sweep-level result.
 | `bench triage`                  | `success`, `usage_error`, `internal_error` |
 | `bench frontier`                | `success`, `usage_error`, `internal_error` |
 
-> **Legacy note:** `hello-world` and `replay` do not yet produce distinct
-> outcome classes beyond `success` / `internal_error`; they are interactive or
-> debugging surfaces not intended for CI automation.
+> **Note:** `hello-world` does not produce distinct outcome classes beyond
+> `success` / `internal_error`; it is an interactive debugging surface.
 >
 > **Future surfaces:** `doctor` (standalone) and verification surfaces must
 > extend this table before merging.

--- a/docs/spec-replay.md
+++ b/docs/spec-replay.md
@@ -51,19 +51,29 @@ bytes, encoded as 16 lowercase hex characters.
 ```json
 "model_call": {
   "input_fingerprint": "a1b2c3d4e5f60718",
-  "input_canonical_size": 1234
+  "input_canonical_size": 1234,
+  "input_canonical": "[{\"content\":\"…\",\"role\":\"user\"},…]",
+  "input_canonical_truncated": false
 }
 ```
+
+`input_canonical` stores the compact canonical JSON string up to 64 KiB per step
+(capped with a `[truncated]` marker). It is used by `bench replay` to produce a
+human-readable unified diff when a fingerprint mismatch is detected — the diff
+shows exactly which messages changed and how.
+
+`input_canonical_truncated` is `true` when the canonical was larger than the 64 KiB
+cap; in that case the unified diff in the drift report is best-effort.
 
 ---
 
 ## Schema version
 
-The `input_fingerprint` and `input_canonical_size` fields were introduced in
-trajectory schema version **1.4**. Reader code is forward-compatible:
-trajectories without these fields (schema < 1.4 or pre-versioning) are
-classified as _legacy_ and handled according to the `--allow-unfingerprinted`
-flag.
+The `input_fingerprint`, `input_canonical_size`, `input_canonical`, and
+`input_canonical_truncated` fields were introduced in trajectory schema version
+**1.4**. Reader code is forward-compatible: trajectories without these fields
+(schema < 1.4 or pre-versioning) are classified as _legacy_ and handled
+according to the `--allow-unfingerprinted` flag.
 
 ---
 
@@ -84,8 +94,8 @@ prompt refactor.
 
 ### `--drift-cap-bytes <N>` (default: 8192)
 
-Maximum bytes of the actual canonical input JSON to include per divergent step
-in the drift report. Excess is replaced with `[truncated]`.
+Maximum bytes of the unified diff string to include per divergent step in the
+drift report. Excess is replaced with `[truncated]`.
 
 ---
 
@@ -103,8 +113,8 @@ When drift is detected the harness writes a structured JSON report to
       "step_index": 0,
       "recorded_fingerprint": "deadbeef00000000",
       "actual_fingerprint":   "a1b2c3d4e5f60718",
-      "actual_canonical_snippet": "[{\"content\":\"…\",\"role\":\"user\"}]",
-      "truncated": false
+      "unified_diff": "--- recorded\n+++ actual\n-  \"content\": \"Fix the bug\",\n+  \"content\": \"Fix the bug (attempt 2)\",\n",
+      "diff_truncated": false
     }
   ]
 }
@@ -115,12 +125,8 @@ When drift is detected the harness writes a structured JSON report to
 | `step_index` | 0-based model-query index where drift was detected. |
 | `recorded_fingerprint` | Hash stored in the cassette trajectory. |
 | `actual_fingerprint` | Hash computed from the actual replay input. |
-| `actual_canonical_snippet` | First `drift_cap_bytes` of the actual canonical JSON (full input to the model during replay). Helps pinpoint which message changed. |
-| `truncated` | `true` when `actual_canonical_snippet` was capped. |
-
-> **Note:** The recorded canonical JSON is not stored in the trajectory (only
-> the hash and byte count are). The `actual_canonical_snippet` shows what the
-> model was actually asked during the replay run.
+| `unified_diff` | Line-level unified diff (`-` = recorded, `+` = actual) of the pretty-printed canonical inputs, capped to `drift_cap_bytes` with a `[truncated]` marker if cut. |
+| `diff_truncated` | `true` when the diff was capped **or** when the recorded canonical was already truncated in the cassette (best-effort diff). |
 
 ---
 

--- a/docs/spec-replay.md
+++ b/docs/spec-replay.md
@@ -1,0 +1,177 @@
+# `bench replay` — Spec and Drift-Detection Contract
+
+`bench replay` re-runs a previously recorded agent trajectory using a
+`DeterministicModel` that emits the original scripted assistant responses in
+order. Starting with schema version **1.4**, each assistant message in a
+trajectory stores a cryptographic fingerprint of the model-input that produced
+it. During replay the harness recomputes the fingerprint before consuming each
+scripted response and fails loudly when the inputs have drifted.
+
+---
+
+## Why it matters
+
+`bench replay` is the $0 regression gate for prompt and harness changes. Before
+fingerprinting, replay consumed scripted responses in order and reported success
+even when the agent was asking the model completely different questions (changed
+system prompt, changed observation format, changed tool schema, …). Fingerprint
+enforcement turns replay into an honest cassette: it fails the moment the first
+input diverges from what was recorded.
+
+---
+
+## Exit-code contract
+
+| Code | `outcome_class`              | When emitted |
+|-----:|------------------------------|--------------|
+| 0    | `success`                    | Replay completed with no drift. |
+| 1    | `internal_error`             | I/O failure, JSON parse error, or other unexpected error. |
+| 2    | `usage_error`                | Trajectory has no fingerprints and `--allow-unfingerprinted` was not passed. |
+| 9    | `replay_prompt_drift`        | At least one step's input fingerprint did not match the cassette. |
+| 10   | `replay_response_exhausted`  | Scripted responses ran out before the agent finished (structural drift). |
+
+---
+
+## Fingerprint algorithm
+
+**What is hashed:** The full input message vector passed to `model.query()` at
+each step. Each message contributes only its `role` and `content`; `extra`
+fields (cost, timestamp, raw API response) and `cache_hint` are **excluded**
+because they carry per-run metadata that legitimately varies.
+
+**Canonical form:** Compact JSON array where each element is
+`{"content": "<string>", "role": "<string>"}` — keys in ASCII-alphabetical
+order, no indentation, no trailing whitespace.
+
+**Hash:** SHA-256 over the UTF-8 canonical string, truncated to the first 8
+bytes, encoded as 16 lowercase hex characters.
+
+**Stored fields** (on each assistant `MessageRecord.extra.model_call`):
+
+```json
+"model_call": {
+  "input_fingerprint": "a1b2c3d4e5f60718",
+  "input_canonical_size": 1234
+}
+```
+
+---
+
+## Schema version
+
+The `input_fingerprint` and `input_canonical_size` fields were introduced in
+trajectory schema version **1.4**. Reader code is forward-compatible:
+trajectories without these fields (schema < 1.4 or pre-versioning) are
+classified as _legacy_ and handled according to the `--allow-unfingerprinted`
+flag.
+
+---
+
+## CLI flags
+
+### `--allow-unfingerprinted`
+
+Opt-in to replaying trajectories that have no stored fingerprints. A warning is
+emitted to stderr for every unfingerprinted step. Without this flag, the first
+step without a fingerprint causes exit code 2.
+
+### `--report-only`
+
+Run to completion despite any fingerprint drift. All divergent steps are
+collected into `{output-dir}/replay-drift.json` and the command exits 0.
+Useful for "show me everything that changed" diagnostics after a large
+prompt refactor.
+
+### `--drift-cap-bytes <N>` (default: 8192)
+
+Maximum bytes of the actual canonical input JSON to include per divergent step
+in the drift report. Excess is replaced with `[truncated]`.
+
+---
+
+## Drift report (`replay-drift.json`)
+
+When drift is detected the harness writes a structured JSON report to
+`{output-dir}/replay-drift.json` and echoes a summary to stderr.
+
+**Schema:**
+
+```json
+{
+  "steps": [
+    {
+      "step_index": 0,
+      "recorded_fingerprint": "deadbeef00000000",
+      "actual_fingerprint":   "a1b2c3d4e5f60718",
+      "actual_canonical_snippet": "[{\"content\":\"…\",\"role\":\"user\"}]",
+      "truncated": false
+    }
+  ]
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `step_index` | 0-based model-query index where drift was detected. |
+| `recorded_fingerprint` | Hash stored in the cassette trajectory. |
+| `actual_fingerprint` | Hash computed from the actual replay input. |
+| `actual_canonical_snippet` | First `drift_cap_bytes` of the actual canonical JSON (full input to the model during replay). Helps pinpoint which message changed. |
+| `truncated` | `true` when `actual_canonical_snippet` was capped. |
+
+> **Note:** The recorded canonical JSON is not stored in the trajectory (only
+> the hash and byte count are). The `actual_canonical_snippet` shows what the
+> model was actually asked during the replay run.
+
+---
+
+## Example workflow
+
+### Recording a trajectory (normal `mini` run)
+
+```bash
+rust-swe-agent mini --task "Fix the off-by-one in sort.py" \
+  --output runs/baseline/
+# → runs/baseline/fix-the-off-by-one-in-sort-py.traj.json
+#   (each assistant message now carries extra.model_call.input_fingerprint)
+```
+
+### Replaying as a regression gate
+
+```bash
+# After changing a prompt template:
+rust-swe-agent replay \
+  --trajectory-path runs/baseline/fix-the-off-by-one-in-sort-py.traj.json \
+  --output runs/replay/
+echo "exit: $?"
+# → 0   if nothing drifted
+# → 9   if any prompt changed (drift report at runs/replay/replay-drift.json)
+```
+
+### Diagnosing drift with `--report-only`
+
+```bash
+rust-swe-agent replay \
+  --trajectory-path runs/baseline/fix-the-off-by-one-in-sort-py.traj.json \
+  --output runs/replay-diag/ \
+  --report-only
+# exits 0; runs/replay-diag/replay-drift.json lists every divergent step
+```
+
+### Accepting a legacy trajectory
+
+```bash
+rust-swe-agent replay \
+  --trajectory-path runs/old/pre-1.4-trajectory.traj.json \
+  --output runs/replay/ \
+  --allow-unfingerprinted
+# exits 0 with per-step warnings; no fingerprint checking performed
+```
+
+---
+
+## Out of scope
+
+- Auto-rerecording or auto-healing cassettes on drift.
+- Semantic / fuzzy equivalence ("these two prompts mean the same thing").
+- Storing or comparing model *output* (this spec is strictly about *input* drift).
+- Cross-model replay (replaying a Claude trajectory against an OpenAI agent run).

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -474,8 +474,10 @@ impl Agent for DefaultAgent {
         // `self.history` is the exact message slice that was sent to the model.
         let fp = crate::fingerprint::compute_input_fingerprint(&self.history);
         let raw_canonical = crate::fingerprint::canonical_json(&self.history);
-        let (canonical_stored, canonical_truncated) =
-            crate::fingerprint::cap_canonical(&raw_canonical, crate::run::replay::CANONICAL_CAP_BYTES);
+        let (canonical_stored, canonical_truncated) = crate::fingerprint::cap_canonical(
+            &raw_canonical,
+            crate::run::replay::CANONICAL_CAP_BYTES,
+        );
         asst.extra.other.insert(
             "model_call".to_owned(),
             serde_json::json!({

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -492,10 +492,7 @@ impl Agent for DefaultAgent {
             .iter()
             .map(|m| {
                 let mut m2 = m.clone();
-                m2.content = self
-                    .redactor
-                    .redact_text(&m.content, surface::TRAJECTORY)
-                    .text;
+                m2.content = self.redactor.redact_text_scratch(&m.content);
                 m2
             })
             .collect();

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -470,14 +470,19 @@ impl Agent for DefaultAgent {
         asst.extra.response = Some(resp.raw.clone());
         asst.extra.timestamp = Some(asst_ts.clone());
 
-        // Store input fingerprint for replay drift detection (issue #155).
+        // Store input fingerprint + canonical for replay drift detection (issue #155).
         // `self.history` is the exact message slice that was sent to the model.
         let fp = crate::fingerprint::compute_input_fingerprint(&self.history);
+        let raw_canonical = crate::fingerprint::canonical_json(&self.history);
+        let (canonical_stored, canonical_truncated) =
+            crate::fingerprint::cap_canonical(&raw_canonical, crate::run::replay::CANONICAL_CAP_BYTES);
         asst.extra.other.insert(
             "model_call".to_owned(),
             serde_json::json!({
                 "input_fingerprint": fp.hex,
-                "input_canonical_size": fp.canonical_size
+                "input_canonical_size": fp.canonical_size,
+                "input_canonical": canonical_stored,
+                "input_canonical_truncated": canonical_truncated
             }),
         );
 

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -470,6 +470,17 @@ impl Agent for DefaultAgent {
         asst.extra.response = Some(resp.raw.clone());
         asst.extra.timestamp = Some(asst_ts.clone());
 
+        // Store input fingerprint for replay drift detection (issue #155).
+        // `self.history` is the exact message slice that was sent to the model.
+        let fp = crate::fingerprint::compute_input_fingerprint(&self.history);
+        asst.extra.other.insert(
+            "model_call".to_owned(),
+            serde_json::json!({
+                "input_fingerprint": fp.hex,
+                "input_canonical_size": fp.canonical_size
+            }),
+        );
+
         self.stream.emit(StreamEvent::AssistantMessage {
             step: self.steps,
             content: resp.content.clone(),

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -471,22 +471,23 @@ impl Agent for DefaultAgent {
         asst.extra.timestamp = Some(asst_ts.clone());
 
         // Store input fingerprint + canonical for replay drift detection (issue #155).
-        // Fingerprint the TRAJECTORY-redacted view of history so that replay — which
-        // reconstructs the initial prompt from the redacted cassette — computes the
-        // same hash even when the original task or extra context contained secrets.
-        // Subsequent messages in self.history are already redacted (observations and
-        // assistant responses go through surface::MODEL_OBSERVATION before being
-        // pushed), so redacting again is a no-op for those; only the initial system
-        // and user messages (built before the Redactor was constructed) are affected.
+        // Fingerprint the TRAJECTORY-redacted, marker-normalized view of history so
+        // that replay computes the same hash even when:
+        //   (a) the initial task/context contained secrets (redacted before hashing), or
+        //   (b) tool observations contained secrets that were redacted with a per-run
+        //       salt; normalize_redaction_markers strips the salt-bearing hash segment
+        //       from [REDACTED:kind:size:hash] → [REDACTED:kind:size] so recording and
+        //       replay produce identical canonical JSON for the same logical content.
         let redacted_history: Vec<crate::model::Message> = self
             .history
             .iter()
             .map(|m| {
                 let mut m2 = m.clone();
-                m2.content = self
+                let redacted = self
                     .redactor
                     .redact_text(&m.content, surface::TRAJECTORY)
                     .text;
+                m2.content = crate::fingerprint::normalize_redaction_markers(&redacted);
                 m2
             })
             .collect();

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -478,20 +478,38 @@ impl Agent for DefaultAgent {
         //       salt; normalize_redaction_markers strips the salt-bearing hash segment
         //       from [REDACTED:kind:size:hash] → [REDACTED:kind:size] so recording and
         //       replay produce identical canonical JSON for the same logical content.
+        //
+        // Two passes over history:
+        //   1. Redact (TRAJECTORY surface) — produces hashed markers like
+        //      [REDACTED:kind:size:HASH].  This form is stored in the trajectory so
+        //      the canonical doesn't introduce a second, hash-free marker variant
+        //      that would break the "one stable marker per run" invariant.
+        //   2. Normalize (strip the per-run salt hash) — produces stable markers
+        //      like [REDACTED:kind:size].  Used only to compute a run-independent
+        //      fingerprint hash; NOT stored in the trajectory.
         let redacted_history: Vec<crate::model::Message> = self
             .history
             .iter()
             .map(|m| {
                 let mut m2 = m.clone();
-                let redacted = self
+                m2.content = self
                     .redactor
                     .redact_text(&m.content, surface::TRAJECTORY)
                     .text;
-                m2.content = crate::fingerprint::normalize_redaction_markers(&redacted);
                 m2
             })
             .collect();
-        let fp = crate::fingerprint::compute_input_fingerprint(&redacted_history);
+        let normalized_history: Vec<crate::model::Message> = redacted_history
+            .iter()
+            .map(|m| {
+                let mut m2 = m.clone();
+                m2.content = crate::fingerprint::normalize_redaction_markers(&m.content);
+                m2
+            })
+            .collect();
+        let fp = crate::fingerprint::compute_input_fingerprint(&normalized_history);
+        // Store the redacted (hashed-marker) canonical — replay normalizes it
+        // before diffing so per-run salts don't pollute the drift report.
         let raw_canonical = crate::fingerprint::canonical_json(&redacted_history);
         let (canonical_stored, canonical_truncated) = crate::fingerprint::cap_canonical(
             &raw_canonical,

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -471,9 +471,27 @@ impl Agent for DefaultAgent {
         asst.extra.timestamp = Some(asst_ts.clone());
 
         // Store input fingerprint + canonical for replay drift detection (issue #155).
-        // `self.history` is the exact message slice that was sent to the model.
-        let fp = crate::fingerprint::compute_input_fingerprint(&self.history);
-        let raw_canonical = crate::fingerprint::canonical_json(&self.history);
+        // Fingerprint the TRAJECTORY-redacted view of history so that replay — which
+        // reconstructs the initial prompt from the redacted cassette — computes the
+        // same hash even when the original task or extra context contained secrets.
+        // Subsequent messages in self.history are already redacted (observations and
+        // assistant responses go through surface::MODEL_OBSERVATION before being
+        // pushed), so redacting again is a no-op for those; only the initial system
+        // and user messages (built before the Redactor was constructed) are affected.
+        let redacted_history: Vec<crate::model::Message> = self
+            .history
+            .iter()
+            .map(|m| {
+                let mut m2 = m.clone();
+                m2.content = self
+                    .redactor
+                    .redact_text(&m.content, surface::TRAJECTORY)
+                    .text;
+                m2
+            })
+            .collect();
+        let fp = crate::fingerprint::compute_input_fingerprint(&redacted_history);
+        let raw_canonical = crate::fingerprint::canonical_json(&redacted_history);
         let (canonical_stored, canonical_truncated) = crate::fingerprint::cap_canonical(
             &raw_canonical,
             crate::run::replay::CANONICAL_CAP_BYTES,

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -20,7 +20,7 @@ pub struct ArtifactSchemaVersion {
 }
 
 impl ArtifactSchemaVersion {
-    pub const CURRENT: Self = Self { major: 1, minor: 3 };
+    pub const CURRENT: Self = Self { major: 1, minor: 4 };
     pub const LEGACY_PRE_VERSIONING: Self = Self { major: 0, minor: 0 };
 
     #[must_use]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -225,6 +225,23 @@ pub struct ReplayCmd {
     /// Override trajectory filename (default: derived from task).
     #[arg(long)]
     pub trajectory_name: Option<String>,
+
+    /// Allow replaying trajectories that have no stored input fingerprints
+    /// (pre-feature "legacy" trajectories). A warning is emitted to stderr.
+    /// Without this flag, an unfingerprinted trajectory causes a non-zero exit.
+    #[arg(long, default_value_t = false)]
+    pub allow_unfingerprinted: bool,
+
+    /// Run to completion despite prompt drift, collect all divergent steps into
+    /// `replay-drift.json`, and exit 0. Useful for "show me everything that
+    /// changed" diagnostics. Without this flag replay stops at the first drift.
+    #[arg(long, default_value_t = false)]
+    pub report_only: bool,
+
+    /// Maximum bytes of the actual canonical input JSON to include per drift
+    /// step in the drift report. Excess is replaced with `[truncated]`.
+    #[arg(long, default_value_t = crate::run::replay::DEFAULT_DRIFT_CAP_BYTES)]
+    pub drift_cap_bytes: usize,
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -226,6 +226,9 @@ async fn replay_cmd(r: args::ReplayCmd) -> Result<(), Error> {
         config: cfg,
         output_dir: r.output,
         trajectory_name: r.trajectory_name,
+        allow_unfingerprinted: r.allow_unfingerprinted,
+        report_only: r.report_only,
+        drift_cap_bytes: r.drift_cap_bytes,
     };
     crate::run::replay::run(args).await
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,23 @@ pub enum ModelError {
     /// The structured attempt records are preserved for trajectory telemetry.
     #[error("all fallback candidates failed: {0}")]
     AllCandidatesFailed(String, Vec<FailedAttempt>),
+
+    /// Replay only: prompt fingerprint drift detected at step {0}.
+    /// Recorded fingerprint and actual fingerprint differ.
+    #[error("replay prompt drift at step {0}: fingerprints do not match")]
+    ReplayDrift(usize),
+
+    /// Replay only: the scripted-response queue is exhausted at step {0}.
+    #[error("replay response exhausted: no scripted response for step {0}")]
+    ScriptedResponsesExhausted(u32),
+
+    /// Replay only: the trajectory has no fingerprint at step {0} and
+    /// `--allow-unfingerprinted` was not passed.
+    #[error(
+        "trajectory has no fingerprint at step {0}; \
+         use --allow-unfingerprinted to permit replaying legacy trajectories"
+    )]
+    ReplayUnfingerprintedLegacy(usize),
 }
 
 /// A single failed attempt record carried inside `AllCandidatesFailed`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,7 +63,17 @@ pub enum ModelError {
     #[error("replay prompt drift at step {0}: fingerprints do not match")]
     ReplayDrift(usize),
 
-    /// Replay only: the scripted-response queue is exhausted at step {0}.
+    /// Generic scripted model exhaustion: the response queue ran out at step {0}.
+    /// Used by `DeterministicModel` in any context (tests, sweeps, replay).
+    /// Replay code translates this into `ScriptedResponsesExhausted` so that
+    /// exit-code routing can distinguish replay-structural failures from ordinary
+    /// test/sweep failures.
+    #[error("scripted responses exhausted at step {0}")]
+    ResponsesExhausted(u32),
+
+    /// Replay only: the scripted-response queue is exhausted at step {0},
+    /// meaning the cassette trajectory is structurally incompatible with the
+    /// current agent (e.g. the agent issued more model calls than were recorded).
     #[error("replay response exhausted: no scripted response for step {0}")]
     ScriptedResponsesExhausted(u32),
 

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -181,4 +181,20 @@ mod tests {
             ExitCode::InternalError
         );
     }
+
+    #[test]
+    fn from_error_replay_response_exhausted() {
+        assert_eq!(
+            ExitCode::from_error(&Error::Model(ModelError::ScriptedResponsesExhausted(3))),
+            ExitCode::ReplayResponseExhausted
+        );
+    }
+
+    #[test]
+    fn from_error_replay_unfingerprinted_legacy_is_usage_error() {
+        assert_eq!(
+            ExitCode::from_error(&Error::Model(ModelError::ReplayUnfingerprintedLegacy(0))),
+            ExitCode::UsageError
+        );
+    }
 }

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -106,6 +106,10 @@ impl ExitCode {
                     Self::ReplayResponseExhausted
                 }
                 crate::error::ModelError::ReplayUnfingerprintedLegacy(_) => Self::UsageError,
+                // ResponsesExhausted (generic DeterministicModel exhaustion used in
+                // non-replay contexts) and all other model errors → task unsuccessful.
+                // Replay translates ResponsesExhausted → ScriptedResponsesExhausted
+                // before this function is called, so exit-10 is replay-only.
                 _ => Self::TaskUnsuccessful,
             },
             Error::Template(_)
@@ -195,6 +199,15 @@ mod tests {
         assert_eq!(
             ExitCode::from_error(&Error::Model(ModelError::ReplayUnfingerprintedLegacy(0))),
             ExitCode::UsageError
+        );
+    }
+
+    #[test]
+    fn from_error_responses_exhausted_is_task_unsuccessful() {
+        // Generic DeterministicModel exhaustion (non-replay) must not exit 10.
+        assert_eq!(
+            ExitCode::from_error(&Error::Model(ModelError::ResponsesExhausted(0))),
+            ExitCode::TaskUnsuccessful
         );
     }
 }

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -47,6 +47,12 @@ pub enum ExitCode {
     /// 8 - calibration gate failure (`bench calibrate --fail-on-optimistic`
     /// found actuals above the forecast interval).
     CalibrationOptimistic = 8,
+    /// 9 — replay prompt-drift detected: the agent's current input messages do
+    /// not match the fingerprint stored in the cassette trajectory.
+    ReplayPromptDrift = 9,
+    /// 10 — replay response exhausted: the scripted-response queue ran out
+    /// before the agent finished (trajectory is structurally incompatible).
+    ReplayResponseExhausted = 10,
     /// 130 — user interruption (graceful SIGINT / Ctrl-C; 128 + SIGINT(2)).
     Interrupted = 130,
     /// 137 — forced kill (SIGKILL escalation after graceful-cancel deadline; 128 + SIGKILL(9)).
@@ -76,6 +82,8 @@ impl ExitCode {
             Self::RegressionGateFailure => "regression_gate_failure",
             Self::VerificationFailure => "verification_failure",
             Self::CalibrationOptimistic => "calibration_optimistic",
+            Self::ReplayPromptDrift => "replay_prompt_drift",
+            Self::ReplayResponseExhausted => "replay_response_exhausted",
             Self::Interrupted => "interrupted",
             Self::Killed => "killed",
         }
@@ -92,7 +100,14 @@ impl ExitCode {
             Error::Config(_) => Self::UsageError,
             Error::VerificationFailed(..) => Self::VerificationFailure,
             Error::Env(env_e) => Self::from_env_error(env_e),
-            Error::Model(_) => Self::TaskUnsuccessful,
+            Error::Model(model_e) => match model_e {
+                crate::error::ModelError::ReplayDrift(_) => Self::ReplayPromptDrift,
+                crate::error::ModelError::ScriptedResponsesExhausted(_) => {
+                    Self::ReplayResponseExhausted
+                }
+                crate::error::ModelError::ReplayUnfingerprintedLegacy(_) => Self::UsageError,
+                _ => Self::TaskUnsuccessful,
+            },
             Error::Template(_)
             | Error::Trajectory(_)
             | Error::Github(_)

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -1,0 +1,152 @@
+//! Stable fingerprinting of model-query input messages for replay drift detection.
+//!
+//! Each model call's input message vector is canonically serialized (compact JSON,
+//! alphabetically-sorted keys, only `role` + `content` — metadata-free) and hashed
+//! with SHA-256. The first 8 bytes are returned as a 16-hex-char string together
+//! with the byte length of the canonical form.
+//!
+//! Only `role` and `content` are included; `cache_hint` and `extra` are intentionally
+//! excluded because they carry per-run metadata (cost, timestamps, raw API response)
+//! that legitimately differs between the recording run and a replay.
+
+use sha2::{Digest, Sha256};
+
+use crate::model::Message;
+
+/// Fingerprint of a model-query input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InputFingerprint {
+    /// SHA-256 of the canonical JSON, first 8 bytes as lowercase hex (16 chars).
+    pub hex: String,
+    /// Byte length of the canonical JSON string.
+    pub canonical_size: usize,
+}
+
+/// Compute a stable fingerprint for a slice of messages.
+///
+/// The canonical form is compact JSON (no extra whitespace) where each message
+/// is represented as `{"content": "…", "role": "…"}` (keys alphabetically sorted,
+/// no other fields). The fingerprint is SHA-256 over that UTF-8 string, truncated
+/// to the first 8 bytes and hex-encoded.
+pub fn compute_input_fingerprint(messages: &[Message]) -> InputFingerprint {
+    let canonical = canonical_json(messages);
+    let canonical_size = canonical.len();
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    let hash = hasher.finalize();
+    let mut hex = String::with_capacity(16);
+    for b in &hash[..8] {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{b:02x}");
+    }
+    InputFingerprint { hex, canonical_size }
+}
+
+/// Produce the canonical JSON string for a slice of messages.
+///
+/// Each message becomes `{"content": <string>, "role": <string>}`. Keys are in
+/// ASCII-alphabetical order ("content" < "role"). The array is compact (no
+/// indentation or trailing whitespace). `extra` and `cache_hint` are excluded.
+///
+/// This function is `pub` so tests can inspect and assert on the canonical form.
+pub fn canonical_json(messages: &[Message]) -> String {
+    use serde_json::{Map, Value};
+    let arr: Vec<Value> = messages
+        .iter()
+        .map(|m| {
+            let mut obj = Map::new();
+            // Alphabetical: "content" < "role" — insert in that order so IndexMap
+            // preserves insertion order in the serialized output.
+            obj.insert("content".to_owned(), Value::String(m.content.clone()));
+            obj.insert("role".to_owned(), role_to_json_str(m.role));
+            Value::Object(obj)
+        })
+        .collect();
+    // serde_json::to_string on a Vec<Value> produces compact JSON.
+    serde_json::to_string(&Value::Array(arr))
+        .unwrap_or_else(|_| "[]".to_owned())
+}
+
+fn role_to_json_str(role: crate::model::Role) -> serde_json::Value {
+    use crate::model::Role;
+    serde_json::Value::String(
+        match role {
+            Role::System => "system",
+            Role::User => "user",
+            Role::Assistant => "assistant",
+            Role::Tool => "tool",
+        }
+        .to_owned(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use crate::model::{Message, Role};
+
+    #[test]
+    fn fingerprint_is_16_hex_chars() {
+        let fp = compute_input_fingerprint(&[Message::user("hello")]);
+        assert_eq!(fp.hex.len(), 16);
+        assert!(fp.hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn same_input_same_fingerprint() {
+        let msgs = vec![Message::user("a"), Message::assistant("b")];
+        assert_eq!(
+            compute_input_fingerprint(&msgs).hex,
+            compute_input_fingerprint(&msgs).hex
+        );
+    }
+
+    #[test]
+    fn different_content_different_fingerprint() {
+        let fp1 = compute_input_fingerprint(&[Message::user("hello")]);
+        let fp2 = compute_input_fingerprint(&[Message::user("world")]);
+        assert_ne!(fp1.hex, fp2.hex);
+    }
+
+    #[test]
+    fn canonical_json_sorted_keys() {
+        let json = canonical_json(&[Message::user("x")]);
+        let cp = json.find("\"content\"").unwrap();
+        let rp = json.find("\"role\"").unwrap();
+        assert!(cp < rp);
+    }
+
+    #[test]
+    fn canonical_json_excludes_extra_and_cache_hint() {
+        let mut m = Message::user("hi");
+        m.extra.cost = Some(9.99);
+        m.extra.timestamp = Some("ts".into());
+        m.cache_hint = crate::model::CacheHint::Breakpoint;
+        let json = canonical_json(&[m]);
+        assert!(!json.contains("cost"));
+        assert!(!json.contains("timestamp"));
+        assert!(!json.contains("cache_hint"));
+    }
+
+    #[test]
+    fn canonical_size_matches_json_len() {
+        let msgs = vec![Message::user("hello"), Message::assistant("world")];
+        let fp = compute_input_fingerprint(&msgs);
+        assert_eq!(fp.canonical_size, canonical_json(&msgs).len());
+    }
+
+    #[test]
+    fn all_roles_serialize() {
+        for &role in &[Role::System, Role::User, Role::Assistant, Role::Tool] {
+            let m = Message {
+                role,
+                content: "x".into(),
+                cache_hint: crate::model::CacheHint::None,
+                extra: crate::model::MessageExtra::default(),
+            };
+            let json = canonical_json(&[m]);
+            assert!(json.contains("\"role\""), "role field missing for {role:?}");
+        }
+    }
+}

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -13,6 +13,62 @@ use sha2::{Digest, Sha256};
 
 use crate::model::Message;
 
+/// Normalize per-run salted redaction markers so fingerprints are stable
+/// across recording and replay sessions.
+///
+/// The `Redactor` embeds a run-specific salt in every marker:
+/// `[REDACTED:{kind}:{size_class}:{salt_hash}]`
+///
+/// Stripping the `:{salt_hash}` suffix produces a canonical form that is
+/// identical for any run redacting the same secret, preventing false
+/// prompt-drift reports when tool observations contain secrets.
+pub fn normalize_redaction_markers(s: &str) -> String {
+    const PREFIX: &str = "[REDACTED:";
+    if !s.contains(PREFIX) {
+        return s.to_owned();
+    }
+    let mut result = String::with_capacity(s.len());
+    let mut remaining = s;
+    while let Some(offset) = remaining.find(PREFIX) {
+        result.push_str(&remaining[..offset]);
+        let after_prefix = &remaining[offset + PREFIX.len()..];
+        if let Some(close) = after_prefix.find(']') {
+            let inner = &after_prefix[..close];
+            // Format: kind:size_class:hash — build normalized form if all
+            // three colon-separated segments are present; keep as-is otherwise.
+            let mut parts = inner.splitn(3, ':');
+            let kind = parts.next().unwrap_or(inner);
+            let normalized = parts.next().and_then(|sz| {
+                // Third segment present → strip it (the salt-bearing hash).
+                parts.next().map(|_| {
+                    let mut s = String::with_capacity(PREFIX.len() + kind.len() + 1 + sz.len() + 1);
+                    s.push_str(PREFIX);
+                    s.push_str(kind);
+                    s.push(':');
+                    s.push_str(sz);
+                    s.push(']');
+                    s
+                })
+            });
+            if let Some(norm) = normalized {
+                result.push_str(&norm);
+            } else {
+                result.push_str(PREFIX);
+                result.push_str(inner);
+                result.push(']');
+            }
+            remaining = &after_prefix[close + 1..];
+        } else {
+            // No closing ']' — keep the rest verbatim.
+            result.push_str(PREFIX);
+            result.push_str(after_prefix);
+            remaining = "";
+        }
+    }
+    result.push_str(remaining);
+    result
+}
+
 /// Fingerprint of a model-query input.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputFingerprint {
@@ -164,5 +220,29 @@ mod tests {
             let json = canonical_json(&[m]);
             assert!(json.contains("\"role\""), "role field missing for {role:?}");
         }
+    }
+
+    #[test]
+    fn normalize_redaction_markers_strips_hash_segment() {
+        let s = "token=[REDACTED:api_key:medium:a1b2c3d4e5f6] ok";
+        let normalized = normalize_redaction_markers(s);
+        assert_eq!(normalized, "token=[REDACTED:api_key:medium] ok");
+    }
+
+    #[test]
+    fn normalize_redaction_markers_different_salts_produce_same_result() {
+        let s1 = "x=[REDACTED:token:small:aabbccddee11] y";
+        let s2 = "x=[REDACTED:token:small:ffeeddccbb00] y";
+        assert_eq!(
+            normalize_redaction_markers(s1),
+            normalize_redaction_markers(s2),
+            "different salts must normalize to same form"
+        );
+    }
+
+    #[test]
+    fn normalize_redaction_markers_leaves_non_redacted_text_unchanged() {
+        let s = "no secrets here";
+        assert_eq!(normalize_redaction_markers(s), s);
     }
 }

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -67,6 +67,20 @@ pub fn canonical_json(messages: &[Message]) -> String {
         .unwrap_or_else(|_| "[]".to_owned())
 }
 
+/// Cap a canonical JSON string to `cap` bytes, appending `[truncated]` if cut.
+///
+/// Returns the (possibly truncated) string and a bool indicating truncation.
+pub fn cap_canonical(s: &str, cap: usize) -> (String, bool) {
+    if s.len() <= cap {
+        return (s.to_owned(), false);
+    }
+    let mut end = cap;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    (format!("{}[truncated]", &s[..end]), true)
+}
+
 fn role_to_json_str(role: crate::model::Role) -> serde_json::Value {
     use crate::model::Role;
     serde_json::Value::String(

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -39,7 +39,10 @@ pub fn compute_input_fingerprint(messages: &[Message]) -> InputFingerprint {
         use std::fmt::Write as _;
         let _ = write!(hex, "{b:02x}");
     }
-    InputFingerprint { hex, canonical_size }
+    InputFingerprint {
+        hex,
+        canonical_size,
+    }
 }
 
 /// Produce the canonical JSON string for a slice of messages.
@@ -63,8 +66,7 @@ pub fn canonical_json(messages: &[Message]) -> String {
         })
         .collect();
     // serde_json::to_string on a Vec<Value> produces compact JSON.
-    serde_json::to_string(&Value::Array(arr))
-        .unwrap_or_else(|_| "[]".to_owned())
+    serde_json::to_string(&Value::Array(arr)).unwrap_or_else(|_| "[]".to_owned())
 }
 
 /// Cap a canonical JSON string to `cap` bytes, appending `[truncated]` if cut.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cost;
 pub mod env;
 pub mod error;
 pub mod exit_code;
+pub mod fingerprint;
 pub mod ids;
 pub mod model;
 pub mod policy;

--- a/src/model/deterministic.rs
+++ b/src/model/deterministic.rs
@@ -87,14 +87,22 @@ impl Model for DeterministicModel {
             *count += 1;
         }
 
+        // call_count was just incremented above; subtract 1 for 0-indexed step.
+        let step_index = {
+            let count = self
+                .call_count
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            count.saturating_sub(1)
+        };
+
         let content = {
             let mut q = self
                 .responses
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            q.pop_front().ok_or_else(|| {
-                ModelError::Malformed("deterministic model: no scripted response left".into())
-            })?
+            q.pop_front()
+                .ok_or(ModelError::ScriptedResponsesExhausted(step_index))?
         };
 
         // Sentinel: "__rate_limited__:N" → ModelError::RateLimited with

--- a/src/model/deterministic.rs
+++ b/src/model/deterministic.rs
@@ -102,7 +102,7 @@ impl Model for DeterministicModel {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             q.pop_front()
-                .ok_or(ModelError::ScriptedResponsesExhausted(step_index))?
+                .ok_or(ModelError::ResponsesExhausted(step_index))?
         };
 
         // Sentinel: "__rate_limited__:N" → ModelError::RateLimited with

--- a/src/model/fallback.rs
+++ b/src/model/fallback.rs
@@ -47,6 +47,10 @@ fn coarse_reason(e: &ModelError) -> String {
         ModelError::Refused(_) => "refused".into(),
         ModelError::MissingCredentials(_) => "missing_credentials".into(),
         ModelError::AllCandidatesFailed(_, _) => "all_candidates_failed".into(),
+        // Replay-only errors never appear in a live fallback chain.
+        ModelError::ReplayDrift(_)
+        | ModelError::ScriptedResponsesExhausted(_)
+        | ModelError::ReplayUnfingerprintedLegacy(_) => "replay_error".into(),
     }
 }
 

--- a/src/model/fallback.rs
+++ b/src/model/fallback.rs
@@ -47,8 +47,9 @@ fn coarse_reason(e: &ModelError) -> String {
         ModelError::Refused(_) => "refused".into(),
         ModelError::MissingCredentials(_) => "missing_credentials".into(),
         ModelError::AllCandidatesFailed(_, _) => "all_candidates_failed".into(),
-        // Replay-only errors never appear in a live fallback chain.
-        ModelError::ReplayDrift(_)
+        // Scripted/replay errors never appear in a live fallback chain.
+        ModelError::ResponsesExhausted(_)
+        | ModelError::ReplayDrift(_)
         | ModelError::ScriptedResponsesExhausted(_)
         | ModelError::ReplayUnfingerprintedLegacy(_) => "replay_error".into(),
     }

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -179,19 +179,26 @@ impl Redactor {
 
     #[must_use]
     pub fn redact_text(&self, input: &str, surface: &str) -> RedactionOutcome {
+        let (text, redacted) = self.apply_redaction(input, Some(surface));
+        RedactionOutcome { text, redacted }
+    }
+
+    /// Redact `input` without updating redaction-count telemetry.
+    ///
+    /// Use only for internal computations (e.g. fingerprinting) where the
+    /// redaction must not be counted as an actual surface write.
+    pub(crate) fn redact_text_scratch(&self, input: &str) -> String {
+        self.apply_redaction(input, None).0
+    }
+
+    fn apply_redaction(&self, input: &str, surface: Option<&str>) -> (String, bool) {
         if !self.inner.enabled || input.is_empty() {
-            return RedactionOutcome {
-                text: input.to_owned(),
-                redacted: false,
-            };
+            return (input.to_owned(), false);
         }
 
         let mut matches = self.collect_matches(input);
         if matches.is_empty() {
-            return RedactionOutcome {
-                text: input.to_owned(),
-                redacted: false,
-            };
+            return (input.to_owned(), false);
         }
 
         matches.sort_by(|a, b| {
@@ -209,14 +216,13 @@ impl Redactor {
             out.push_str(&input[last..matched.start]);
             let marker = self.marker_for(&matched.raw, &matched.kind);
             out.push_str(&marker);
-            self.increment(surface, &matched.kind);
+            if let Some(srf) = surface {
+                self.increment(srf, &matched.kind);
+            }
             last = matched.end;
         }
         out.push_str(&input[last..]);
-        RedactionOutcome {
-            text: out,
-            redacted: true,
-        }
+        (out, true)
     }
 
     fn filter_overlapping_matches(matches: Vec<RedactionMatch>) -> Vec<RedactionMatch> {

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -406,7 +406,10 @@ impl Model for FingerprintCheckingModel {
             .iter()
             .map(|m| {
                 let mut m2 = m.clone();
-                let redacted = self.redactor.redact_text(&m.content, surface::TRAJECTORY).text;
+                let redacted = self
+                    .redactor
+                    .redact_text(&m.content, surface::TRAJECTORY)
+                    .text;
                 m2.content = crate::fingerprint::normalize_redaction_markers(&redacted);
                 m2
             })

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -29,6 +29,7 @@ use crate::env::{Environment, LocalEnvironment};
 use crate::error::{Error, ModelError};
 use crate::fingerprint::{canonical_json, cap_canonical, compute_input_fingerprint};
 use crate::model::{DeterministicModel, Message, Model, ModelResponse, QueryOpts};
+use crate::redaction::{Redactor, surface};
 use crate::trajectory::Trajectory;
 
 /// Filename written to `output_dir` when drift is detected.
@@ -174,9 +175,19 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
         .unwrap_or_else(|| crate::run::mini::slugify(&task));
 
     // 3. Build fingerprint-checking model.
+    // A dedicated Redactor (same config as the agent's) applies TRAJECTORY
+    // redaction before fingerprinting — needed so secrets still present in
+    // extra_context/skills at replay time are hashed identically to how they
+    // were hashed during recording.
+    let fp_redactor = Redactor::from_config(&args.config.root.redaction).map_err(|err| {
+        Error::Config(crate::error::ConfigError::Invalid(format!(
+            "Invalid redaction config: {err}"
+        )))
+    })?;
     let drift_steps: Arc<Mutex<Vec<DriftStep>>> = Arc::new(Mutex::new(Vec::new()));
     let model: Arc<dyn Model> = Arc::new(FingerprintCheckingModel {
         inner: DeterministicModel::new(responses),
+        redactor: fp_redactor,
         expected_fps,
         expected_canonicals,
         step: Mutex::new(0),
@@ -352,6 +363,11 @@ fn make_unified_diff(
 /// scripted response is consumed.
 struct FingerprintCheckingModel {
     inner: DeterministicModel,
+    /// Redactor used to apply TRAJECTORY-surface redaction to messages before
+    /// fingerprinting — mirrors the same redaction applied on the recording side
+    /// so that raw secrets in extra_context/skills produce the same canonical
+    /// form as they did when the trajectory was recorded.
+    redactor: Redactor,
     /// Stored fingerprints from the cassette trajectory, one per assistant
     /// message in order. `None` means the original was recorded without
     /// fingerprints (legacy trajectory).
@@ -382,15 +398,16 @@ impl Model for FingerprintCheckingModel {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-        // Normalize redaction markers before fingerprinting so the actual hash
-        // matches the stored hash regardless of which per-run Redactor salt was
-        // used (recording and replay produce different [REDACTED:k:s:HASH] forms
-        // for the same underlying secret; strip the hash segment for both sides).
+        // Mirror the recording-side fingerprinting: apply TRAJECTORY-surface
+        // redaction first (so raw secrets in extra_context/skills hash the same
+        // as the recorded [REDACTED:...] markers), then normalize the per-run
+        // salt from every marker so hashes are stable across runs.
         let normalized: Vec<Message> = messages
             .iter()
             .map(|m| {
                 let mut m2 = m.clone();
-                m2.content = crate::fingerprint::normalize_redaction_markers(&m.content);
+                let redacted = self.redactor.redact_text(&m.content, surface::TRAJECTORY).text;
+                m2.content = crate::fingerprint::normalize_redaction_markers(&redacted);
                 m2
             })
             .collect();

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -1,26 +1,87 @@
-use std::path::PathBuf;
-use std::sync::Arc;
+//! `bench replay` runner — re-runs an agent against a recorded trajectory's
+//! scripted responses and, when fingerprints are present, validates that the
+//! agent is asking the model the same questions it asked originally.
+//!
+//! # Exit-code contract
+//!
+//! | Code | Meaning |
+//! |------|---------|
+//! | 0    | Replay completed without drift. |
+//! | 9    | Prompt drift: at least one step's input fingerprint did not match. |
+//! | 10   | Scripted responses exhausted before the agent finished. |
+//! | 2    | Usage error: trajectory has no fingerprints and `--allow-unfingerprinted` was not passed. |
+//! | 1    | Other internal error. |
+//!
+//! See `docs/spec-replay.md` for the full contract.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 
 use crate::agent::{Agent, DefaultAgent, default::DefaultAgentBuilder};
 use crate::config::{Config, EnvKind};
 #[cfg(feature = "docker")]
 use crate::env::DockerEnvironment;
 use crate::env::{Environment, LocalEnvironment};
-use crate::error::Error;
-use crate::model::{DeterministicModel, Model};
+use crate::error::{Error, ModelError};
+use crate::fingerprint::{canonical_json, compute_input_fingerprint};
+use crate::model::{DeterministicModel, Message, Model, ModelResponse, QueryOpts};
 use crate::trajectory::Trajectory;
+
+/// Filename written to `output_dir` when drift is detected.
+pub const DRIFT_REPORT_FILENAME: &str = "replay-drift.json";
+
+/// Default byte cap for the actual-canonical snippet in a drift report.
+pub const DEFAULT_DRIFT_CAP_BYTES: usize = 8 * 1024;
+
+// ── public API ────────────────────────────────────────────────────────────────
 
 pub struct ReplayArgs {
     pub trajectory_path: PathBuf,
     pub config: Config,
     pub output_dir: PathBuf,
     pub trajectory_name: Option<String>,
+    /// When `true`, replaying a trajectory that has no fingerprints on its
+    /// assistant messages emits a warning but succeeds. When `false` (default),
+    /// an unfingerprinted trajectory causes a non-zero exit.
+    pub allow_unfingerprinted: bool,
+    /// When `true`, replay runs to completion despite any fingerprint drift,
+    /// writes a full drift report, and exits 0. When `false` (default), replay
+    /// stops at the first drift and exits with code 9.
+    pub report_only: bool,
+    /// Maximum bytes of the actual canonical JSON to include per drift step.
+    pub drift_cap_bytes: usize,
 }
+
+/// One step that exhibited fingerprint drift.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DriftStep {
+    /// 0-based index of the model-query step where drift was detected.
+    pub step_index: usize,
+    /// Fingerprint stored in the cassette trajectory.
+    pub recorded_fingerprint: String,
+    /// Fingerprint computed from the actual messages during this replay.
+    pub actual_fingerprint: String,
+    /// First `drift_cap_bytes` of the actual canonical input JSON.
+    pub actual_canonical_snippet: String,
+    /// `true` if `actual_canonical_snippet` was truncated.
+    pub truncated: bool,
+}
+
+/// Structured drift report written to `{output_dir}/replay-drift.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DriftReport {
+    pub steps: Vec<DriftStep>,
+}
+
+// ── main entry point ──────────────────────────────────────────────────────────
 
 pub async fn run(args: ReplayArgs) -> Result<(), Error> {
     std::fs::create_dir_all(&args.output_dir)?;
 
-    // 1. Load the original trajectory
+    // 1. Load original trajectory.
     let file_content = std::fs::read_to_string(&args.trajectory_path)?;
     let orig_trajectory: Trajectory = serde_json::from_str(&file_content).map_err(|e| {
         Error::Config(crate::error::ConfigError::Invalid(format!(
@@ -28,13 +89,23 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
         )))
     })?;
 
-    // 2. Extract assistant messages (the agent's actions)
-    let responses: Vec<String> = orig_trajectory
+    // 2. Extract assistant messages — responses + expected fingerprints.
+    let (responses, expected_fps): (Vec<String>, Vec<Option<String>>) = orig_trajectory
         .messages
-        .into_iter()
+        .iter()
         .filter(|m| m.role == "assistant")
-        .map(|m| m.content)
-        .collect();
+        .map(|m| {
+            let content = m.content.clone();
+            let fp = m
+                .extra
+                .other
+                .get("model_call")
+                .and_then(|mc| mc.get("input_fingerprint"))
+                .and_then(|v| v.as_str())
+                .map(str::to_owned);
+            (content, fp)
+        })
+        .unzip();
 
     if responses.is_empty() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(
@@ -42,8 +113,27 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
         )));
     }
 
-    // 3. Setup the replay environment and model
-    let model: Arc<dyn Model> = Arc::new(DeterministicModel::new(responses));
+    let task = orig_trajectory
+        .info
+        .task
+        .unwrap_or_else(|| "Replayed Task".into());
+    let traj_name = args
+        .trajectory_name
+        .unwrap_or_else(|| crate::run::mini::slugify(&task));
+
+    // 3. Build fingerprint-checking model.
+    let drift_steps: Arc<Mutex<Vec<DriftStep>>> = Arc::new(Mutex::new(Vec::new()));
+    let model: Arc<dyn Model> = Arc::new(FingerprintCheckingModel {
+        inner: DeterministicModel::new(responses),
+        expected_fps,
+        step: Mutex::new(0),
+        allow_unfingerprinted: args.allow_unfingerprinted,
+        report_only: args.report_only,
+        drift_cap_bytes: args.drift_cap_bytes,
+        drift_steps: Arc::clone(&drift_steps),
+    });
+
+    // 4. Build environment and agent.
     let env = build_env(&args.config).await?;
     let tool_providers = crate::tool::discover_mcp_servers(
         env.as_ref(),
@@ -53,14 +143,7 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
     )
     .await?;
 
-    let task = orig_trajectory
-        .info
-        .task
-        .unwrap_or_else(|| "Replayed Task".into());
     let resolved_skills = crate::skills::resolve_for_task(&args.config.root.skills, &task, None)?;
-    let traj_name = args
-        .trajectory_name
-        .unwrap_or_else(|| crate::run::mini::slugify(&task));
 
     let mut agent: DefaultAgent = DefaultAgentBuilder {
         config: args.config.clone(),
@@ -76,22 +159,183 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
         .active_skills
         .record_redacted_provenance(&mut agent.trajectory.info, &agent.redactor)?;
 
-    // 4. Run the replay
+    // 5. Run the replay.
     tracing::info!(?args.trajectory_path, "starting replay mode");
-    let exit = agent.run().await?;
+    let run_result = agent.run().await;
 
-    // 5. Save the new trajectory
-    let traj_path = args.output_dir.join(format!("{traj_name}.traj.json"));
-    agent.trajectory.save_pretty(&traj_path)?;
+    // 6. Collect any drift steps recorded during the run.
+    let collected = {
+        drift_steps
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    };
 
-    if let crate::agent::ExitReason::Submitted { final_output } = &exit {
-        let out_path = args.output_dir.join(format!("{traj_name}.output.txt"));
-        std::fs::write(&out_path, final_output)?;
+    // 7. Write drift report to disk and stderr when there is drift.
+    if !collected.is_empty() {
+        let report = DriftReport { steps: collected };
+        write_drift_report(&args.output_dir, &report)?;
     }
 
-    tracing::info!(?traj_path, "replay trajectory written");
+    // 8. In --report-only mode always exit 0 (drift was collected above).
+    if args.report_only {
+        // Best-effort trajectory save even when the run had errors.
+        if let Ok(ref exit) = run_result {
+            save_outputs(&agent, &args.output_dir, &traj_name, exit)?;
+        } else {
+            // Save whatever trajectory we managed to produce.
+            let traj_path = args.output_dir.join(format!("{traj_name}.traj.json"));
+            agent.trajectory.save_pretty(&traj_path)?;
+        }
+        return Ok(());
+    }
+
+    // 9. Fail-fast mode: propagate errors from the run.
+    let exit = run_result?;
+    save_outputs(&agent, &args.output_dir, &traj_name, &exit)?;
+    tracing::info!("replay trajectory written");
     Ok(())
 }
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn save_outputs(
+    agent: &DefaultAgent,
+    output_dir: &Path,
+    traj_name: &str,
+    exit: &crate::agent::ExitReason,
+) -> Result<(), Error> {
+    let traj_path = output_dir.join(format!("{traj_name}.traj.json"));
+    agent.trajectory.save_pretty(&traj_path)?;
+
+    if let crate::agent::ExitReason::Submitted { final_output } = exit {
+        let out_path = output_dir.join(format!("{traj_name}.output.txt"));
+        std::fs::write(out_path, final_output)?;
+    }
+    Ok(())
+}
+
+fn write_drift_report(output_dir: &Path, report: &DriftReport) -> Result<(), Error> {
+    let json = serde_json::to_string_pretty(report)?;
+    let path = output_dir.join(DRIFT_REPORT_FILENAME);
+    std::fs::write(&path, json)?;
+
+    eprintln!(
+        "replay-drift: {} step(s) with prompt divergence",
+        report.steps.len()
+    );
+    for s in &report.steps {
+        eprintln!(
+            "  step {}: recorded={} actual={}",
+            s.step_index, s.recorded_fingerprint, s.actual_fingerprint
+        );
+    }
+    Ok(())
+}
+
+fn truncate_canonical(canonical: &str, cap: usize) -> (String, bool) {
+    if canonical.len() <= cap {
+        return (canonical.to_owned(), false);
+    }
+    let mut end = cap;
+    while end > 0 && !canonical.is_char_boundary(end) {
+        end -= 1;
+    }
+    (
+        format!("{}[truncated]", &canonical[..end]),
+        true,
+    )
+}
+
+// ── FingerprintCheckingModel ──────────────────────────────────────────────────
+
+/// Wraps `DeterministicModel` and enforces fingerprint integrity before each
+/// scripted response is consumed.
+struct FingerprintCheckingModel {
+    inner: DeterministicModel,
+    /// Stored fingerprints from the cassette trajectory, one per assistant
+    /// message in order. `None` means the original was recorded without
+    /// fingerprints (legacy trajectory).
+    expected_fps: Vec<Option<String>>,
+    step: Mutex<usize>,
+    allow_unfingerprinted: bool,
+    report_only: bool,
+    drift_cap_bytes: usize,
+    drift_steps: Arc<Mutex<Vec<DriftStep>>>,
+}
+
+#[async_trait]
+impl Model for FingerprintCheckingModel {
+    fn name(&self) -> &'static str {
+        "fingerprint-checking-replay"
+    }
+
+    async fn query(
+        &self,
+        messages: &[Message],
+        opts: &QueryOpts,
+    ) -> Result<ModelResponse, ModelError> {
+        let step = *self
+            .step
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let actual_fp = compute_input_fingerprint(messages);
+
+        match self.expected_fps.get(step) {
+            Some(None) => {
+                // Legacy trajectory — no fingerprint stored.
+                if !self.allow_unfingerprinted {
+                    return Err(ModelError::ReplayUnfingerprintedLegacy(step));
+                }
+                tracing::warn!(
+                    step,
+                    "replaying step without stored fingerprint (--allow-unfingerprinted active)"
+                );
+            }
+            Some(Some(expected)) if actual_fp.hex != *expected => {
+                // Fingerprint mismatch — prompt drift.
+                let canonical = canonical_json(messages);
+                let (snippet, truncated) =
+                    truncate_canonical(&canonical, self.drift_cap_bytes);
+                {
+                    let mut guard = self
+                        .drift_steps
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    guard.push(DriftStep {
+                        step_index: step,
+                        recorded_fingerprint: expected.clone(),
+                        actual_fingerprint: actual_fp.hex.clone(),
+                        actual_canonical_snippet: snippet,
+                        truncated,
+                    });
+                }
+
+                if !self.report_only {
+                    // Fail-fast: do NOT consume the scripted response.
+                    return Err(ModelError::ReplayDrift(step));
+                }
+                // Report-only: fall through and consume the response.
+            }
+            Some(Some(_)) | None => {
+                // Fingerprint matches or step is out of expected range;
+                // proceed normally (inner model handles out-of-range via
+                // ScriptedResponsesExhausted).
+            }
+        }
+
+        // Advance step counter only after the fingerprint check passes.
+        *self
+            .step
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = step + 1;
+
+        self.inner.query(messages, opts).await
+    }
+}
+
+// ── environment helpers ───────────────────────────────────────────────────────
 
 async fn build_env(cfg: &Config) -> Result<Box<dyn Environment>, Error> {
     match cfg.root.environment.kind {
@@ -113,12 +357,14 @@ async fn build_docker_env(cfg: &Config) -> Result<Box<dyn Environment>, Error> {
 }
 
 #[cfg(not(feature = "docker"))]
-#[allow(clippy::unused_async)] // Mirrors the docker-feature signature.
+#[allow(clippy::unused_async)]
 async fn build_docker_env(_cfg: &Config) -> Result<Box<dyn Environment>, Error> {
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "docker support not compiled in — rebuild with --features docker".into(),
     )))
 }
+
+// ── tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
@@ -128,12 +374,8 @@ mod tests {
     use crate::trajectory::MessageRecord;
     use tempfile::tempdir;
 
-    #[tokio::test]
-    async fn test_replay_mode() {
-        let dir = tempdir().unwrap();
-
-        // Setup a dummy trajectory file
-        let traj = Trajectory {
+    fn make_simple_traj() -> Trajectory {
+        Trajectory {
             trajectory_format: "mini-swe-agent-1.1".into(),
             info: crate::trajectory::TrajectoryInfo {
                 task: Some("dummy task".into()),
@@ -161,7 +403,13 @@ mod tests {
                     extra: MessageExtra::default(),
                 },
             ],
-        };
+        }
+    }
+
+    #[tokio::test]
+    async fn test_replay_mode_allow_unfingerprinted() {
+        let dir = tempdir().unwrap();
+        let traj = make_simple_traj();
         let dummy_path = dir.path().join("input.traj.json");
         traj.save_pretty(&dummy_path).unwrap();
 
@@ -171,6 +419,9 @@ mod tests {
             config: cfg,
             output_dir: dir.path().to_path_buf(),
             trajectory_name: Some("replayed-run".into()),
+            allow_unfingerprinted: true,
+            report_only: false,
+            drift_cap_bytes: DEFAULT_DRIFT_CAP_BYTES,
         };
 
         run(args).await.unwrap();
@@ -180,14 +431,26 @@ mod tests {
             .filter_map(Result::ok)
             .collect();
 
-        let traj_written = entries
+        assert!(entries
             .iter()
-            .any(|e| e.file_name().to_string_lossy() == "replayed-run.traj.json");
-        assert!(traj_written);
+            .any(|e| e.file_name().to_string_lossy() == "replayed-run.traj.json"));
+        assert!(entries
+            .iter()
+            .any(|e| e.file_name().to_string_lossy() == "replayed-run.output.txt"));
+        assert!(!dir.path().join(DRIFT_REPORT_FILENAME).exists());
+    }
 
-        let output_written = entries
-            .iter()
-            .any(|e| e.file_name().to_string_lossy() == "replayed-run.output.txt");
-        assert!(output_written);
+    #[test]
+    fn truncate_canonical_under_cap_is_unchanged() {
+        let (s, truncated) = truncate_canonical("hello", 10);
+        assert_eq!(s, "hello");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn truncate_canonical_over_cap_adds_marker() {
+        let (s, truncated) = truncate_canonical("hello world", 5);
+        assert!(s.ends_with("[truncated]"));
+        assert!(truncated);
     }
 }

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -93,7 +93,11 @@ struct CassetteEntry {
     canonical_truncated: bool,
 }
 
-type CassetteVecs = (Vec<String>, Vec<Option<String>>, Vec<Option<(String, bool)>>);
+type CassetteVecs = (
+    Vec<String>,
+    Vec<Option<String>>,
+    Vec<Option<(String, bool)>>,
+);
 
 fn extract_cassette(trajectory: &Trajectory) -> Vec<CassetteEntry> {
     trajectory
@@ -230,10 +234,7 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
     //    all other errors (usage errors, exhausted responses, I/O failures, …)
     //    so operators see an honest exit code for structural problems.
     if args.report_only {
-        let is_drift_only = matches!(
-            &run_result,
-            Err(Error::Model(ModelError::ReplayDrift(_)))
-        );
+        let is_drift_only = matches!(&run_result, Err(Error::Model(ModelError::ReplayDrift(_))));
         if is_drift_only || run_result.is_ok() {
             if let Ok(ref exit) = run_result {
                 save_outputs(&agent, &args.output_dir, &traj_name, exit)?;
@@ -539,12 +540,16 @@ mod tests {
             .filter_map(Result::ok)
             .collect();
 
-        assert!(entries
-            .iter()
-            .any(|e| e.file_name().to_string_lossy() == "replayed-run.traj.json"));
-        assert!(entries
-            .iter()
-            .any(|e| e.file_name().to_string_lossy() == "replayed-run.output.txt"));
+        assert!(
+            entries
+                .iter()
+                .any(|e| e.file_name().to_string_lossy() == "replayed-run.traj.json")
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|e| e.file_name().to_string_lossy() == "replayed-run.output.txt")
+        );
         assert!(!dir.path().join(DRIFT_REPORT_FILENAME).exists());
     }
 

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -29,7 +29,7 @@ use crate::env::{Environment, LocalEnvironment};
 use crate::error::{Error, ModelError};
 use crate::fingerprint::{canonical_json, cap_canonical, compute_input_fingerprint};
 use crate::model::{DeterministicModel, Message, Model, ModelResponse, QueryOpts};
-use crate::redaction::{Redactor, surface};
+use crate::redaction::Redactor;
 use crate::trajectory::Trajectory;
 
 /// Filename written to `output_dir` when drift is detected.
@@ -402,14 +402,13 @@ impl Model for FingerprintCheckingModel {
         // redaction first (so raw secrets in extra_context/skills hash the same
         // as the recorded [REDACTED:...] markers), then normalize the per-run
         // salt from every marker so hashes are stable across runs.
+        // Use redact_text_scratch so this pass does not inflate the run's
+        // redaction-count telemetry.
         let normalized: Vec<Message> = messages
             .iter()
             .map(|m| {
                 let mut m2 = m.clone();
-                let redacted = self
-                    .redactor
-                    .redact_text(&m.content, surface::TRAJECTORY)
-                    .text;
+                let redacted = self.redactor.redact_text_scratch(&m.content);
                 m2.content = crate::fingerprint::normalize_redaction_markers(&redacted);
                 m2
             })

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -444,7 +444,13 @@ impl Model for FingerprintCheckingModel {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = step + 1;
 
-        self.inner.query(messages, opts).await
+        // Translate the generic scripted-model exhaustion into the
+        // replay-specific variant so that `ExitCode::from_error` maps it to
+        // `ReplayResponseExhausted` (10) only in replay context.
+        self.inner.query(messages, opts).await.map_err(|e| match e {
+            ModelError::ResponsesExhausted(n) => ModelError::ScriptedResponsesExhausted(n),
+            other => other,
+        })
     }
 }
 

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -19,6 +19,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use similar::{ChangeTag, TextDiff};
 
 use crate::agent::{Agent, DefaultAgent, default::DefaultAgentBuilder};
 use crate::config::{Config, EnvKind};
@@ -26,15 +27,19 @@ use crate::config::{Config, EnvKind};
 use crate::env::DockerEnvironment;
 use crate::env::{Environment, LocalEnvironment};
 use crate::error::{Error, ModelError};
-use crate::fingerprint::{canonical_json, compute_input_fingerprint};
+use crate::fingerprint::{canonical_json, cap_canonical, compute_input_fingerprint};
 use crate::model::{DeterministicModel, Message, Model, ModelResponse, QueryOpts};
 use crate::trajectory::Trajectory;
 
 /// Filename written to `output_dir` when drift is detected.
 pub const DRIFT_REPORT_FILENAME: &str = "replay-drift.json";
 
-/// Default byte cap for the actual-canonical snippet in a drift report.
+/// Default byte cap applied to the unified diff string in each drift step.
 pub const DEFAULT_DRIFT_CAP_BYTES: usize = 8 * 1024;
+
+/// Byte cap applied when storing `input_canonical` in trajectory assistant messages.
+/// Exported so `DefaultAgent` can reference a single source of truth.
+pub const CANONICAL_CAP_BYTES: usize = 64 * 1024;
 
 // ── public API ────────────────────────────────────────────────────────────────
 
@@ -51,7 +56,7 @@ pub struct ReplayArgs {
     /// writes a full drift report, and exits 0. When `false` (default), replay
     /// stops at the first drift and exits with code 9.
     pub report_only: bool,
-    /// Maximum bytes of the actual canonical JSON to include per drift step.
+    /// Maximum bytes of the unified diff string included per drift step.
     pub drift_cap_bytes: usize,
 }
 
@@ -64,16 +69,73 @@ pub struct DriftStep {
     pub recorded_fingerprint: String,
     /// Fingerprint computed from the actual messages during this replay.
     pub actual_fingerprint: String,
-    /// First `drift_cap_bytes` of the actual canonical input JSON.
-    pub actual_canonical_snippet: String,
-    /// `true` if `actual_canonical_snippet` was truncated.
-    pub truncated: bool,
+    /// Unified diff (`-` recorded, `+` actual) of the pretty-printed canonical
+    /// inputs, capped to `drift_cap_bytes` with a `[truncated]` marker if cut.
+    pub unified_diff: String,
+    /// `true` if the diff was truncated OR if the recorded canonical was already
+    /// truncated when stored in the cassette.
+    pub diff_truncated: bool,
 }
 
 /// Structured drift report written to `{output_dir}/replay-drift.json`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DriftReport {
     pub steps: Vec<DriftStep>,
+}
+
+// ── cassette extraction ───────────────────────────────────────────────────────
+
+struct CassetteEntry {
+    response: String,
+    fingerprint: Option<String>,
+    canonical: Option<String>,
+    canonical_truncated: bool,
+}
+
+type CassetteVecs = (Vec<String>, Vec<Option<String>>, Vec<Option<(String, bool)>>);
+
+fn extract_cassette(trajectory: &Trajectory) -> Vec<CassetteEntry> {
+    trajectory
+        .messages
+        .iter()
+        .filter(|m| m.role == "assistant")
+        .map(|m| {
+            let mc = m.extra.other.get("model_call");
+            let fingerprint = mc
+                .and_then(|v| v.get("input_fingerprint"))
+                .and_then(|v| v.as_str())
+                .map(str::to_owned);
+            let canonical = mc
+                .and_then(|v| v.get("input_canonical"))
+                .and_then(|v| v.as_str())
+                .map(str::to_owned);
+            let canonical_truncated = mc
+                .and_then(|v| v.get("input_canonical_truncated"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+            CassetteEntry {
+                response: m.content.clone(),
+                fingerprint,
+                canonical,
+                canonical_truncated,
+            }
+        })
+        .collect()
+}
+
+fn unzip_cassette(cassette: Vec<CassetteEntry>) -> CassetteVecs {
+    cassette
+        .into_iter()
+        .fold(
+            (Vec::new(), Vec::new(), Vec::new()),
+            |(mut rs, mut fps, mut cs), e| {
+                let canon = e.canonical.map(|c| (c, e.canonical_truncated));
+                rs.push(e.response);
+                fps.push(e.fingerprint);
+                cs.push(canon);
+                (rs, fps, cs)
+            },
+        )
 }
 
 // ── main entry point ──────────────────────────────────────────────────────────
@@ -89,29 +151,16 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
         )))
     })?;
 
-    // 2. Extract assistant messages — responses + expected fingerprints.
-    let (responses, expected_fps): (Vec<String>, Vec<Option<String>>) = orig_trajectory
-        .messages
-        .iter()
-        .filter(|m| m.role == "assistant")
-        .map(|m| {
-            let content = m.content.clone();
-            let fp = m
-                .extra
-                .other
-                .get("model_call")
-                .and_then(|mc| mc.get("input_fingerprint"))
-                .and_then(|v| v.as_str())
-                .map(str::to_owned);
-            (content, fp)
-        })
-        .unzip();
+    // 2. Extract assistant messages — responses, expected fingerprints, recorded canonicals.
+    let cassette = extract_cassette(&orig_trajectory);
 
-    if responses.is_empty() {
+    if cassette.is_empty() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(
             "No assistant messages found in trajectory to replay".into(),
         )));
     }
+
+    let (responses, expected_fps, expected_canonicals) = unzip_cassette(cassette);
 
     let task = orig_trajectory
         .info
@@ -126,6 +175,7 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
     let model: Arc<dyn Model> = Arc::new(FingerprintCheckingModel {
         inner: DeterministicModel::new(responses),
         expected_fps,
+        expected_canonicals,
         step: Mutex::new(0),
         allow_unfingerprinted: args.allow_unfingerprinted,
         report_only: args.report_only,
@@ -183,7 +233,6 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
         if let Ok(ref exit) = run_result {
             save_outputs(&agent, &args.output_dir, &traj_name, exit)?;
         } else {
-            // Save whatever trajectory we managed to produce.
             let traj_path = args.output_dir.join(format!("{traj_name}.traj.json"));
             agent.trajectory.save_pretty(&traj_path)?;
         }
@@ -233,18 +282,50 @@ fn write_drift_report(output_dir: &Path, report: &DriftReport) -> Result<(), Err
     Ok(())
 }
 
-fn truncate_canonical(canonical: &str, cap: usize) -> (String, bool) {
-    if canonical.len() <= cap {
-        return (canonical.to_owned(), false);
+/// Pretty-print a compact canonical JSON string for human-readable diffing.
+/// Falls back to the raw string if parsing fails.
+fn pretty_canonical(compact: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(compact)
+        .ok()
+        .and_then(|v| serde_json::to_string_pretty(&v).ok())
+        .unwrap_or_else(|| compact.to_owned())
+}
+
+/// Produce a unified diff (`-` = recorded, `+` = actual) between two pretty-printed
+/// canonical strings, capped to `cap` bytes.
+///
+/// `recorded_was_truncated` indicates the cassette stored a truncated form — the
+/// diff is best-effort in that case and `diff_truncated` is set to `true`.
+fn make_unified_diff(
+    recorded: &str,
+    actual: &str,
+    recorded_was_truncated: bool,
+    cap: usize,
+) -> (String, bool) {
+    let recorded_pretty = pretty_canonical(recorded);
+    let actual_pretty = pretty_canonical(actual);
+
+    let diff = TextDiff::from_lines(&recorded_pretty, &actual_pretty);
+    let mut out = String::new();
+    for group in diff.grouped_ops(3) {
+        for op in &group {
+            for change in diff.iter_changes(op) {
+                let prefix = match change.tag() {
+                    ChangeTag::Delete => "-",
+                    ChangeTag::Insert => "+",
+                    ChangeTag::Equal => " ",
+                };
+                out.push_str(prefix);
+                out.push_str(change.value());
+                if change.missing_newline() {
+                    out.push('\n');
+                }
+            }
+        }
     }
-    let mut end = cap;
-    while end > 0 && !canonical.is_char_boundary(end) {
-        end -= 1;
-    }
-    (
-        format!("{}[truncated]", &canonical[..end]),
-        true,
-    )
+
+    let (capped, diff_cap_hit) = cap_canonical(&out, cap);
+    (capped, diff_cap_hit || recorded_was_truncated)
 }
 
 // ── FingerprintCheckingModel ──────────────────────────────────────────────────
@@ -257,6 +338,9 @@ struct FingerprintCheckingModel {
     /// message in order. `None` means the original was recorded without
     /// fingerprints (legacy trajectory).
     expected_fps: Vec<Option<String>>,
+    /// Stored canonical JSON from the cassette, paired with a truncation flag.
+    /// `None` means the original was recorded without canonical storage (legacy).
+    expected_canonicals: Vec<Option<(String, bool)>>,
     step: Mutex<usize>,
     allow_unfingerprinted: bool,
     report_only: bool,
@@ -295,9 +379,20 @@ impl Model for FingerprintCheckingModel {
             }
             Some(Some(expected)) if actual_fp.hex != *expected => {
                 // Fingerprint mismatch — prompt drift.
-                let canonical = canonical_json(messages);
-                let (snippet, truncated) =
-                    truncate_canonical(&canonical, self.drift_cap_bytes);
+                let actual_canonical = canonical_json(messages);
+                let (recorded_canonical, recorded_was_truncated) = self
+                    .expected_canonicals
+                    .get(step)
+                    .and_then(Option::as_ref)
+                    .map_or(("", false), |(c, t)| (c.as_str(), *t));
+
+                let (unified_diff, diff_truncated) = make_unified_diff(
+                    recorded_canonical,
+                    &actual_canonical,
+                    recorded_was_truncated,
+                    self.drift_cap_bytes,
+                );
+
                 {
                     let mut guard = self
                         .drift_steps
@@ -307,8 +402,8 @@ impl Model for FingerprintCheckingModel {
                         step_index: step,
                         recorded_fingerprint: expected.clone(),
                         actual_fingerprint: actual_fp.hex.clone(),
-                        actual_canonical_snippet: snippet,
-                        truncated,
+                        unified_diff,
+                        diff_truncated,
                     });
                 }
 
@@ -441,16 +536,44 @@ mod tests {
     }
 
     #[test]
-    fn truncate_canonical_under_cap_is_unchanged() {
-        let (s, truncated) = truncate_canonical("hello", 10);
-        assert_eq!(s, "hello");
+    fn make_unified_diff_shows_changes() {
+        let recorded = r#"[{"content":"hello","role":"user"}]"#;
+        let actual = r#"[{"content":"world","role":"user"}]"#;
+        let (diff, truncated) = make_unified_diff(recorded, actual, false, DEFAULT_DRIFT_CAP_BYTES);
         assert!(!truncated);
+        assert!(diff.contains('-'), "diff must have deletion lines");
+        assert!(diff.contains('+'), "diff must have insertion lines");
+        assert!(diff.contains("hello"), "diff must show removed text");
+        assert!(diff.contains("world"), "diff must show added text");
     }
 
     #[test]
-    fn truncate_canonical_over_cap_adds_marker() {
-        let (s, truncated) = truncate_canonical("hello world", 5);
-        assert!(s.ends_with("[truncated]"));
-        assert!(truncated);
+    fn make_unified_diff_identical_inputs_is_empty() {
+        let canon = r#"[{"content":"hi","role":"user"}]"#;
+        let (diff, truncated) = make_unified_diff(canon, canon, false, DEFAULT_DRIFT_CAP_BYTES);
+        assert!(!truncated);
+        // All lines are equal — grouped_ops(3) produces no hunks for identical input.
+        assert!(diff.is_empty(), "no diff expected for identical inputs");
+    }
+
+    #[test]
+    fn make_unified_diff_truncates_when_over_cap() {
+        let long = "x".repeat(100);
+        let recorded = format!(r#"[{{"content":"{long}","role":"user"}}]"#);
+        let actual = format!(r#"[{{"content":"{long}z","role":"user"}}]"#);
+        let (diff, truncated) =
+            make_unified_diff(&recorded, &actual, false, 10);
+        assert!(truncated, "diff must be marked truncated when over cap");
+        assert!(diff.ends_with("[truncated]"));
+    }
+
+    #[test]
+    fn make_unified_diff_recorded_truncated_flag_propagates() {
+        let canon = r#"[{"content":"hi","role":"user"}]"#;
+        let (_, truncated) = make_unified_diff(canon, canon, true, DEFAULT_DRIFT_CAP_BYTES);
+        assert!(
+            truncated,
+            "diff_truncated must be true when recorded canonical was truncated"
+        );
     }
 }

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -430,14 +430,19 @@ impl Model for FingerprintCheckingModel {
             Some(Some(expected)) if actual_fp.hex != *expected => {
                 // Fingerprint mismatch — prompt drift.
                 let actual_canonical = canonical_json(&normalized);
-                let (recorded_canonical, recorded_was_truncated) = self
+                let (recorded_canonical_raw, recorded_was_truncated) = self
                     .expected_canonicals
                     .get(step)
                     .and_then(Option::as_ref)
                     .map_or(("", false), |(c, t)| (c.as_str(), *t));
+                // The stored canonical uses hashed markers ([REDACTED:k:s:HASH]).
+                // Normalize it before diffing so per-run salts don't appear as
+                // spurious differences in the drift report.
+                let recorded_canonical_normalized =
+                    crate::fingerprint::normalize_redaction_markers(recorded_canonical_raw);
 
                 let (unified_diff, diff_truncated) = make_unified_diff(
-                    recorded_canonical,
+                    &recorded_canonical_normalized,
                     &actual_canonical,
                     recorded_was_truncated,
                     self.drift_cap_bytes,

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -382,7 +382,19 @@ impl Model for FingerprintCheckingModel {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-        let actual_fp = compute_input_fingerprint(messages);
+        // Normalize redaction markers before fingerprinting so the actual hash
+        // matches the stored hash regardless of which per-run Redactor salt was
+        // used (recording and replay produce different [REDACTED:k:s:HASH] forms
+        // for the same underlying secret; strip the hash segment for both sides).
+        let normalized: Vec<Message> = messages
+            .iter()
+            .map(|m| {
+                let mut m2 = m.clone();
+                m2.content = crate::fingerprint::normalize_redaction_markers(&m.content);
+                m2
+            })
+            .collect();
+        let actual_fp = compute_input_fingerprint(&normalized);
 
         match self.expected_fps.get(step) {
             Some(None) => {
@@ -397,7 +409,7 @@ impl Model for FingerprintCheckingModel {
             }
             Some(Some(expected)) if actual_fp.hex != *expected => {
                 // Fingerprint mismatch — prompt drift.
-                let actual_canonical = canonical_json(messages);
+                let actual_canonical = canonical_json(&normalized);
                 let (recorded_canonical, recorded_was_truncated) = self
                     .expected_canonicals
                     .get(step)

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -224,10 +224,14 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
             .clone()
     };
 
-    // 7. Write drift report to disk and stderr when there is drift.
+    // 7. Write drift report when there is drift; remove any stale report when
+    //    there is none, so reused CI output directories don't show old results.
+    let drift_report_path = args.output_dir.join(DRIFT_REPORT_FILENAME);
     if !collected.is_empty() {
         let report = DriftReport { steps: collected };
         write_drift_report(&args.output_dir, &report)?;
+    } else if drift_report_path.exists() {
+        std::fs::remove_file(&drift_report_path)?;
     }
 
     // 8. In --report-only mode suppress only prompt-drift failures; propagate
@@ -551,6 +555,36 @@ mod tests {
                 .any(|e| e.file_name().to_string_lossy() == "replayed-run.output.txt")
         );
         assert!(!dir.path().join(DRIFT_REPORT_FILENAME).exists());
+    }
+
+    #[tokio::test]
+    async fn clean_replay_removes_stale_drift_report() {
+        let dir = tempdir().unwrap();
+        let traj = make_simple_traj();
+        let dummy_path = dir.path().join("input.traj.json");
+        traj.save_pretty(&dummy_path).unwrap();
+
+        // Pre-plant a stale drift report from a previous run.
+        let stale_path = dir.path().join(DRIFT_REPORT_FILENAME);
+        std::fs::write(&stale_path, r#"{"steps":[]}"#).unwrap();
+        assert!(stale_path.exists(), "precondition: stale report exists");
+
+        let cfg = Config::defaults().unwrap();
+        let args = ReplayArgs {
+            trajectory_path: dummy_path,
+            config: cfg,
+            output_dir: dir.path().to_path_buf(),
+            trajectory_name: Some("clean-run".into()),
+            allow_unfingerprinted: true,
+            report_only: false,
+            drift_cap_bytes: DEFAULT_DRIFT_CAP_BYTES,
+        };
+        run(args).await.unwrap();
+
+        assert!(
+            !stale_path.exists(),
+            "clean replay must remove the stale drift report"
+        );
     }
 
     #[test]

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -166,6 +166,15 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
 
     let (responses, expected_fps, expected_canonicals) = unzip_cassette(cassette);
 
+    // Validate fingerprint coverage before any environment setup so that legacy
+    // cassettes are rejected immediately, without starting Docker containers or
+    // connecting to MCP servers.
+    if !args.allow_unfingerprinted {
+        if let Some(pos) = expected_fps.iter().position(Option::is_none) {
+            return Err(Error::Model(ModelError::ReplayUnfingerprintedLegacy(pos)));
+        }
+    }
+
     let task = orig_trajectory
         .info
         .task

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -6063,7 +6063,7 @@ instance = "inst"
         assert_eq!(v["artifact_kind"], "preflight_report");
         assert_eq!(
             v["schema_version"],
-            serde_json::json!({"major": 1, "minor": 3})
+            serde_json::json!({"major": 1, "minor": 4})
         );
         assert!(v.get("mode").is_some());
         assert!(v.get("checks").is_some());

--- a/tests/artifact_schema.rs
+++ b/tests/artifact_schema.rs
@@ -21,10 +21,10 @@ mod support;
 use support::binary_path;
 
 #[test]
-fn artifact_schema_current_minor_bumped_for_calibration_report() {
+fn artifact_schema_current_minor_bumped_for_replay_fingerprinting() {
     assert_eq!(
         ArtifactSchemaVersion::CURRENT,
-        ArtifactSchemaVersion::new(1, 3)
+        ArtifactSchemaVersion::new(1, 4)
     );
 }
 
@@ -32,7 +32,7 @@ fn artifact_schema_current_minor_bumped_for_calibration_report() {
 fn artifact_classifier_marks_exact_current_version_supported_current() {
     let payload = serde_json::json!({
         "artifact_kind": "sweep_results",
-        "schema_version": {"major": 1, "minor": 3},
+        "schema_version": {"major": 1, "minor": 4},
         "total": 0,
         "instances": []
     });
@@ -142,7 +142,7 @@ fn trajectory_serialization_includes_artifact_header() {
     assert_eq!(value["artifact_kind"], "trajectory");
     assert_eq!(
         value["schema_version"],
-        serde_json::json!({"major": 1, "minor": 3})
+        serde_json::json!({"major": 1, "minor": 4})
     );
 }
 
@@ -170,7 +170,7 @@ async fn swebench_run_writes_versioned_results_and_prediction_metadata() {
     assert_eq!(results["artifact_kind"], "sweep_results");
     assert_eq!(
         results["schema_version"],
-        serde_json::json!({"major": 1, "minor": 3})
+        serde_json::json!({"major": 1, "minor": 4})
     );
 
     let predictions = std::fs::read_to_string(output.join("all_preds.jsonl")).unwrap();
@@ -194,7 +194,7 @@ async fn swebench_run_writes_versioned_results_and_prediction_metadata() {
     assert_eq!(metadata["artifact_kind"], "swebench_predictions_metadata");
     assert_eq!(
         metadata["schema_version"],
-        serde_json::json!({"major": 1, "minor": 3})
+        serde_json::json!({"major": 1, "minor": 4})
     );
     assert_eq!(metadata["predictions_file"], "all_preds.jsonl");
     assert_eq!(metadata["row_count"], 1);
@@ -237,7 +237,7 @@ async fn evaluate_run_writes_versioned_evaluation_json() {
     assert_eq!(eval["artifact_kind"], "evaluation_results");
     assert_eq!(
         eval["schema_version"],
-        serde_json::json!({"major": 1, "minor": 3})
+        serde_json::json!({"major": 1, "minor": 4})
     );
 }
 
@@ -252,7 +252,7 @@ fn forecast_json_includes_artifact_header() {
     assert_eq!(value["artifact_kind"], "forecast_report");
     assert_eq!(
         value["schema_version"],
-        serde_json::json!({"major": 1, "minor": 3})
+        serde_json::json!({"major": 1, "minor": 4})
     );
 }
 
@@ -287,7 +287,7 @@ async fn forecast_run_keeps_calibration_results_versioned_after_manifest_mark() 
     assert_eq!(calibration_results["artifact_kind"], "sweep_results");
     assert_eq!(
         calibration_results["schema_version"],
-        serde_json::json!({"major": 1, "minor": 3})
+        serde_json::json!({"major": 1, "minor": 4})
     );
 }
 
@@ -535,7 +535,7 @@ async fn current_contract_fixtures_match_emitted_artifact_top_level_fields() {
 
     let preflight = serde_json::json!({
         "artifact_kind": "preflight_report",
-        "schema_version": {"major": 1, "minor": 3},
+        "schema_version": {"major": 1, "minor": 4},
         "mode": "doctor",
         "checks": [{
             "status": "ok",

--- a/tests/bench_triage.rs
+++ b/tests/bench_triage.rs
@@ -342,7 +342,7 @@ fn inject_results_only_errored_instance(sweep: &Path) {
         serde_json::to_string_pretty(&json!({
             "trajectory_format": "mini-swe-agent-1.1",
             "artifact_kind": "trajectory",
-            "schema_version": {"major": 1, "minor": 3},
+            "schema_version": {"major": 1, "minor": 4},
             "info": {
                 "task": "eval-missing-error",
                 "model_name": "fixture-model",
@@ -424,7 +424,7 @@ fn inject_resolved_rerun_aggregate_with_run1_failure(sweep: &Path) {
         serde_json::to_string_pretty(&json!({
             "trajectory_format": "mini-swe-agent-1.1",
             "artifact_kind": "trajectory",
-            "schema_version": {"major": 1, "minor": 3},
+            "schema_version": {"major": 1, "minor": 4},
             "info": {
                 "task": "resolved-rerun",
                 "model_name": "fixture-model",

--- a/tests/fallback_model.rs
+++ b/tests/fallback_model.rs
@@ -88,7 +88,8 @@ impl Model for ErrModel {
             ModelError::AllCandidatesFailed(s, _) => {
                 Err(ModelError::AllCandidatesFailed(s.clone(), Vec::new()))
             }
-            // Replay-only errors never appear in a fallback-model test harness.
+            // Scripted/replay errors never appear in a fallback-model test harness.
+            ModelError::ResponsesExhausted(n) => Err(ModelError::ResponsesExhausted(*n)),
             ModelError::ReplayDrift(n) => Err(ModelError::ReplayDrift(*n)),
             ModelError::ScriptedResponsesExhausted(n) => {
                 Err(ModelError::ScriptedResponsesExhausted(*n))

--- a/tests/fallback_model.rs
+++ b/tests/fallback_model.rs
@@ -88,6 +88,14 @@ impl Model for ErrModel {
             ModelError::AllCandidatesFailed(s, _) => {
                 Err(ModelError::AllCandidatesFailed(s.clone(), Vec::new()))
             }
+            // Replay-only errors never appear in a fallback-model test harness.
+            ModelError::ReplayDrift(n) => Err(ModelError::ReplayDrift(*n)),
+            ModelError::ScriptedResponsesExhausted(n) => {
+                Err(ModelError::ScriptedResponsesExhausted(*n))
+            }
+            ModelError::ReplayUnfingerprintedLegacy(n) => {
+                Err(ModelError::ReplayUnfingerprintedLegacy(*n))
+            }
         }
     }
 }

--- a/tests/fixtures/artifact_schema/current/all_preds.metadata.json
+++ b/tests/fixtures/artifact_schema/current/all_preds.metadata.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "swebench_predictions_metadata",
-  "schema_version": {"major": 1, "minor": 3},
+  "schema_version": {"major": 1, "minor": 4},
   "predictions_file": "all_preds.jsonl",
   "aggregate": true,
   "row_count": 1,

--- a/tests/fixtures/artifact_schema/current/calibration.json
+++ b/tests/fixtures/artifact_schema/current/calibration.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "calibration_report",
-  "schema_version": {"major": 1, "minor": 3},
+  "schema_version": {"major": 1, "minor": 4},
   "forecast_path": "forecast.json",
   "results_path": "results.json",
   "forecast_artifact": "forecast_report@1.3",

--- a/tests/fixtures/artifact_schema/current/evaluation.json
+++ b/tests/fixtures/artifact_schema/current/evaluation.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "evaluation_results",
-  "schema_version": {"major": 1, "minor": 3},
+  "schema_version": {"major": 1, "minor": 4},
   "instances": [
     {
       "instance_id": "task-a",

--- a/tests/fixtures/artifact_schema/current/forecast.json
+++ b/tests/fixtures/artifact_schema/current/forecast.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "forecast_report",
-  "schema_version": {"major": 1, "minor": 3},
+  "schema_version": {"major": 1, "minor": 4},
   "calibration": {
     "n": 1,
     "seed": 42,

--- a/tests/fixtures/artifact_schema/current/preflight.json
+++ b/tests/fixtures/artifact_schema/current/preflight.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "preflight_report",
-  "schema_version": {"major": 1, "minor": 3},
+  "schema_version": {"major": 1, "minor": 4},
   "mode": "doctor",
   "checks": [
     {

--- a/tests/fixtures/artifact_schema/current/results.json
+++ b/tests/fixtures/artifact_schema/current/results.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "sweep_results",
-  "schema_version": {"major": 1, "minor": 3},
+  "schema_version": {"major": 1, "minor": 4},
   "total": 1,
   "sweep_status": "completed",
   "completed": 1,

--- a/tests/fixtures/artifact_schema/current/sweep/evaluation.json
+++ b/tests/fixtures/artifact_schema/current/sweep/evaluation.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "evaluation_results",
-  "schema_version": {"major": 1, "minor": 3},
+  "schema_version": {"major": 1, "minor": 4},
   "instances": [
     {
       "instance_id": "task-a",

--- a/tests/fixtures/artifact_schema/current/sweep/results.json
+++ b/tests/fixtures/artifact_schema/current/sweep/results.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "sweep_results",
-  "schema_version": {"major": 1, "minor": 3},
+  "schema_version": {"major": 1, "minor": 4},
   "total": 1,
   "sweep_status": "completed",
   "completed": 1,

--- a/tests/fixtures/artifact_schema/current/sweep/task-a.traj.json
+++ b/tests/fixtures/artifact_schema/current/sweep/task-a.traj.json
@@ -1,7 +1,7 @@
 {
   "trajectory_format": "mini-swe-agent-1.1",
   "artifact_kind": "trajectory",
-  "schema_version": {"major": 1, "minor": 3},
+  "schema_version": {"major": 1, "minor": 4},
   "info": {
     "task": "task-a",
     "model_name": "fixture-model",

--- a/tests/fixtures/artifact_schema/current/trajectory.traj.json
+++ b/tests/fixtures/artifact_schema/current/trajectory.traj.json
@@ -1,7 +1,7 @@
 {
   "trajectory_format": "mini-swe-agent-1.1",
   "artifact_kind": "trajectory",
-  "schema_version": {"major": 1, "minor": 3},
+  "schema_version": {"major": 1, "minor": 4},
   "info": {
     "task": "task-a",
     "model_name": "fixture-model",

--- a/tests/fixtures/triage/sweep/env-1.traj.json
+++ b/tests/fixtures/triage/sweep/env-1.traj.json
@@ -3,7 +3,7 @@
   "artifact_kind": "trajectory",
   "schema_version": {
     "major": 1,
-    "minor": 3
+    "minor": 4
   },
   "info": {
     "task": "env-1",

--- a/tests/fixtures/triage/sweep/evaluation.json
+++ b/tests/fixtures/triage/sweep/evaluation.json
@@ -2,7 +2,7 @@
   "artifact_kind": "evaluation_results",
   "schema_version": {
     "major": 1,
-    "minor": 3
+    "minor": 4
   },
   "instances": [
     {

--- a/tests/fixtures/triage/sweep/model-a-1.traj.json
+++ b/tests/fixtures/triage/sweep/model-a-1.traj.json
@@ -3,7 +3,7 @@
   "artifact_kind": "trajectory",
   "schema_version": {
     "major": 1,
-    "minor": 3
+    "minor": 4
   },
   "info": {
     "task": "model-a-1",

--- a/tests/fixtures/triage/sweep/model-a-2.traj.json
+++ b/tests/fixtures/triage/sweep/model-a-2.traj.json
@@ -3,7 +3,7 @@
   "artifact_kind": "trajectory",
   "schema_version": {
     "major": 1,
-    "minor": 3
+    "minor": 4
   },
   "info": {
     "task": "model-a-2",

--- a/tests/fixtures/triage/sweep/model-b-1.traj.json
+++ b/tests/fixtures/triage/sweep/model-b-1.traj.json
@@ -3,7 +3,7 @@
   "artifact_kind": "trajectory",
   "schema_version": {
     "major": 1,
-    "minor": 3
+    "minor": 4
   },
   "info": {
     "task": "model-b-1",

--- a/tests/fixtures/triage/sweep/resolved-1.traj.json
+++ b/tests/fixtures/triage/sweep/resolved-1.traj.json
@@ -3,7 +3,7 @@
   "artifact_kind": "trajectory",
   "schema_version": {
     "major": 1,
-    "minor": 3
+    "minor": 4
   },
   "info": {
     "task": "resolved-1",

--- a/tests/fixtures/triage/sweep/results.json
+++ b/tests/fixtures/triage/sweep/results.json
@@ -2,7 +2,7 @@
   "artifact_kind": "sweep_results",
   "schema_version": {
     "major": 1,
-    "minor": 3
+    "minor": 4
   },
   "total": 6,
   "submitted": 1,

--- a/tests/fixtures/triage/sweep/step-1.traj.json
+++ b/tests/fixtures/triage/sweep/step-1.traj.json
@@ -3,7 +3,7 @@
   "artifact_kind": "trajectory",
   "schema_version": {
     "major": 1,
-    "minor": 3
+    "minor": 4
   },
   "info": {
     "task": "step-1",

--- a/tests/replay_fingerprint.rs
+++ b/tests/replay_fingerprint.rs
@@ -221,9 +221,14 @@ async fn prompt_drift_exits_drift_code_at_step_zero() {
         tampered
     );
     assert!(!steps[0]["actual_fingerprint"].as_str().unwrap().is_empty());
+    // unified_diff must be present (may be empty string if no stored canonical)
     assert!(
-        steps[0]["actual_canonical_snippet"].as_str().is_some(),
-        "actual canonical snippet must be present"
+        steps[0]["unified_diff"].as_str().is_some(),
+        "unified_diff field must be present in drift step"
+    );
+    assert!(
+        steps[0]["diff_truncated"].as_bool().is_some(),
+        "diff_truncated field must be present"
     );
 }
 

--- a/tests/replay_fingerprint.rs
+++ b/tests/replay_fingerprint.rs
@@ -72,7 +72,9 @@ async fn record_fingerprinted_trajectory(dir: &Path) -> std::path::PathBuf {
         report_only: false,
         drift_cap_bytes: 8192,
     };
-    replay_run(args).await.expect("pass-1 recording should succeed");
+    replay_run(args)
+        .await
+        .expect("pass-1 recording should succeed");
     dir.join("recorded.traj.json")
 }
 
@@ -97,7 +99,11 @@ fn different_messages_produce_different_fingerprints() {
 #[test]
 fn fingerprint_hex_is_16_chars() {
     let fp = compute_input_fingerprint(&[Message::user("x")]);
-    assert_eq!(fp.hex.len(), 16, "fingerprint should be 16 hex chars (8 bytes)");
+    assert_eq!(
+        fp.hex.len(),
+        16,
+        "fingerprint should be 16 hex chars (8 bytes)"
+    );
     assert!(fp.hex.chars().all(|c| c.is_ascii_hexdigit()));
 }
 
@@ -108,7 +114,10 @@ fn canonical_json_keys_are_sorted() {
     // "content" should appear before "role" (alphabetical order)
     let content_pos = json.find("\"content\"").unwrap();
     let role_pos = json.find("\"role\"").unwrap();
-    assert!(content_pos < role_pos, "canonical JSON must have sorted keys");
+    assert!(
+        content_pos < role_pos,
+        "canonical JSON must have sorted keys"
+    );
 }
 
 #[test]
@@ -117,7 +126,10 @@ fn canonical_json_excludes_extra_metadata() {
     msg.extra.cost = Some(1.23);
     msg.extra.timestamp = Some("2026-01-01".into());
     let json = canonical_json(&[msg]);
-    assert!(!json.contains("cost"), "canonical JSON must not include cost");
+    assert!(
+        !json.contains("cost"),
+        "canonical JSON must not include cost"
+    );
     assert!(
         !json.contains("timestamp"),
         "canonical JSON must not include timestamp"
@@ -127,7 +139,10 @@ fn canonical_json_excludes_extra_metadata() {
 #[test]
 fn replay_prompt_drift_exit_code_is_9() {
     assert_eq!(ExitCode::ReplayPromptDrift.as_i32(), 9);
-    assert_eq!(ExitCode::ReplayPromptDrift.outcome_class(), "replay_prompt_drift");
+    assert_eq!(
+        ExitCode::ReplayPromptDrift.outcome_class(),
+        "replay_prompt_drift"
+    );
 }
 
 #[test]
@@ -160,7 +175,10 @@ async fn identical_replay_exits_zero_no_drift_file() {
         drift_cap_bytes: 8192,
     };
     let result = replay_run(args).await;
-    assert!(result.is_ok(), "identical replay should succeed: {result:?}");
+    assert!(
+        result.is_ok(),
+        "identical replay should succeed: {result:?}"
+    );
 
     // No drift report should be written.
     assert!(
@@ -216,10 +234,7 @@ async fn prompt_drift_exits_drift_code_at_step_zero() {
     let steps = drift["steps"].as_array().unwrap();
     assert_eq!(steps.len(), 1, "exactly one drift step");
     assert_eq!(steps[0]["step_index"].as_u64().unwrap(), 0);
-    assert_eq!(
-        steps[0]["recorded_fingerprint"].as_str().unwrap(),
-        tampered
-    );
+    assert_eq!(steps[0]["recorded_fingerprint"].as_str().unwrap(), tampered);
     assert!(!steps[0]["actual_fingerprint"].as_str().unwrap().is_empty());
     // unified_diff must be present (may be empty string if no stored canonical)
     assert!(
@@ -318,7 +333,10 @@ async fn report_only_with_two_divergences_exits_zero() {
 
     // Both divergent steps must appear in the report.
     let drift_path = dir.path().join("replay-drift.json");
-    assert!(drift_path.exists(), "drift report must be written in --report-only mode");
+    assert!(
+        drift_path.exists(),
+        "drift report must be written in --report-only mode"
+    );
     let drift: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&drift_path).unwrap()).unwrap();
     let steps = drift["steps"].as_array().unwrap();

--- a/tests/replay_fingerprint.rs
+++ b/tests/replay_fingerprint.rs
@@ -1,0 +1,330 @@
+//! TDD tests for replay prompt-drift detection (issue #155).
+//!
+//! RED phase: written before implementation. Tests cover all four acceptance
+//! scenarios from the issue:
+//!   (a) identical replay → exit 0, no drift report
+//!   (b) one tampered fingerprint → exit code ReplayPromptDrift, drift JSON valid
+//!   (c) legacy trajectory (no fingerprints) → refused without flag, accepted with flag
+//!   (d) --report-only with two divergences → exit 0 and both steps listed
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::Path;
+
+use rust_swe_agent::{
+    config::Config,
+    exit_code::ExitCode,
+    fingerprint::{InputFingerprint, canonical_json, compute_input_fingerprint},
+    model::{Message, MessageExtra},
+    run::replay::{ReplayArgs, run as replay_run},
+    trajectory::{MessageRecord, Trajectory, TrajectoryInfo},
+};
+use tempfile::tempdir;
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+/// Build a minimal 2-step trajectory without fingerprints (simulates legacy).
+fn make_legacy_trajectory(dir: &Path) -> std::path::PathBuf {
+    let traj = Trajectory {
+        trajectory_format: "mini-swe-agent-1.1".into(),
+        info: TrajectoryInfo {
+            task: Some("dummy task".into()),
+            ..Default::default()
+        },
+        messages: vec![
+            MessageRecord {
+                role: "user".into(),
+                content: "dummy task".into(),
+                extra: MessageExtra::default(),
+            },
+            MessageRecord {
+                role: "assistant".into(),
+                content: "```bash\necho hi\n```".into(),
+                extra: MessageExtra::default(),
+            },
+            MessageRecord {
+                role: "user".into(),
+                content: "hi".into(),
+                extra: MessageExtra::default(),
+            },
+            MessageRecord {
+                role: "assistant".into(),
+                content: "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nhi\n```".into(),
+                extra: MessageExtra::default(),
+            },
+        ],
+    };
+    let path = dir.join("legacy.traj.json");
+    traj.save_pretty(&path).unwrap();
+    path
+}
+
+/// Run pass-1 replay (allow_unfingerprinted=true) to produce a fingerprinted
+/// trajectory, then return the path to that output trajectory.
+async fn record_fingerprinted_trajectory(dir: &Path) -> std::path::PathBuf {
+    let legacy = make_legacy_trajectory(dir);
+    let args = ReplayArgs {
+        trajectory_path: legacy,
+        config: Config::defaults().unwrap(),
+        output_dir: dir.to_path_buf(),
+        trajectory_name: Some("recorded".into()),
+        allow_unfingerprinted: true,
+        report_only: false,
+        drift_cap_bytes: 8192,
+    };
+    replay_run(args).await.expect("pass-1 recording should succeed");
+    dir.join("recorded.traj.json")
+}
+
+// ── unit tests ─────────────────────────────────────────────────────────────
+
+#[test]
+fn compute_fingerprint_is_stable() {
+    let msgs = vec![Message::user("hello"), Message::assistant("world")];
+    let fp1 = compute_input_fingerprint(&msgs);
+    let fp2 = compute_input_fingerprint(&msgs);
+    assert_eq!(fp1.hex, fp2.hex);
+    assert_eq!(fp1.canonical_size, fp2.canonical_size);
+}
+
+#[test]
+fn different_messages_produce_different_fingerprints() {
+    let fp_a = compute_input_fingerprint(&[Message::user("hello")]);
+    let fp_b = compute_input_fingerprint(&[Message::user("world")]);
+    assert_ne!(fp_a.hex, fp_b.hex);
+}
+
+#[test]
+fn fingerprint_hex_is_16_chars() {
+    let fp = compute_input_fingerprint(&[Message::user("x")]);
+    assert_eq!(fp.hex.len(), 16, "fingerprint should be 16 hex chars (8 bytes)");
+    assert!(fp.hex.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[test]
+fn canonical_json_keys_are_sorted() {
+    let msgs = vec![Message::user("hello")];
+    let json = canonical_json(&msgs);
+    // "content" should appear before "role" (alphabetical order)
+    let content_pos = json.find("\"content\"").unwrap();
+    let role_pos = json.find("\"role\"").unwrap();
+    assert!(content_pos < role_pos, "canonical JSON must have sorted keys");
+}
+
+#[test]
+fn canonical_json_excludes_extra_metadata() {
+    let mut msg = Message::user("hello");
+    msg.extra.cost = Some(1.23);
+    msg.extra.timestamp = Some("2026-01-01".into());
+    let json = canonical_json(&[msg]);
+    assert!(!json.contains("cost"), "canonical JSON must not include cost");
+    assert!(
+        !json.contains("timestamp"),
+        "canonical JSON must not include timestamp"
+    );
+}
+
+#[test]
+fn replay_prompt_drift_exit_code_is_9() {
+    assert_eq!(ExitCode::ReplayPromptDrift.as_i32(), 9);
+    assert_eq!(ExitCode::ReplayPromptDrift.outcome_class(), "replay_prompt_drift");
+}
+
+#[test]
+fn replay_response_exhausted_exit_code_is_10() {
+    assert_eq!(ExitCode::ReplayResponseExhausted.as_i32(), 10);
+    assert_eq!(
+        ExitCode::ReplayResponseExhausted.outcome_class(),
+        "replay_response_exhausted"
+    );
+}
+
+// ── integration tests ──────────────────────────────────────────────────────
+
+/// (a) Identical replay → exit 0, no drift file.
+#[tokio::test]
+async fn identical_replay_exits_zero_no_drift_file() {
+    let dir = tempdir().unwrap();
+
+    // Pass 1: produce a trajectory with fingerprints.
+    let fp_traj = record_fingerprinted_trajectory(dir.path()).await;
+
+    // Pass 2: replay the fingerprinted trajectory — fingerprints must match.
+    let args = ReplayArgs {
+        trajectory_path: fp_traj,
+        config: Config::defaults().unwrap(),
+        output_dir: dir.path().to_path_buf(),
+        trajectory_name: Some("pass2".into()),
+        allow_unfingerprinted: false,
+        report_only: false,
+        drift_cap_bytes: 8192,
+    };
+    let result = replay_run(args).await;
+    assert!(result.is_ok(), "identical replay should succeed: {result:?}");
+
+    // No drift report should be written.
+    assert!(
+        !dir.path().join("replay-drift.json").exists(),
+        "no drift file expected on clean replay"
+    );
+}
+
+/// (b) One tampered fingerprint → exit code ReplayPromptDrift (9), drift JSON valid.
+#[tokio::test]
+async fn prompt_drift_exits_drift_code_at_step_zero() {
+    let dir = tempdir().unwrap();
+
+    // Pass 1: produce fingerprinted trajectory.
+    let fp_traj = record_fingerprinted_trajectory(dir.path()).await;
+
+    // Tamper with the fingerprint of the first assistant message.
+    let content = std::fs::read_to_string(&fp_traj).unwrap();
+    let mut traj: Trajectory = serde_json::from_str(&content).unwrap();
+    let tampered = "deadbeef00000000";
+    for msg in &mut traj.messages {
+        if msg.role == "assistant" {
+            if let Some(mc) = msg.extra.other.get_mut("model_call") {
+                mc["input_fingerprint"] = serde_json::json!(tampered);
+            }
+            break; // only first assistant message
+        }
+    }
+    traj.save_pretty(&fp_traj).unwrap();
+
+    // Pass 2: replay should detect drift.
+    let args = ReplayArgs {
+        trajectory_path: fp_traj,
+        config: Config::defaults().unwrap(),
+        output_dir: dir.path().to_path_buf(),
+        trajectory_name: Some("drifted".into()),
+        allow_unfingerprinted: false,
+        report_only: false,
+        drift_cap_bytes: 8192,
+    };
+    let result = replay_run(args).await;
+    assert!(result.is_err(), "should fail on drift");
+    assert_eq!(
+        ExitCode::from_error(&result.unwrap_err()),
+        ExitCode::ReplayPromptDrift
+    );
+
+    // Drift report must be written with correct content.
+    let drift_path = dir.path().join("replay-drift.json");
+    assert!(drift_path.exists(), "drift report should be written");
+    let drift: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&drift_path).unwrap()).unwrap();
+    let steps = drift["steps"].as_array().unwrap();
+    assert_eq!(steps.len(), 1, "exactly one drift step");
+    assert_eq!(steps[0]["step_index"].as_u64().unwrap(), 0);
+    assert_eq!(
+        steps[0]["recorded_fingerprint"].as_str().unwrap(),
+        tampered
+    );
+    assert!(!steps[0]["actual_fingerprint"].as_str().unwrap().is_empty());
+    assert!(
+        steps[0]["actual_canonical_snippet"].as_str().is_some(),
+        "actual canonical snippet must be present"
+    );
+}
+
+/// (c-1) Legacy trajectory without fingerprints is refused without --allow-unfingerprinted.
+#[tokio::test]
+async fn legacy_trajectory_refused_without_flag() {
+    let dir = tempdir().unwrap();
+    let traj = make_legacy_trajectory(dir.path());
+
+    let args = ReplayArgs {
+        trajectory_path: traj,
+        config: Config::defaults().unwrap(),
+        output_dir: dir.path().to_path_buf(),
+        trajectory_name: Some("no-flag".into()),
+        allow_unfingerprinted: false, // must refuse
+        report_only: false,
+        drift_cap_bytes: 8192,
+    };
+    let result = replay_run(args).await;
+    assert!(
+        result.is_err(),
+        "should fail without --allow-unfingerprinted"
+    );
+    // No drift report for this case (it's a configuration error, not drift)
+}
+
+/// (c-2) Legacy trajectory accepted with --allow-unfingerprinted, exit 0.
+#[tokio::test]
+async fn legacy_trajectory_accepted_with_flag() {
+    let dir = tempdir().unwrap();
+    let traj = make_legacy_trajectory(dir.path());
+
+    let args = ReplayArgs {
+        trajectory_path: traj,
+        config: Config::defaults().unwrap(),
+        output_dir: dir.path().to_path_buf(),
+        trajectory_name: Some("with-flag".into()),
+        allow_unfingerprinted: true, // should succeed
+        report_only: false,
+        drift_cap_bytes: 8192,
+    };
+    let result = replay_run(args).await;
+    assert!(
+        result.is_ok(),
+        "--allow-unfingerprinted should succeed: {result:?}"
+    );
+    assert!(
+        !dir.path().join("replay-drift.json").exists(),
+        "no drift file for unfingerprinted run"
+    );
+}
+
+/// (d) --report-only with two divergences exits 0 and lists both steps.
+#[tokio::test]
+async fn report_only_with_two_divergences_exits_zero() {
+    let dir = tempdir().unwrap();
+
+    // Pass 1: produce fingerprinted trajectory.
+    let fp_traj = record_fingerprinted_trajectory(dir.path()).await;
+
+    // Tamper with BOTH assistant fingerprints.
+    let content = std::fs::read_to_string(&fp_traj).unwrap();
+    let mut traj: Trajectory = serde_json::from_str(&content).unwrap();
+    let mut idx = 0usize;
+    for msg in &mut traj.messages {
+        if msg.role == "assistant" {
+            if let Some(mc) = msg.extra.other.get_mut("model_call") {
+                mc["input_fingerprint"] = serde_json::json!(format!("deadbeef0000000{idx}"));
+            }
+            idx += 1;
+        }
+    }
+    traj.save_pretty(&fp_traj).unwrap();
+
+    // Pass 2: --report-only must exit 0 despite two divergences.
+    let args = ReplayArgs {
+        trajectory_path: fp_traj,
+        config: Config::defaults().unwrap(),
+        output_dir: dir.path().to_path_buf(),
+        trajectory_name: Some("report-run".into()),
+        allow_unfingerprinted: false,
+        report_only: true, // key flag
+        drift_cap_bytes: 8192,
+    };
+    let result = replay_run(args).await;
+    assert!(result.is_ok(), "--report-only should exit 0: {result:?}");
+
+    // Both divergent steps must appear in the report.
+    let drift_path = dir.path().join("replay-drift.json");
+    assert!(drift_path.exists(), "drift report must be written in --report-only mode");
+    let drift: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&drift_path).unwrap()).unwrap();
+    let steps = drift["steps"].as_array().unwrap();
+    assert_eq!(steps.len(), 2, "both divergent steps must be listed");
+}
+
+// ── InputFingerprint is a real type ────────────────────────────────────────
+
+#[test]
+fn input_fingerprint_fields_are_accessible() {
+    let fp: InputFingerprint = compute_input_fingerprint(&[Message::user("hi")]);
+    assert!(!fp.hex.is_empty());
+    assert!(fp.canonical_size > 0);
+}


### PR DESCRIPTION
## Summary

Implements cryptographic fingerprinting of model-query inputs to detect prompt drift during trajectory replay. This turns `bench replay` into an honest cassette that fails when the agent's inputs diverge from what was originally recorded, catching changes to system prompts, observation formats, tool schemas, and other harness modifications.

## Key Changes

- **New fingerprinting module** (`src/fingerprint.rs`): Computes SHA-256 fingerprints of model-query message vectors using a canonical JSON representation (compact, sorted keys, metadata-free). Fingerprints are stored as 16 lowercase hex characters (8-byte truncation).

- **Enhanced replay runner** (`src/run/replay.rs`): 
  - Extracts cassette entries (responses, fingerprints, canonical JSON) from recorded trajectories
  - Wraps `DeterministicModel` with `FingerprintCheckingModel` that validates fingerprints before consuming scripted responses
  - Collects drift steps when fingerprints mismatch and generates structured drift reports
  - Supports `--allow-unfingerprinted` flag for legacy trajectories without fingerprints
  - Supports `--report-only` mode to collect all drift without stopping at first divergence
  - Produces human-readable unified diffs of canonical inputs when drift is detected

- **Trajectory storage** (`src/agent/default.rs`): Each assistant message now stores:
  - `input_fingerprint`: 16-char hex hash of the input messages
  - `input_canonical_size`: Byte length of canonical JSON
  - `input_canonical`: Compact canonical JSON (capped at 64 KiB)
  - `input_canonical_truncated`: Boolean flag for truncation

- **Exit code contract**:
  - Exit 0: Replay completed without drift
  - Exit 9: Prompt drift detected (fingerprint mismatch)
  - Exit 10: Scripted responses exhausted before agent finished
  - Exit 2: Trajectory has no fingerprints and `--allow-unfingerprinted` not passed
  - Exit 1: Other internal errors

- **CLI enhancements** (`src/cli/args.rs`): New flags for replay command:
  - `--allow-unfingerprinted`: Accept legacy trajectories without fingerprints
  - `--report-only`: Run to completion despite drift, collect all divergences
  - `--drift-cap-bytes`: Cap unified diff output per step (default 8 KiB)

- **Schema version bump**: Trajectory schema updated from 1.3 to 1.4 to reflect fingerprint fields

- **Comprehensive test suite** (`tests/replay_fingerprint.rs`): TDD-style tests covering:
  - Fingerprint stability and determinism
  - Identical replay exits cleanly
  - Prompt drift detection with structured report
  - Legacy trajectory handling with/without flag
  - `--report-only` mode with multiple divergences

- **Documentation** (`docs/spec-replay.md`): Full specification of fingerprinting algorithm, exit codes, drift report schema, and usage examples

## Implementation Details

- Canonical form excludes `extra` and `cache_hint` fields to avoid false positives from per-run metadata (cost, timestamps, API responses)
- Unified diffs use the `similar` crate for line-level comparison of pretty-printed canonical JSON
- Drift report written to `{output_dir}/replay-drift.json` with step index, both fingerprints, and diff
- Fingerprint checking happens before each scripted response is consumed, enabling fail-fast on first divergence (or full collection in `--report-only` mode)
- All error paths properly propagate through `ModelError` enum with new `ReplayDrift` and `ReplayUnfingerprintedLegacy` variants

https://claude.ai/code/session_01UcTjBG2riQtvXUdbqBAckr