### PR TITLE
🗺️ Atlas: Replace stringly-typed Trajectory error with TrajectoryError enum

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -17,8 +17,8 @@ pub enum Error {
     #[error(transparent)]
     Template(#[from] minijinja::Error),
 
-    #[error("trajectory io: {0}")]
-    Trajectory(String),
+    #[error(transparent)]
+    Trajectory(#[from] TrajectoryError),
 
     #[error("github pr: {0}")]
     Github(String),
@@ -209,4 +209,19 @@ impl From<toml::de::Error> for ConfigError {
     fn from(e: toml::de::Error) -> Self {
         Self::Toml(e.to_string())
     }
+}
+
+#[derive(Debug, Error)]
+pub enum TrajectoryError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    #[error("trajectory format error: {0}")]
+    Format(String),
+
+    #[error("trajectory validation error: {0}")]
+    Validation(String),
 }

--- a/src/run/calibrate.rs
+++ b/src/run/calibrate.rs
@@ -341,7 +341,7 @@ fn load_forecast(path: &Path) -> Result<LoadedForecast, Error> {
         ArtifactKind::ForecastReport,
         path.display().to_string(),
     )
-    .map_err(|err| Error::Trajectory(err.to_string()))?;
+    .map_err(|err| Error::Trajectory(crate::error::TrajectoryError::Format(err.to_string())))?;
     let warnings = artifact.warnings.clone();
     let report: ForecastReport = serde_json::from_value(value)?;
     Ok(LoadedForecast {
@@ -358,7 +358,7 @@ fn load_results(path: &Path, label: &str) -> Result<LoadedResults, Error> {
         ArtifactKind::SweepResults,
         path.display().to_string(),
     )
-    .map_err(|err| Error::Trajectory(err.to_string()))?;
+    .map_err(|err| Error::Trajectory(crate::error::TrajectoryError::Format(err.to_string())))?;
     let warnings = artifact.warnings.clone();
     let results: SweepResults = serde_json::from_value(value)?;
     Ok(LoadedResults {

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -869,7 +869,7 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
             ArtifactKind::SweepResults,
             results_path.display().to_string(),
         )
-        .map_err(|err| Error::Trajectory(err.to_string()))?;
+        .map_err(|err| Error::Trajectory(crate::error::TrajectoryError::Format(err.to_string())))?;
         let artifact_warnings = artifact.warnings.clone();
         let filter_spec_present = value.get("filter_spec").is_some();
         let sweep: SweepResults = serde_json::from_value(value)?;
@@ -951,10 +951,12 @@ pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
         });
     }
     if !dir.exists() {
-        return Err(Error::Trajectory(format!(
-            "compare: directory does not exist: {}",
-            dir.display()
-        )));
+        return Err(Error::Trajectory(
+            crate::error::TrajectoryError::Validation(format!(
+                "compare: directory does not exist: {}",
+                dir.display()
+            )),
+        ));
     }
 
     let slots = scan_trajectory_run_slots(dir, None)?;
@@ -1116,7 +1118,7 @@ fn instance_result_from_trajectory(
         Err(_) => return Ok(None),
     };
     classify_json_value(&value, ArtifactKind::Trajectory, path.display().to_string())
-        .map_err(|err| Error::Trajectory(err.to_string()))?;
+        .map_err(|err| Error::Trajectory(crate::error::TrajectoryError::Format(err.to_string())))?;
     let traj: Trajectory = match serde_json::from_value(value) {
         Ok(t) => t,
         Err(_) => return Ok(None),
@@ -1462,22 +1464,22 @@ pub fn write_diff_script(report: &CompareReport, out_path: &Path) -> Result<(), 
             &regression.instance_id,
         )
         .ok_or_else(|| {
-            Error::Trajectory(format!(
+            Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
                 "compare: baseline trajectory not found for `{}` in {}",
                 regression.instance_id,
                 report.baseline_dir.display()
-            ))
+            )))
         })?;
         let candidate = crate::run::trajectory_diff::resolve_trajectory_path(
             &report.candidate_dir,
             &regression.instance_id,
         )
         .ok_or_else(|| {
-            Error::Trajectory(format!(
+            Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
                 "compare: candidate trajectory not found for `{}` in {}",
                 regression.instance_id,
                 report.candidate_dir.display()
-            ))
+            )))
         })?;
         let _ = writeln!(
             script,
@@ -2133,7 +2135,7 @@ pub fn load_evaluation_results_checked(
         ArtifactKind::EvaluationResults,
         path.display().to_string(),
     )
-    .map_err(|err| Error::Trajectory(err.to_string()))?;
+    .map_err(|err| Error::Trajectory(crate::error::TrajectoryError::Format(err.to_string())))?;
     let artifact_warnings = artifact.warnings.clone();
     Ok(Some(LoadedEvaluationResults {
         results: serde_json::from_value(value)?,

--- a/src/run/dataset.rs
+++ b/src/run/dataset.rs
@@ -228,10 +228,10 @@ pub fn write_cache(
 ) -> Result<PathBuf, Error> {
     let path = cache_path_for(cache_dir, alias, split);
     let parent = path.parent().ok_or_else(|| {
-        Error::Trajectory(format!(
+        Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
             "cache path `{}` has no parent directory",
             path.display()
-        ))
+        )))
     })?;
     std::fs::create_dir_all(parent)?;
     std::fs::write(&path, content)?;

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -332,7 +332,9 @@ pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
     let model_name = loaded.manifest.as_ref().map(|m| m.model.name.clone());
     if loaded.manifest.as_ref().and_then(|m| m.purpose.as_deref()) == Some("forecast") {
         return Err(Error::Trajectory(
-            "bench evaluate: refusing to evaluate forecast calibration output".into(),
+            crate::error::TrajectoryError::Validation(
+                "bench evaluate: refusing to evaluate forecast calibration output".into(),
+            ),
         ));
     }
     let results = loaded.instances;
@@ -876,10 +878,12 @@ fn run_sb_cli(
 ) -> Result<EvaluateRunOutput, Error> {
     let preds = swebench::predictions_path(&args.sweep_dir);
     if !preds.exists() {
-        return Err(Error::Trajectory(format!(
-            "bench evaluate: missing predictions file at {}",
-            preds.display()
-        )));
+        return Err(Error::Trajectory(
+            crate::error::TrajectoryError::Validation(format!(
+                "bench evaluate: missing predictions file at {}",
+                preds.display()
+            )),
+        ));
     }
 
     let report_dir = args.sweep_dir.join("sb_cli_reports");
@@ -963,21 +967,23 @@ fn submit_sb_cli_predictions(
 
     let output = cmd.output().map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
-            Error::Trajectory(
+            Error::Trajectory(crate::error::TrajectoryError::Validation(
                 "bench evaluate: `sb-cli` not found on PATH; install it or run --backend none"
                     .into(),
-            )
+            ))
         } else {
             Error::Io(e)
         }
     })?;
 
     if !output.status.success() {
-        return Err(Error::Trajectory(format!(
-            "bench evaluate: sb-cli submit failed (status={}): {}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr)
-        )));
+        return Err(Error::Trajectory(
+            crate::error::TrajectoryError::Validation(format!(
+                "bench evaluate: sb-cli submit failed (status={}): {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            )),
+        ));
     }
 
     let report_path = report_dir.join(format!(
@@ -997,11 +1003,13 @@ fn submit_sb_cli_predictions(
             .arg("1")
             .output()?;
         if !output.status.success() {
-            return Err(Error::Trajectory(format!(
-                "bench evaluate: sb-cli get-report failed (status={}): {}",
-                output.status,
-                String::from_utf8_lossy(&output.stderr)
-            )));
+            return Err(Error::Trajectory(
+                crate::error::TrajectoryError::Validation(format!(
+                    "bench evaluate: sb-cli get-report failed (status={}): {}",
+                    output.status,
+                    String::from_utf8_lossy(&output.stderr)
+                )),
+            ));
         }
     }
 

--- a/src/run/forecast.rs
+++ b/src/run/forecast.rs
@@ -268,7 +268,7 @@ pub fn load_calibration_results(calibration_dir: &Path) -> Result<LoadedCalibrat
         ArtifactKind::SweepResults,
         path.display().to_string(),
     )
-    .map_err(|err| Error::Trajectory(err.to_string()))?;
+    .map_err(|err| Error::Trajectory(crate::error::TrajectoryError::Format(err.to_string())))?;
     let warnings = compatibility.warnings.clone();
     let results: SweepResults = serde_json::from_value(value)?;
     Ok(LoadedCalibrationResults {

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -143,20 +143,26 @@ pub enum InspectOutput {
 
 pub fn run(args: &InspectArgs) -> Result<InspectOutput, Error> {
     if !args.sweep.exists() {
-        return Err(Error::Trajectory(format!(
-            "inspect: sweep directory does not exist: {}",
-            args.sweep.display()
-        )));
+        return Err(Error::Trajectory(
+            crate::error::TrajectoryError::Validation(format!(
+                "inspect: sweep directory does not exist: {}",
+                args.sweep.display()
+            )),
+        ));
     }
     match (&args.instance, &args.filter) {
         (Some(_), Some(_)) => {
             return Err(Error::Trajectory(
-                "inspect: pass exactly one of --instance or --filter".into(),
+                crate::error::TrajectoryError::Validation(
+                    "inspect: pass exactly one of --instance or --filter".into(),
+                ),
             ));
         }
         (None, None) => {
             return Err(Error::Trajectory(
-                "inspect: one of --instance or --filter is required".into(),
+                crate::error::TrajectoryError::Validation(
+                    "inspect: one of --instance or --filter is required".into(),
+                ),
             ));
         }
         _ => {}
@@ -215,10 +221,10 @@ fn build_instance_report(
     evaluation_overrides: Option<&HashMap<String, EvaluationOverride>>,
 ) -> Result<InspectReport, Error> {
     let traj_path = resolve_trajectory_path(sweep, instance_id).ok_or_else(|| {
-        Error::Trajectory(format!(
+        Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
             "inspect: trajectory not found for instance `{instance_id}` in {}",
             sweep.display()
-        ))
+        )))
     })?;
     let text = std::fs::read_to_string(&traj_path)?;
     let mut warnings = Vec::new();
@@ -228,7 +234,7 @@ fn build_instance_report(
             ArtifactKind::Trajectory,
             traj_path.display().to_string(),
         )
-        .map_err(|err| Error::Trajectory(err.to_string()))?;
+        .map_err(|err| Error::Trajectory(crate::error::TrajectoryError::Format(err.to_string())))?;
         warnings.extend(compat.warnings);
     }
     let mut traj: Trajectory = match serde_json::from_str(&text) {
@@ -775,7 +781,7 @@ fn load_evaluation_overrides(
         ArtifactKind::EvaluationResults,
         eval_path.display().to_string(),
     )
-    .map_err(|err| Error::Trajectory(err.to_string()))?;
+    .map_err(|err| Error::Trajectory(crate::error::TrajectoryError::Format(err.to_string())))?;
     let eval: EvaluationResults = serde_json::from_value(value)?;
     Ok(Some(
         eval.instances
@@ -821,17 +827,23 @@ fn parse_filter(s: &str) -> Result<FilterSpec, Error> {
     let value = it.next().unwrap_or_default().trim().to_owned();
     if key.is_empty() || value.is_empty() {
         return Err(Error::Trajectory(
-            "inspect: --filter expects key=value (e.g. resolved=false)".into(),
+            crate::error::TrajectoryError::Validation(
+                "inspect: --filter expects key=value (e.g. resolved=false)".into(),
+            ),
         ));
     }
     if key != "resolved" && key != "failure_category" {
         return Err(Error::Trajectory(
-            "inspect: supported filters are `resolved` and `failure_category`".into(),
+            crate::error::TrajectoryError::Validation(
+                "inspect: supported filters are `resolved` and `failure_category`".into(),
+            ),
         ));
     }
     if key == "resolved" && value != "true" && value != "false" {
         return Err(Error::Trajectory(
-            "inspect: resolved filter must be true or false".into(),
+            crate::error::TrajectoryError::Validation(
+                "inspect: resolved filter must be true or false".into(),
+            ),
         ));
     }
     Ok(FilterSpec {

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -144,7 +144,9 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         Some(addr) => {
             let bcast = Arc::new(BroadcastSink::default());
             let server = SseServer::start(addr, bcast.clone()).await.map_err(|e| {
-                Error::Trajectory(format!("failed to bind SSE server on {addr}: {e}"))
+                Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
+                    "failed to bind SSE server on {addr}: {e}"
+                )))
             })?;
             tracing::info!(addr = %server.local_addr(), "streaming events on http://{}/", server.local_addr());
             (Some(bcast as Arc<dyn StreamSink>), Some(server))
@@ -453,9 +455,9 @@ async fn run_agent_with_timeout(
             serde_json::Value::String(err.to_string()),
         );
     }
-    Err(Error::Trajectory(format!(
-        "task wallclock timeout after {secs}s"
-    )))
+    Err(Error::Trajectory(
+        crate::error::TrajectoryError::Validation(format!("task wallclock timeout after {secs}s")),
+    ))
 }
 
 fn classify_error(err: &Error) -> FailureCategory {

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -1371,8 +1371,11 @@ pub fn load_dataset(path: &std::path::Path) -> Result<Vec<SweBenchInstance>, Err
 }
 
 fn load_dataset_from_bytes(bytes: &[u8]) -> Result<Vec<SweBenchInstance>, Error> {
-    let text = std::str::from_utf8(bytes)
-        .map_err(|e| Error::Trajectory(format!("dataset utf8 decode: {e}")))?;
+    let text = std::str::from_utf8(bytes).map_err(|e| {
+        Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
+            "dataset utf8 decode: {e}"
+        )))
+    })?;
     parse_dataset_lines(text)
 }
 
@@ -1389,8 +1392,12 @@ fn parse_dataset_lines(text: &str) -> Result<Vec<SweBenchInstance>, Error> {
         if line.is_empty() {
             continue;
         }
-        let instance: SweBenchInstance = serde_json::from_str(line)
-            .map_err(|e| Error::Trajectory(format!("dataset line {}: {e}", i + 1)))?;
+        let instance: SweBenchInstance = serde_json::from_str(line).map_err(|e| {
+            Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
+                "dataset line {}: {e}",
+                i + 1
+            )))
+        })?;
         if instance.instance_id.contains('/')
             || instance.instance_id.contains('\\')
             || instance.instance_id == ".."
@@ -1398,11 +1405,13 @@ fn parse_dataset_lines(text: &str) -> Result<Vec<SweBenchInstance>, Error> {
             || instance.instance_id.contains(':')
             || instance.instance_id.is_empty()
         {
-            return Err(Error::Trajectory(format!(
-                "dataset line {}: invalid instance_id for path generation: '{}'",
-                i + 1,
-                instance.instance_id
-            )));
+            return Err(Error::Trajectory(
+                crate::error::TrajectoryError::Validation(format!(
+                    "dataset line {}: invalid instance_id for path generation: '{}'",
+                    i + 1,
+                    instance.instance_id
+                )),
+            ));
         }
         out.push(instance);
     }
@@ -2538,8 +2547,13 @@ fn render_preflight_report(
                 })
                 .collect(),
         };
-        return crate::artifact::to_string_pretty(ArtifactKind::PreflightReport, &payload)
-            .map_err(|e| Error::Trajectory(format!("preflight json encode: {e}")));
+        return crate::artifact::to_string_pretty(ArtifactKind::PreflightReport, &payload).map_err(
+            |e| {
+                Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
+                    "preflight json encode: {e}"
+                )))
+            },
+        );
     }
     let mut out = String::new();
     for c in checks {
@@ -2607,8 +2621,16 @@ where
                 "preflight: {name}: timeout exceeded"
             )))
         })?
-        .map_err(|e| Error::Trajectory(format!("{name}: join error: {e}")))?
-        .map_err(|e| Error::Trajectory(format!("{name}: {e}")))?;
+        .map_err(|e| {
+            Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
+                "{name}: join error: {e}"
+            )))
+        })?
+        .map_err(|e| {
+            Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
+                "{name}: {e}"
+            )))
+        })?;
     ensure_total_deadline(deadline)?;
     Ok(out)
 }

--- a/src/run/tail.rs
+++ b/src/run/tail.rs
@@ -174,10 +174,12 @@ impl TerminalRecord {
 #[allow(clippy::too_many_lines)]
 pub fn snapshot(sweep_dir: &Path, options: &SnapshotOptions) -> Result<TailSnapshot, Error> {
     if !sweep_dir.exists() {
-        return Err(Error::Trajectory(format!(
-            "tail: sweep directory does not exist: {}",
-            sweep_dir.display()
-        )));
+        return Err(Error::Trajectory(
+            crate::error::TrajectoryError::Validation(format!(
+                "tail: sweep directory does not exist: {}",
+                sweep_dir.display()
+            )),
+        ));
     }
 
     let mut warnings = Vec::new();
@@ -360,7 +362,9 @@ fn read_json_value(
         Ok(v) => {
             let compat =
                 classify_json_value(&v, ArtifactKind::SweepResults, path.display().to_string())
-                    .map_err(|err| Error::Trajectory(err.to_string()))?;
+                    .map_err(|err| {
+                        Error::Trajectory(crate::error::TrajectoryError::Format(err.to_string()))
+                    })?;
             warnings.extend(compat.warnings);
             Ok(Some(v))
         }
@@ -591,7 +595,11 @@ fn terminal_record_from_trajectory(
     };
     match classify_json_value(&value, ArtifactKind::Trajectory, path.display().to_string()) {
         Ok(compat) => warnings.extend(compat.warnings),
-        Err(err) => return Err(Error::Trajectory(err.to_string())),
+        Err(err) => {
+            return Err(Error::Trajectory(crate::error::TrajectoryError::Format(
+                err.to_string(),
+            )));
+        }
     }
     let traj: Trajectory = match serde_json::from_value(value) {
         Ok(traj) => traj,

--- a/src/run/trajectory_diff.rs
+++ b/src/run/trajectory_diff.rs
@@ -139,10 +139,12 @@ pub fn diff_paths(args: &TrajectoryDiffArgs) -> Result<TrajectoryDiffReport, Err
     let baseline = load_named_trajectory(&args.baseline)?;
     let candidate = load_named_trajectory(&args.candidate)?;
     if baseline.instance_id != candidate.instance_id {
-        return Err(Error::Trajectory(format!(
-            "inspect diff: instance_id mismatch: baseline `{}` candidate `{}`",
-            baseline.instance_id, candidate.instance_id
-        )));
+        return Err(Error::Trajectory(
+            crate::error::TrajectoryError::Validation(format!(
+                "inspect diff: instance_id mismatch: baseline `{}` candidate `{}`",
+                baseline.instance_id, candidate.instance_id
+            )),
+        ));
     }
     Ok(diff_trajectories(&baseline, &candidate, args.show_noise))
 }
@@ -154,16 +156,16 @@ pub fn diff_sweep_instance(
     show_noise: bool,
 ) -> Result<TrajectoryDiffReport, Error> {
     let baseline = resolve_trajectory_path(baseline_sweep, instance_id).ok_or_else(|| {
-        Error::Trajectory(format!(
+        Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
             "inspect diff: baseline trajectory not found for `{instance_id}` in {}",
             baseline_sweep.display()
-        ))
+        )))
     })?;
     let candidate = resolve_trajectory_path(candidate_sweep, instance_id).ok_or_else(|| {
-        Error::Trajectory(format!(
+        Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
             "inspect diff: candidate trajectory not found for `{instance_id}` in {}",
             candidate_sweep.display()
-        ))
+        )))
     })?;
     diff_paths(&TrajectoryDiffArgs {
         baseline,
@@ -454,15 +456,15 @@ fn load_named_trajectory(path: &Path) -> Result<NamedTrajectory, Error> {
     let text = std::fs::read_to_string(path)?;
     let value: serde_json::Value = serde_json::from_str(&text)?;
     classify_json_value(&value, ArtifactKind::Trajectory, path.display().to_string())
-        .map_err(|err| Error::Trajectory(err.to_string()))?;
+        .map_err(|err| Error::Trajectory(crate::error::TrajectoryError::Format(err.to_string())))?;
     let trajectory: Trajectory = serde_json::from_value(value)?;
     let instance_id = explicit_instance_id(&trajectory)
         .or_else(|| derive_instance_id(path))
         .ok_or_else(|| {
-            Error::Trajectory(format!(
+            Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
                 "inspect diff: unable to infer instance_id from {}",
                 path.display()
-            ))
+            )))
         })?;
     Ok(NamedTrajectory {
         path: path.to_path_buf(),

--- a/src/run/triage.rs
+++ b/src/run/triage.rs
@@ -329,11 +329,11 @@ pub fn render_text(report: &TriageReport, top: usize) -> String {
 fn build_report(args: &TriageArgs) -> Result<TriageReport, Error> {
     let sweep = load_sweep(&args.sweep_dir)?;
     let evaluation = load_evaluation_results_checked(&args.sweep_dir)?.ok_or_else(|| {
-        Error::Trajectory(format!(
+        Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
             "bench triage: missing evaluation.json in {}; run `bench evaluate --sweep {}` first",
             args.sweep_dir.display(),
             args.sweep_dir.display()
-        ))
+        )))
     })?;
 
     let candidate_ids = candidate_instance_ids(evaluation.results, &sweep.instances);
@@ -405,15 +405,15 @@ fn build_accumulators(
     let mut accumulators: BTreeMap<String, ClusterAccumulator> = BTreeMap::new();
     for instance_id in candidate_ids {
         let instance = instances.get(&instance_id).ok_or_else(|| {
-            Error::Trajectory(format!(
+            Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
                 "bench triage: evaluation.json references `{instance_id}` but results.json has no matching instance"
-            ))
+            )))
         })?;
         let trajectory_path =
             resolve_trajectory_path(&args.sweep_dir, &instance_id).ok_or_else(|| {
-                Error::Trajectory(format!(
+                Error::Trajectory(crate::error::TrajectoryError::Validation(format!(
                     "bench triage: trajectory not found for unresolved instance `{instance_id}`"
-                ))
+                )))
             })?;
         let trajectory = load_trajectory(&trajectory_path)?;
         let failure_category = instance
@@ -503,7 +503,7 @@ fn load_trajectory(path: &Path) -> Result<Trajectory, Error> {
     let text = std::fs::read_to_string(path)?;
     let value: serde_json::Value = serde_json::from_str(&text)?;
     classify_json_value(&value, ArtifactKind::Trajectory, path.display().to_string())
-        .map_err(|err| Error::Trajectory(err.to_string()))?;
+        .map_err(|err| Error::Trajectory(crate::error::TrajectoryError::Format(err.to_string())))?;
     serde_json::from_value(value).map_err(Into::into)
 }
 

--- a/tests/exit_code_contract.rs
+++ b/tests/exit_code_contract.rs
@@ -254,7 +254,9 @@ fn json_error_maps_to_internal_error() {
 
 #[test]
 fn trajectory_error_maps_to_internal_error() {
-    let e = Error::Trajectory("corrupt file".into());
+    let e = Error::Trajectory(rust_swe_agent::error::TrajectoryError::Format(
+        "corrupt file".into(),
+    ));
     assert_eq!(ExitCode::from_error(&e), ExitCode::InternalError);
 }
 
@@ -385,7 +387,12 @@ fn text_and_numeric_surfaces_agree_for_every_error_variant() {
             "task_unsuccessful",
             Error::Model(ModelError::Malformed("bad".into())),
         ),
-        ("internal_error", Error::Trajectory("corrupt".into())),
+        (
+            "internal_error",
+            Error::Trajectory(rust_swe_agent::error::TrajectoryError::Format(
+                "corrupt".into(),
+            )),
+        ),
         ("internal_error", Error::Github("api 500".into())),
         (
             "internal_error",


### PR DESCRIPTION
🕸️ Tangle: The `Error` enum inside `src/error.rs` contained a stringly-typed `Trajectory(String)` variant, forcing consumers to rely on brittle string matching instead of structured domain types when diagnosing IO, Parse, Format, or Validation failures for Trajectories.
📐 Blueprint: Extracted a new `TrajectoryError` enum equipped with explicit, strictly typed variants (`Io`, `Json`, `Format`, `Validation`). Wrapped this inside the core `Error` type and aggressively refactored 40+ call-sites across `src/run/` and test files.
🧱 Stability: Strengthens architectural boundaries by replacing generic string wrappers with structured sum types, improving both compiler enforcement and exhaustive pattern matching.
🔬 Verification: Verified strict adherence via `cargo check`, `cargo fmt`, `cargo clippy`, and `cargo test` to ensure syntactic correctness, formatting, lack of warnings, and overall stability.

---
*PR created automatically by Jules for task [4539315033761404052](https://jules.google.com/task/4539315033761404052) started by @madmax983*