### PR TITLE
🔒 Warden: Fix unbounded memory allocation in environment pipe readers (DoS)

### DIFF
--- a/exploit_test3.patch
+++ b/exploit_test3.patch
@@ -1,0 +1,29 @@
+<<<<<<< SEARCH
+    #[tokio::test]
+    async fn exploit_test_memory_exhaustion_dos() {
+        let env = LocalEnvironment::new();
+        let cmd = if cfg!(windows) {
+            "for /L %i in (1,1,100000) do @echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        } else {
+            "yes aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | head -n 100000"
+        };
+        let req = RunRequest::new(cmd);
+        let r = env.run(req).await.unwrap();
+        // if unbounded, length is around 10MB.
+        println!("Length: {}", r.stdout.len());
+    }
+=======
+    #[tokio::test]
+    async fn exploit_test_memory_exhaustion_dos() {
+        let env = LocalEnvironment::new();
+        let cmd = if cfg!(windows) {
+            "for /L %i in (1,1,200000) do @echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        } else {
+            "yes aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | head -n 200000"
+        };
+        let req = RunRequest::new(cmd);
+        let r = env.run(req).await.unwrap();
+        // if unbounded, length is around 20MB. The cap is 16MB.
+        assert_eq!(r.stdout.len(), 16 * 1024 * 1024);
+    }
+>>>>>>> REPLACE

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -327,23 +327,34 @@ where
     (handle, buffer)
 }
 
+const MAX_PIPE_BUFFER_SIZE: usize = 16 * 1024 * 1024; // 16MB cap
+
 async fn read_pipe_to_buffer<R>(mut pipe: R, buffer: Arc<Mutex<Vec<u8>>>) -> Result<(), EnvError>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut chunk = [0u8; 8192];
+
     loop {
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
+
         if n == 0 {
             return Ok(());
         }
-        buffer
+
+        let mut guard = buffer
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .extend_from_slice(&chunk[..n]);
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let remaining = MAX_PIPE_BUFFER_SIZE.saturating_sub(guard.len());
+
+        if remaining > 0 {
+            let take = std::cmp::min(n, remaining);
+
+            guard.extend_from_slice(&chunk[..take]);
+        }
     }
 }
-
 async fn join_reader(
     handle: PipeCollector,
     buffer: PipeBuffer,

--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -232,23 +232,34 @@ where
     (handle, buffer)
 }
 
+const MAX_PIPE_BUFFER_SIZE: usize = 16 * 1024 * 1024; // 16MB cap
+
 async fn read_pipe_to_buffer<R>(mut pipe: R, buffer: Arc<Mutex<Vec<u8>>>) -> Result<(), EnvError>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut chunk = [0u8; 8192];
+
     loop {
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
+
         if n == 0 {
             return Ok(());
         }
-        buffer
+
+        let mut guard = buffer
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .extend_from_slice(&chunk[..n]);
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let remaining = MAX_PIPE_BUFFER_SIZE.saturating_sub(guard.len());
+
+        if remaining > 0 {
+            let take = std::cmp::min(n, remaining);
+
+            guard.extend_from_slice(&chunk[..take]);
+        }
     }
 }
-
 async fn join_reader(
     handle: PipeCollector,
     buffer: PipeBuffer,
@@ -603,6 +614,20 @@ mod tests {
         } else {
             "printf 'child stdout\n'; printf 'child stderr\n' >&2; exit 7"
         }
+    }
+
+    #[tokio::test]
+    async fn exploit_test_memory_exhaustion_dos() {
+        let env = LocalEnvironment::new();
+        let cmd = if cfg!(windows) {
+            "for /L %i in (1,1,200000) do @echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        } else {
+            "yes aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | head -n 200000"
+        };
+        let req = RunRequest::new(cmd);
+        let r = env.run(req).await.unwrap();
+        // if unbounded, length is around 10MB.
+        assert_eq!(r.stdout.len(), 16 * 1024 * 1024);
     }
 
     fn sleep_command() -> &'static str {


### PR DESCRIPTION
🦠 Threat: The pipe reading implementation in `src/env/local.rs` and `src/env/docker.rs` was unbounded. A malicious script producing a massive amount of stdout or stderr output could exhaust memory, leading to a Denial-of-Service (DoS) and application crash.
🛡️ Defense: Added a `MAX_PIPE_BUFFER_SIZE` of 16MB to both `local` and `docker` environment pipe readers. We explicitly calculate the remaining capacity with `saturating_sub` and limit the chunk reading with `std::cmp::min` to ensure the buffer never exceeds 16MB. The process output keeps reading to prevent blocking the child but discards any extra output.
💥 Severity: High - memory exhaustion DoS could crash the main application/agent.
🧪 Verification: Created an exploit test `exploit_test_memory_exhaustion_dos` in `src/env/local.rs` which verifies memory doesn't exceed 16MB when outputting huge text. Ran all tests, clippy, and rustfmt.

---
*PR created automatically by Jules for task [12330483283719763816](https://jules.google.com/task/12330483283719763816) started by @madmax983*