### PR TITLE
Improve nightly smoke agent resilience

### DIFF
--- a/docs/plans/2026-05-11-nightly-smoke-resilience.md
+++ b/docs/plans/2026-05-11-nightly-smoke-resilience.md
@@ -1,0 +1,64 @@
+# Nightly Smoke Resilience Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make nightly smoke runs recover from provider-native tool calls, warn the model before wallclock cutoff, and discourage dependency-install detours in constrained local SWE-bench runs.
+
+**Architecture:** Keep changes inside the existing model/agent contract. Preserve fenced-block parsing as the primary protocol, but normalize OpenAI-style `tool_calls` from raw model responses into the same `Action` path. Add a model-visible deadline warning before the hard timeout by reusing the existing agent history/trajectory machinery.
+
+**Tech Stack:** Rust 2024, Tokio, serde_json, existing `DefaultAgent`, `mini::run` timeout wrapper, and TOML prompt defaults.
+
+---
+
+### Task 1: Native Tool Calls
+
+**Files:**
+- Modify: `src/agent/parse.rs`
+- Modify: `src/agent/default.rs`
+- Test: `src/agent/parse.rs`
+- Test: `src/agent/default.rs`
+
+**Step 1:** Add failing tests showing OpenAI-style raw `tool_calls` with `function.name = "bash"` and JSON `arguments.command` parse into `Action::Bash`.
+
+**Step 2:** Add a failing agent-loop test where a model response has empty content but raw `tool_calls`, and assert the command executes without a format-error turn.
+
+**Step 3:** Implement a helper that extracts one registered tool call from `ModelResponse.raw` and falls back to content parsing.
+
+**Step 4:** Run `cargo test agent::parse agent::default::tests::<new test>`.
+
+### Task 2: Deadline Submit Nudge
+
+**Files:**
+- Modify: `src/agent/default.rs`
+- Modify: `src/run/mini.rs`
+- Test: `src/agent/default.rs`
+
+**Step 1:** Add a failing test that calls a deadline-warning helper and asserts it appends a user message telling the model to submit if it has a useful patch.
+
+**Step 2:** Add a best-effort warning before `run_agent_with_timeout` reaches the hard timeout.
+
+**Step 3:** Preserve existing wallclock timeout behavior when the warning does not lead to submission.
+
+**Step 4:** Run focused agent/mini timeout tests.
+
+### Task 3: Dependency Install Guidance
+
+**Files:**
+- Modify: `src/config/defaults/default.toml`
+- Test: `tests/config_reference.rs` or `tests/agent_loop.rs`
+
+**Step 1:** Add a failing prompt regression asserting the default system prompt tells the model not to install dependencies unless explicitly needed.
+
+**Step 2:** Update the default system prompt with concise guidance: inspect first, avoid dependency installation tar pits, and submit when a patch is ready.
+
+**Step 3:** Run focused prompt/config tests.
+
+### Final Verification
+
+**Commands:**
+- `cargo fmt --all`
+- `cargo test agent::parse`
+- `cargo test --test agent_loop`
+- `cargo test --test config_reference`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `git diff --check`

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -15,7 +15,10 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use super::{Action, Agent, ExitReason, StepOutcome, extract_action_from_model_response};
+use super::{
+    Action, Agent, ExitReason, StepOutcome, extract_action_for_tools,
+    extract_action_from_model_response,
+};
 use crate::config::{Config, ToolHookCfg};
 use crate::cost::{BASELINE_COST_MODEL, CostSource, estimate_cost_usd, is_free_tier_model};
 use crate::env::{CancellationToken, Environment, RunRequest, RunResult};
@@ -369,6 +372,37 @@ fn redact_message_extra(
     extra
 }
 
+fn assistant_content_with_normalized_action(
+    provider_content: &str,
+    action: &Action,
+    tool_names: &[String],
+) -> String {
+    if !matches!(
+        extract_action_for_tools(provider_content, tool_names),
+        Action::None
+    ) {
+        return provider_content.to_owned();
+    }
+
+    let Some(fenced_action) = action_as_fenced_block(action) else {
+        return provider_content.to_owned();
+    };
+
+    if provider_content.trim().is_empty() {
+        fenced_action
+    } else {
+        format!("{}\n{}", provider_content.trim_end(), fenced_action)
+    }
+}
+
+fn action_as_fenced_block(action: &Action) -> Option<String> {
+    match action {
+        Action::Bash(cmd) => Some(format!("```bash\n{cmd}\n```")),
+        Action::Tool(call) => Some(format!("```{}\n{}\n```", call.name, call.input)),
+        Action::Submit(_) | Action::None => None,
+    }
+}
+
 #[async_trait]
 impl Agent for DefaultAgent {
     // The step body walks through 7 sequential phases (limit checks →
@@ -486,9 +520,15 @@ impl Agent for DefaultAgent {
             return Ok(StepOutcome::Terminate(ExitReason::UserInterrupt));
         }
 
+        // 4. Parse action.
+        let tool_names = self.tool_registry.tool_names();
+        let action = extract_action_from_model_response(&resp.content, &resp.raw, &tool_names);
+        let assistant_content =
+            assistant_content_with_normalized_action(&resp.content, &action, &tool_names);
+
         // Record assistant message in trajectory with raw + cost.
         let asst_ts = chrono::Utc::now().to_rfc3339();
-        let mut asst = Message::assistant(resp.content.clone());
+        let mut asst = Message::assistant(assistant_content.clone());
         asst.extra.cost = resp.usage.cost_usd;
         asst.extra.response = Some(resp.raw.clone());
         asst.extra.timestamp = Some(asst_ts.clone());
@@ -500,18 +540,12 @@ impl Agent for DefaultAgent {
             timestamp: asst_ts,
         });
 
-        // 4. Parse action.
-        let action = extract_action_from_model_response(
-            &resp.content,
-            &resp.raw,
-            &self.tool_registry.tool_names(),
-        );
         match &action {
             Action::Submit(output) => {
                 asst.extra.actions = Some(vec!["__SUBMIT__".into()]);
                 self.history.push(Message::assistant(
                     self.redactor
-                        .redact_text(&resp.content, surface::MODEL_OBSERVATION)
+                        .redact_text(&assistant_content, surface::MODEL_OBSERVATION)
                         .text,
                 ));
                 record_redacted_message(
@@ -550,7 +584,7 @@ impl Agent for DefaultAgent {
                     .get_or_insert(FailureCategory::ModelParse);
                 self.history.push(Message::assistant(
                     self.redactor
-                        .redact_text(&resp.content, surface::MODEL_OBSERVATION)
+                        .redact_text(&assistant_content, surface::MODEL_OBSERVATION)
                         .text,
                 ));
                 record_redacted_message(
@@ -607,7 +641,7 @@ impl Agent for DefaultAgent {
         // gating decision so blocked attempts are still audited.
         self.history.push(Message::assistant(
             self.redactor
-                .redact_text(&resp.content, surface::MODEL_OBSERVATION)
+                .redact_text(&assistant_content, surface::MODEL_OBSERVATION)
                 .text,
         ));
         record_redacted_message(
@@ -919,20 +953,19 @@ impl DefaultAgent {
     }
 
     fn maybe_warn_wallclock_deadline(&mut self) {
-        let Some(deadline) = self.wallclock_deadline.as_ref() else {
+        let Some((timeout, remaining)) = self.wallclock_deadline.as_mut().and_then(|deadline| {
+            if deadline.warned {
+                return None;
+            }
+            let remaining = deadline.deadline.saturating_duration_since(Instant::now());
+            if remaining > deadline.warn_before {
+                return None;
+            }
+            deadline.warned = true;
+            Some((deadline.timeout, remaining))
+        }) else {
             return;
         };
-        if deadline.warned {
-            return;
-        }
-        let remaining = deadline.deadline.saturating_duration_since(Instant::now());
-        if remaining > deadline.warn_before {
-            return;
-        }
-        let timeout = deadline.timeout;
-        if let Some(deadline) = &mut self.wallclock_deadline {
-            deadline.warned = true;
-        }
         self.push_wallclock_deadline_warning(timeout, remaining);
     }
 

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -4,7 +4,7 @@
 //!   1. Limit check → Terminate if exceeded
 //!   2. Retag cache hints on history
 //!   3. model.query
-//!   4. parse::extract_action_for_tools
+//!   4. parse::extract_action_from_model_response
 //!   5. tool dispatch through env.run
 //!   6. observation template → push as user message, record in trajectory
 //!   7. bump steps, Continue
@@ -15,7 +15,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use super::{Action, Agent, ExitReason, StepOutcome, extract_action_for_tools};
+use super::{Action, Agent, ExitReason, StepOutcome, extract_action_from_model_response};
 use crate::config::{Config, ToolHookCfg};
 use crate::cost::{BASELINE_COST_MODEL, CostSource, estimate_cost_usd, is_free_tier_model};
 use crate::env::{CancellationToken, Environment, RunRequest, RunResult};
@@ -36,6 +36,26 @@ use crate::trajectory::{
 };
 
 const MAX_TOOL_HOOK_ENV_VALUE_BYTES: usize = 1024;
+const WALLCLOCK_WARNING_BEFORE_SECS: u64 = 30;
+
+#[derive(Debug, Clone)]
+struct WallclockDeadline {
+    deadline: Instant,
+    timeout: Duration,
+    warn_before: Duration,
+    warned: bool,
+}
+
+fn wallclock_warning_before(timeout: Duration) -> Duration {
+    let default = Duration::from_secs(WALLCLOCK_WARNING_BEFORE_SECS);
+    if timeout > default {
+        default
+    } else if timeout.is_zero() {
+        Duration::ZERO
+    } else {
+        Duration::from_secs((timeout.as_secs() / 2).max(1))
+    }
+}
 
 #[derive(Debug, Clone)]
 struct TruncateResult {
@@ -126,6 +146,7 @@ pub struct DefaultAgent {
     pub actual_cost_source: Option<CostSource>,
     /// Wall-clock start, used to compute `duration_secs` on terminate.
     pub started_at_instant: Instant,
+    wallclock_deadline: Option<WallclockDeadline>,
     /// Accumulated uncached input tokens across every model call in this run.
     pub prompt_tokens: u64,
     /// Accumulated prompt-cache reads across every model call in this run.
@@ -253,6 +274,7 @@ impl DefaultAgentBuilder {
             total_cost_usd: 0.0,
             actual_cost_source: None,
             started_at_instant: Instant::now(),
+            wallclock_deadline: None,
             prompt_tokens: 0,
             cache_read_tokens: 0,
             cache_creation_tokens: 0,
@@ -406,6 +428,7 @@ impl Agent for DefaultAgent {
                 }));
             }
         }
+        self.maybe_warn_wallclock_deadline();
 
         // 2. Retag cache hints (one line; backend handles capping).
         retag_cache_hints(&mut self.history);
@@ -478,7 +501,11 @@ impl Agent for DefaultAgent {
         });
 
         // 4. Parse action.
-        let action = extract_action_for_tools(&resp.content, &self.tool_registry.tool_names());
+        let action = extract_action_from_model_response(
+            &resp.content,
+            &resp.raw,
+            &self.tool_registry.tool_names(),
+        );
         match &action {
             Action::Submit(output) => {
                 asst.extra.actions = Some(vec!["__SUBMIT__".into()]);
@@ -872,6 +899,66 @@ impl Agent for DefaultAgent {
 }
 
 impl DefaultAgent {
+    pub fn set_wallclock_deadline(&mut self, timeout: Duration) {
+        self.wallclock_deadline = Some(WallclockDeadline {
+            deadline: Instant::now() + timeout,
+            timeout,
+            warn_before: wallclock_warning_before(timeout),
+            warned: false,
+        });
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_wallclock_deadline_for_test(&mut self, deadline: Instant, timeout: Duration) {
+        self.wallclock_deadline = Some(WallclockDeadline {
+            deadline,
+            timeout,
+            warn_before: wallclock_warning_before(timeout),
+            warned: false,
+        });
+    }
+
+    fn maybe_warn_wallclock_deadline(&mut self) {
+        let Some(deadline) = self.wallclock_deadline.as_ref() else {
+            return;
+        };
+        if deadline.warned {
+            return;
+        }
+        let remaining = deadline.deadline.saturating_duration_since(Instant::now());
+        if remaining > deadline.warn_before {
+            return;
+        }
+        let timeout = deadline.timeout;
+        if let Some(deadline) = &mut self.wallclock_deadline {
+            deadline.warned = true;
+        }
+        self.push_wallclock_deadline_warning(timeout, remaining);
+    }
+
+    fn push_wallclock_deadline_warning(&mut self, timeout: Duration, remaining: Duration) {
+        let remaining_secs = remaining.as_secs();
+        let timeout_secs = timeout.as_secs();
+        let content = format!(
+            "The task wallclock deadline is near: about {remaining_secs}s remain from the \
+             {timeout_secs}s task budget. If you already have a useful patch, stop exploratory \
+             work and submit now with COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT. Do not install \
+             dependencies unless they are strictly required to produce the final patch."
+        );
+        let msg = Message::user(
+            self.redactor
+                .redact_text(&content, surface::MODEL_OBSERVATION)
+                .text,
+        );
+        self.history.push(msg.clone());
+        let mut extra = MessageExtra::default();
+        extra.other.insert(
+            "wallclock_deadline_warning".into(),
+            serde_json::Value::Bool(true),
+        );
+        record_redacted_message(&mut self.trajectory, &msg, extra, &self.redactor);
+    }
+
     fn record_model_cost(&mut self, cost_usd: Option<f64>) {
         let source = match cost_usd {
             Some(cost) => {
@@ -1806,6 +1893,56 @@ mod tests {
             a.history
                 .iter()
                 .any(|m| m.content.contains("did not include a valid tool call"))
+        );
+    }
+
+    #[tokio::test]
+    async fn wallclock_deadline_warning_is_visible_before_model_query() {
+        let model = Arc::new(DeterministicModel::new([
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into(),
+        ]));
+        let mut cfg = Config::defaults().unwrap();
+        cfg.root.agent.step_limit = 5;
+        let mut agent = DefaultAgentBuilder {
+            config: cfg,
+            model: model.clone(),
+            env: Box::new(LocalEnvironment::new()),
+            task: "test".into(),
+            extra_context: None,
+            renderer: None,
+            stream: None,
+        }
+        .build()
+        .unwrap();
+
+        agent.set_wallclock_deadline_for_test(
+            Instant::now().checked_sub(Duration::from_secs(1)).unwrap(),
+            Duration::from_secs(300),
+        );
+
+        let exit = agent.step().await.unwrap();
+        assert!(matches!(
+            exit,
+            StepOutcome::Terminate(ExitReason::Submitted { .. })
+        ));
+
+        let recorded = model.recorded_inputs();
+        let first_query = recorded.first().unwrap();
+        assert!(
+            first_query.iter().any(|m| {
+                m.role == Role::User
+                    && m.content.contains("wallclock deadline")
+                    && m.content.contains("submit")
+            }),
+            "deadline warning should be model-visible before the query: {first_query:#?}"
+        );
+        assert!(
+            agent
+                .trajectory
+                .messages
+                .iter()
+                .any(|m| m.content.contains("wallclock deadline")),
+            "deadline warning should be recorded in the trajectory"
         );
     }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -15,7 +15,9 @@ pub mod parse;
 
 pub use default::DefaultAgent;
 pub use interactive::InteractiveAgent;
-pub use parse::{Action, extract_action, extract_action_for_tools};
+pub use parse::{
+    Action, extract_action, extract_action_for_tools, extract_action_from_model_response,
+};
 
 /// Represents the typed, successful termination of an agent loop.
 ///

--- a/src/agent/parse.rs
+++ b/src/agent/parse.rs
@@ -13,6 +13,7 @@
 pub const SUBMIT_SENTINEL: &str = "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT";
 
 use crate::tool::{BASH_TOOL_NAME, ToolCall};
+use serde_json::Value;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Action {
@@ -110,6 +111,29 @@ pub fn extract_action(content: &str) -> Action {
     extract_action_for_tools(content, &[BASH_TOOL_NAME.to_owned()])
 }
 
+/// Extracts an action from model text plus the raw provider response.
+///
+/// Some OpenAI-compatible providers return native `tool_calls` even when the
+/// prompt asks for fenced tool blocks. Submit text still wins, but otherwise
+/// structured tool calls are normalized into the same action path as fences.
+pub fn extract_action_from_model_response(
+    content: &str,
+    raw: &Value,
+    tool_names: &[String],
+) -> Action {
+    let text_action = extract_action_for_tools(content, tool_names);
+    if matches!(text_action, Action::Submit(_)) {
+        return text_action;
+    }
+    if let Some(call) = extract_first_registered_raw_tool_call(raw, tool_names) {
+        if call.name == BASH_TOOL_NAME {
+            return Action::Bash(call.input);
+        }
+        return Action::Tool(call);
+    }
+    text_action
+}
+
 /// Extracts the intended action using the supplied runtime tool names.
 pub fn extract_action_for_tools(content: &str, tool_names: &[String]) -> Action {
     // 1) Submit wins if the sentinel appears on its own line.
@@ -141,6 +165,82 @@ pub fn extract_action_for_tools(content: &str, tool_names: &[String]) -> Action 
     }
 
     Action::None
+}
+
+fn extract_first_registered_raw_tool_call(raw: &Value, tool_names: &[String]) -> Option<ToolCall> {
+    for calls in raw_tool_call_arrays(raw) {
+        for call in calls {
+            if let Some(tool_call) = raw_tool_call_to_tool_call(call, tool_names) {
+                return Some(tool_call);
+            }
+        }
+    }
+    None
+}
+
+fn raw_tool_call_arrays(raw: &Value) -> Vec<&[Value]> {
+    let mut arrays = Vec::new();
+    if let Some(calls) = raw.get("tool_calls").and_then(Value::as_array) {
+        arrays.push(calls.as_slice());
+    }
+    if let Some(calls) = raw.pointer("/message/tool_calls").and_then(Value::as_array) {
+        arrays.push(calls.as_slice());
+    }
+    if let Some(choices) = raw.get("choices").and_then(Value::as_array) {
+        for choice in choices {
+            if let Some(calls) = choice
+                .pointer("/message/tool_calls")
+                .and_then(Value::as_array)
+            {
+                arrays.push(calls.as_slice());
+            }
+        }
+    }
+    arrays
+}
+
+fn raw_tool_call_to_tool_call(call: &Value, tool_names: &[String]) -> Option<ToolCall> {
+    let name = call
+        .pointer("/function/name")
+        .or_else(|| call.get("name"))
+        .and_then(Value::as_str)?;
+    if !tool_names.iter().any(|tool_name| tool_name == name) {
+        return None;
+    }
+    let arguments = call
+        .pointer("/function/arguments")
+        .or_else(|| call.get("arguments"))?;
+    let input = raw_tool_arguments_to_input(name, arguments)?;
+    if input.trim().is_empty() {
+        return None;
+    }
+    Some(ToolCall {
+        name: name.to_owned(),
+        input,
+    })
+}
+
+fn raw_tool_arguments_to_input(tool_name: &str, arguments: &Value) -> Option<String> {
+    match arguments {
+        Value::String(s) => {
+            if let Ok(parsed) = serde_json::from_str::<Value>(s) {
+                raw_tool_arguments_to_input(tool_name, &parsed)
+            } else {
+                Some(s.clone())
+            }
+        }
+        Value::Object(map) if tool_name == BASH_TOOL_NAME => map
+            .get("command")
+            .or_else(|| map.get("cmd"))
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+        Value::Object(map) => map
+            .get("input")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .or_else(|| serde_json::to_string(arguments).ok()),
+        _ => serde_json::to_string(arguments).ok(),
+    }
 }
 
 #[cfg(test)]
@@ -215,5 +315,55 @@ mod tests {
     fn ignores_unregistered_tool_fence() {
         let s = "```diagnose\ncheck flaky test\n```";
         assert_eq!(extract_action_for_tools(s, &["bash".into()]), Action::None);
+    }
+
+    #[test]
+    fn extracts_openai_style_bash_tool_call_from_raw_response() {
+        let raw = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "Let me inspect the repository.",
+                    "tool_calls": [{
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {
+                            "name": "bash",
+                            "arguments": "{\"command\":\"pwd && ls -la\"}"
+                        }
+                    }]
+                }
+            }]
+        });
+
+        assert_eq!(
+            extract_action_from_model_response(
+                "Let me inspect the repository.",
+                &raw,
+                &["bash".into()]
+            ),
+            Action::Bash("pwd && ls -la".into())
+        );
+    }
+
+    #[test]
+    fn submit_text_wins_over_raw_tool_call() {
+        let raw = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "tool_calls": [{
+                        "function": {
+                            "name": "bash",
+                            "arguments": "{\"command\":\"echo should-not-run\"}"
+                        }
+                    }]
+                }
+            }]
+        });
+        let content = "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```";
+
+        assert_eq!(
+            extract_action_from_model_response(content, &raw, &["bash".into()]),
+            Action::Submit("final".into())
+        );
     }
 }

--- a/src/agent/parse.rs
+++ b/src/agent/parse.rs
@@ -180,21 +180,21 @@ fn extract_first_registered_raw_tool_call(raw: &Value, tool_names: &[String]) ->
 
 fn raw_tool_call_arrays(raw: &Value) -> Vec<&[Value]> {
     let mut arrays = Vec::new();
+    if let Some(choices) = raw.get("choices").and_then(Value::as_array) {
+        if let Some(calls) = choices
+            .first()
+            .and_then(|choice| choice.pointer("/message/tool_calls"))
+            .and_then(Value::as_array)
+        {
+            arrays.push(calls.as_slice());
+        }
+        return arrays;
+    }
     if let Some(calls) = raw.get("tool_calls").and_then(Value::as_array) {
         arrays.push(calls.as_slice());
     }
     if let Some(calls) = raw.pointer("/message/tool_calls").and_then(Value::as_array) {
         arrays.push(calls.as_slice());
-    }
-    if let Some(choices) = raw.get("choices").and_then(Value::as_array) {
-        for choice in choices {
-            if let Some(calls) = choice
-                .pointer("/message/tool_calls")
-                .and_then(Value::as_array)
-            {
-                arrays.push(calls.as_slice());
-            }
-        }
     }
     arrays
 }
@@ -407,6 +407,35 @@ mod tests {
 
         assert_eq!(
             extract_action_from_model_response("Let me run that.", &raw, &["bash".into()]),
+            Action::None
+        );
+    }
+
+    #[test]
+    fn raw_tool_calls_from_unselected_choices_are_ignored() {
+        let raw = serde_json::json!({
+            "choices": [
+                {
+                    "message": {
+                        "content": "No tool call here."
+                    }
+                },
+                {
+                    "message": {
+                        "content": "",
+                        "tool_calls": [{
+                            "function": {
+                                "name": "bash",
+                                "arguments": "{\"command\":\"echo unselected\"}"
+                            }
+                        }]
+                    }
+                }
+            ]
+        });
+
+        assert_eq!(
+            extract_action_from_model_response("No tool call here.", &raw, &["bash".into()]),
             Action::None
         );
     }

--- a/src/agent/parse.rs
+++ b/src/agent/parse.rs
@@ -122,7 +122,7 @@ pub fn extract_action_from_model_response(
     tool_names: &[String],
 ) -> Action {
     let text_action = extract_action_for_tools(content, tool_names);
-    if matches!(text_action, Action::Submit(_)) {
+    if !matches!(text_action, Action::None) {
         return text_action;
     }
     if let Some(call) = extract_first_registered_raw_tool_call(raw, tool_names) {
@@ -232,6 +232,7 @@ fn raw_tool_arguments_to_input(tool_name: &str, arguments: &Value) -> Option<Str
         Value::Object(map) if tool_name == BASH_TOOL_NAME => map
             .get("command")
             .or_else(|| map.get("cmd"))
+            .or_else(|| map.get("input"))
             .and_then(Value::as_str)
             .map(str::to_owned),
         Value::Object(map) => map
@@ -239,6 +240,7 @@ fn raw_tool_arguments_to_input(tool_name: &str, arguments: &Value) -> Option<Str
             .and_then(Value::as_str)
             .map(str::to_owned)
             .or_else(|| serde_json::to_string(arguments).ok()),
+        Value::Null => None,
         _ => serde_json::to_string(arguments).ok(),
     }
 }
@@ -342,6 +344,70 @@ mod tests {
                 &["bash".into()]
             ),
             Action::Bash("pwd && ls -la".into())
+        );
+    }
+
+    #[test]
+    fn fenced_bash_wins_over_conflicting_raw_tool_call() {
+        let raw = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "tool_calls": [{
+                        "function": {
+                            "name": "bash",
+                            "arguments": "{\"command\":\"echo raw\"}"
+                        }
+                    }]
+                }
+            }]
+        });
+        let content = "```bash\necho fenced\n```";
+
+        assert_eq!(
+            extract_action_from_model_response(content, &raw, &["bash".into()]),
+            Action::Bash("echo fenced".into())
+        );
+    }
+
+    #[test]
+    fn raw_bash_tool_call_accepts_generic_input_argument() {
+        let raw = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "tool_calls": [{
+                        "function": {
+                            "name": "bash",
+                            "arguments": "{\"input\":\"echo from-input\"}"
+                        }
+                    }]
+                }
+            }]
+        });
+
+        assert_eq!(
+            extract_action_from_model_response("Let me run that.", &raw, &["bash".into()]),
+            Action::Bash("echo from-input".into())
+        );
+    }
+
+    #[test]
+    fn raw_null_tool_call_arguments_are_ignored() {
+        let raw = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "tool_calls": [{
+                        "function": {
+                            "name": "bash",
+                            "arguments": null
+                        }
+                    }]
+                }
+            }]
+        });
+
+        assert_eq!(
+            extract_action_from_model_response("Let me run that.", &raw, &["bash".into()]),
+            Action::None
         );
     }
 

--- a/src/config/defaults/default.toml
+++ b/src/config/defaults/default.toml
@@ -158,6 +158,12 @@ Each response must contain exactly one action:
 either a single fenced block for one listed tool, or the literal sentinel
 `COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT` on its own line followed by a
 final output block.
+
+Do not install dependencies unless they are strictly required to produce the
+final patch. Prefer inspecting code and tests already present in the repository.
+If a local dependency problem blocks validation, explain it briefly and continue
+with the patch. Once you have a useful patch, submit it instead of continuing
+exploratory work.
 '''
 instance = '''
 Task: {{ task }}

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -441,6 +441,7 @@ async fn run_agent_with_timeout(
     secs: u64,
 ) -> Result<crate::agent::ExitReason, Error> {
     let timeout = Duration::from_secs(secs);
+    agent.set_wallclock_deadline(timeout);
     if let Ok(result) = tokio::time::timeout(timeout, agent.run()).await {
         return result;
     }

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -230,6 +230,74 @@ async fn fenced_action_wins_over_conflicting_native_tool_call() {
     assert_eq!(requests[0].0, "echo fenced-call");
 }
 
+#[tokio::test]
+async fn ignores_native_tool_calls_from_unselected_choices() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+
+    let model = Arc::new(RawResponseModel::new([
+        raw_response(
+            "No tool call here.",
+            serde_json::json!({
+                "choices": [
+                    {
+                        "message": {
+                            "content": "No tool call here."
+                        }
+                    },
+                    {
+                        "message": {
+                            "content": "",
+                            "tool_calls": [{
+                                "id": "call-2",
+                                "type": "function",
+                                "function": {
+                                    "name": "bash",
+                                    "arguments": "{\"command\":\"echo unselected-choice\"}"
+                                }
+                            }]
+                        }
+                    }
+                ]
+            }),
+        ),
+        raw_response(
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```",
+            serde_json::json!({"deterministic": true}),
+        ),
+    ]));
+    let env = RecordingCancellationEnv::default();
+    let requests = Arc::clone(&env.requests);
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env: Box::new(env),
+        task: "round trip".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+    assert!(matches!(exit, ExitReason::Submitted { .. }));
+
+    let requests = requests.lock().unwrap().clone();
+    assert!(
+        requests.is_empty(),
+        "unselected choice tool_calls must not execute: {requests:#?}"
+    );
+    assert!(
+        agent
+            .history
+            .iter()
+            .any(|m| m.content.contains("did not include a valid tool call")),
+        "selected choice without an action should follow format-error recovery: {:#?}",
+        agent.history
+    );
+}
+
 #[test]
 fn default_system_prompt_discourages_dependency_install_detours() {
     let cfg = Config::defaults().unwrap();

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -163,6 +163,13 @@ async fn provider_native_bash_tool_call_executes_without_format_error_turn() {
         agent.history
     );
     assert!(
+        agent.history.iter().any(|m| {
+            m.role == Role::Assistant && m.content.contains("```bash\necho native-call\n```")
+        }),
+        "native bash tool_call should be normalized into assistant history: {:#?}",
+        agent.history
+    );
+    assert!(
         !agent
             .history
             .iter()
@@ -170,6 +177,57 @@ async fn provider_native_bash_tool_call_executes_without_format_error_turn() {
         "native tool_call should not trigger format-error recovery: {:#?}",
         agent.history
     );
+}
+
+#[tokio::test]
+async fn fenced_action_wins_over_conflicting_native_tool_call() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+
+    let model = Arc::new(RawResponseModel::new([
+        raw_response(
+            "```bash\necho fenced-call\n```",
+            serde_json::json!({
+                "choices": [{
+                    "message": {
+                        "content": "```bash\necho fenced-call\n```",
+                        "tool_calls": [{
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "bash",
+                                "arguments": "{\"command\":\"echo raw-call\"}"
+                            }
+                        }]
+                    }
+                }]
+            }),
+        ),
+        raw_response(
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```",
+            serde_json::json!({"deterministic": true}),
+        ),
+    ]));
+    let env = RecordingCancellationEnv::default();
+    let requests = Arc::clone(&env.requests);
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env: Box::new(env),
+        task: "round trip".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+    assert!(matches!(exit, ExitReason::Submitted { .. }));
+
+    let requests = requests.lock().unwrap().clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].0, "echo fenced-call");
 }
 
 #[test]

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -3,6 +3,7 @@
 
 #![allow(clippy::unwrap_used)]
 
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -11,9 +12,50 @@ use rust_swe_agent::env::CancellationToken;
 use rust_swe_agent::error::EnvError;
 use rust_swe_agent::{
     Agent, CacheHint, Config, DeterministicModel, Environment, Error, ExitReason, LocalEnvironment,
-    McpServerCfg, McpStdioServer, Message, Role, RunRequest, RunResult, ToolDefinition,
-    ToolHookCfg, ToolInvocation, ToolOutput, ToolProvider,
+    McpServerCfg, McpStdioServer, Message, Model, ModelResponse, ModelUsage, QueryOpts, Role,
+    RunRequest, RunResult, ToolDefinition, ToolHookCfg, ToolInvocation, ToolOutput, ToolProvider,
 };
+
+struct RawResponseModel {
+    responses: Mutex<VecDeque<ModelResponse>>,
+}
+
+impl RawResponseModel {
+    fn new(responses: impl IntoIterator<Item = ModelResponse>) -> Self {
+        Self {
+            responses: Mutex::new(responses.into_iter().collect()),
+        }
+    }
+}
+
+#[async_trait]
+impl Model for RawResponseModel {
+    fn name(&self) -> &'static str {
+        "raw-response"
+    }
+
+    async fn query(
+        &self,
+        _messages: &[Message],
+        _opts: &QueryOpts,
+    ) -> Result<ModelResponse, rust_swe_agent::ModelError> {
+        self.responses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or_else(|| rust_swe_agent::ModelError::Malformed("no scripted response".into()))
+    }
+}
+
+fn raw_response(content: impl Into<String>, raw: serde_json::Value) -> ModelResponse {
+    ModelResponse {
+        content: content.into(),
+        usage: ModelUsage::default(),
+        raw,
+        responding_model: None,
+        fallback_attempts: Vec::new(),
+    }
+}
 
 #[tokio::test]
 async fn two_turn_echo_submit_produces_well_formed_trajectory() {
@@ -66,6 +108,80 @@ async fn two_turn_echo_submit_produces_well_formed_trajectory() {
 
     // Model saw 2 calls.
     assert_eq!(model.call_count(), 2);
+}
+
+#[tokio::test]
+async fn provider_native_bash_tool_call_executes_without_format_error_turn() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+
+    let model = Arc::new(RawResponseModel::new([
+        raw_response(
+            "Let me inspect the repository.",
+            serde_json::json!({
+                "choices": [{
+                    "message": {
+                        "content": "Let me inspect the repository.",
+                        "tool_calls": [{
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "bash",
+                                "arguments": "{\"command\":\"echo native-call\"}"
+                            }
+                        }]
+                    }
+                }]
+            }),
+        ),
+        raw_response(
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```",
+            serde_json::json!({"deterministic": true}),
+        ),
+    ]));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "round trip".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+    assert!(matches!(exit, ExitReason::Submitted { .. }));
+    assert!(
+        agent
+            .history
+            .iter()
+            .any(|m| m.role == Role::User && m.content.contains("native-call")),
+        "native bash tool_call should execute and produce an observation: {:#?}",
+        agent.history
+    );
+    assert!(
+        !agent
+            .history
+            .iter()
+            .any(|m| m.content.contains("did not include a valid tool call")),
+        "native tool_call should not trigger format-error recovery: {:#?}",
+        agent.history
+    );
+}
+
+#[test]
+fn default_system_prompt_discourages_dependency_install_detours() {
+    let cfg = Config::defaults().unwrap();
+    assert!(
+        cfg.root
+            .prompts
+            .system
+            .contains("Do not install dependencies"),
+        "default system prompt should keep smoke runs out of dependency-install detours"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Accept provider-native tool_calls, add a near-timeout submit nudge, and steer smoke runs away from dependency-install detours.