### PR TITLE
Add per-turn wall-clock latency attribution (model/tool/harness)

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -122,6 +122,11 @@ fn truncate_observation_text(input: &str, max_bytes: usize, head_ratio: f64) -> 
     }
 }
 
+/// Wall-clock elapsed since `since` in milliseconds, saturating to `u64::MAX`.
+fn elapsed_ms_since(since: Instant) -> u64 {
+    u64::try_from(since.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
 fn floor_char_boundary(input: &str, idx: usize) -> usize {
     let mut i = idx.min(input.len());
     while i > 0 && !input.is_char_boundary(i) {
@@ -150,6 +155,10 @@ pub struct DefaultAgent {
     pub actual_cost_source: Option<CostSource>,
     /// Wall-clock start, used to compute `duration_secs` on terminate.
     pub started_at_instant: Instant,
+    /// End of the most recently measured stage (model query or tool exec).
+    /// `harness_overhead_ms` for the next recorded turn is `Instant::now() -
+    /// last_measurement_end`. Initialized to `started_at_instant`.
+    last_measurement_end: Instant,
     wallclock_deadline: Option<WallclockDeadline>,
     /// Accumulated uncached input tokens across every model call in this run.
     pub prompt_tokens: u64,
@@ -295,6 +304,7 @@ impl DefaultAgentBuilder {
             started_at,
         });
 
+        let started_at_instant = Instant::now();
         Ok(DefaultAgent {
             config: self.config,
             model: self.model,
@@ -305,7 +315,8 @@ impl DefaultAgentBuilder {
             steps: 0,
             total_cost_usd: 0.0,
             actual_cost_source: None,
-            started_at_instant: Instant::now(),
+            started_at_instant,
+            last_measurement_end: started_at_instant,
             wallclock_deadline: None,
             prompt_tokens: 0,
             cache_read_tokens: 0,
@@ -503,6 +514,12 @@ impl Agent for DefaultAgent {
             max_tokens: Some(self.config.root.model.max_tokens),
             extra: serde_json::Map::new(),
         };
+        // Harness overhead leading up to this assistant turn = time since
+        // the previous measurement boundary (start of run or end of the
+        // previous tool exec). Captured BEFORE model.query so the harness
+        // bucket does not double-count model wall-clock.
+        let assistant_harness_ms = elapsed_ms_since(self.last_measurement_end);
+        let model_query_start = Instant::now();
         let query_result = query_model_until_cancelled(
             self.model.as_ref(),
             &self.history,
@@ -510,6 +527,13 @@ impl Agent for DefaultAgent {
             self.cancellation.clone(),
         )
         .await;
+        let model_latency_ms_value = elapsed_ms_since(model_query_start);
+        let model_latency_recorded = if self.model.skip_latency_telemetry() {
+            None
+        } else {
+            Some(model_latency_ms_value)
+        };
+        self.last_measurement_end = Instant::now();
         // When every model in a fallback chain fails transiently the error
         // carries the structured attempt records. Capture them before
         // propagating so finalize_run_metadata can still emit a summary.
@@ -562,6 +586,8 @@ impl Agent for DefaultAgent {
         asst.extra.cost = resp.usage.cost_usd;
         asst.extra.response = Some(resp.raw.clone());
         asst.extra.timestamp = Some(asst_ts.clone());
+        asst.extra.model_latency_ms = model_latency_recorded;
+        asst.extra.harness_overhead_ms = Some(assistant_harness_ms);
 
         // Store input fingerprint + canonical for replay drift detection (issue #155).
         // Fingerprint the TRAJECTORY-redacted, marker-normalized view of history so
@@ -687,18 +713,22 @@ impl Agent for DefaultAgent {
                     content: err.clone(),
                     timestamp: chrono::Utc::now().to_rfc3339(),
                 });
-                let obs = Message::user(
+                let mut obs = Message::user(
                     self.redactor
                         .redact_text(&err, surface::MODEL_OBSERVATION)
                         .text,
                 );
+                obs.extra.harness_overhead_ms =
+                    Some(elapsed_ms_since(self.last_measurement_end));
                 self.history.push(obs.clone());
+                let obs_extra = obs.extra.clone();
                 record_redacted_message(
                     &mut self.trajectory,
                     &obs,
-                    obs.extra.clone(),
+                    obs_extra,
                     &self.redactor,
                 );
+                self.last_measurement_end = Instant::now();
                 self.steps += 1;
                 return Ok(StepOutcome::Continue);
             }
@@ -759,7 +789,10 @@ impl Agent for DefaultAgent {
                 );
                 let obs_msg = Message::user(rejection.clone());
                 self.history.push(obs_msg.clone());
-                let mut obs_extra = crate::model::MessageExtra::default();
+                let mut obs_extra = crate::model::MessageExtra {
+                    harness_overhead_ms: Some(elapsed_ms_since(self.last_measurement_end)),
+                    ..crate::model::MessageExtra::default()
+                };
                 obs_extra
                     .other
                     .insert("policy_blocked".into(), serde_json::Value::Bool(true));
@@ -781,6 +814,7 @@ impl Agent for DefaultAgent {
                     content: rejection,
                     timestamp: chrono::Utc::now().to_rfc3339(),
                 });
+                self.last_measurement_end = Instant::now();
                 self.steps += 1;
                 return Ok(StepOutcome::Continue);
             }
@@ -807,9 +841,14 @@ impl Agent for DefaultAgent {
             return Ok(StepOutcome::Terminate(ExitReason::UserInterrupt));
         }
 
-        let (result, post_hook_results) = if tool_use_blocked {
-            (blocked_run_result(&pre_hook_results), Vec::new())
+        // Harness overhead from the end of the model query to just before
+        // the tool starts executing: policy gate, pre-hooks, message
+        // construction.
+        let obs_harness_ms = elapsed_ms_since(self.last_measurement_end);
+        let (result, post_hook_results, tool_latency_recorded) = if tool_use_blocked {
+            (blocked_run_result(&pre_hook_results), Vec::new(), None)
         } else {
+            let tool_start = Instant::now();
             let result = if is_bash {
                 self.stream.emit(StreamEvent::BashStart {
                     step: self.steps,
@@ -837,6 +876,8 @@ impl Agent for DefaultAgent {
             } else {
                 self.run_non_bash_tool(&tool_name, &tool_input).await?
             };
+            let tool_latency = elapsed_ms_since(tool_start);
+            self.last_measurement_end = Instant::now();
             let post_hook_results = self
                 .run_tool_hooks(
                     ToolHookPhase::PostToolUse,
@@ -846,7 +887,7 @@ impl Agent for DefaultAgent {
                     Some(&result),
                 )
                 .await?;
-            (result, post_hook_results)
+            (result, post_hook_results, Some(tool_latency))
         };
 
         if is_bash && !tool_use_blocked {
@@ -997,6 +1038,8 @@ impl Agent for DefaultAgent {
             serde_json::json!(trunc_output.bytes_omitted),
         );
         obs_extra.timestamp = Some(obs_ts.clone());
+        obs_extra.tool_latency_ms = tool_latency_recorded;
+        obs_extra.harness_overhead_ms = Some(obs_harness_ms);
         record_redacted_message(&mut self.trajectory, &obs_msg, obs_extra, &self.redactor);
 
         self.stream.emit(StreamEvent::Observation {

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -835,15 +835,12 @@ impl Agent for DefaultAgent {
             return Ok(StepOutcome::Terminate(ExitReason::UserInterrupt));
         }
 
-        // Harness overhead from the end of the model query to just before
-        // the tool starts executing: policy gate, pre-hooks, message
-        // construction.
-        let obs_harness_ms = elapsed_ms_since(self.last_measurement_end);
+        // Don't compute harness yet — we want post-tool hooks and
+        // observation rendering inside *this* turn's harness, not leaked to
+        // the next turn (and lost entirely if the run terminates here).
+        // We compute obs_harness_ms = (total elapsed since prior boundary)
+        // − tool_latency at record time, just below.
         let (result, post_hook_results, tool_latency_recorded) = if tool_use_blocked {
-            // No tool exec, but obs_harness_ms above already captured time
-            // up to this point. Bump the measurement boundary so the next
-            // turn's harness doesn't re-count this same wall-clock window.
-            self.last_measurement_end = Instant::now();
             (blocked_run_result(&pre_hook_results), Vec::new(), None)
         } else {
             let tool_start = Instant::now();
@@ -875,7 +872,6 @@ impl Agent for DefaultAgent {
                 self.run_non_bash_tool(&tool_name, &tool_input).await?
             };
             let tool_latency = elapsed_ms_since(tool_start);
-            self.last_measurement_end = Instant::now();
             let post_hook_results = self
                 .run_tool_hooks(
                     ToolHookPhase::PostToolUse,
@@ -1037,7 +1033,16 @@ impl Agent for DefaultAgent {
         );
         obs_extra.timestamp = Some(obs_ts.clone());
         obs_extra.tool_latency_ms = tool_latency_recorded;
+        // Total elapsed since the prior measurement boundary (end of model
+        // query) minus the measured tool window = everything else this turn
+        // spent in the harness: pre-hooks, policy gate, env wrappers,
+        // post-hooks, redaction, observation rendering. Bumping the
+        // boundary here keeps post-hook + render time in the *current*
+        // turn so it can't be lost if the run terminates this step.
+        let obs_harness_ms = elapsed_ms_since(self.last_measurement_end)
+            .saturating_sub(tool_latency_recorded.unwrap_or(0));
         obs_extra.harness_overhead_ms = Some(obs_harness_ms);
+        self.last_measurement_end = Instant::now();
         record_redacted_message(&mut self.trajectory, &obs_msg, obs_extra, &self.redactor);
 
         self.stream.emit(StreamEvent::Observation {

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -718,16 +718,10 @@ impl Agent for DefaultAgent {
                         .redact_text(&err, surface::MODEL_OBSERVATION)
                         .text,
                 );
-                obs.extra.harness_overhead_ms =
-                    Some(elapsed_ms_since(self.last_measurement_end));
+                obs.extra.harness_overhead_ms = Some(elapsed_ms_since(self.last_measurement_end));
                 self.history.push(obs.clone());
                 let obs_extra = obs.extra.clone();
-                record_redacted_message(
-                    &mut self.trajectory,
-                    &obs,
-                    obs_extra,
-                    &self.redactor,
-                );
+                record_redacted_message(&mut self.trajectory, &obs, obs_extra, &self.redactor);
                 self.last_measurement_end = Instant::now();
                 self.steps += 1;
                 return Ok(StepOutcome::Continue);

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -840,6 +840,10 @@ impl Agent for DefaultAgent {
         // construction.
         let obs_harness_ms = elapsed_ms_since(self.last_measurement_end);
         let (result, post_hook_results, tool_latency_recorded) = if tool_use_blocked {
+            // No tool exec, but obs_harness_ms above already captured time
+            // up to this point. Bump the measurement boundary so the next
+            // turn's harness doesn't re-count this same wall-clock window.
+            self.last_measurement_end = Instant::now();
             (blocked_run_result(&pre_hook_results), Vec::new(), None)
         } else {
             let tool_start = Instant::now();

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -20,7 +20,7 @@ pub struct ArtifactSchemaVersion {
 }
 
 impl ArtifactSchemaVersion {
-    pub const CURRENT: Self = Self { major: 1, minor: 4 };
+    pub const CURRENT: Self = Self { major: 1, minor: 5 };
     pub const LEGACY_PRE_VERSIONING: Self = Self { major: 0, minor: 0 };
 
     #[must_use]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -972,6 +972,9 @@ fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
         "evaluation complete"
     );
     print!("{}", crate::run::evaluate::render_summary_table(&summary));
+    if let Some(latency) = &eval.latency_summary {
+        print!("{}", crate::run::evaluate::render_latency_summary(latency));
+    }
     if let Some(prov) = &eval.provenance {
         println!(
             "evaluator_provenance: backend={} subset={} split={}",

--- a/src/model/deterministic.rs
+++ b/src/model/deterministic.rs
@@ -67,6 +67,10 @@ impl Model for DeterministicModel {
         &self.name
     }
 
+    fn skip_latency_telemetry(&self) -> bool {
+        true
+    }
+
     async fn query(
         &self,
         messages: &[Message],

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -63,6 +63,25 @@ pub struct MessageExtra {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub timestamp: Option<String>,
 
+    /// Wall-clock spent inside the model provider call that produced this
+    /// assistant turn. Absent on turns where the model produced no
+    /// measurable latency (deterministic fixtures, replay).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub model_latency_ms: Option<u64>,
+
+    /// Wall-clock spent executing the tool/bash command for the
+    /// observation turn that follows the assistant proposal. Absent on
+    /// turns that did not run a tool (format error, policy block, etc.).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub tool_latency_ms: Option<u64>,
+
+    /// Harness-side wall-clock between the previous turn's measurement
+    /// boundary and this turn's measurement boundary: rate-limit waits,
+    /// retries, redaction, file IO, template rendering. Always recorded
+    /// for live runs; absent on replays where it cannot be reconstructed.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub harness_overhead_ms: Option<u64>,
+
     #[serde(flatten, default)]
     pub other: BTreeMap<String, serde_json::Value>,
 }
@@ -87,6 +106,9 @@ fn message_extra_is_empty(e: &MessageExtra) -> bool {
         && e.cost.is_none()
         && e.response.is_none()
         && e.timestamp.is_none()
+        && e.model_latency_ms.is_none()
+        && e.tool_latency_ms.is_none()
+        && e.harness_overhead_ms.is_none()
         && e.other.is_empty()
 }
 
@@ -170,6 +192,15 @@ pub trait Model: Send + Sync {
     /// Does this backend/model honor explicit cache breakpoints? Used by
     /// `InteractiveAgent` for the status display — zero behavioral effect.
     fn supports_explicit_cache(&self) -> bool {
+        false
+    }
+
+    /// Signals that wall-clock measurements of `query` are not meaningful
+    /// for this backend (deterministic fixtures, in-memory replay). The
+    /// agent loop uses this to *omit* `MessageExtra.model_latency_ms`
+    /// instead of writing a near-zero value that would be indistinguishable
+    /// from a fast real backend on inspection.
+    fn skip_latency_telemetry(&self) -> bool {
         false
     }
 

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -3457,6 +3457,7 @@ mod tests {
             breakdown: Vec::new(),
             cost_attribution: Vec::new(),
             model_mix_summary: Vec::new(),
+            latency_summary: None,
             provenance: None,
         };
         let candidate_eval = crate::run::evaluate::EvaluationResults {
@@ -3476,6 +3477,7 @@ mod tests {
             breakdown: Vec::new(),
             cost_attribution: Vec::new(),
             model_mix_summary: Vec::new(),
+            latency_summary: None,
             provenance: None,
         };
 
@@ -3531,6 +3533,7 @@ mod tests {
             breakdown: Vec::new(),
             cost_attribution: Vec::new(),
             model_mix_summary: Vec::new(),
+            latency_summary: None,
             provenance: None,
         };
         std::fs::write(

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -206,10 +206,36 @@ pub struct EvaluationResults {
     pub cost_attribution: Vec<CostAttributionBucket>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub model_mix_summary: Vec<ModelMixBucket>,
+    /// Per-stage wall-clock distribution across the sweep, computed from the
+    /// `model_latency_ms` / `tool_latency_ms` / `harness_overhead_ms` fields
+    /// on per-turn `MessageExtra`. `None` when no trajectory in the sweep
+    /// recorded latency telemetry (legacy, deterministic-only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latency_summary: Option<LatencySummary>,
     /// Evaluator provenance recorded at evaluation time.
     /// `None` for artifacts produced before this field was added (legacy).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provenance: Option<EvaluatorProvenance>,
+}
+
+/// p50 / p95 of each wall-clock stage measured across every trajectory in
+/// the sweep. Each per-stage field is itself optional so that a sweep that
+/// only ran tools deterministically still reports `tool_latency_ms` while
+/// omitting `model_latency_ms`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LatencySummary {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_latency_ms: Option<LatencyStat>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_latency_ms: Option<LatencyStat>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness_overhead_ms: Option<LatencyStat>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LatencyStat {
+    pub p50: u64,
+    pub p95: u64,
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq)]
@@ -373,6 +399,7 @@ pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
         .rows;
     }
     eval.model_mix_summary = build_model_mix_summary_from_slots(&run_slots, &resolved_by_run);
+    eval.latency_summary = build_latency_summary_from_slots(&args.sweep_dir, &run_slots);
     eval.provenance = Some(provenance);
     let file = std::fs::File::create(evaluation_path(&args.sweep_dir))?;
     crate::artifact::to_writer_pretty(
@@ -847,6 +874,7 @@ fn build_none_eval(results: &HashMap<String, InstanceResult>) -> EvaluationResul
         breakdown: Vec::new(),
         cost_attribution: Vec::new(),
         model_mix_summary: Vec::new(),
+        latency_summary: None,
         provenance: None,
     }
 }
@@ -1203,6 +1231,7 @@ fn merge_with_results(
         breakdown: Vec::new(),
         cost_attribution: Vec::new(),
         model_mix_summary: Vec::new(),
+        latency_summary: None,
         provenance: None,
     }
 }
@@ -1312,6 +1341,7 @@ fn merge_rerun_reports_with_results(
         breakdown: Vec::new(),
         cost_attribution: Vec::new(),
         model_mix_summary: Vec::new(),
+        latency_summary: None,
         provenance: None,
     }
 }
@@ -1385,6 +1415,104 @@ fn build_model_mix_summary_from_slots(
             }
         })
         .collect()
+}
+
+/// Walks every trajectory in the sweep, sums each stage's per-turn ms
+/// into one number per instance-run, and returns the p50 / p95 of those
+/// per-instance totals. Each component (model/tool/harness) is omitted
+/// when no instance reported that stage so legacy/deterministic sweeps
+/// stay schema-clean.
+fn build_latency_summary_from_slots(
+    sweep_dir: &Path,
+    slots: &[crate::run::compare::LoadedRunSlot],
+) -> Option<LatencySummary> {
+    let mut model_totals: Vec<u64> = Vec::new();
+    let mut tool_totals: Vec<u64> = Vec::new();
+    let mut harness_totals: Vec<u64> = Vec::new();
+    for slot in slots {
+        let path = swebench::trajectory_path_for_run(sweep_dir, &slot.instance_id, slot.run_index);
+        let path = if path.exists() {
+            path
+        } else {
+            sweep_dir.join(format!("{}.traj.json", slot.instance_id))
+        };
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(traj) = serde_json::from_str::<crate::trajectory::Trajectory>(&text) else {
+            continue;
+        };
+        let mut model = None::<u64>;
+        let mut tool = None::<u64>;
+        let mut harness = None::<u64>;
+        for m in &traj.messages {
+            if let Some(v) = m.extra.model_latency_ms {
+                model = Some(model.unwrap_or(0).saturating_add(v));
+            }
+            if let Some(v) = m.extra.tool_latency_ms {
+                tool = Some(tool.unwrap_or(0).saturating_add(v));
+            }
+            if let Some(v) = m.extra.harness_overhead_ms {
+                harness = Some(harness.unwrap_or(0).saturating_add(v));
+            }
+        }
+        if let Some(v) = model {
+            model_totals.push(v);
+        }
+        if let Some(v) = tool {
+            tool_totals.push(v);
+        }
+        if let Some(v) = harness {
+            harness_totals.push(v);
+        }
+    }
+    let summary = LatencySummary {
+        model_latency_ms: percentile_stat(&mut model_totals),
+        tool_latency_ms: percentile_stat(&mut tool_totals),
+        harness_overhead_ms: percentile_stat(&mut harness_totals),
+    };
+    if summary.model_latency_ms.is_none()
+        && summary.tool_latency_ms.is_none()
+        && summary.harness_overhead_ms.is_none()
+    {
+        None
+    } else {
+        Some(summary)
+    }
+}
+
+fn percentile_stat(values: &mut [u64]) -> Option<LatencyStat> {
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_unstable();
+    Some(LatencyStat {
+        p50: percentile_u64(values, 0.50),
+        p95: percentile_u64(values, 0.95),
+    })
+}
+
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+fn percentile_u64(sorted: &[u64], q: f64) -> u64 {
+    if sorted.len() == 1 {
+        return sorted[0];
+    }
+    let span = (sorted.len() - 1) as f64;
+    let pos = q.clamp(0.0, 1.0) * span;
+    let lo = pos.floor() as usize;
+    let hi = pos.ceil() as usize;
+    if lo == hi {
+        sorted[lo]
+    } else {
+        let weight = pos - lo as f64;
+        let lo_v = sorted[lo] as f64;
+        let hi_v = sorted[hi] as f64;
+        lo_v.mul_add(1.0 - weight, hi_v * weight).round() as u64
+    }
 }
 
 fn build_breakdown(
@@ -1696,6 +1824,19 @@ pub fn render_cost_attribution_table(rows: &[CostAttributionBucket]) -> String {
 }
 
 #[must_use]
+pub fn render_latency_summary(summary: &LatencySummary) -> String {
+    let mut out = String::new();
+    let line = |out: &mut String, label: &str, stat: Option<LatencyStat>| {
+        if let Some(s) = stat {
+            let _ = writeln!(out, "{label}_p50_ms: {} {label}_p95_ms: {}", s.p50, s.p95);
+        }
+    };
+    line(&mut out, "model_latency", summary.model_latency_ms);
+    line(&mut out, "tool_latency", summary.tool_latency_ms);
+    line(&mut out, "harness_overhead", summary.harness_overhead_ms);
+    out
+}
+
 pub fn render_summary_table(summary: &EvaluationSummary) -> String {
     let mut out = String::new();
     let _ = writeln!(out, "resolved: {}", summary.resolved);
@@ -1875,6 +2016,7 @@ mod tests {
             breakdown: Vec::new(),
             cost_attribution: Vec::new(),
             model_mix_summary: Vec::new(),
+            latency_summary: None,
             provenance: None,
             behavioral: BehavioralMetrics::default(),
         };
@@ -2057,6 +2199,7 @@ mod tests {
             breakdown: vec![],
             cost_attribution: vec![],
             model_mix_summary: vec![],
+            latency_summary: None,
             provenance: None,
         };
         let summary = summarize_with_model(&eval, &results, None);
@@ -2180,6 +2323,7 @@ mod tests {
             breakdown: Vec::new(),
             cost_attribution: Vec::new(),
             model_mix_summary: Vec::new(),
+            latency_summary: None,
             provenance: None,
         };
         let summary = summarize(&eval, &results);
@@ -2231,6 +2375,7 @@ mod tests {
             breakdown: Vec::new(),
             cost_attribution: Vec::new(),
             model_mix_summary: Vec::new(),
+            latency_summary: None,
             provenance: None,
         };
         let summary = summarize(&eval, &results);
@@ -2264,6 +2409,7 @@ mod tests {
             breakdown: Vec::new(),
             cost_attribution: Vec::new(),
             model_mix_summary: Vec::new(),
+            latency_summary: None,
             provenance: None,
         };
         let summary = summarize(&eval, &results);
@@ -2286,6 +2432,7 @@ mod tests {
             breakdown: Vec::new(),
             cost_attribution: Vec::new(),
             model_mix_summary: Vec::new(),
+            latency_summary: None,
             provenance: None,
         };
         let summary = summarize(&eval, &results);
@@ -2315,6 +2462,7 @@ mod tests {
             breakdown: Vec::new(),
             cost_attribution: Vec::new(),
             model_mix_summary: Vec::new(),
+            latency_summary: None,
             provenance: None,
         };
         let summary = summarize(&eval, &results);
@@ -2342,6 +2490,7 @@ mod tests {
             breakdown: Vec::new(),
             cost_attribution: Vec::new(),
             model_mix_summary: Vec::new(),
+            latency_summary: None,
             provenance: None,
         };
         let summary = summarize(&eval, &results);

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -676,10 +676,9 @@ fn render_instance_text(report: &InspectReport) -> String {
         let harness_ms = report
             .harness_overhead_ms_total
             .map_or_else(|| "unknown".to_owned(), |v| v.to_string());
-        let share = report.latency_share_pct.map_or_else(
-            String::new,
-            |s| format!(" ({}% / {}% / {}%)", s.model_pct, s.tool_pct, s.harness_pct),
-        );
+        let share = report.latency_share_pct.map_or_else(String::new, |s| {
+            format!(" ({}% / {}% / {}%)", s.model_pct, s.tool_pct, s.harness_pct)
+        });
         let _ = writeln!(
             s,
             "latency:          model_ms={model_ms} tool_ms={tool_ms} harness_ms={harness_ms}{share}",

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -684,6 +684,10 @@ fn render_instance_text(report: &InspectReport) -> String {
             s,
             "latency:          model_ms={model_ms} tool_ms={tool_ms} harness_ms={harness_ms}{share}",
         );
+    } else {
+        // Legacy trajectory pre-1.5: no stage attribution recorded.
+        // Surface explicitly so operators don't misread silence as zero.
+        let _ = writeln!(s, "latency:          unknown (pre-1.5 trajectory)");
     }
     for w in &report.warnings {
         let _ = writeln!(s, "warning:          {w}");

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -103,10 +103,31 @@ pub struct InspectReport {
     pub verification_status: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub verification_results: Vec<VerificationResult>,
+    /// Sum of `model_latency_ms` over all messages. `None` when no turn
+    /// recorded model latency (legacy trajectory or deterministic fixture).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_latency_ms_total: Option<u64>,
+    /// Sum of `tool_latency_ms` over all messages.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_latency_ms_total: Option<u64>,
+    /// Sum of `harness_overhead_ms` over all messages.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness_overhead_ms_total: Option<u64>,
+    /// Each stage's share of `duration_secs`, rounded to whole percent.
+    /// Empty when `duration_secs` is missing or zero.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latency_share_pct: Option<LatencySharePct>,
     #[serde(default)]
     pub warnings: Vec<String>,
     #[serde(default)]
     pub steps: Vec<InspectStep>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+pub struct LatencySharePct {
+    pub model_pct: u32,
+    pub tool_pct: u32,
+    pub harness_pct: u32,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -266,6 +287,10 @@ fn build_instance_report(
                 fallback_summary: None,
                 verification_status: None,
                 verification_results: vec![],
+                model_latency_ms_total: None,
+                tool_latency_ms_total: None,
+                harness_overhead_ms_total: None,
+                latency_share_pct: None,
                 warnings,
                 steps: vec![],
             });
@@ -287,6 +312,14 @@ fn build_instance_report(
     }
 
     let steps = build_inspect_steps(&traj, full);
+    let (model_latency_ms_total, tool_latency_ms_total, harness_overhead_ms_total) =
+        sum_stage_latencies(&traj);
+    let latency_share_pct = compute_latency_share(
+        traj.info.duration_secs,
+        model_latency_ms_total,
+        tool_latency_ms_total,
+        harness_overhead_ms_total,
+    );
 
     let token_usage = traj.info.token_usage.as_ref();
     Ok(InspectReport {
@@ -322,8 +355,62 @@ fn build_instance_report(
         fallback_summary: traj.info.fallback_summary,
         verification_status: traj.info.verification_status,
         verification_results: traj.info.verification_results,
+        model_latency_ms_total,
+        tool_latency_ms_total,
+        harness_overhead_ms_total,
+        latency_share_pct,
         warnings,
         steps,
+    })
+}
+
+/// Returns `(model_total, tool_total, harness_total)` summed across messages.
+/// Each component is `None` when no message recorded that stage. Recording
+/// `Some(0)` is preserved as a measured zero (e.g., a fast tool turn).
+fn sum_stage_latencies(traj: &Trajectory) -> (Option<u64>, Option<u64>, Option<u64>) {
+    let mut model = None::<u64>;
+    let mut tool = None::<u64>;
+    let mut harness = None::<u64>;
+    for m in &traj.messages {
+        if let Some(v) = m.extra.model_latency_ms {
+            model = Some(model.unwrap_or(0).saturating_add(v));
+        }
+        if let Some(v) = m.extra.tool_latency_ms {
+            tool = Some(tool.unwrap_or(0).saturating_add(v));
+        }
+        if let Some(v) = m.extra.harness_overhead_ms {
+            harness = Some(harness.unwrap_or(0).saturating_add(v));
+        }
+    }
+    (model, tool, harness)
+}
+
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+fn compute_latency_share(
+    duration_secs: Option<f64>,
+    model_ms: Option<u64>,
+    tool_ms: Option<u64>,
+    harness_ms: Option<u64>,
+) -> Option<LatencySharePct> {
+    let dur_ms = duration_secs? * 1000.0;
+    if dur_ms <= 0.0 {
+        return None;
+    }
+    if model_ms.is_none() && tool_ms.is_none() && harness_ms.is_none() {
+        return None;
+    }
+    let pct = |ms: Option<u64>| -> u32 {
+        let v = ms.unwrap_or(0) as f64;
+        ((v / dur_ms) * 100.0).round() as u32
+    };
+    Some(LatencySharePct {
+        model_pct: pct(model_ms),
+        tool_pct: pct(tool_ms),
+        harness_pct: pct(harness_ms),
     })
 }
 
@@ -575,6 +662,28 @@ fn render_instance_text(report: &InspectReport) -> String {
                 r.name, r.passed, r.exit_code, r.duration_ms, timeout_note,
             );
         }
+    }
+    if report.model_latency_ms_total.is_some()
+        || report.tool_latency_ms_total.is_some()
+        || report.harness_overhead_ms_total.is_some()
+    {
+        let model_ms = report
+            .model_latency_ms_total
+            .map_or_else(|| "unknown".to_owned(), |v| v.to_string());
+        let tool_ms = report
+            .tool_latency_ms_total
+            .map_or_else(|| "unknown".to_owned(), |v| v.to_string());
+        let harness_ms = report
+            .harness_overhead_ms_total
+            .map_or_else(|| "unknown".to_owned(), |v| v.to_string());
+        let share = report.latency_share_pct.map_or_else(
+            String::new,
+            |s| format!(" ({}% / {}% / {}%)", s.model_pct, s.tool_pct, s.harness_pct),
+        );
+        let _ = writeln!(
+            s,
+            "latency:          model_ms={model_ms} tool_ms={tool_ms} harness_ms={harness_ms}{share}",
+        );
     }
     for w in &report.warnings {
         let _ = writeln!(s, "warning:          {w}");

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -399,6 +399,14 @@ impl Model for FingerprintCheckingModel {
         "fingerprint-checking-replay"
     }
 
+    fn skip_latency_telemetry(&self) -> bool {
+        // Replay drives a `DeterministicModel` for responses; the wall-clock
+        // here reflects fingerprint-checking + scripted lookup, not real
+        // model latency. Omit `model_latency_ms` so inspect/evaluate can't
+        // mistake replay runs for fast real-model runs (#159).
+        true
+    }
+
     async fn query(
         &self,
         messages: &[Message],

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -6355,7 +6355,7 @@ instance = "inst"
         assert_eq!(v["artifact_kind"], "preflight_report");
         assert_eq!(
             v["schema_version"],
-            serde_json::json!({"major": 1, "minor": 4})
+            serde_json::json!({"major": 1, "minor": 5})
         );
         assert!(v.get("mode").is_some());
         assert!(v.get("checks").is_some());

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -496,6 +496,9 @@ fn extra_is_empty(e: &MessageExtra) -> bool {
         && e.cost.is_none()
         && e.response.is_none()
         && e.timestamp.is_none()
+        && e.model_latency_ms.is_none()
+        && e.tool_latency_ms.is_none()
+        && e.harness_overhead_ms.is_none()
         && e.other.is_empty()
 }
 

--- a/tests/artifact_schema.rs
+++ b/tests/artifact_schema.rs
@@ -22,9 +22,11 @@ use support::binary_path;
 
 #[test]
 fn artifact_schema_current_minor_bumped_for_replay_fingerprinting() {
+    // Additive minor bumps: 1.4 added replay fingerprinting, 1.5 added
+    // per-turn wall-clock attribution (model/tool/harness latency).
     assert_eq!(
         ArtifactSchemaVersion::CURRENT,
-        ArtifactSchemaVersion::new(1, 4)
+        ArtifactSchemaVersion::new(1, 5)
     );
 }
 
@@ -32,7 +34,7 @@ fn artifact_schema_current_minor_bumped_for_replay_fingerprinting() {
 fn artifact_classifier_marks_exact_current_version_supported_current() {
     let payload = serde_json::json!({
         "artifact_kind": "sweep_results",
-        "schema_version": {"major": 1, "minor": 4},
+        "schema_version": {"major": 1, "minor": 5},
         "total": 0,
         "instances": []
     });
@@ -142,7 +144,7 @@ fn trajectory_serialization_includes_artifact_header() {
     assert_eq!(value["artifact_kind"], "trajectory");
     assert_eq!(
         value["schema_version"],
-        serde_json::json!({"major": 1, "minor": 4})
+        serde_json::json!({"major": 1, "minor": 5})
     );
 }
 
@@ -170,7 +172,7 @@ async fn swebench_run_writes_versioned_results_and_prediction_metadata() {
     assert_eq!(results["artifact_kind"], "sweep_results");
     assert_eq!(
         results["schema_version"],
-        serde_json::json!({"major": 1, "minor": 4})
+        serde_json::json!({"major": 1, "minor": 5})
     );
 
     let predictions = std::fs::read_to_string(output.join("all_preds.jsonl")).unwrap();
@@ -194,7 +196,7 @@ async fn swebench_run_writes_versioned_results_and_prediction_metadata() {
     assert_eq!(metadata["artifact_kind"], "swebench_predictions_metadata");
     assert_eq!(
         metadata["schema_version"],
-        serde_json::json!({"major": 1, "minor": 4})
+        serde_json::json!({"major": 1, "minor": 5})
     );
     assert_eq!(metadata["predictions_file"], "all_preds.jsonl");
     assert_eq!(metadata["row_count"], 1);
@@ -237,7 +239,7 @@ async fn evaluate_run_writes_versioned_evaluation_json() {
     assert_eq!(eval["artifact_kind"], "evaluation_results");
     assert_eq!(
         eval["schema_version"],
-        serde_json::json!({"major": 1, "minor": 4})
+        serde_json::json!({"major": 1, "minor": 5})
     );
 }
 
@@ -252,7 +254,7 @@ fn forecast_json_includes_artifact_header() {
     assert_eq!(value["artifact_kind"], "forecast_report");
     assert_eq!(
         value["schema_version"],
-        serde_json::json!({"major": 1, "minor": 4})
+        serde_json::json!({"major": 1, "minor": 5})
     );
 }
 
@@ -287,7 +289,7 @@ async fn forecast_run_keeps_calibration_results_versioned_after_manifest_mark() 
     assert_eq!(calibration_results["artifact_kind"], "sweep_results");
     assert_eq!(
         calibration_results["schema_version"],
-        serde_json::json!({"major": 1, "minor": 4})
+        serde_json::json!({"major": 1, "minor": 5})
     );
 }
 
@@ -535,7 +537,7 @@ async fn current_contract_fixtures_match_emitted_artifact_top_level_fields() {
 
     let preflight = serde_json::json!({
         "artifact_kind": "preflight_report",
-        "schema_version": {"major": 1, "minor": 4},
+        "schema_version": {"major": 1, "minor": 5},
         "mode": "doctor",
         "checks": [{
             "status": "ok",

--- a/tests/evaluator_provenance.rs
+++ b/tests/evaluator_provenance.rs
@@ -72,6 +72,7 @@ fn minimal_evaluation_results(resolved: bool) -> EvaluationResults {
         breakdown: vec![],
         cost_attribution: vec![],
         model_mix_summary: vec![],
+        latency_summary: None,
         provenance: None,
     }
 }

--- a/tests/fixtures/artifact_schema/current/all_preds.metadata.json
+++ b/tests/fixtures/artifact_schema/current/all_preds.metadata.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "swebench_predictions_metadata",
-  "schema_version": {"major": 1, "minor": 4},
+  "schema_version": {"major": 1, "minor": 5},
   "predictions_file": "all_preds.jsonl",
   "aggregate": true,
   "row_count": 1,

--- a/tests/fixtures/artifact_schema/current/calibration.json
+++ b/tests/fixtures/artifact_schema/current/calibration.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "calibration_report",
-  "schema_version": {"major": 1, "minor": 4},
+  "schema_version": {"major": 1, "minor": 5},
   "forecast_path": "forecast.json",
   "results_path": "results.json",
   "forecast_artifact": "forecast_report@1.3",

--- a/tests/fixtures/artifact_schema/current/evaluation.json
+++ b/tests/fixtures/artifact_schema/current/evaluation.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "evaluation_results",
-  "schema_version": {"major": 1, "minor": 4},
+  "schema_version": {"major": 1, "minor": 5},
   "instances": [
     {
       "instance_id": "task-a",
@@ -24,6 +24,9 @@
     "tests_run_before_submit_rate": 0.0,
     "resolved_rate_when_tests_run": 0.0,
     "resolved_rate_when_tests_skipped": 0.0
+  },
+  "latency_summary": {
+    "harness_overhead_ms": {"p50": 0, "p95": 0}
   },
   "provenance": {
     "backend": "none",

--- a/tests/fixtures/artifact_schema/current/forecast.json
+++ b/tests/fixtures/artifact_schema/current/forecast.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "forecast_report",
-  "schema_version": {"major": 1, "minor": 4},
+  "schema_version": {"major": 1, "minor": 5},
   "calibration": {
     "n": 1,
     "seed": 42,

--- a/tests/fixtures/artifact_schema/current/preflight.json
+++ b/tests/fixtures/artifact_schema/current/preflight.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "preflight_report",
-  "schema_version": {"major": 1, "minor": 4},
+  "schema_version": {"major": 1, "minor": 5},
   "mode": "doctor",
   "checks": [
     {

--- a/tests/fixtures/artifact_schema/current/results.json
+++ b/tests/fixtures/artifact_schema/current/results.json
@@ -2,7 +2,7 @@
   "artifact_kind": "sweep_results",
   "schema_version": {
     "major": 1,
-    "minor": 4
+    "minor": 5
   },
   "total": 1,
   "sweep_status": "completed",

--- a/tests/fixtures/artifact_schema/current/sweep/evaluation.json
+++ b/tests/fixtures/artifact_schema/current/sweep/evaluation.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "evaluation_results",
-  "schema_version": {"major": 1, "minor": 4},
+  "schema_version": {"major": 1, "minor": 5},
   "instances": [
     {
       "instance_id": "task-a",

--- a/tests/fixtures/artifact_schema/current/sweep/results.json
+++ b/tests/fixtures/artifact_schema/current/sweep/results.json
@@ -1,6 +1,6 @@
 {
   "artifact_kind": "sweep_results",
-  "schema_version": {"major": 1, "minor": 4},
+  "schema_version": {"major": 1, "minor": 5},
   "total": 1,
   "sweep_status": "completed",
   "completed": 1,

--- a/tests/fixtures/artifact_schema/current/sweep/task-a.traj.json
+++ b/tests/fixtures/artifact_schema/current/sweep/task-a.traj.json
@@ -1,7 +1,7 @@
 {
   "trajectory_format": "mini-swe-agent-1.1",
   "artifact_kind": "trajectory",
-  "schema_version": {"major": 1, "minor": 4},
+  "schema_version": {"major": 1, "minor": 5},
   "info": {
     "task": "task-a",
     "model_name": "fixture-model",

--- a/tests/fixtures/artifact_schema/current/trajectory.traj.json
+++ b/tests/fixtures/artifact_schema/current/trajectory.traj.json
@@ -1,7 +1,7 @@
 {
   "trajectory_format": "mini-swe-agent-1.1",
   "artifact_kind": "trajectory",
-  "schema_version": {"major": 1, "minor": 4},
+  "schema_version": {"major": 1, "minor": 5},
   "info": {
     "task": "task-a",
     "model_name": "fixture-model",

--- a/tests/per_turn_latency.rs
+++ b/tests/per_turn_latency.rs
@@ -94,7 +94,7 @@ impl SlowModel {
 
 #[async_trait]
 impl Model for SlowModel {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "slow-model"
     }
     async fn query(
@@ -268,8 +268,7 @@ async fn per_turn_stage_times_reconcile_to_duration_within_5_percent() {
     .unwrap();
     agent.run().await.unwrap();
 
-    let duration_ms =
-        agent.trajectory.info.duration_secs.unwrap_or(0.0) * 1000.0;
+    let duration_ms = agent.trajectory.info.duration_secs.unwrap_or(0.0) * 1000.0;
     let stage_sum_ms: u64 = agent
         .trajectory
         .messages
@@ -280,6 +279,7 @@ async fn per_turn_stage_times_reconcile_to_duration_within_5_percent() {
                 + m.extra.harness_overhead_ms.unwrap_or(0)
         })
         .sum();
+    #[allow(clippy::cast_precision_loss)]
     let stage_sum = stage_sum_ms as f64;
     let drift = (stage_sum - duration_ms).abs();
     assert!(
@@ -378,7 +378,9 @@ fn inspect_report_aggregates_stage_totals() {
     let out = rust_swe_agent::run::inspect::run(&args).unwrap();
     let report: &InspectReport = match &out {
         rust_swe_agent::run::inspect::InspectOutput::Instance(r) => r,
-        _ => panic!("expected instance report"),
+        rust_swe_agent::run::inspect::InspectOutput::Summary(_) => {
+            panic!("expected instance report")
+        }
     };
     assert_eq!(report.model_latency_ms_total, Some(400));
     assert_eq!(report.tool_latency_ms_total, Some(500));

--- a/tests/per_turn_latency.rs
+++ b/tests/per_turn_latency.rs
@@ -289,6 +289,60 @@ async fn per_turn_stage_times_reconcile_to_duration_within_5_percent() {
 }
 
 #[tokio::test]
+async fn slow_post_tool_hook_time_is_attributed_to_current_obs_turn() {
+    // A slow post_tool_use hook runs *after* tool exec but before the
+    // observation is recorded. Its wall-clock must land in the current
+    // obs turn's harness_overhead_ms — not leak to the next turn (and
+    // get lost entirely if the run terminates here).
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+    cfg.root.agent.hooks.post_tool_use = vec![ToolHookCfg {
+        name: "slow-post".into(),
+        command: "sleep 0.1".into(),
+        timeout_secs: Some(5),
+    }];
+
+    let model = Arc::new(SlowModel::new(
+        vec![
+            "```bash\necho hi\n```".into(),
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
+        ],
+        Duration::from_millis(2),
+    ));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "post-hook".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+    agent.run().await.unwrap();
+
+    let obs_with_post_hook_time = agent
+        .trajectory
+        .messages
+        .iter()
+        .filter(|m| m.role == "user")
+        .find(|m| m.extra.harness_overhead_ms.unwrap_or(0) >= 80);
+    assert!(
+        obs_with_post_hook_time.is_some(),
+        "slow post-hook (≥100ms) must show up as harness_overhead_ms (≥80) on the current obs turn; got {:?}",
+        agent
+            .trajectory
+            .messages
+            .iter()
+            .filter(|m| m.role == "user")
+            .map(|m| (m.extra.harness_overhead_ms, m.extra.tool_latency_ms))
+            .collect::<Vec<_>>(),
+    );
+}
+
+#[tokio::test]
 async fn slow_pre_tool_hook_makes_harness_overhead_dominate_observation_turn() {
     // A slow pre-tool hook simulates harness-side time (rate-limit waits,
     // retries, redaction, env setup). The tool itself runs instantly and

--- a/tests/per_turn_latency.rs
+++ b/tests/per_turn_latency.rs
@@ -16,7 +16,7 @@ use rust_swe_agent::run::inspect::{InspectReport, render_text};
 use rust_swe_agent::trajectory::Trajectory;
 use rust_swe_agent::{
     Agent, Config, DeterministicModel, Environment, ExitReason, LocalEnvironment, Message,
-    MessageExtra, Model, ModelResponse, ModelUsage, QueryOpts,
+    MessageExtra, Model, ModelResponse, ModelUsage, QueryOpts, ToolHookCfg,
 };
 
 // -- 1. Schema: MessageExtra carries the three latency fields.
@@ -288,6 +288,64 @@ async fn per_turn_stage_times_reconcile_to_duration_within_5_percent() {
     );
 }
 
+#[tokio::test]
+async fn slow_pre_tool_hook_makes_harness_overhead_dominate_observation_turn() {
+    // A slow pre-tool hook simulates harness-side time (rate-limit waits,
+    // retries, redaction, env setup). The tool itself runs instantly and
+    // the model is near-instant — so the observation turn's
+    // harness_overhead_ms should outweigh both.
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+    cfg.root.agent.hooks.pre_tool_use = vec![ToolHookCfg {
+        name: "slow-stub".into(),
+        command: "sleep 0.1".into(),
+        timeout_secs: Some(5),
+    }];
+
+    let model = Arc::new(SlowModel::new(
+        vec![
+            "```bash\necho hi\n```".into(),
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
+        ],
+        Duration::from_millis(2),
+    ));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "harness-dominant".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+    agent.run().await.unwrap();
+
+    let dominated_obs = agent
+        .trajectory
+        .messages
+        .iter()
+        .filter(|m| m.role == "user")
+        .find(|m| {
+            let h = m.extra.harness_overhead_ms.unwrap_or(0);
+            let t = m.extra.tool_latency_ms.unwrap_or(0);
+            h >= 80 && h > t
+        });
+    assert!(
+        dominated_obs.is_some(),
+        "expected an observation turn where harness_overhead_ms (≥80) dominates tool_latency_ms; got {:?}",
+        agent
+            .trajectory
+            .messages
+            .iter()
+            .filter(|m| m.role == "user")
+            .map(|m| (m.extra.harness_overhead_ms, m.extra.tool_latency_ms))
+            .collect::<Vec<_>>(),
+    );
+}
+
 // -- 4. `bench inspect` exposes per-stage totals and shares.
 
 #[test]
@@ -330,6 +388,37 @@ fn inspect_report_aggregates_stage_totals() {
     assert!(text.contains("model_ms"), "{text}");
     assert!(text.contains("tool_ms"), "{text}");
     assert!(text.contains("harness_ms"), "{text}");
+}
+
+#[test]
+fn legacy_trajectory_inspect_renders_latency_unknown() {
+    // A trajectory with no per-turn latency fields (pre-1.5) must render an
+    // explicit `latency: unknown` marker in the inspect text header so
+    // operators don't misread silence as zero.
+    let traj_json = r#"{
+  "trajectory_format": "mini-swe-agent-1.2",
+  "info": {"task": "legacy", "duration_secs": 1.0},
+  "messages": [
+    {"role": "system", "content": "sys"},
+    {"role": "user", "content": "task"}
+  ]
+}"#;
+    let tmp = tempfile::tempdir().unwrap();
+    let sweep = tmp.path();
+    std::fs::write(sweep.join("legacy.traj.json"), traj_json).unwrap();
+
+    let args = rust_swe_agent::run::inspect::InspectArgs {
+        sweep: sweep.to_path_buf(),
+        instance: Some("legacy".into()),
+        filter: None,
+        full: true,
+    };
+    let out = rust_swe_agent::run::inspect::run(&args).unwrap();
+    let text = render_text(&out);
+    assert!(
+        text.contains("latency:") && text.contains("unknown"),
+        "expected `latency: unknown` line on legacy trajectory, got:\n{text}"
+    );
 }
 
 // -- 5. `bench evaluate` exposes per-stage p50/p95 in EvaluationResults JSON.

--- a/tests/per_turn_latency.rs
+++ b/tests/per_turn_latency.rs
@@ -1,0 +1,361 @@
+//! Per-turn wall-clock attribution: model / tool / harness latency on each
+//! turn's `MessageExtra`, with totals surfaced through `bench inspect` and
+//! distributional stats through `bench evaluate`. See issue #159.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rust_swe_agent::agent::default::DefaultAgentBuilder;
+use rust_swe_agent::artifact::ArtifactSchemaVersion;
+use rust_swe_agent::run::evaluate::EvaluationResults;
+use rust_swe_agent::run::inspect::{InspectReport, render_text};
+use rust_swe_agent::trajectory::Trajectory;
+use rust_swe_agent::{
+    Agent, Config, DeterministicModel, Environment, ExitReason, LocalEnvironment, Message,
+    MessageExtra, Model, ModelResponse, ModelUsage, QueryOpts,
+};
+
+// -- 1. Schema: MessageExtra carries the three latency fields.
+
+#[test]
+fn message_extra_supports_latency_fields_roundtrip() {
+    let extra = MessageExtra {
+        model_latency_ms: Some(1234),
+        tool_latency_ms: Some(56),
+        harness_overhead_ms: Some(78),
+        ..MessageExtra::default()
+    };
+    let json = serde_json::to_string(&extra).unwrap();
+    assert!(json.contains("\"model_latency_ms\":1234"), "{json}");
+    assert!(json.contains("\"tool_latency_ms\":56"), "{json}");
+    assert!(json.contains("\"harness_overhead_ms\":78"), "{json}");
+
+    let back: MessageExtra = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.model_latency_ms, Some(1234));
+    assert_eq!(back.tool_latency_ms, Some(56));
+    assert_eq!(back.harness_overhead_ms, Some(78));
+}
+
+#[test]
+fn message_extra_omits_latency_fields_when_none() {
+    let extra = MessageExtra::default();
+    let json = serde_json::to_string(&extra).unwrap();
+    assert!(!json.contains("model_latency_ms"), "{json}");
+    assert!(!json.contains("tool_latency_ms"), "{json}");
+    assert!(!json.contains("harness_overhead_ms"), "{json}");
+}
+
+#[test]
+fn legacy_trajectory_without_latency_fields_parses_cleanly() {
+    // Old artifact: no latency fields anywhere. Must still parse with
+    // omitted-as-unknown semantics.
+    let json = r#"{
+  "trajectory_format": "mini-swe-agent-1.2",
+  "info": {},
+  "messages": [{"role":"assistant","content":"hi","extra":{}}]
+}"#;
+    let traj: Trajectory = serde_json::from_str(json).unwrap();
+    assert_eq!(traj.messages[0].extra.model_latency_ms, None);
+    assert_eq!(traj.messages[0].extra.tool_latency_ms, None);
+    assert_eq!(traj.messages[0].extra.harness_overhead_ms, None);
+}
+
+// -- 2. Artifact schema bump: 1.4 -> 1.5.
+
+#[test]
+fn artifact_schema_minor_bumped_for_latency_attribution() {
+    assert_eq!(
+        ArtifactSchemaVersion::CURRENT,
+        ArtifactSchemaVersion::new(1, 5),
+    );
+}
+
+// -- 3. Agent loop: a real (non-skip) model produces model_latency on
+// assistant turns and tool_latency on observation turns; reconciliation
+// holds within tolerance.
+
+struct SlowModel {
+    responses: Mutex<VecDeque<String>>,
+    model_delay: Duration,
+}
+
+impl SlowModel {
+    fn new(responses: impl IntoIterator<Item = String>, model_delay: Duration) -> Self {
+        Self {
+            responses: Mutex::new(responses.into_iter().collect()),
+            model_delay,
+        }
+    }
+}
+
+#[async_trait]
+impl Model for SlowModel {
+    fn name(&self) -> &str {
+        "slow-model"
+    }
+    async fn query(
+        &self,
+        _messages: &[Message],
+        _opts: &QueryOpts,
+    ) -> Result<ModelResponse, rust_swe_agent::ModelError> {
+        tokio::time::sleep(self.model_delay).await;
+        let content = self
+            .responses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or_else(|| rust_swe_agent::ModelError::Malformed("scripted: no more".into()))?;
+        Ok(ModelResponse {
+            content,
+            usage: ModelUsage {
+                cost_usd: Some(0.0),
+                ..ModelUsage::default()
+            },
+            raw: serde_json::json!({}),
+            responding_model: None,
+            fallback_attempts: vec![],
+        })
+    }
+}
+
+#[tokio::test]
+async fn assistant_turn_records_model_latency_when_model_is_real() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+
+    let model = Arc::new(SlowModel::new(
+        vec![
+            "```bash\nsleep 0.1 && echo done\n```".into(),
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
+        ],
+        Duration::from_millis(60),
+    ));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "latency".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+    assert!(matches!(exit, ExitReason::Submitted { .. }));
+
+    let assistant_with_model_latency: Vec<u64> = agent
+        .trajectory
+        .messages
+        .iter()
+        .filter(|m| m.role == "assistant")
+        .filter_map(|m| m.extra.model_latency_ms)
+        .collect();
+    assert!(
+        !assistant_with_model_latency.is_empty(),
+        "expected at least one assistant turn with model_latency_ms"
+    );
+    // The 60ms sleep should be measurable.
+    assert!(
+        assistant_with_model_latency.iter().any(|ms| *ms >= 40),
+        "expected at least one model_latency_ms ≥ 40, got {assistant_with_model_latency:?}",
+    );
+}
+
+#[tokio::test]
+async fn observation_turn_records_tool_latency_when_bash_runs() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+
+    let model = Arc::new(SlowModel::new(
+        vec![
+            "```bash\nsleep 0.1\n```".into(),
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
+        ],
+        Duration::from_millis(5),
+    ));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "latency".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+    agent.run().await.unwrap();
+
+    let tool_latencies: Vec<u64> = agent
+        .trajectory
+        .messages
+        .iter()
+        .filter(|m| m.role == "user")
+        .filter_map(|m| m.extra.tool_latency_ms)
+        .collect();
+    assert!(
+        tool_latencies.iter().any(|ms| *ms >= 80),
+        "expected an observation with tool_latency_ms ≥ 80, got {tool_latencies:?}",
+    );
+}
+
+#[tokio::test]
+async fn deterministic_model_assistant_turn_omits_model_latency() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 3;
+
+    let model = Arc::new(DeterministicModel::new(vec![
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfin\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "x".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+    agent.run().await.unwrap();
+
+    // For DeterministicModel, model_latency_ms is unmeasurable in a
+    // meaningful sense — it must be omitted, not zeroed.
+    for m in &agent.trajectory.messages {
+        if m.role == "assistant" {
+            assert!(
+                m.extra.model_latency_ms.is_none(),
+                "deterministic-model assistant turn must omit model_latency_ms; got {:?}",
+                m.extra.model_latency_ms
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn per_turn_stage_times_reconcile_to_duration_within_5_percent() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+
+    let model = Arc::new(SlowModel::new(
+        vec![
+            "```bash\necho hi\n```".into(),
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
+        ],
+        Duration::from_millis(20),
+    ));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "rec".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+    agent.run().await.unwrap();
+
+    let duration_ms =
+        agent.trajectory.info.duration_secs.unwrap_or(0.0) * 1000.0;
+    let stage_sum_ms: u64 = agent
+        .trajectory
+        .messages
+        .iter()
+        .map(|m| {
+            m.extra.model_latency_ms.unwrap_or(0)
+                + m.extra.tool_latency_ms.unwrap_or(0)
+                + m.extra.harness_overhead_ms.unwrap_or(0)
+        })
+        .sum();
+    let stage_sum = stage_sum_ms as f64;
+    let drift = (stage_sum - duration_ms).abs();
+    assert!(
+        drift <= duration_ms * 0.05 + 50.0, // tolerance + 50ms slack for short runs
+        "stage sum {stage_sum}ms drifted from duration {duration_ms}ms by {drift}ms",
+    );
+}
+
+// -- 4. `bench inspect` exposes per-stage totals and shares.
+
+#[test]
+fn inspect_report_aggregates_stage_totals() {
+    let mut traj = Trajectory::new();
+    traj.info.duration_secs = Some(1.0);
+    let mut a = Message::assistant("hi");
+    a.extra.model_latency_ms = Some(400);
+    a.extra.harness_overhead_ms = Some(20);
+    traj.record_message(&a);
+    let mut u = Message::user("obs");
+    u.extra.tool_latency_ms = Some(500);
+    u.extra.harness_overhead_ms = Some(30);
+    traj.record_message(&u);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let sweep = tmp.path();
+    let traj_path = sweep.join("aa.traj.json");
+    traj.save_pretty(&traj_path).unwrap();
+    // Required by run::compare::load_sweep when walking the sweep, but inspect
+    // can also load a specific .traj.json directly. We bypass load_sweep here
+    // by using build_instance_report through public `run`.
+
+    let args = rust_swe_agent::run::inspect::InspectArgs {
+        sweep: sweep.to_path_buf(),
+        instance: Some("aa".into()),
+        filter: None,
+        full: true,
+    };
+    let out = rust_swe_agent::run::inspect::run(&args).unwrap();
+    let report: &InspectReport = match &out {
+        rust_swe_agent::run::inspect::InspectOutput::Instance(r) => r,
+        _ => panic!("expected instance report"),
+    };
+    assert_eq!(report.model_latency_ms_total, Some(400));
+    assert_eq!(report.tool_latency_ms_total, Some(500));
+    assert_eq!(report.harness_overhead_ms_total, Some(50));
+
+    let text = render_text(&out);
+    assert!(text.contains("model_ms"), "{text}");
+    assert!(text.contains("tool_ms"), "{text}");
+    assert!(text.contains("harness_ms"), "{text}");
+}
+
+// -- 5. `bench evaluate` exposes per-stage p50/p95 in EvaluationResults JSON.
+
+#[test]
+fn evaluation_results_carry_latency_summary_field() {
+    let json = r#"{
+        "instances": [],
+        "behavioral": {
+            "tests_run_before_submit_rate": 0.0,
+            "resolved_rate_when_tests_run": 0.0,
+            "resolved_rate_when_tests_skipped": 0.0
+        },
+        "latency_summary": {
+            "model_latency_ms": {"p50": 100, "p95": 200},
+            "tool_latency_ms": {"p50": 50, "p95": 80},
+            "harness_overhead_ms": {"p50": 10, "p95": 30}
+        }
+    }"#;
+    let parsed: EvaluationResults = serde_json::from_str(json).unwrap();
+    let summary = parsed
+        .latency_summary
+        .as_ref()
+        .expect("evaluation results must carry latency_summary");
+    assert_eq!(summary.model_latency_ms.as_ref().unwrap().p50, 100);
+    assert_eq!(summary.model_latency_ms.as_ref().unwrap().p95, 200);
+    assert_eq!(summary.tool_latency_ms.as_ref().unwrap().p95, 80);
+    assert_eq!(summary.harness_overhead_ms.as_ref().unwrap().p50, 10);
+}

--- a/tests/replay_fingerprint.rs
+++ b/tests/replay_fingerprint.rs
@@ -156,6 +156,37 @@ fn replay_response_exhausted_exit_code_is_10() {
 
 // ── integration tests ──────────────────────────────────────────────────────
 
+/// Replay must omit per-turn `model_latency_ms` — the wall-clock spent in
+/// the fingerprint-checking wrapper is not real model latency (#159).
+#[tokio::test]
+async fn replay_omits_model_latency_ms_on_assistant_turns() {
+    let dir = tempdir().unwrap();
+    let fp_traj = record_fingerprinted_trajectory(dir.path()).await;
+    let args = ReplayArgs {
+        trajectory_path: fp_traj,
+        config: Config::defaults().unwrap(),
+        output_dir: dir.path().to_path_buf(),
+        trajectory_name: Some("latency-check".into()),
+        allow_unfingerprinted: false,
+        report_only: false,
+        drift_cap_bytes: 8192,
+    };
+    replay_run(args).await.expect("replay should succeed");
+
+    let traj_path = dir.path().join("latency-check.traj.json");
+    let text = std::fs::read_to_string(&traj_path).unwrap();
+    let traj: rust_swe_agent::trajectory::Trajectory = serde_json::from_str(&text).unwrap();
+    for m in &traj.messages {
+        if m.role == "assistant" {
+            assert!(
+                m.extra.model_latency_ms.is_none(),
+                "replay assistant turns must omit model_latency_ms; got {:?}",
+                m.extra.model_latency_ms,
+            );
+        }
+    }
+}
+
 /// (a) Identical replay → exit 0, no drift file.
 #[tokio::test]
 async fn identical_replay_exits_zero_no_drift_file() {


### PR DESCRIPTION
## Summary

Implements comprehensive per-turn wall-clock latency attribution across three stages: model inference, tool execution, and harness overhead. This enables operators to understand where time is spent during agent runs through `bench inspect` (totals and percentages) and `bench evaluate` (p50/p95 distributions).

## Key Changes

- **Schema Extension (1.4 → 1.5)**: Added three optional fields to `MessageExtra`:
  - `model_latency_ms`: Wall-clock time inside model provider calls (assistant turns only)
  - `tool_latency_ms`: Wall-clock time executing bash/tools (observation turns only)
  - `harness_overhead_ms`: Harness-side time (rate limits, retries, redaction, file I/O)

- **Agent Loop Instrumentation**: Modified `DefaultAgent` to measure and record latency:
  - Tracks measurement boundaries using `last_measurement_end` to isolate each stage
  - Records model latency before/after `query_model_until_cancelled`
  - Records tool latency before/after tool execution
  - Computes harness overhead as time between measurement boundaries
  - Skips latency recording for deterministic models via `skip_latency_telemetry()`

- **Inspect Report Enhancement**: `InspectReport` now includes:
  - Per-stage totals (`model_latency_ms_total`, `tool_latency_ms_total`, `harness_overhead_ms_total`)
  - Percentage shares of total duration (`latency_share_pct`)
  - Explicit "unknown (pre-1.5 trajectory)" marker for legacy artifacts to prevent misinterpretation

- **Evaluation Results**: Added `LatencySummary` with p50/p95 percentiles for each stage across the sweep:
  - Computed from per-instance totals via `build_latency_summary_from_slots`
  - Omits stages with no recorded data (e.g., deterministic-only sweeps)
  - Rendered in `bench evaluate` output

- **Backward Compatibility**: 
  - Legacy trajectories without latency fields parse cleanly with `None` values
  - Optional fields serialize only when present (clean JSON)
  - Reconciliation tolerance: per-turn stage sums must match total duration within 5% + 50ms slack

## Implementation Details

- Latency measurement uses `Instant::now()` with saturating arithmetic to handle edge cases
- Percentile calculation supports linear interpolation for p50/p95 across sorted values
- Harness overhead captured *before* model query to avoid double-counting model wall-clock
- All latency fields skip serialization when `None` to maintain schema cleanliness
- Comprehensive test suite validates schema roundtrips, agent loop recording, and reconciliation

## Testing

Added 450-line test module (`tests/per_turn_latency.rs`) covering:
- Schema serialization/deserialization with and without latency fields
- Real model latency measurement (60ms+ observable)
- Tool execution latency measurement (100ms+ observable)
- Deterministic model latency omission
- Per-turn reconciliation to total duration (within tolerance)
- Harness overhead dominance with slow pre-tool hooks
- Inspect report aggregation and legacy trajectory rendering
- Evaluation results latency summary structure

https://claude.ai/code/session_01P4eb5rpB9BgUakGN6B9Rtw