### PR TITLE
Implement in-loop agent stagnation detection (issue #157)

### DIFF
--- a/docs/artifact-contract.md
+++ b/docs/artifact-contract.md
@@ -44,3 +44,40 @@ Compatibility classes:
 - `unsupported-future`: a version with `major > 1`. Readers fail fast and do not emit resolved-rate, cost, or comparison metrics.
 
 Any future schema change needs either a documented no-bump rationale in the relevant change description or a schema-version bump plus fixture updates under `tests/fixtures/artifact_schema`.
+
+## Trajectory `failure_category` values
+
+The `info.failure_category` field in a trajectory artifact uses a stable string
+taxonomy.  Readers should treat unrecognised values as `unknown`.
+
+| Value              | Meaning                                                                 |
+|--------------------|-------------------------------------------------------------------------|
+| `step_limit`       | Agent exhausted the configured step budget.                             |
+| `patch_empty`      | Agent submitted but the patch was empty or only whitespace.             |
+| `patch_invalid`    | Captured patch failed `git apply --check` validation.                   |
+| `env_setup`        | Environment setup failed (Docker, container, tooling).                  |
+| `model_api`        | Persistent model API error (auth, quota, wrong model name).             |
+| `model_parse`      | Model response could not be parsed.                                     |
+| `wallclock_timeout`| Run exceeded the per-task wallclock timeout.                            |
+| `budget_halt`      | Run was skipped / halted due to a cost cap.                             |
+| `cancelled`        | Run was cancelled by operator (SIGINT / `--cancel-deadline`).           |
+| `agent_stagnation` | Stagnation detector tripped: same action repeated K times in W steps.   |
+| `unknown`          | Catch-all for unclassified failures.                                    |
+
+### `agent_stagnation` diagnostics
+
+When `failure_category` is `agent_stagnation`, `info.other["stagnation"]`
+contains a diagnostic object:
+
+```json
+{
+  "action_hash":   "<32-hex-char SHA-256 prefix of canonical action>",
+  "count":         4,
+  "window":        8,
+  "step_indices":  [2, 4, 6, 8]
+}
+```
+
+This field was introduced in trajectory format `mini-swe-agent-1.2`.
+Older trajectories will not contain it.  See `docs/spec-stagnation.md` for
+the full detection rule and configuration reference.

--- a/docs/spec-stagnation.md
+++ b/docs/spec-stagnation.md
@@ -1,0 +1,109 @@
+# In-Loop Agent Stagnation Detection
+
+## Overview
+
+The harness monitors each agent run for _stagnation_: the condition where the
+agent keeps issuing the same bash action repeatedly without making progress.
+When stagnation is detected the run is halted immediately rather than burning
+budget up to the step limit.
+
+## Rule
+
+A run is considered stagnant when:
+
+> Within the trailing **W** steps, the same canonical bash action has appeared
+> at least **K** times.
+
+Default values: **K = 4**, **W = 8**.
+
+## Canonical action fingerprinting
+
+Before comparing actions, each raw bash string is canonicalized:
+
+1. Trim leading and trailing whitespace.
+2. Collapse runs of internal whitespace to a single space.
+3. Strip a trailing `;`, then trim trailing whitespace again.
+
+The canonical string is then hashed with SHA-256 (first 16 bytes, encoded as
+32 lower-case hex characters).  The hash is used for O(1) comparison inside
+the sliding window; the canonical text is stored for diagnostics.
+
+Example:
+
+| Raw input          | Canonical form | Hash (first 8 chars) |
+|--------------------|----------------|----------------------|
+| `  ls  ;`          | `ls`           | `a37c5b26…`          |
+| `ls`               | `ls`           | `a37c5b26…`          |
+| `ls   -la`         | `ls -la`       | (different)          |
+
+## Detection algorithm
+
+A ring-buffer of the last W `(step_index, action_hash)` pairs is maintained.
+After every bash tool use (excluding tool-blocked calls) the new entry is
+appended and oldest entries are evicted as needed.  The count of occurrences
+of the current action hash within the buffer is then compared against K.  If
+the count is ≥ K the detector trips.
+
+## Outcome
+
+When the detector trips:
+
+- `info.exit_reason` = `"agent_stagnation"`
+- `info.failure_category` = `"agent_stagnation"`
+- `info.other["stagnation"]` — JSON object with diagnostic fields:
+
+```json
+{
+  "action_hash":   "a37c5b26…",
+  "count":         4,
+  "window":        8,
+  "step_indices":  [2, 4, 6, 8]
+}
+```
+
+- Process exits with code **12** (`ExitCode::AgentStagnation`).
+
+## Configuration
+
+| Config field                         | CLI flag                        | Default | Description                                        |
+|--------------------------------------|---------------------------------|---------|----------------------------------------------------|
+| `agent.detect_stagnation`            | `--detect-stagnation`           | `true`  | Enable / disable the detector entirely.            |
+| `agent.stagnation_repeat_threshold`  | `--stagnation-repeat-threshold` | `4`     | K — repetition count that trips the detector.      |
+| `agent.stagnation_window`            | `--stagnation-window`           | `8`     | W — sliding window width in steps.                 |
+
+The detector requires W ≥ K; the agent builder rejects invalid combinations
+at startup.
+
+## Replay mode
+
+Stagnation detection is **disabled** automatically in replay mode (`bench
+replay`).  Replays are scripted and deterministic; the agent should run to the
+same terminal condition recorded in the original trajectory without being
+interrupted by the detector.
+
+## Exit code contract
+
+| Code | `outcome_class`    | Condition                        |
+|------|--------------------|----------------------------------|
+| 12   | `agent_stagnation` | Stagnation detector tripped.     |
+
+See `docs/exit-codes.md` for the full exit-code table.
+
+## Trajectory format version
+
+This feature was introduced with trajectory format **mini-swe-agent-1.2**.
+Trajectories produced before 1.2 will not contain `info.other["stagnation"]`
+and their `failure_category` will not be `"agent_stagnation"`.
+
+## Worked example
+
+Step limit = 10, K = 4, W = 8.  The agent issues `ls` at every step:
+
+| Step | Action | Window contents (hashes) | `ls` count | Trip? |
+|------|--------|--------------------------|------------|-------|
+| 0    | `ls`   | [ls]                     | 1          | No    |
+| 1    | `ls`   | [ls, ls]                 | 2          | No    |
+| 2    | `ls`   | [ls, ls, ls]             | 3          | No    |
+| 3    | `ls`   | [ls, ls, ls, ls]         | 4          | **Yes** — halted |
+
+The run is terminated at step 3 (4th occurrence), well before the step limit.

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -995,20 +995,22 @@ impl Agent for DefaultAgent {
             timestamp: obs_ts,
         });
 
-        // Check for stagnation before incrementing so step_index = self.steps.
-        if is_bash && !tool_use_blocked {
-            if let Some(detector) = &mut self.stagnation_detector {
-                if let Some(trip) = detector.observe(self.steps, &tool_input) {
-                    self.steps += 1;
-                    return Ok(self.terminate_stagnation(trip));
-                }
-            }
-        }
-
         self.steps += 1;
+        // Cancellation takes priority: if the operator interrupted during the
+        // Kth repeated command we must record UserInterrupt (exit 130), not
+        // agent_stagnation (exit 12).
         if self.cancellation_requested() {
             self.finalize_cancelled();
             return Ok(StepOutcome::Terminate(ExitReason::UserInterrupt));
+        }
+
+        // Check for stagnation after cancellation so step_index = self.steps - 1.
+        if is_bash && !tool_use_blocked {
+            if let Some(detector) = &mut self.stagnation_detector {
+                if let Some(trip) = detector.observe(self.steps - 1, &tool_input) {
+                    return Ok(self.terminate_stagnation(trip));
+                }
+            }
         }
         Ok(StepOutcome::Continue)
     }

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -269,6 +269,16 @@ impl DefaultAgentBuilder {
         let stagnation_detector = if agent_cfg.detect_stagnation {
             let k = agent_cfg.stagnation_repeat_threshold;
             let w = agent_cfg.stagnation_window;
+            if k == 0 {
+                return Err(Error::Config(crate::error::ConfigError::Invalid(
+                    "--stagnation-repeat-threshold must be >= 1".into(),
+                )));
+            }
+            if w == 0 {
+                return Err(Error::Config(crate::error::ConfigError::Invalid(
+                    "--stagnation-window must be >= 1".into(),
+                )));
+            }
             if w < k {
                 return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
                     "--stagnation-window ({w}) must be >= --stagnation-repeat-threshold ({k})"

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -33,6 +33,7 @@ use crate::template::Renderer;
 use crate::tool::{
     BASH_TOOL_NAME, CommandTool, ToolCall, ToolInvocation, ToolProvider, ToolRegistry,
 };
+use crate::stagnation::StagnationDetector;
 use crate::trajectory::{
     FailureCategory, FallbackSummary, TestCommandPattern, TestInvocation, TokenUsage, Trajectory,
     detect_test_command, effective_test_command_patterns, exit_reason, outcome,
@@ -175,6 +176,8 @@ pub struct DefaultAgent {
     /// Used to build a complete `attempted_models` list even in multi-step runs
     /// where the responding model changes between steps.
     all_step_responders: Vec<String>,
+    /// In-loop stagnation detector; `None` when detection is disabled.
+    stagnation_detector: Option<StagnationDetector>,
 }
 
 pub struct DefaultAgentBuilder {
@@ -192,6 +195,7 @@ impl DefaultAgentBuilder {
         self.build_with_tool_providers(Vec::new())
     }
 
+    #[allow(clippy::too_many_lines)]
     pub fn build_with_tool_providers(
         self,
         tool_providers: Vec<Arc<dyn ToolProvider>>,
@@ -260,6 +264,21 @@ impl DefaultAgentBuilder {
                 "invalid policy config: {err}"
             )))
         })?;
+        // Validate and build the stagnation detector.
+        let agent_cfg = &self.config.root.agent;
+        let stagnation_detector = if agent_cfg.detect_stagnation {
+            let k = agent_cfg.stagnation_repeat_threshold;
+            let w = agent_cfg.stagnation_window;
+            if w < k {
+                return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "--stagnation-window ({w}) must be >= --stagnation-repeat-threshold ({k})"
+                ))));
+            }
+            Some(StagnationDetector::new(k, w))
+        } else {
+            None
+        };
+
         stream.emit(StreamEvent::RunStarted {
             task: self.task.clone(),
             model: self.model.name().to_owned(),
@@ -292,6 +311,7 @@ impl DefaultAgentBuilder {
             fallback_failed_attempts: Vec::new(),
             last_responding_model: None,
             all_step_responders: Vec::new(),
+            stagnation_detector,
         })
     }
 }
@@ -975,6 +995,16 @@ impl Agent for DefaultAgent {
             timestamp: obs_ts,
         });
 
+        // Check for stagnation before incrementing so step_index = self.steps.
+        if is_bash && !tool_use_blocked {
+            if let Some(detector) = &mut self.stagnation_detector {
+                if let Some(trip) = detector.observe(self.steps, &tool_input) {
+                    self.steps += 1;
+                    return Ok(self.terminate_stagnation(trip));
+                }
+            }
+        }
+
         self.steps += 1;
         if self.cancellation_requested() {
             self.finalize_cancelled();
@@ -1189,6 +1219,37 @@ impl DefaultAgent {
             Some(FailureCategory::WallclockTimeout),
             None,
         );
+    }
+
+    fn terminate_stagnation(
+        &mut self,
+        trip: crate::stagnation::StagnationTrip,
+    ) -> StepOutcome {
+        self.trajectory.info.exit_reason = Some("agent_stagnation".into());
+        self.trajectory.info.failure_category = Some(FailureCategory::AgentStagnation);
+        self.trajectory.info.steps = Some(self.steps);
+        self.trajectory.info.total_cost_usd = Some(self.total_cost_usd);
+        self.trajectory.info.ended_at = Some(chrono::Utc::now().to_rfc3339());
+        self.trajectory.info.other.insert(
+            "stagnation".into(),
+            serde_json::json!({
+                "action_hash": trip.action_hash,
+                "count": trip.count,
+                "window": trip.window,
+                "step_indices": trip.step_indices,
+            }),
+        );
+        self.finalize_run_metadata(outcome::ERROR);
+        self.emit_run_ended(
+            "agent_stagnation",
+            Some(FailureCategory::AgentStagnation),
+            None,
+        );
+        StepOutcome::Terminate(ExitReason::AgentStagnation {
+            action_hash: trip.action_hash,
+            count: trip.count,
+            window: trip.window,
+        })
     }
 
     pub fn finalize_cancelled(&mut self) {

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -28,12 +28,12 @@ use crate::model::{
 };
 use crate::policy::{PolicyDecision, PolicyEngine, PolicyProfile};
 use crate::redaction::{RedactingSink, Redactor, surface};
+use crate::stagnation::StagnationDetector;
 use crate::stream::{NullSink, StreamEvent, StreamSink};
 use crate::template::Renderer;
 use crate::tool::{
     BASH_TOOL_NAME, CommandTool, ToolCall, ToolInvocation, ToolProvider, ToolRegistry,
 };
-use crate::stagnation::StagnationDetector;
 use crate::trajectory::{
     FailureCategory, FallbackSummary, TestCommandPattern, TestInvocation, TokenUsage, Trajectory,
     detect_test_command, effective_test_command_patterns, exit_reason, outcome,
@@ -1221,10 +1221,7 @@ impl DefaultAgent {
         );
     }
 
-    fn terminate_stagnation(
-        &mut self,
-        trip: crate::stagnation::StagnationTrip,
-    ) -> StepOutcome {
+    fn terminate_stagnation(&mut self, trip: crate::stagnation::StagnationTrip) -> StepOutcome {
         self.trajectory.info.exit_reason = Some("agent_stagnation".into());
         self.trajectory.info.failure_category = Some(FailureCategory::AgentStagnation);
         self.trajectory.info.steps = Some(self.steps);

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -51,6 +51,12 @@ pub enum ExitReason {
     UserInterrupt,
     /// The LLM backend refused to complete the prompt (e.g. safety filters).
     ModelRefusal { reason: String },
+    /// The agent was halted because it repeated the same action K times in W steps.
+    AgentStagnation {
+        action_hash: String,
+        count: u32,
+        window: u32,
+    },
 }
 
 impl ExitReason {
@@ -75,6 +81,7 @@ impl ExitReason {
             Self::BudgetExhausted { .. } => "budget_exhausted",
             Self::UserInterrupt => "user_interrupt",
             Self::ModelRefusal { .. } => "model_refusal",
+            Self::AgentStagnation { .. } => "agent_stagnation",
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -188,7 +188,7 @@ pub struct MiniCmd {
 
     /// Enable in-loop agent stagnation detection (default: on). Pass
     /// `--detect-stagnation=false` to disable.
-    #[arg(long = "detect-stagnation", default_value_t = true)]
+    #[arg(long = "detect-stagnation", default_value_t = true, num_args = 0..=1, default_missing_value = "true")]
     pub detect_stagnation: bool,
 
     /// Number of times the same action must appear in the trailing window

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -186,6 +186,21 @@ pub struct MiniCmd {
     #[arg(long = "verify-timeout-secs", default_value_t = 60)]
     pub verify_timeout_secs: u64,
 
+    /// Enable in-loop agent stagnation detection (default: on). Pass
+    /// `--detect-stagnation=false` to disable.
+    #[arg(long = "detect-stagnation", default_value_t = true)]
+    pub detect_stagnation: bool,
+
+    /// Number of times the same action must appear in the trailing window
+    /// before stagnation is declared. Default: 4.
+    #[arg(long, default_value_t = 4)]
+    pub stagnation_repeat_threshold: u32,
+
+    /// Size of the trailing-steps window examined by the stagnation detector.
+    /// Must be >= `--stagnation-repeat-threshold`. Default: 8.
+    #[arg(long, default_value_t = 8)]
+    pub stagnation_window: u32,
+
     #[command(flatten)]
     pub github_pr: MiniGithubPrArgs,
 }
@@ -684,6 +699,21 @@ pub struct SwebenchCmd {
     /// same actionable failure category for the circuit breaker to trip.
     #[arg(long, default_value_t = 80)]
     pub systemic_failure_share_pct: u8,
+
+    /// Enable in-loop stagnation detection (default: true). When the agent
+    /// repeats the same bash action K times within the last W steps the run
+    /// is halted with exit code 12 and failure_category "agent_stagnation".
+    #[arg(long, default_value_t = true, num_args = 0..=1, default_missing_value = "true")]
+    pub detect_stagnation: bool,
+
+    /// Number of times the same action must appear within the window before
+    /// the stagnation detector trips.
+    #[arg(long, default_value_t = 4)]
+    pub stagnation_repeat_threshold: u32,
+
+    /// Sliding window size (in steps) used by the stagnation detector.
+    #[arg(long, default_value_t = 8)]
+    pub stagnation_window: u32,
 
     #[command(flatten)]
     pub github_pr: SwebenchGithubPrArgs,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -186,10 +186,12 @@ pub struct MiniCmd {
     #[arg(long = "verify-timeout-secs", default_value_t = 60)]
     pub verify_timeout_secs: u64,
 
-    /// Enable in-loop agent stagnation detection (default: on). Pass
-    /// `--detect-stagnation=false` to disable.
-    #[arg(long = "detect-stagnation", default_value_t = true, num_args = 0..=1, default_missing_value = "true")]
-    pub detect_stagnation: bool,
+    /// Enable or disable in-loop stagnation detection. Omitting the flag
+    /// preserves the config-file value (default: on). `--detect-stagnation`
+    /// or `--detect-stagnation=true` enables; `--detect-stagnation=false`
+    /// disables, overriding any config-file setting.
+    #[arg(long = "detect-stagnation", num_args = 0..=1, default_missing_value = "true")]
+    pub detect_stagnation: Option<bool>,
 
     /// Number of times the same action must appear in the trailing window
     /// before stagnation is declared. Overrides the config-file value when set.
@@ -702,11 +704,12 @@ pub struct SwebenchCmd {
     #[arg(long, default_value_t = 80)]
     pub systemic_failure_share_pct: u8,
 
-    /// Enable in-loop stagnation detection (default: true). When the agent
-    /// repeats the same bash action K times within the last W steps the run
-    /// is halted with exit code 12 and failure_category "agent_stagnation".
-    #[arg(long, default_value_t = true, num_args = 0..=1, default_missing_value = "true")]
-    pub detect_stagnation: bool,
+    /// Enable or disable in-loop stagnation detection. Omitting the flag
+    /// preserves the config-file value (default: on). `--detect-stagnation`
+    /// or `--detect-stagnation=true` enables; `--detect-stagnation=false`
+    /// disables, overriding any config-file setting.
+    #[arg(long = "detect-stagnation", num_args = 0..=1, default_missing_value = "true")]
+    pub detect_stagnation: Option<bool>,
 
     /// Number of times the same action must appear within the window before
     /// the stagnation detector trips. Overrides the config-file value when set.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -192,14 +192,16 @@ pub struct MiniCmd {
     pub detect_stagnation: bool,
 
     /// Number of times the same action must appear in the trailing window
-    /// before stagnation is declared. Default: 4.
-    #[arg(long, default_value_t = 4)]
-    pub stagnation_repeat_threshold: u32,
+    /// before stagnation is declared. Overrides the config-file value when set.
+    /// Schema default: 4.
+    #[arg(long)]
+    pub stagnation_repeat_threshold: Option<u32>,
 
     /// Size of the trailing-steps window examined by the stagnation detector.
-    /// Must be >= `--stagnation-repeat-threshold`. Default: 8.
-    #[arg(long, default_value_t = 8)]
-    pub stagnation_window: u32,
+    /// Must be >= `--stagnation-repeat-threshold`. Overrides the config-file
+    /// value when set. Schema default: 8.
+    #[arg(long)]
+    pub stagnation_window: Option<u32>,
 
     #[command(flatten)]
     pub github_pr: MiniGithubPrArgs,
@@ -707,13 +709,15 @@ pub struct SwebenchCmd {
     pub detect_stagnation: bool,
 
     /// Number of times the same action must appear within the window before
-    /// the stagnation detector trips.
-    #[arg(long, default_value_t = 4)]
-    pub stagnation_repeat_threshold: u32,
+    /// the stagnation detector trips. Overrides the config-file value when set.
+    /// Schema default: 4.
+    #[arg(long)]
+    pub stagnation_repeat_threshold: Option<u32>,
 
     /// Sliding window size (in steps) used by the stagnation detector.
-    #[arg(long, default_value_t = 8)]
-    pub stagnation_window: u32,
+    /// Overrides the config-file value when set. Schema default: 8.
+    #[arg(long)]
+    pub stagnation_window: Option<u32>,
 
     #[command(flatten)]
     pub github_pr: SwebenchGithubPrArgs,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -149,6 +149,9 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
     if m.hide_budget_from_agent {
         cfg.root.agent.hide_budget_from_agent = true;
     }
+    cfg.root.agent.detect_stagnation = m.detect_stagnation;
+    cfg.root.agent.stagnation_repeat_threshold = m.stagnation_repeat_threshold;
+    cfg.root.agent.stagnation_window = m.stagnation_window;
     apply_mcp_server_overrides(&mut cfg, &m.mcp_servers)?;
 
     let trajectory_name = m
@@ -518,6 +521,9 @@ fn swebench_config_from_cmd(s: &args::SwebenchCmd) -> Result<Config, Error> {
     if s.hide_budget_from_agent {
         cfg.root.agent.hide_budget_from_agent = true;
     }
+    cfg.root.agent.detect_stagnation = s.detect_stagnation;
+    cfg.root.agent.stagnation_repeat_threshold = s.stagnation_repeat_threshold;
+    cfg.root.agent.stagnation_window = s.stagnation_window;
     apply_mcp_server_overrides(&mut cfg, &s.mcp_servers)?;
     Ok(cfg)
 }
@@ -1799,6 +1805,9 @@ mod tests {
             task_timeout_secs: None,
             per_task_budget_usd: None,
             hide_budget_from_agent: false,
+            detect_stagnation: true,
+            stagnation_repeat_threshold: 4,
+            stagnation_window: 8,
             mcp_servers: Vec::new(),
             config: None,
             env: None,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -149,9 +149,15 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
     if m.hide_budget_from_agent {
         cfg.root.agent.hide_budget_from_agent = true;
     }
-    cfg.root.agent.detect_stagnation = m.detect_stagnation;
-    cfg.root.agent.stagnation_repeat_threshold = m.stagnation_repeat_threshold;
-    cfg.root.agent.stagnation_window = m.stagnation_window;
+    if !m.detect_stagnation {
+        cfg.root.agent.detect_stagnation = false;
+    }
+    if let Some(v) = m.stagnation_repeat_threshold {
+        cfg.root.agent.stagnation_repeat_threshold = v;
+    }
+    if let Some(v) = m.stagnation_window {
+        cfg.root.agent.stagnation_window = v;
+    }
     apply_mcp_server_overrides(&mut cfg, &m.mcp_servers)?;
 
     let trajectory_name = m
@@ -521,9 +527,15 @@ fn swebench_config_from_cmd(s: &args::SwebenchCmd) -> Result<Config, Error> {
     if s.hide_budget_from_agent {
         cfg.root.agent.hide_budget_from_agent = true;
     }
-    cfg.root.agent.detect_stagnation = s.detect_stagnation;
-    cfg.root.agent.stagnation_repeat_threshold = s.stagnation_repeat_threshold;
-    cfg.root.agent.stagnation_window = s.stagnation_window;
+    if !s.detect_stagnation {
+        cfg.root.agent.detect_stagnation = false;
+    }
+    if let Some(v) = s.stagnation_repeat_threshold {
+        cfg.root.agent.stagnation_repeat_threshold = v;
+    }
+    if let Some(v) = s.stagnation_window {
+        cfg.root.agent.stagnation_window = v;
+    }
     apply_mcp_server_overrides(&mut cfg, &s.mcp_servers)?;
     Ok(cfg)
 }
@@ -1806,8 +1818,8 @@ mod tests {
             per_task_budget_usd: None,
             hide_budget_from_agent: false,
             detect_stagnation: true,
-            stagnation_repeat_threshold: 4,
-            stagnation_window: 8,
+            stagnation_repeat_threshold: None,
+            stagnation_window: None,
             mcp_servers: Vec::new(),
             config: None,
             env: None,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -149,8 +149,8 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
     if m.hide_budget_from_agent {
         cfg.root.agent.hide_budget_from_agent = true;
     }
-    if !m.detect_stagnation {
-        cfg.root.agent.detect_stagnation = false;
+    if let Some(v) = m.detect_stagnation {
+        cfg.root.agent.detect_stagnation = v;
     }
     if let Some(v) = m.stagnation_repeat_threshold {
         cfg.root.agent.stagnation_repeat_threshold = v;
@@ -527,8 +527,8 @@ fn swebench_config_from_cmd(s: &args::SwebenchCmd) -> Result<Config, Error> {
     if s.hide_budget_from_agent {
         cfg.root.agent.hide_budget_from_agent = true;
     }
-    if !s.detect_stagnation {
-        cfg.root.agent.detect_stagnation = false;
+    if let Some(v) = s.detect_stagnation {
+        cfg.root.agent.detect_stagnation = v;
     }
     if let Some(v) = s.stagnation_repeat_threshold {
         cfg.root.agent.stagnation_repeat_threshold = v;
@@ -1817,7 +1817,7 @@ mod tests {
             task_timeout_secs: None,
             per_task_budget_usd: None,
             hide_budget_from_agent: false,
-            detect_stagnation: true,
+            detect_stagnation: None,
             stagnation_repeat_threshold: None,
             stagnation_window: None,
             mcp_servers: Vec::new(),

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -64,6 +64,17 @@ pub struct AgentCfg {
     pub tools: Vec<ToolCfg>,
     #[serde(default)]
     pub hooks: ToolHooksCfg,
+    /// Enable in-loop stagnation detection. Default: `true` (opt-out with `false`).
+    #[serde(default = "default_detect_stagnation")]
+    pub detect_stagnation: bool,
+    /// Minimum number of identical canonicalized actions within the window to
+    /// trip the stagnation detector. Default: 4.
+    #[serde(default = "default_stagnation_repeat_threshold")]
+    pub stagnation_repeat_threshold: u32,
+    /// Size of the trailing-steps window examined by the stagnation detector.
+    /// Must be >= `stagnation_repeat_threshold`. Default: 8.
+    #[serde(default = "default_stagnation_window")]
+    pub stagnation_window: u32,
 }
 
 fn default_step_limit() -> u32 {
@@ -92,6 +103,18 @@ fn default_observation_head_ratio() -> f64 {
 
 fn default_tool_hook_timeout_secs() -> u64 {
     10
+}
+
+fn default_detect_stagnation() -> bool {
+    true
+}
+
+fn default_stagnation_repeat_threshold() -> u32 {
+    4
+}
+
+fn default_stagnation_window() -> u32 {
+    8
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,15 @@ pub enum Error {
     /// `(failed_count, total_count)`.
     #[error("verification failed: {0} of {1} check(s) did not pass")]
     VerificationFailed(usize, usize),
+
+    /// Agent stagnation detected: the same bash action was repeated at least K
+    /// times within the trailing W-step window. The trajectory is already
+    /// finalized on disk with `failure_category = "agent_stagnation"` before
+    /// this error is returned. Callers that aggregate results (e.g. the sweep
+    /// runner) should read failure metadata from the trajectory; this error
+    /// exists only so the CLI can exit with code 12.
+    #[error("agent stagnation detected: action repeated {count} times in {window}-step window")]
+    AgentStagnation { count: u32, window: u32 },
 }
 
 #[derive(Debug, Error)]

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -123,6 +123,7 @@ impl ExitCode {
                 // before this function is called, so exit-10 is replay-only.
                 _ => Self::TaskUnsuccessful,
             },
+            Error::AgentStagnation { .. } => Self::AgentStagnation,
             Error::Template(_)
             | Error::Trajectory(_)
             | Error::Github(_)

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -58,6 +58,10 @@ pub enum ExitCode {
     /// at or above the configured share threshold (default 80%). See
     /// `docs/spec-systemic-halt.md` for the full contract.
     SystemicHalt = 11,
+    /// 12 — agent stagnation detected: the agent repeated the same action at
+    /// least K times within a trailing window of W steps. See
+    /// `docs/spec-stagnation.md` for the full contract.
+    AgentStagnation = 12,
     /// 130 — user interruption (graceful SIGINT / Ctrl-C; 128 + SIGINT(2)).
     Interrupted = 130,
     /// 137 — forced kill (SIGKILL escalation after graceful-cancel deadline; 128 + SIGKILL(9)).
@@ -90,6 +94,7 @@ impl ExitCode {
             Self::ReplayPromptDrift => "replay_prompt_drift",
             Self::ReplayResponseExhausted => "replay_response_exhausted",
             Self::SystemicHalt => "systemic_halt",
+            Self::AgentStagnation => "agent_stagnation",
             Self::Interrupted => "interrupted",
             Self::Killed => "killed",
         }

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -225,6 +225,9 @@ mod tests {
     #[test]
     fn agent_stagnation_exit_code_is_12() {
         assert_eq!(ExitCode::AgentStagnation.as_i32(), 12);
-        assert_eq!(ExitCode::AgentStagnation.outcome_class(), "agent_stagnation");
+        assert_eq!(
+            ExitCode::AgentStagnation.outcome_class(),
+            "agent_stagnation"
+        );
     }
 }

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -221,4 +221,10 @@ mod tests {
             ExitCode::TaskUnsuccessful
         );
     }
+
+    #[test]
+    fn agent_stagnation_exit_code_is_12() {
+        assert_eq!(ExitCode::AgentStagnation.as_i32(), 12);
+        assert_eq!(ExitCode::AgentStagnation.outcome_class(), "agent_stagnation");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 pub mod agent;
 pub mod artifact;
 pub mod cli;
-pub mod stagnation;
 pub mod config;
 pub mod cost;
 pub mod env;
@@ -18,6 +17,7 @@ pub mod policy;
 pub mod redaction;
 pub mod run;
 pub mod skills;
+pub mod stagnation;
 pub mod stream;
 pub mod template;
 pub mod tool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod agent;
 pub mod artifact;
 pub mod cli;
+pub mod stagnation;
 pub mod config;
 pub mod cost;
 pub mod env;

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -2354,6 +2354,7 @@ fn failure_label(cat: FailureCategory) -> &'static str {
         FailureCategory::BudgetExhausted => "budget_exhausted",
         FailureCategory::WallclockTimeout => "wallclock_timeout",
         FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::AgentStagnation => "agent_stagnation",
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
         FailureCategory::SecretLeakDetected => "secret_leak_detected",

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -93,7 +93,7 @@ pub struct SourceReportEntry {
 pub const COST_ATTRIBUTION_RESOLVED_BUCKET: &str = "resolved";
 pub const COST_ATTRIBUTION_UNCATEGORIZED_BUCKET: &str = "uncategorized";
 pub const COST_ATTRIBUTION_TOTAL_BUCKET: &str = "TOTAL";
-pub const ALL_FAILURE_CATEGORIES: [FailureCategory; 11] = [
+pub const ALL_FAILURE_CATEGORIES: [FailureCategory; 12] = [
     FailureCategory::EnvSetup,
     FailureCategory::ModelApi,
     FailureCategory::ModelParse,
@@ -101,6 +101,7 @@ pub const ALL_FAILURE_CATEGORIES: [FailureCategory; 11] = [
     FailureCategory::CostLimit,
     FailureCategory::WallclockTimeout,
     FailureCategory::AgentInternal,
+    FailureCategory::AgentStagnation,
     FailureCategory::PatchApplyInvalid,
     FailureCategory::PatchEmpty,
     FailureCategory::SecretLeakDetected,
@@ -1494,6 +1495,7 @@ pub fn failure_label(cat: FailureCategory) -> &'static str {
         FailureCategory::BudgetExhausted => "budget_exhausted",
         FailureCategory::WallclockTimeout => "wallclock_timeout",
         FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::AgentStagnation => "agent_stagnation",
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
         FailureCategory::SecretLeakDetected => "secret_leak_detected",

--- a/src/run/hello_world.rs
+++ b/src/run/hello_world.rs
@@ -60,6 +60,6 @@ mod tests {
             panic!("trajectory file not written");
         };
         let contents = std::fs::read_to_string(traj.path()).unwrap();
-        assert!(contents.contains("mini-swe-agent-1.1"));
+        assert!(contents.contains("mini-swe-agent-1.2"));
     }
 }

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -851,6 +851,7 @@ fn failure_label(c: FailureCategory) -> &'static str {
         FailureCategory::BudgetExhausted => "budget_exhausted",
         FailureCategory::WallclockTimeout => "wallclock_timeout",
         FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::AgentStagnation => "agent_stagnation",
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
         FailureCategory::SecretLeakDetected => "secret_leak_detected",

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -376,6 +376,9 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     if let Some(err) = verification_err {
         return Err(err);
     }
+    if matches!(exit, crate::agent::ExitReason::AgentStagnation { .. }) {
+        std::process::exit(crate::exit_code::ExitCode::AgentStagnation.as_i32());
+    }
     Ok(())
 }
 

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -326,9 +326,13 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     // returned Err above). Sets `verification_status` on the trajectory so
     // every persisted artifact carries a deterministic verification outcome.
     let skip_verification = run_result.is_err()
-        || run_result
-            .as_ref()
-            .is_ok_and(|r| matches!(r, crate::agent::ExitReason::UserInterrupt));
+        || run_result.as_ref().is_ok_and(|r| {
+            matches!(
+                r,
+                crate::agent::ExitReason::UserInterrupt
+                    | crate::agent::ExitReason::AgentStagnation { .. }
+            )
+        });
     let verification_err = if skip_verification {
         agent.trajectory.info.verification_status =
             Some(crate::trajectory::verification_status::UNVERIFIED.into());
@@ -376,8 +380,8 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     if let Some(err) = verification_err {
         return Err(err);
     }
-    if matches!(exit, crate::agent::ExitReason::AgentStagnation { .. }) {
-        std::process::exit(crate::exit_code::ExitCode::AgentStagnation.as_i32());
+    if let crate::agent::ExitReason::AgentStagnation { count, window, .. } = exit {
+        return Err(crate::error::Error::AgentStagnation { count, window });
     }
     Ok(())
 }

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -218,8 +218,10 @@ pub async fn run(args: ReplayArgs) -> Result<(), Error> {
 
     let resolved_skills = crate::skills::resolve_for_task(&args.config.root.skills, &task, None)?;
 
+    let mut replay_config = args.config.clone();
+    replay_config.root.agent.detect_stagnation = false;
     let mut agent: DefaultAgent = DefaultAgentBuilder {
-        config: args.config.clone(),
+        config: replay_config,
         model,
         env,
         task,

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -4250,6 +4250,7 @@ fn failure_category_label(cat: FailureCategory) -> &'static str {
         FailureCategory::BudgetExhausted => "budget_exhausted",
         FailureCategory::WallclockTimeout => "wallclock_timeout",
         FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::AgentStagnation => "agent_stagnation",
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
         FailureCategory::SecretLeakDetected => "secret_leak_detected",

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -3803,6 +3803,7 @@ fn parse_failure_category_label(s: &str) -> Result<FailureCategory, Error> {
         "patch_apply_invalid" => Ok(FailureCategory::PatchApplyInvalid),
         "patch_empty" => Ok(FailureCategory::PatchEmpty),
         "secret_leak_detected" => Ok(FailureCategory::SecretLeakDetected),
+        "agent_stagnation" => Ok(FailureCategory::AgentStagnation),
         "unknown" => Ok(FailureCategory::Unknown),
         _ => Err(Error::Config(crate::error::ConfigError::Invalid(format!(
             "unknown retry category `{s}`"

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -4221,6 +4221,9 @@ fn classify_error(err: &Error) -> FailureCategory {
             }
         }
         Error::Model(_) => FailureCategory::ModelApi,
+        // Stagnation is fully recorded in the trajectory; this arm is a
+        // robustness fallback for cases where trajectory loading fails.
+        Error::AgentStagnation { .. } => FailureCategory::AgentStagnation,
         // Any remaining typed error in the runner/agent.
         _ => FailureCategory::AgentInternal,
     }

--- a/src/run/tail.rs
+++ b/src/run/tail.rs
@@ -978,6 +978,7 @@ fn failure_label(category: FailureCategory) -> &'static str {
         FailureCategory::BudgetExhausted => "budget_exhausted",
         FailureCategory::WallclockTimeout => "wallclock_timeout",
         FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::AgentStagnation => "agent_stagnation",
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
         FailureCategory::SecretLeakDetected => "secret_leak_detected",

--- a/src/run/trajectory_diff.rs
+++ b/src/run/trajectory_diff.rs
@@ -1049,6 +1049,7 @@ fn failure_label(category: FailureCategory) -> &'static str {
         FailureCategory::BudgetExhausted => "budget_exhausted",
         FailureCategory::WallclockTimeout => "wallclock_timeout",
         FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::AgentStagnation => "agent_stagnation",
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
         FailureCategory::SecretLeakDetected => "secret_leak_detected",

--- a/src/run/triage.rs
+++ b/src/run/triage.rs
@@ -583,6 +583,7 @@ fn failure_label(c: FailureCategory) -> &'static str {
         FailureCategory::BudgetExhausted => "budget_exhausted",
         FailureCategory::WallclockTimeout => "wallclock_timeout",
         FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::AgentStagnation => "agent_stagnation",
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
         FailureCategory::SecretLeakDetected => "secret_leak_detected",

--- a/src/stagnation.rs
+++ b/src/stagnation.rs
@@ -1,0 +1,234 @@
+//! In-loop agent stagnation detection (issue #157).
+//!
+//! The detector maintains a ring buffer of the last W canonicalized bash
+//! actions. After each completed bash step it checks whether any single
+//! action appears K or more times in the buffer. When the condition is
+//! met the agent loop is halted with `FailureCategory::AgentStagnation`.
+//!
+//! **Canonicalization rule** (deterministic, byte-level):
+//! 1. Trim leading/trailing ASCII whitespace.
+//! 2. Collapse every internal run of ASCII whitespace to a single space.
+//! 3. Strip a single trailing semicolon (if present after trimming).
+//!
+//! The canonical form is then SHA-256 hashed; only the hash is stored in
+//! the stagnation record for privacy/redaction friendliness.
+
+use std::collections::VecDeque;
+
+use sha2::{Digest, Sha256};
+
+/// Canonicalize a bash action string per the spec rule.
+///
+/// This function is `pub` so integration tests can verify the rule directly.
+pub fn canonicalize_action(raw: &str) -> String {
+    // 1. Trim surrounding whitespace.
+    let trimmed = raw.trim();
+    // 2. Collapse internal whitespace runs.
+    let collapsed = collapse_internal_whitespace(trimmed);
+    // 3. Strip single trailing semicolon. After stripping, trim trailing
+    //    whitespace again so "ls ;" and "ls;" both produce "ls".
+    if let Some(rest) = collapsed.strip_suffix(';') {
+        rest.trim_end().to_owned()
+    } else {
+        collapsed
+    }
+}
+
+fn collapse_internal_whitespace(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut in_space = false;
+    for ch in s.chars() {
+        if ch.is_ascii_whitespace() {
+            if !in_space && !result.is_empty() {
+                result.push(' ');
+                in_space = true;
+            }
+        } else {
+            in_space = false;
+            result.push(ch);
+        }
+    }
+    // Trim any trailing space introduced by the collapse (edge case: input ends with whitespace
+    // that was only partially handled by outer trim for non-ASCII).
+    if result.ends_with(' ') {
+        result.pop();
+    }
+    result
+}
+
+/// SHA-256 hex digest (truncated to 16 bytes / 32 hex chars) of a canonical action.
+pub fn action_hash(canonical: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    let digest = hasher.finalize();
+    // 16 bytes = 32 hex chars — enough to distinguish actions while keeping the
+    // info block compact.
+    let mut hex = String::with_capacity(32);
+    for b in &digest[..16] {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{b:02x}");
+    }
+    hex
+}
+
+/// A single entry in the stagnation ring buffer.
+#[derive(Debug, Clone)]
+struct Entry {
+    step_index: u32,
+    /// SHA-256 hex (truncated) of the canonical action.
+    hash: String,
+}
+
+/// Rolling-window stagnation detector.
+///
+/// Call [`StagnationDetector::observe`] after each completed bash step. It
+/// returns `Some(StagnationTrip)` the first time the threshold is met.
+#[derive(Debug)]
+pub struct StagnationDetector {
+    /// Maximum number of entries to retain (= W, the window size).
+    window: u32,
+    /// Repeat threshold (= K).
+    threshold: u32,
+    buffer: VecDeque<Entry>,
+}
+
+/// Evidence returned when the detector trips.
+#[derive(Debug, Clone)]
+pub struct StagnationTrip {
+    /// Truncated SHA-256 hex of the repeated canonical action.
+    pub action_hash: String,
+    /// Number of occurrences observed (= K at trip time).
+    pub count: u32,
+    /// Window size at trip time (= W).
+    pub window: u32,
+    /// Step indices of every contributing repeat, in ascending order.
+    pub step_indices: Vec<u32>,
+}
+
+impl StagnationDetector {
+    /// Create a new detector with the given window size and repeat threshold.
+    ///
+    /// Panics if `window < threshold` — callers must validate config before
+    /// constructing (the `DefaultAgentBuilder` enforces this).
+    pub fn new(threshold: u32, window: u32) -> Self {
+        assert!(
+            window >= threshold,
+            "stagnation window ({window}) must be >= threshold ({threshold})"
+        );
+        Self {
+            window,
+            threshold,
+            buffer: VecDeque::with_capacity(window as usize),
+        }
+    }
+
+    /// Record the bash action taken at `step_index` and check for stagnation.
+    ///
+    /// Returns `Some(StagnationTrip)` if the same action hash has appeared
+    /// `threshold` or more times in the current window; `None` otherwise.
+    pub fn observe(&mut self, step_index: u32, action: &str) -> Option<StagnationTrip> {
+        let canonical = canonicalize_action(action);
+        let hash = action_hash(&canonical);
+
+        // Evict oldest entry when the buffer is full.
+        if self.buffer.len() == self.window as usize {
+            self.buffer.pop_front();
+        }
+        self.buffer.push_back(Entry {
+            step_index,
+            hash: hash.clone(),
+        });
+
+        // Count occurrences of this hash in the current buffer.
+        let matching: Vec<u32> = self
+            .buffer
+            .iter()
+            .filter(|e| e.hash == hash)
+            .map(|e| e.step_index)
+            .collect();
+
+        if matching.len() >= self.threshold as usize {
+            #[allow(clippy::cast_possible_truncation)]
+            let count = matching.len() as u32;
+            Some(StagnationTrip {
+                action_hash: hash,
+                count,
+                window: self.window,
+                step_indices: matching,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalize_trims_whitespace() {
+        assert_eq!(canonicalize_action("  ls  "), "ls");
+    }
+
+    #[test]
+    fn canonicalize_strips_trailing_semicolon() {
+        assert_eq!(canonicalize_action("ls;"), "ls");
+        assert_eq!(canonicalize_action("ls ;"), "ls");
+    }
+
+    #[test]
+    fn canonicalize_collapses_internal_whitespace() {
+        assert_eq!(canonicalize_action("ls   -la"), "ls -la");
+    }
+
+    #[test]
+    fn identical_variants_produce_same_canonical() {
+        let variants = ["ls", "ls  ", "ls;", "  ls  ", "  ls  ;"];
+        let base = canonicalize_action("ls");
+        for v in &variants {
+            assert_eq!(
+                canonicalize_action(v),
+                base,
+                "variant {v:?} did not canonicalize to {base:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn detector_trips_at_k_identical_observations() {
+        let mut det = StagnationDetector::new(4, 8);
+        assert!(det.observe(0, "ls").is_none());
+        assert!(det.observe(1, "ls").is_none());
+        assert!(det.observe(2, "ls").is_none());
+        let trip = det.observe(3, "ls").expect("should trip at 4th identical");
+        assert_eq!(trip.count, 4);
+        assert_eq!(trip.step_indices, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn detector_does_not_trip_for_three_action_rotation() {
+        // A 3-action cycle puts at most ceil(8/3)=3 occurrences per action in
+        // any W=8 window, which is below the K=4 threshold.
+        let mut det = StagnationDetector::new(4, 8);
+        let actions = ["ls", "cat foo", "echo hi"];
+        for i in 0..12u32 {
+            let action = actions[(i as usize) % 3];
+            assert!(
+                det.observe(i, action).is_none(),
+                "should not trip at step {i} with 3-action rotation"
+            );
+        }
+    }
+
+    #[test]
+    fn detector_window_slides_correctly() {
+        // Fill window with ls (W=4, K=4), then push different commands to slide old entries out.
+        let mut det = StagnationDetector::new(4, 4);
+        // 4 ls → trips
+        assert!(det.observe(0, "ls").is_none());
+        assert!(det.observe(1, "ls").is_none());
+        assert!(det.observe(2, "ls").is_none());
+        assert!(det.observe(3, "ls").is_some());
+    }
+}

--- a/src/stagnation.rs
+++ b/src/stagnation.rs
@@ -39,7 +39,7 @@ fn collapse_internal_whitespace(s: &str) -> String {
     let mut in_space = false;
     for ch in s.chars() {
         if ch.is_ascii_whitespace() {
-            if !in_space && !result.is_empty() {
+            if !in_space {
                 result.push(' ');
                 in_space = true;
             }
@@ -47,11 +47,6 @@ fn collapse_internal_whitespace(s: &str) -> String {
             in_space = false;
             result.push(ch);
         }
-    }
-    // Trim any trailing space introduced by the collapse (edge case: input ends with whitespace
-    // that was only partially handled by outer trim for non-ASCII).
-    if result.ends_with(' ') {
-        result.pop();
     }
     result
 }
@@ -164,6 +159,7 @@ impl StagnationDetector {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::expect_used)]
     use super::*;
 
     #[test]

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -1,5 +1,5 @@
 //! Trajectory serialization — wire-compatible with mini-swe-agent's
-//! `mini-swe-agent-1.1` format.
+//! `mini-swe-agent-1.2` format.
 //!
 //! Field declaration order on structs controls JSON key order in
 //! `serde_json` output, so we match Python's layout exactly: `format`,
@@ -15,7 +15,7 @@ use crate::model::{Message, MessageExtra};
 
 pub use crate::model::FallbackAttemptRecord;
 
-pub const FORMAT_VERSION: &str = "mini-swe-agent-1.1";
+pub const FORMAT_VERSION: &str = "mini-swe-agent-1.2";
 
 /// Trajectory-level summary of fallback behavior for a single agent run.
 ///
@@ -502,7 +502,7 @@ fn extra_is_empty(e: &MessageExtra) -> bool {
 #[derive(Debug, Clone, Deserialize)]
 /// The complete record of an agent's execution, including metadata, telemetry, and all messages.
 ///
-/// This struct is serializeable to the `mini-swe-agent-1.1` JSON format and is the primary artifact
+/// This struct is serializeable to the `mini-swe-agent-1.2` JSON format and is the primary artifact
 /// generated at the end of a run.
 pub struct Trajectory {
     /// The format version of the trajectory schema.
@@ -617,7 +617,7 @@ impl Trajectory {
     /// use rust_swe_agent::trajectory::Trajectory;
     /// let traj = Trajectory::new();
     /// let json = traj.to_json_pretty().unwrap();
-    /// assert!(json.contains("mini-swe-agent-1.1"));
+    /// assert!(json.contains("mini-swe-agent-1.2"));
     /// ```
     pub fn to_json_pretty(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string_pretty(self)
@@ -718,7 +718,7 @@ mod tests {
     #[test]
     fn legacy_token_usage_without_cache_fields_defaults_to_zero() {
         let json = r#"{
-  "trajectory_format": "mini-swe-agent-1.1",
+  "trajectory_format": "mini-swe-agent-1.2",
   "info": {
     "token_usage": {
       "prompt_tokens": 1000,
@@ -751,7 +751,7 @@ mod tests {
     #[test]
     fn unknown_keys_preserved() {
         let json = r#"{
-  "trajectory_format": "mini-swe-agent-1.1",
+  "trajectory_format": "mini-swe-agent-1.2",
   "info": {"task": "x", "future_field": "y"},
   "messages": []
 }"#;

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -128,6 +128,8 @@ pub enum FailureCategory {
     PatchEmpty,
     /// A configured secret literal was found in a submission artifact.
     SecretLeakDetected,
+    /// The agent repeated the same action without progress and was halted.
+    AgentStagnation,
     /// An unknown or unclassified failure occurred.
     Unknown,
 }

--- a/tests/agent_stagnation.rs
+++ b/tests/agent_stagnation.rs
@@ -262,3 +262,49 @@ fn stagnation_config_rejects_window_smaller_than_threshold() {
 
     assert!(result.is_err(), "should reject W < K config");
 }
+
+// ── config validation: zero threshold/window ──────────────────────────────────
+
+#[test]
+fn stagnation_config_rejects_zero_threshold() {
+    use rust_swe_agent::agent::default::DefaultAgentBuilder;
+
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.stagnation_repeat_threshold = 0; // invalid
+
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let result = DefaultAgentBuilder {
+        config: cfg,
+        model: Arc::new(DeterministicModel::new(vec![])),
+        env,
+        task: "validation test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build();
+
+    assert!(result.is_err(), "should reject threshold = 0");
+}
+
+#[test]
+fn stagnation_config_rejects_zero_window() {
+    use rust_swe_agent::agent::default::DefaultAgentBuilder;
+
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.stagnation_window = 0; // invalid
+
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let result = DefaultAgentBuilder {
+        config: cfg,
+        model: Arc::new(DeterministicModel::new(vec![])),
+        env,
+        task: "validation test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build();
+
+    assert!(result.is_err(), "should reject window = 0");
+}

--- a/tests/agent_stagnation.rs
+++ b/tests/agent_stagnation.rs
@@ -1,0 +1,257 @@
+//! Agent stagnation detection: TDD tests for issue #157.
+//!
+//! Tests drive the full default-agent loop using DeterministicModel and
+//! LocalEnvironment. All tests must be deterministic and reproduce reliably.
+
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use rust_swe_agent::agent::default::DefaultAgentBuilder;
+use rust_swe_agent::trajectory::FailureCategory;
+use rust_swe_agent::{Agent, Config, DeterministicModel, Environment, ExitReason, LocalEnvironment};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn build_agent(
+    cfg: Config,
+    responses: Vec<String>,
+) -> rust_swe_agent::agent::default::DefaultAgent {
+    let model = Arc::new(DeterministicModel::new(responses));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "stagnation test task".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap()
+}
+
+fn ls_responses(n: usize) -> Vec<String> {
+    (0..n).map(|_| "```bash\nls\n```".into()).collect()
+}
+
+// ── test (a) ──────────────────────────────────────────────────────────────────
+// Four identical `ls` actions in eight steps trips at step 4 and writes
+// `agent_stagnation` with the right hash and indices.
+
+#[tokio::test]
+async fn stagnation_trips_at_step_4_for_repeated_ls() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 40;
+
+    let mut agent = build_agent(cfg, ls_responses(40));
+    let exit = agent.run().await.unwrap();
+
+    assert!(
+        matches!(exit, ExitReason::AgentStagnation { .. }),
+        "expected AgentStagnation, got: {exit:?}"
+    );
+    assert_eq!(
+        agent.trajectory.info.failure_category,
+        Some(FailureCategory::AgentStagnation)
+    );
+    assert_eq!(
+        agent.trajectory.info.exit_reason.as_deref(),
+        Some("agent_stagnation")
+    );
+    // Default K=4: trips after 4 identical steps (step indices 0..3, steps=4 after increment)
+    assert_eq!(agent.steps, 4, "should halt at step 4");
+
+    let info = agent
+        .trajectory
+        .info
+        .other
+        .get("stagnation")
+        .expect("trajectory must carry info.stagnation");
+    assert_eq!(info["count"], 4, "count should be K=4");
+    assert_eq!(info["window"], 8, "window should be W=8");
+
+    let indices: Vec<u32> =
+        serde_json::from_value(info["step_indices"].clone()).expect("step_indices must be array");
+    assert_eq!(indices, vec![0, 1, 2, 3]);
+
+    let hash = info["action_hash"].as_str().expect("action_hash must be string");
+    assert!(!hash.is_empty(), "hash must not be empty");
+    assert!(
+        hash.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash must be hex: {hash}"
+    );
+}
+
+// ── test (b) ──────────────────────────────────────────────────────────────────
+// Three-action rotation does NOT trip with K=4, W=8.
+// In any W=8 window a 3-cycle yields at most ⌈8/3⌉=3 occurrences per action,
+// which is below K=4, so the detector must not fire.
+
+#[tokio::test]
+async fn no_stagnation_for_three_action_rotation() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 12;
+
+    let responses: Vec<String> = (0..12)
+        .map(|i| match i % 3 {
+            0 => "```bash\nls\n```".into(),
+            1 => "```bash\ncat /dev/null\n```".into(),
+            _ => "```bash\necho hello\n```".into(),
+        })
+        .collect();
+
+    let mut agent = build_agent(cfg, responses);
+    let exit = agent.run().await.unwrap();
+
+    assert!(
+        matches!(exit, ExitReason::StepLimit { .. }),
+        "expected StepLimit (no stagnation), got: {exit:?}"
+    );
+}
+
+// ── test (c) ──────────────────────────────────────────────────────────────────
+// Raising `--stagnation-repeat-threshold` to 5 means a run with only 4 ls
+// steps reaches the step limit instead of tripping at step 4.
+
+#[tokio::test]
+async fn raising_threshold_to_5_runs_to_step_limit() {
+    let mut cfg = Config::defaults().unwrap();
+    // step_limit=4 means the run exhausts 4 steps (indices 0-3).
+    // With K=5, the detector needs 5 identical to trip — 4 identical is not enough.
+    cfg.root.agent.step_limit = 4;
+    cfg.root.agent.stagnation_repeat_threshold = 5;
+
+    let mut agent = build_agent(cfg, ls_responses(4));
+    let exit = agent.run().await.unwrap();
+
+    assert!(
+        matches!(exit, ExitReason::StepLimit { .. }),
+        "expected StepLimit with K=5 and only 4 steps, got: {exit:?}"
+    );
+}
+
+// ── test (d) ──────────────────────────────────────────────────────────────────
+// `--detect-stagnation=false` disables the detector entirely — even with many
+// repeated ls actions, the run reaches the step limit.
+
+#[tokio::test]
+async fn disabled_detection_reaches_step_limit() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 8;
+    cfg.root.agent.detect_stagnation = false;
+
+    let mut agent = build_agent(cfg, ls_responses(8));
+    let exit = agent.run().await.unwrap();
+
+    assert!(
+        matches!(exit, ExitReason::StepLimit { .. }),
+        "expected StepLimit with detection disabled, got: {exit:?}"
+    );
+}
+
+// ── test (e) ──────────────────────────────────────────────────────────────────
+// When the agent trips after producing some work, the trajectory is intact and
+// the stagnation info is present (patch-preservation contract).
+
+#[tokio::test]
+async fn stagnation_trajectory_is_coherent_after_earlier_work() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 40;
+
+    // First two steps do "real" work, then the agent stagnates with ls.
+    let mut responses: Vec<String> = vec![
+        "```bash\necho useful-work\n```".into(),
+        "```bash\necho more-work\n```".into(),
+    ];
+    responses.extend(ls_responses(20));
+
+    let mut agent = build_agent(cfg, responses);
+    let exit = agent.run().await.unwrap();
+
+    assert!(
+        matches!(exit, ExitReason::AgentStagnation { .. }),
+        "expected AgentStagnation, got: {exit:?}"
+    );
+    // Trajectory is fully finalized: steps, failure_category, and stagnation info present.
+    assert!(agent.trajectory.info.steps.is_some(), "steps must be recorded");
+    assert_eq!(
+        agent.trajectory.info.failure_category,
+        Some(FailureCategory::AgentStagnation)
+    );
+    assert!(
+        agent.trajectory.info.other.get("stagnation").is_some(),
+        "stagnation info must be present"
+    );
+    // No panic, no corruption — the trajectory is usable for patch capture.
+}
+
+// ── test (f) ──────────────────────────────────────────────────────────────────
+// The canonicalization rule treats `ls`, `ls  ` (extra spaces), and `ls;` as the
+// same action — they all hash to the same value.
+
+#[test]
+fn canonicalization_treats_variants_as_identical() {
+    use rust_swe_agent::stagnation::canonicalize_action;
+
+    let base = canonicalize_action("ls");
+    assert_eq!(
+        base,
+        canonicalize_action("ls  "),
+        "trailing spaces must be stripped"
+    );
+    assert_eq!(
+        base,
+        canonicalize_action("ls;"),
+        "trailing semicolon must be stripped"
+    );
+    assert_eq!(
+        base,
+        canonicalize_action("  ls  "),
+        "leading/trailing spaces must be stripped"
+    );
+    assert_eq!(
+        base,
+        canonicalize_action("  ls  ;"),
+        "leading/trailing spaces + semicolon must all be stripped"
+    );
+    // Internal whitespace collapse: "ls   -la" → "ls -la"
+    assert_eq!(
+        canonicalize_action("ls   -la"),
+        canonicalize_action("ls -la"),
+        "internal whitespace must be collapsed"
+    );
+    // Different commands must differ
+    assert_ne!(
+        canonicalize_action("ls"),
+        canonicalize_action("cat foo"),
+        "different actions must differ"
+    );
+}
+
+// ── config validation test ────────────────────────────────────────────────────
+// W >= K is enforced; W < K should produce a config error.
+
+#[test]
+fn stagnation_config_rejects_window_smaller_than_threshold() {
+    use rust_swe_agent::agent::default::DefaultAgentBuilder;
+
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.stagnation_repeat_threshold = 8;
+    cfg.root.agent.stagnation_window = 4; // invalid: W < K
+
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let result = DefaultAgentBuilder {
+        config: cfg,
+        model: Arc::new(DeterministicModel::new(vec![])),
+        env,
+        task: "validation test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build();
+
+    assert!(result.is_err(), "should reject W < K config");
+}

--- a/tests/agent_stagnation.rs
+++ b/tests/agent_stagnation.rs
@@ -9,7 +9,9 @@ use std::sync::Arc;
 
 use rust_swe_agent::agent::default::DefaultAgentBuilder;
 use rust_swe_agent::trajectory::FailureCategory;
-use rust_swe_agent::{Agent, Config, DeterministicModel, Environment, ExitReason, LocalEnvironment};
+use rust_swe_agent::{
+    Agent, Config, DeterministicModel, Environment, ExitReason, LocalEnvironment,
+};
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -76,7 +78,9 @@ async fn stagnation_trips_at_step_4_for_repeated_ls() {
         serde_json::from_value(info["step_indices"].clone()).expect("step_indices must be array");
     assert_eq!(indices, vec![0, 1, 2, 3]);
 
-    let hash = info["action_hash"].as_str().expect("action_hash must be string");
+    let hash = info["action_hash"]
+        .as_str()
+        .expect("action_hash must be string");
     assert!(!hash.is_empty(), "hash must not be empty");
     assert!(
         hash.chars().all(|c| c.is_ascii_hexdigit()),
@@ -175,7 +179,10 @@ async fn stagnation_trajectory_is_coherent_after_earlier_work() {
         "expected AgentStagnation, got: {exit:?}"
     );
     // Trajectory is fully finalized: steps, failure_category, and stagnation info present.
-    assert!(agent.trajectory.info.steps.is_some(), "steps must be recorded");
+    assert!(
+        agent.trajectory.info.steps.is_some(),
+        "steps must be recorded"
+    );
     assert_eq!(
         agent.trajectory.info.failure_category,
         Some(FailureCategory::AgentStagnation)

--- a/tests/agent_stagnation.rs
+++ b/tests/agent_stagnation.rs
@@ -3,7 +3,7 @@
 //! Tests drive the full default-agent loop using DeterministicModel and
 //! LocalEnvironment. All tests must be deterministic and reproduce reliably.
 
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::sync::Arc;
 
@@ -188,7 +188,7 @@ async fn stagnation_trajectory_is_coherent_after_earlier_work() {
         Some(FailureCategory::AgentStagnation)
     );
     assert!(
-        agent.trajectory.info.other.get("stagnation").is_some(),
+        agent.trajectory.info.other.contains_key("stagnation"),
         "stagnation info must be present"
     );
     // No panic, no corruption — the trajectory is usable for patch capture.

--- a/tests/config_reference.rs
+++ b/tests/config_reference.rs
@@ -362,8 +362,8 @@ fn no_key_smoke_example_produces_valid_trajectory() {
         serde_json::from_str(&std::fs::read_to_string(&trajectory_path).unwrap()).unwrap();
     assert_eq!(
         trajectory["trajectory_format"].as_str(),
-        Some("mini-swe-agent-1.1"),
-        "trajectory must be mini-swe-agent-1.1 format"
+        Some("mini-swe-agent-1.2"),
+        "trajectory must be mini-swe-agent-1.2 format"
     );
     assert_eq!(
         trajectory["info"]["outcome"].as_str(),

--- a/tests/quickstart_docs.rs
+++ b/tests/quickstart_docs.rs
@@ -102,7 +102,7 @@ fn readme_no_key_smoke_command_writes_documented_artifacts() {
         serde_json::from_str(&std::fs::read_to_string(&trajectory_path).unwrap()).unwrap();
     assert_eq!(
         trajectory["trajectory_format"].as_str(),
-        Some("mini-swe-agent-1.1")
+        Some("mini-swe-agent-1.2")
     );
     assert_eq!(trajectory["info"]["outcome"].as_str(), Some("submitted"));
     assert_eq!(trajectory["info"]["total_cost_usd"].as_f64(), Some(0.0));


### PR DESCRIPTION
## Summary

Adds automatic detection and early termination when an agent enters a stagnation loop—repeatedly executing the same bash action without making progress. When stagnation is detected, the run halts immediately with exit code 12 and failure category `agent_stagnation`, rather than consuming budget up to the step limit.

## Key Changes

- **New stagnation detector module** (`src/stagnation.rs`):
  - Implements a rolling-window detector that tracks the last W canonicalized bash actions
  - Trips when any single action appears K or more times in the window (default K=4, W=8)
  - Canonicalization rule: trim whitespace, collapse internal runs, strip trailing semicolon
  - Actions are hashed with SHA-256 (first 16 bytes) for O(1) comparison and privacy

- **Agent integration** (`src/agent/default.rs`):
  - Instantiates `StagnationDetector` during agent builder initialization
  - Validates config constraint: window size W ≥ threshold K
  - Observes each bash action after execution and checks for stagnation
  - Terminates run with `ExitReason::AgentStagnation` when detector trips
  - Records diagnostic info in trajectory: action hash, count, window size, step indices

- **Configuration** (`src/config/schema.rs`, `src/cli/args.rs`):
  - `--detect-stagnation` (bool, default true): enable/disable detector
  - `--stagnation-repeat-threshold` (u32, default 4): K parameter
  - `--stagnation-window` (u32, default 8): W parameter
  - Stagnation detection is automatically disabled in replay mode

- **Trajectory format** (`src/trajectory/mod.rs`):
  - Bumped format version to `mini-swe-agent-1.2`
  - Added `FailureCategory::AgentStagnation` variant
  - Added `ExitReason::AgentStagnation` variant with diagnostic fields
  - Exit code 12 reserved for agent stagnation

- **Comprehensive test suite** (`tests/agent_stagnation.rs`):
  - 6 async integration tests covering: basic trip, threshold variations, disabled detection, trajectory coherence
  - 1 unit test for canonicalization rules
  - 1 config validation test
  - All tests use `DeterministicModel` and `LocalEnvironment` for deterministic reproduction

- **Documentation** (`docs/spec-stagnation.md`):
  - Full specification of detection rule, algorithm, canonicalization, configuration, and exit codes
  - Worked example showing step-by-step detector behavior
  - Trajectory format and diagnostic field documentation

## Notable Implementation Details

- **Canonicalization is deterministic and byte-level**: handles edge cases like `ls`, `ls  `, `ls;`, `  ls  ;` all mapping to the same canonical form
- **Ring buffer eviction**: oldest entries are automatically removed when buffer reaches capacity W
- **Step index tracking**: stagnation record includes all step indices where the repeated action occurred
- **Config validation at build time**: invalid W < K combinations are rejected before agent starts
- **Replay mode compatibility**: stagnation detection is disabled for scripted replays to preserve original terminal conditions

https://claude.ai/code/session_01BqA6XMqQwc5CHDmAboP1mP