### PR TITLE
🛡️ Sentry: Fix async blocking in ProcessTreeGuard drop

### DIFF
--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -323,7 +323,13 @@ impl Drop for ProcessTreeGuard {
             return;
         }
         if let Some(pid) = self.pid {
-            terminate_process_tree_blocking(pid);
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                let _task = handle.spawn_blocking(move || {
+                    terminate_process_tree_blocking(pid);
+                });
+            } else {
+                terminate_process_tree_blocking(pid);
+            }
         }
     }
 }


### PR DESCRIPTION
🎯 Target: `ProcessTreeGuard` in `src/env/local.rs`
💣 Risk: `ProcessTreeGuard::drop` was executing a synchronous `std::thread::sleep(250ms)` (to give processes a graceful exit window) directly on the Tokio executor thread. This stalled the runtime and caused tests like `swebench_wallclock_timeout` to run upwards of 5+ seconds and fail due to timeouts.
🧪 Strategy: Check for an active Tokio runtime using `Handle::try_current()`. If a runtime is present, offload the blocking kill sequence to `spawn_blocking`. By design, Tokio waits for blocking tasks to complete during runtime shutdown, ensuring processes are successfully killed without leaving zombie processes, all without blocking the main async reactor.
🔬 Verification: Run `cargo test --test swebench_wallclock_timeout`

---
*PR created automatically by Jules for task [9525498635052131251](https://jules.google.com/task/9525498635052131251) started by @madmax983*