### PR TITLE
👺 Havoc: Bounded pipe readers to prevent DoS

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -327,20 +327,29 @@ where
     (handle, buffer)
 }
 
+const MAX_PIPE_BUFFER_BYTES: usize = 16 * 1024 * 1024;
+
 async fn read_pipe_to_buffer<R>(mut pipe: R, buffer: Arc<Mutex<Vec<u8>>>) -> Result<(), EnvError>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut chunk = [0u8; 8192];
+    let mut total = 0;
     loop {
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {
             return Ok(());
         }
+        let remaining = MAX_PIPE_BUFFER_BYTES.saturating_sub(total);
+        if remaining == 0 {
+            continue;
+        }
+        let to_add = std::cmp::min(n, remaining);
         buffer
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .extend_from_slice(&chunk[..n]);
+            .extend_from_slice(&chunk[..to_add]);
+        total += to_add;
     }
 }
 

--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -232,20 +232,29 @@ where
     (handle, buffer)
 }
 
+const MAX_PIPE_BUFFER_BYTES: usize = 16 * 1024 * 1024;
+
 async fn read_pipe_to_buffer<R>(mut pipe: R, buffer: Arc<Mutex<Vec<u8>>>) -> Result<(), EnvError>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut chunk = [0u8; 8192];
+    let mut total = 0;
     loop {
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {
             return Ok(());
         }
+        let remaining = MAX_PIPE_BUFFER_BYTES.saturating_sub(total);
+        if remaining == 0 {
+            continue;
+        }
+        let to_add = std::cmp::min(n, remaining);
         buffer
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .extend_from_slice(&chunk[..n]);
+            .extend_from_slice(&chunk[..to_add]);
+        total += to_add;
     }
 }
 
@@ -645,5 +654,26 @@ mod tests {
             std::thread::sleep(Duration::from_millis(25));
         }
         !process_is_alive(pid)
+    }
+
+    #[tokio::test]
+    async fn havoc_dos_memory_exhaustion_is_prevented() {
+
+        let pipe = tokio::io::repeat(b'A');
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let task_buffer = std::sync::Arc::clone(&buffer);
+
+        // Let it read for a short time to hit the limit
+        let handle = tokio::spawn(async move {
+            let _ = tokio::time::timeout(
+                std::time::Duration::from_millis(100),
+                read_pipe_to_buffer(pipe, task_buffer)
+            ).await;
+        });
+
+        let _ = handle.await;
+
+        let size = buffer.lock().unwrap().len();
+        assert!(size <= MAX_PIPE_BUFFER_BYTES, "Buffer exceeded max size: {size}");
     }
 }


### PR DESCRIPTION
🧨 **The Trigger:** A malicious command outputting an infinite stream of text (e.g., `yes` or `while true; do echo "junk"; done`) to a piped process.
📉 **The Stack Trace:** OOM Kill of the agent process (Memory limits exhausted).
🧪 **Reproduction:** Run `cargo test` locally with an infinite loop stdout test (simulated via `tokio::io::repeat(b'A')`).
😈 **Comment:** You assumed the pipe output would never be larger than RAM. You were wrong.

---
*PR created automatically by Jules for task [6863085303812089531](https://jules.google.com/task/6863085303812089531) started by @madmax983*