### PR TITLE
Add `bench matrix` subcommand for multi-arm experiment runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ a valid trajectory in hand:
   pass@k, and compare regression gates.
 - [`bench triage`](docs/spec-triage.md): deterministic unresolved-failure
   clustering, ranked stdout tables, and the `triage.json` schema.
+- [`bench matrix`](docs/spec-matrix.md): multi-arm experiment runner — compare
+  models or configs against the same instance set, shared budget enforcement,
+  `matrix.json` state, ranked `matrix-summary.json`, and `--resume` support.
 - [`agent scriptability`](docs/spec-scriptability.md): invocation-time MCP
   servers plus `PreToolUse` and `PostToolUse` hooks for A/B testing agent
   toolsets without rebuilding Rust.

--- a/docs/spec-matrix.md
+++ b/docs/spec-matrix.md
@@ -1,0 +1,186 @@
+# `bench matrix` Spec
+
+`bench matrix` runs multiple sweep arms against the **same** deterministically-
+selected instance set so that results are directly comparable. Each arm is a
+distinct (model, config) pair defined in a TOML manifest file.
+
+## CLI
+
+```bash
+rust-swe-agent bench matrix \
+  --config matrix.toml \
+  --dataset-path data/swe-bench-verified.jsonl \
+  --output runs/matrix-2025-01 \
+  --limit 50 \
+  --seed 42 \
+  --sweep-cost-limit-usd 20.00
+```
+
+Options:
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--config <path>` | required | TOML matrix manifest containing `[[arm]]` entries. |
+| `--dataset-path <file>` | required¹ | Local JSONL dataset file. |
+| `--dataset <alias>` | required¹ | Named SWE-bench alias (`verified`, `lite`, `full`). |
+| `--output <dir>` | required | Root output directory. Arm artifacts go in `{output}/{arm_name}/`. |
+| `--sweep-cost-limit-usd <f>` | unset | Shared USD ceiling across all arms. Arms that would start once the budget is exhausted are recorded as `skipped_budget`. |
+| `--matrix-parallelism <n>` | `1` | Number of arms to run concurrently (sequential by default). |
+| `--resume` | off | Load existing `matrix.json` and skip `complete`/`skipped_budget` arms. |
+| `--limit <n>` | unset | Keep at most N instances after filtering and sampling. |
+| `--sample <n>` | unset | Reproducibly random-subset to N instances (requires `--seed`). |
+| `--seed <n>` | unset | RNG seed for `--sample`. |
+| `--parallel <n>` | 4 | Worker parallelism per arm sweep. |
+| `--skip-preflight` | off | Skip startup preflight checks. |
+| `--skip-model-probe` | off | Skip model-endpoint probe during preflight. |
+
+¹ Exactly one of `--dataset-path` or `--dataset` must be provided.
+
+## Manifest format
+
+```toml
+[[arm]]
+name = "baseline"
+model = "claude-opus-4-7"
+
+[[arm]]
+name = "tuned"
+model = "claude-sonnet-4-6"
+step_limit = 30
+per_task_budget_usd = 0.50
+prompt_file = "/path/to/custom-prompt.toml"
+extra_args = ["--skip-patch-validation"]
+```
+
+Each `[[arm]]` entry supports:
+
+| Field | Required | Type | Meaning |
+| --- | --- | --- | --- |
+| `name` | yes | string | Unique arm name; used as the output subdirectory. Must not contain `/`, `\`, or `..`. |
+| `model` | yes | string | Model name passed to the sweep (e.g. `claude-opus-4-7`). |
+| `step_limit` | no | integer | Override the default agent step limit for this arm. |
+| `per_task_budget_usd` | no | float | Override per-task USD ceiling for this arm. |
+| `prompt_file` | no | path | TOML config file overlaid on defaults for this arm. |
+| `extra_args` | no | list of strings | Additional CLI args forwarded to the arm sweep (parsed as overrides). |
+
+## Output artifacts
+
+After a run, the output directory contains:
+
+```
+{output}/
+  matrix.json           ← machine-readable state (written before every arm, updated after)
+  matrix-summary.json   ← ranked summary of all arms
+  matrix-summary.txt    ← human-readable ranked table
+  {arm_name}/           ← standard sweep artifacts (results.json, trajectories, …)
+    results.json
+    *.traj.json
+  …
+```
+
+### `matrix.json`
+
+```json
+{
+  "artifact_kind": "matrix",
+  "config_path": "matrix.toml",
+  "instance_ids": ["django__django-1234", "…"],
+  "filter_spec": { "original_count": 500, "selected_count": 50, "seed": 42 },
+  "cost_limit_usd": 20.0,
+  "arms": [
+    { "name": "baseline", "model": "claude-opus-4-7", "state": "complete",
+      "sweep_dir": "runs/matrix-2025-01/baseline",
+      "total_cost_usd": 7.32, "resolved": 12, "submitted": 18 },
+    { "name": "tuned", "model": "claude-sonnet-4-6", "state": "skipped_budget",
+      "sweep_dir": "runs/matrix-2025-01/tuned",
+      "total_cost_usd": 0.0, "resolved": 0, "submitted": 0 }
+  ]
+}
+```
+
+#### Arm states
+
+| State | Meaning |
+| --- | --- |
+| `pending` | Not yet started. |
+| `running` | Currently executing. |
+| `complete` | Sweep finished (regardless of individual instance outcomes). |
+| `skipped_budget` | Shared cost limit was already reached; arm was not started. |
+| `not_started` | Ctrl-C abort arrived before this arm began. |
+| `cancelled` | Arm was in-flight when a Ctrl-C abort arrived. |
+
+### `matrix-summary.json`
+
+```json
+{
+  "arms": [
+    {
+      "rank": 1,
+      "name": "tuned",
+      "model": "claude-sonnet-4-6",
+      "state": "complete",
+      "resolved": 15,
+      "resolved_rate": 0.30,
+      "total_cost_usd": 8.12,
+      "cost_per_resolved_usd": 0.5413,
+      "delta_resolved_rate_pp": 0.0,
+      "delta_cost_per_resolved_usd": 0.0
+    },
+    {
+      "rank": 2,
+      "name": "baseline",
+      "model": "claude-opus-4-7",
+      "state": "complete",
+      "resolved": 12,
+      "resolved_rate": 0.24,
+      "total_cost_usd": 7.32,
+      "cost_per_resolved_usd": 0.61,
+      "delta_resolved_rate_pp": -6.0,
+      "delta_cost_per_resolved_usd": 0.0687
+    }
+  ]
+}
+```
+
+Arms are ranked by resolved rate descending (ties broken by lower total cost).
+`skipped_budget` and other incomplete arms appear after all complete arms.
+`delta_*` fields are relative to the rank-1 arm.
+
+## Budget enforcement
+
+The `--sweep-cost-limit-usd` ceiling is **shared** across all arms and tracked
+cumulatively. The check fires *before* each arm starts:
+
+1. If `cumulative_cost_so_far >= limit`, the arm is marked `skipped_budget` and
+   the runner moves to the next arm.
+2. There is no mid-arm interruption — once an arm starts, it runs to completion
+   (or until its own per-task budget is exhausted).
+
+## Resume behaviour
+
+`--resume` loads the existing `matrix.json` and skips any arm whose state is
+`complete` or `skipped_budget`. All other arms (including `running` arms that
+were interrupted by a crash) are re-run from the beginning. The instance set is
+re-resolved from the manifest parameters on every invocation so that the
+`--seed`/`--sample` selection is always reproducible even after a crash.
+
+## Instance set consistency
+
+The instance set is resolved **once** before any arm runs:
+
+1. Load the dataset from `--dataset-path` or the named alias.
+2. Apply `--instance-ids` / `--sample` / `--limit` filters.
+3. Persist the final list of instance IDs in `matrix.json`.
+4. Pass exactly those IDs to every arm sweep via `--instance-ids`.
+
+This guarantees every arm evaluates the identical workload regardless of any
+non-determinism in the dataset loading path.
+
+## Graceful abort (Ctrl-C)
+
+When a cancellation signal arrives:
+
+- The in-flight arm is allowed to finish its current in-flight tasks (up to
+  `--cancel-deadline-secs`; default 60 s).
+- Arms that had not yet started are marked `not_started` in `matrix.json`.
+- `--resume` can restart the experiment from where it left off.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -290,6 +290,72 @@ pub enum BenchCmd {
     Reproduce(ReproduceCmd),
     /// Export or verify a portable, redacted sweep archive.
     Bundle(BundleCmd),
+    /// Run multiple sweep arms against the same instance set.
+    Matrix(MatrixCmd),
+}
+
+#[derive(Debug, Args)]
+pub struct MatrixCmd {
+    /// Path to the TOML matrix manifest with `[[arm]]` entries.
+    #[arg(long)]
+    pub config: PathBuf,
+
+    /// Local JSONL dataset file. Mutually exclusive with `--dataset`.
+    #[arg(long)]
+    pub dataset_path: Option<PathBuf>,
+
+    /// Named SWE-bench dataset alias (e.g. `verified`). Alternative to `--dataset-path`.
+    #[arg(long, value_name = "ALIAS")]
+    pub dataset: Option<String>,
+
+    /// Dataset split for named aliases: `train`, `test`, or `dev`.
+    #[arg(long, default_value = "test")]
+    pub split: Option<String>,
+
+    /// Directory for the named-dataset on-disk cache.
+    #[arg(long)]
+    pub dataset_cache_dir: Option<PathBuf>,
+
+    /// Root output directory (arm results land in `{output}/{arm_name}/`).
+    #[arg(long)]
+    pub output: PathBuf,
+
+    /// Shared USD ceiling across all arms. Arms that would start after the
+    /// limit is reached are recorded as `skipped_budget`.
+    #[arg(long)]
+    pub sweep_cost_limit_usd: Option<f64>,
+
+    /// Number of arms to run concurrently (default: 1 = sequential).
+    #[arg(long, default_value_t = 1)]
+    pub matrix_parallelism: usize,
+
+    /// Resume from a previous run, skipping `complete` and `skipped_budget` arms.
+    #[arg(long, default_value_t = false)]
+    pub resume: bool,
+
+    /// Keep at most N instances after filtering and sampling.
+    #[arg(long)]
+    pub limit: Option<usize>,
+
+    /// Reproducibly random-subset to N instances (requires `--seed`).
+    #[arg(long)]
+    pub sample: Option<usize>,
+
+    /// RNG seed used by `--sample`.
+    #[arg(long)]
+    pub seed: Option<u64>,
+
+    /// Worker parallelism per arm sweep.
+    #[arg(long, default_value_t = crate::run::swebench::DEFAULT_PARALLEL)]
+    pub parallel: usize,
+
+    /// Skip startup preflight checks before launching arm sweeps.
+    #[arg(long, default_value_t = false)]
+    pub skip_preflight: bool,
+
+    /// Skip model-endpoint probe during preflight.
+    #[arg(long, default_value_t = false)]
+    pub skip_model_probe: bool,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -333,6 +333,11 @@ pub struct MatrixCmd {
     #[arg(long, default_value_t = false)]
     pub resume: bool,
 
+    /// Dataset subset selector. Either a comma-separated id list
+    /// (`id1,id2`) or `@path/to/file.txt` with one id per line.
+    #[arg(long)]
+    pub instance_ids: Option<String>,
+
     /// Keep at most N instances after filtering and sampling.
     #[arg(long)]
     pub limit: Option<usize>,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -356,6 +356,10 @@ pub struct MatrixCmd {
     /// Skip model-endpoint probe during preflight.
     #[arg(long, default_value_t = false)]
     pub skip_model_probe: bool,
+
+    /// Seconds each arm sweep waits for in-flight tasks after a cancel signal.
+    #[arg(long, default_value_t = 60)]
+    pub cancel_deadline_secs: u64,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -345,6 +345,14 @@ pub struct MatrixCmd {
     #[arg(long)]
     pub seed: Option<u64>,
 
+    /// Stratify `--sample` by key.
+    #[arg(long, value_enum)]
+    pub stratify_by: Option<StratifyByArg>,
+
+    /// Allocation mode used with `--stratify-by`.
+    #[arg(long, value_enum)]
+    pub stratify_mode: Option<StratifyModeArg>,
+
     /// Worker parallelism per arm sweep.
     #[arg(long, default_value_t = crate::run::swebench::DEFAULT_PARALLEL)]
     pub parallel: usize,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1550,8 +1550,16 @@ async fn bench_matrix(m: args::MatrixCmd) -> Result<(), Error> {
         limit: m.limit,
         sample: m.sample,
         seed: m.seed,
-        stratify_by: None,
-        stratify_mode: crate::run::swebench::StratifyMode::Proportional,
+        stratify_by: m.stratify_by.map(|v| match v {
+            args::StratifyByArg::Repo => crate::run::swebench::StratifyBy::Repo,
+        }),
+        stratify_mode: match m
+            .stratify_mode
+            .unwrap_or(args::StratifyModeArg::Proportional)
+        {
+            args::StratifyModeArg::Proportional => crate::run::swebench::StratifyMode::Proportional,
+            args::StratifyModeArg::Balanced => crate::run::swebench::StratifyMode::Balanced,
+        },
         sweep_cost_limit_usd: m.sweep_cost_limit_usd,
         matrix_parallelism: m.matrix_parallelism,
         resume: m.resume,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1560,7 +1560,7 @@ async fn bench_matrix(m: args::MatrixCmd) -> Result<(), Error> {
         skip_model_probe: m.skip_model_probe,
         deterministic_responses: None,
         deterministic_usage_per_call: None,
-        cancel_deadline_secs: 60,
+        cancel_deadline_secs: m.cancel_deadline_secs,
         install_os_signal_handlers: true,
     };
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -99,6 +99,9 @@ pub async fn run() -> Result<(), Error> {
         Command::Bench {
             cmd: args::BenchCmd::Bundle(b),
         } => bench_bundle(b),
+        Command::Bench {
+            cmd: args::BenchCmd::Matrix(m),
+        } => Box::pin(bench_matrix(m)).await,
         #[cfg(feature = "docker")]
         Command::Cleanup => cleanup_cmd().await,
         #[cfg(not(feature = "docker"))]
@@ -1506,6 +1509,77 @@ fn bench_bundle(b: args::BundleCmd) -> Result<(), Error> {
         }
         Err(err) => Err(bundle_error_to_error(err)),
     }
+}
+
+async fn bench_matrix(m: args::MatrixCmd) -> Result<(), Error> {
+    let cache_dir = m
+        .dataset_cache_dir
+        .clone()
+        .unwrap_or_else(crate::run::dataset::default_cache_dir);
+
+    let dataset_source = match (&m.dataset_path, &m.dataset) {
+        (Some(_), Some(_)) => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(
+                "--dataset-path and --dataset are mutually exclusive; provide only one".into(),
+            )));
+        }
+        (None, None) => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(
+                "one of --dataset-path or --dataset is required".into(),
+            )));
+        }
+        (Some(path), None) => crate::run::dataset::DatasetSource::LocalPath(path.clone()),
+        (None, Some(alias_str)) => {
+            let alias = alias_str
+                .parse::<crate::run::dataset::SwebenchAlias>()
+                .map_err(|e| Error::Config(crate::error::ConfigError::Invalid(e)))?;
+            let split_str = m.split.as_deref().unwrap_or("test");
+            let split = split_str
+                .parse::<crate::run::dataset::SwebenchSplit>()
+                .map_err(|e| Error::Config(crate::error::ConfigError::Invalid(e)))?;
+            crate::run::dataset::DatasetSource::Named { alias, split }
+        }
+    };
+
+    let matrix_args = crate::run::matrix::MatrixArgs {
+        config_path: m.config,
+        dataset_source,
+        dataset_cache_dir: cache_dir,
+        output_dir: m.output,
+        instance_ids: None,
+        limit: m.limit,
+        sample: m.sample,
+        seed: m.seed,
+        stratify_by: None,
+        stratify_mode: crate::run::swebench::StratifyMode::Proportional,
+        sweep_cost_limit_usd: m.sweep_cost_limit_usd,
+        matrix_parallelism: m.matrix_parallelism,
+        resume: m.resume,
+        parallel: m.parallel,
+        skip_preflight: m.skip_preflight,
+        skip_model_probe: m.skip_model_probe,
+        deterministic_responses: None,
+        deterministic_usage_per_call: None,
+        cancel_deadline_secs: 60,
+        install_os_signal_handlers: true,
+    };
+
+    let summary = crate::run::matrix::run(matrix_args).await?;
+
+    println!("=== bench matrix ===");
+    for arm in &summary.arms {
+        println!(
+            "  [{rank}] {name}  model={model}  state={state}  resolved={resolved}  \
+             cost=${cost:.4}",
+            rank = arm.rank,
+            name = arm.name,
+            model = arm.model,
+            state = arm.state,
+            resolved = arm.resolved,
+            cost = arm.total_cost_usd,
+        );
+    }
+    Ok(())
 }
 
 fn bundle_error_to_error(err: crate::run::bundle::BundleError) -> Error {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1546,7 +1546,7 @@ async fn bench_matrix(m: args::MatrixCmd) -> Result<(), Error> {
         dataset_source,
         dataset_cache_dir: cache_dir,
         output_dir: m.output,
-        instance_ids: None,
+        instance_ids: m.instance_ids,
         limit: m.limit,
         sample: m.sample,
         seed: m.seed,

--- a/src/run/matrix.rs
+++ b/src/run/matrix.rs
@@ -230,7 +230,6 @@ pub async fn run(args: MatrixArgs) -> Result<MatrixSummary, Error> {
         .iter()
         .map(|i| i.instance_id.clone())
         .collect();
-    let instance_ids_csv = instance_ids.join(",");
 
     std::fs::create_dir_all(&args.output_dir)?;
     let state_path = args.output_dir.join("matrix.json");
@@ -279,6 +278,10 @@ pub async fn run(args: MatrixArgs) -> Result<MatrixSummary, Error> {
         }
     };
     write_matrix_state(&state_path, &state)?;
+
+    // Derive the arm instance list from the authoritative state (persisted on
+    // resume, freshly resolved on a new run) so all arms see a consistent workload.
+    let instance_ids_csv = state.instance_ids.join(",");
 
     // Cumulative cost starts from arms already complete (resume scenario).
     let mut cumulative_cost: f64 = state

--- a/src/run/matrix.rs
+++ b/src/run/matrix.rs
@@ -17,7 +17,7 @@ use crate::error::{ConfigError, Error};
 use crate::model::ModelUsage;
 use crate::run::dataset::DatasetSource;
 use crate::run::swebench::{
-    ApplySubsetParams, FilterSpec, StratifyBy, StratifyMode, apply_subset,
+    ApplySubsetParams, FilterSpec, SWEEP_STATUS_CANCELLED, StratifyBy, StratifyMode, apply_subset,
     load_dataset_from_bytes_pub,
 };
 
@@ -162,6 +162,22 @@ pub struct MatrixSummary {
     pub arms: Vec<ArmSummaryRow>,
 }
 
+// ── Private arm-run context ───────────────────────────────────────────────────
+
+/// Everything `run_arm` needs; cloneable so concurrent tasks can own their copy.
+#[derive(Clone)]
+struct ArmRunCtx {
+    dataset_source: DatasetSource,
+    dataset_cache_dir: PathBuf,
+    parallel: usize,
+    skip_preflight: bool,
+    skip_model_probe: bool,
+    cancel_deadline_secs: u64,
+    install_os_signal_handlers: bool,
+    deterministic_responses: Option<Vec<String>>,
+    deterministic_usage_per_call: Option<ModelUsage>,
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /// Validate arm definitions before running.
@@ -234,13 +250,6 @@ pub async fn run(args: MatrixArgs) -> Result<MatrixSummary, Error> {
     std::fs::create_dir_all(&args.output_dir)?;
     let state_path = args.output_dir.join("matrix.json");
 
-    if args.matrix_parallelism > 1 {
-        return Err(Error::Config(ConfigError::Invalid(format!(
-            "--matrix-parallelism {} is not yet supported; use --matrix-parallelism 1 (sequential)",
-            args.matrix_parallelism
-        ))));
-    }
-
     // Load or create matrix state.
     let mut state = if args.resume && state_path.exists() {
         let text = std::fs::read_to_string(&state_path)?;
@@ -291,43 +300,126 @@ pub async fn run(args: MatrixArgs) -> Result<MatrixSummary, Error> {
         .map(|a| a.total_cost_usd)
         .sum();
 
-    for i in 0..manifest.arms.len() {
-        // Skip arms that are already in a terminal state.
-        match state.arms[i].state {
-            ArmState::Complete | ArmState::SkippedBudget => continue,
-            _ => {}
+    let ctx = ArmRunCtx {
+        dataset_source: args.dataset_source.clone(),
+        dataset_cache_dir: args.dataset_cache_dir.clone(),
+        parallel: args.parallel,
+        skip_preflight: args.skip_preflight,
+        skip_model_probe: args.skip_model_probe,
+        cancel_deadline_secs: args.cancel_deadline_secs,
+        install_os_signal_handlers: args.install_os_signal_handlers,
+        deterministic_responses: args.deterministic_responses.clone(),
+        deterministic_usage_per_call: args.deterministic_usage_per_call.clone(),
+    };
+
+    // Run arms with up to `matrix_parallelism` concurrent arm sweeps.
+    //
+    // Each arm task owns its data (cloned from the manifest), so the tasks are
+    // `'static` and safe to spawn into a `JoinSet`.  For N=1 the loop is
+    // effectively sequential; N>1 fills `N` slots concurrently then refills as
+    // completions arrive.  Ctrl-C is handled by each arm's own OS-signal
+    // machinery: when an arm returns with `sweep_status == "cancelled"` the
+    // matrix stops launching new arms, drains any already-in-flight ones, and
+    // marks the remaining pending arms `not_started`.
+    let mut next_to_launch = 0usize;
+    let mut cancelled = false;
+    let mut join_set: tokio::task::JoinSet<(
+        usize,
+        Result<crate::run::swebench::SweepResults, Error>,
+    )> = tokio::task::JoinSet::new();
+
+    loop {
+        // Fill available parallelism slots with new arms.
+        while !cancelled && join_set.len() < args.matrix_parallelism {
+            // Advance past arms already in a terminal state (resume or prior iteration).
+            while next_to_launch < manifest.arms.len()
+                && matches!(
+                    state.arms[next_to_launch].state,
+                    ArmState::Complete | ArmState::SkippedBudget
+                )
+            {
+                next_to_launch += 1;
+            }
+            if next_to_launch >= manifest.arms.len() {
+                break;
+            }
+            let i = next_to_launch;
+            next_to_launch += 1;
+
+            // Budget guard: mark this arm and all remaining pending arms skipped.
+            if let Some(limit) = args.sweep_cost_limit_usd {
+                if cumulative_cost >= limit {
+                    for j in i..manifest.arms.len() {
+                        if state.arms[j].state == ArmState::Pending {
+                            state.arms[j].state = ArmState::SkippedBudget;
+                        }
+                    }
+                    write_matrix_state(&state_path, &state)?;
+                    break;
+                }
+            }
+
+            let arm_def = manifest.arms[i].clone();
+            let arm_sweep_dir = args.output_dir.join(&arm_def.name);
+            std::fs::create_dir_all(&arm_sweep_dir)?;
+
+            state.arms[i].state = ArmState::Running;
+            write_matrix_state(&state_path, &state)?;
+
+            let ids_csv = instance_ids_csv.clone();
+            let ctx_clone = ctx.clone();
+            join_set.spawn(async move {
+                (i, run_arm(arm_def, arm_sweep_dir, ids_csv, ctx_clone).await)
+            });
         }
 
-        // Budget guard: mark remaining arms skipped when limit is exhausted.
-        if let Some(limit) = args.sweep_cost_limit_usd {
-            if cumulative_cost >= limit {
-                state.arms[i].state = ArmState::SkippedBudget;
+        // Nothing running and nothing queued → done.
+        if join_set.is_empty() {
+            break;
+        }
+
+        // Wait for the next arm to finish.
+        match join_set.join_next().await {
+            None => break,
+            Some(Err(join_err)) => {
+                return Err(Error::Io(std::io::Error::other(format!(
+                    "arm task panicked: {join_err}"
+                ))));
+            }
+            Some(Ok((_arm_idx, Err(e)))) => return Err(e),
+            Some(Ok((arm_idx, Ok(results)))) => {
+                let resolved: usize = results
+                    .instances
+                    .iter()
+                    .map(|r| r.resolved_count as usize)
+                    .sum();
+                cumulative_cost += results.estimated_cost_usd;
+
+                // An arm reports "cancelled" when it received a Ctrl-C / SIGTERM.
+                // Stop launching new arms; let already-in-flight ones drain.
+                if cancelled || results.sweep_status == SWEEP_STATUS_CANCELLED {
+                    state.arms[arm_idx].state = ArmState::Cancelled;
+                    if results.sweep_status == SWEEP_STATUS_CANCELLED {
+                        cancelled = true;
+                    }
+                } else {
+                    state.arms[arm_idx].state = ArmState::Complete;
+                }
+                state.arms[arm_idx].total_cost_usd = results.estimated_cost_usd;
+                state.arms[arm_idx].submitted = results.submitted;
+                state.arms[arm_idx].resolved = resolved;
                 write_matrix_state(&state_path, &state)?;
-                continue;
             }
         }
+    }
 
-        let arm_def = &manifest.arms[i];
-        let arm_sweep_dir = args.output_dir.join(&arm_def.name);
-        std::fs::create_dir_all(&arm_sweep_dir)?;
-
-        state.arms[i].state = ArmState::Running;
-        write_matrix_state(&state_path, &state)?;
-
-        let arm_results = run_arm(arm_def, &arm_sweep_dir, &instance_ids_csv, &args).await?;
-
-        let resolved: usize = arm_results
-            .instances
-            .iter()
-            .map(|r| r.resolved_count as usize)
-            .sum();
-
-        cumulative_cost += arm_results.estimated_cost_usd;
-        state.arms[i].state = ArmState::Complete;
-        state.arms[i].total_cost_usd = arm_results.estimated_cost_usd;
-        state.arms[i].submitted = arm_results.submitted;
-        state.arms[i].resolved = resolved;
-
+    // Mark arms that were queued but never launched as not_started.
+    if cancelled {
+        for arm_status in &mut state.arms {
+            if arm_status.state == ArmState::Pending {
+                arm_status.state = ArmState::NotStarted;
+            }
+        }
         write_matrix_state(&state_path, &state)?;
     }
 
@@ -352,10 +444,10 @@ pub async fn run(args: MatrixArgs) -> Result<MatrixSummary, Error> {
 // ── Private helpers ───────────────────────────────────────────────────────────
 
 async fn run_arm(
-    arm: &ArmDef,
-    arm_sweep_dir: &Path,
-    instance_ids_csv: &str,
-    matrix_args: &MatrixArgs,
+    arm: ArmDef,
+    arm_sweep_dir: PathBuf,
+    instance_ids_csv: String,
+    ctx: ArmRunCtx,
 ) -> Result<crate::run::swebench::SweepResults, Error> {
     // Load prompt_file first so explicit arm-manifest fields override it.
     let mut cfg = if let Some(ref prompt_file) = arm.prompt_file {
@@ -373,16 +465,16 @@ async fn run_arm(
     }
 
     let arm_args = crate::run::swebench::SwebenchArgs {
-        dataset_source: matrix_args.dataset_source.clone(),
-        dataset_cache_dir: matrix_args.dataset_cache_dir.clone(),
-        output_dir: arm_sweep_dir.to_path_buf(),
-        parallel: matrix_args.parallel,
+        dataset_source: ctx.dataset_source,
+        dataset_cache_dir: ctx.dataset_cache_dir,
+        output_dir: arm_sweep_dir,
+        parallel: ctx.parallel,
         config: cfg,
         reruns: 1,
         resume: false,
         cost_limit_usd: None,
         task_timeout_secs: None,
-        instance_ids: Some(instance_ids_csv.to_owned()),
+        instance_ids: Some(instance_ids_csv),
         limit: None,
         sample: None,
         seed: None,
@@ -393,21 +485,21 @@ async fn run_arm(
         retry_backoff_base_ms: 1000,
         retry_backoff_cap_s: 60,
         retry_on_resume: false,
-        deterministic_responses: matrix_args.deterministic_responses.clone(),
-        deterministic_usage_per_call: matrix_args.deterministic_usage_per_call.clone(),
+        deterministic_responses: ctx.deterministic_responses,
+        deterministic_usage_per_call: ctx.deterministic_usage_per_call,
         config_overlay_paths: vec![],
         dry_run: false,
-        skip_preflight: matrix_args.skip_preflight,
+        skip_preflight: ctx.skip_preflight,
         preflight_format: "text".into(),
-        skip_model_probe: matrix_args.skip_model_probe,
+        skip_model_probe: ctx.skip_model_probe,
         preflight_check_timeout_s: 30,
         preflight_total_timeout_s: 120,
         preflight_mode: "sweep".into(),
         skip_patch_validation: false,
         max_rpm: None,
         max_input_tpm: None,
-        cancel_deadline_secs: matrix_args.cancel_deadline_secs,
-        install_os_signal_handlers: matrix_args.install_os_signal_handlers,
+        cancel_deadline_secs: ctx.cancel_deadline_secs,
+        install_os_signal_handlers: ctx.install_os_signal_handlers,
         cancellation_signals: None,
         github_pr: None,
         reproduced_from: None,

--- a/src/run/matrix.rs
+++ b/src/run/matrix.rs
@@ -235,10 +235,27 @@ pub async fn run(args: MatrixArgs) -> Result<MatrixSummary, Error> {
     std::fs::create_dir_all(&args.output_dir)?;
     let state_path = args.output_dir.join("matrix.json");
 
+    if args.matrix_parallelism > 1 {
+        return Err(Error::Config(ConfigError::Invalid(format!(
+            "--matrix-parallelism {} is not yet supported; use --matrix-parallelism 1 (sequential)",
+            args.matrix_parallelism
+        ))));
+    }
+
     // Load or create matrix state.
     let mut state = if args.resume && state_path.exists() {
         let text = std::fs::read_to_string(&state_path)?;
-        serde_json::from_str::<MatrixState>(&text)?
+        let loaded: MatrixState = serde_json::from_str(&text)?;
+        // Warn when the resolved instance set differs from the persisted one.
+        if loaded.instance_ids != instance_ids {
+            tracing::warn!(
+                persisted = loaded.instance_ids.len(),
+                resolved = instance_ids.len(),
+                "resume: resolved instance set differs from persisted matrix.json; \
+                 using persisted list to maintain arm consistency"
+            );
+        }
+        loaded
     } else {
         MatrixState {
             artifact_kind: "matrix".into(),
@@ -337,16 +354,19 @@ async fn run_arm(
     instance_ids_csv: &str,
     matrix_args: &MatrixArgs,
 ) -> Result<crate::run::swebench::SweepResults, Error> {
-    let mut cfg = Config::defaults().map_err(Error::Config)?;
+    // Load prompt_file first so explicit arm-manifest fields override it.
+    let mut cfg = if let Some(ref prompt_file) = arm.prompt_file {
+        Config::load(prompt_file).map_err(Error::Config)?
+    } else {
+        Config::defaults().map_err(Error::Config)?
+    };
+    // Arm manifest values take precedence over anything in prompt_file.
     cfg.root.model.name.clone_from(&arm.model);
-    cfg.root.agent.step_limit = arm.step_limit.unwrap_or(cfg.root.agent.step_limit);
+    if let Some(step_limit) = arm.step_limit {
+        cfg.root.agent.step_limit = step_limit;
+    }
     if let Some(budget) = arm.per_task_budget_usd {
         cfg.root.agent.per_task_budget_usd = Some(budget);
-    }
-    if let Some(ref prompt_file) = arm.prompt_file {
-        let overlay = Config::load(prompt_file).map_err(Error::Config)?;
-        cfg.root.agent = overlay.root.agent;
-        cfg.root.model = overlay.root.model;
     }
 
     let arm_args = crate::run::swebench::SwebenchArgs {

--- a/src/run/matrix.rs
+++ b/src/run/matrix.rs
@@ -1,0 +1,506 @@
+//! `bench matrix`: run multiple sweep arms against the same instance set.
+//!
+//! Each arm in the TOML manifest is a distinct (model, config) pair. All arms
+//! run against the same deterministically-selected instances so results are
+//! directly comparable. A shared budget ceiling is enforced: once cumulative
+//! cost across completed arms meets the limit, remaining arms are recorded as
+//! `skipped_budget`.
+
+use std::collections::HashSet;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::Config;
+use crate::error::{ConfigError, Error};
+use crate::model::ModelUsage;
+use crate::run::dataset::DatasetSource;
+use crate::run::swebench::{
+    ApplySubsetParams, FilterSpec, StratifyBy, StratifyMode, apply_subset,
+    load_dataset_from_bytes_pub,
+};
+
+// ── TOML manifest ─────────────────────────────────────────────────────────────
+
+/// Top-level matrix manifest parsed from the TOML config file.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MatrixManifest {
+    /// The `[[arm]]` array of tables from the TOML file.
+    #[serde(rename = "arm", default)]
+    pub arms: Vec<ArmDef>,
+}
+
+/// One arm definition in the matrix manifest.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ArmDef {
+    pub name: String,
+    pub model: String,
+    pub step_limit: Option<u32>,
+    pub per_task_budget_usd: Option<f64>,
+    pub prompt_file: Option<PathBuf>,
+    #[serde(default)]
+    pub extra_args: Vec<String>,
+}
+
+// ── Runtime args ──────────────────────────────────────────────────────────────
+
+#[allow(clippy::struct_excessive_bools)]
+pub struct MatrixArgs {
+    /// Path to the TOML matrix manifest.
+    pub config_path: PathBuf,
+    /// Dataset source for all arms.
+    pub dataset_source: DatasetSource,
+    /// Directory for the named-dataset cache (unused for local paths).
+    pub dataset_cache_dir: PathBuf,
+    /// Root output directory. Arm results land in `{output_dir}/{arm_name}/`.
+    pub output_dir: PathBuf,
+    /// Optional comma-separated instance ID filter applied before sampling.
+    pub instance_ids: Option<String>,
+    /// Keep at most N instances after filtering and sampling.
+    pub limit: Option<usize>,
+    /// Reproducibly random-subset to N instances (requires `seed`).
+    pub sample: Option<usize>,
+    /// RNG seed used by `sample`.
+    pub seed: Option<u64>,
+    /// Optional stratification key used during sampling.
+    pub stratify_by: Option<StratifyBy>,
+    /// Allocation mode used with stratification.
+    pub stratify_mode: StratifyMode,
+    /// Shared USD ceiling across all arms. Arms that would start after the
+    /// limit is reached are recorded as `skipped_budget`.
+    pub sweep_cost_limit_usd: Option<f64>,
+    /// Number of arms to run concurrently (default: 1 = sequential).
+    pub matrix_parallelism: usize,
+    /// When true, load existing `matrix.json` and skip `complete` arms.
+    pub resume: bool,
+    /// Worker parallelism passed to each arm's sweep.
+    pub parallel: usize,
+    pub skip_preflight: bool,
+    pub skip_model_probe: bool,
+    /// Scripted model responses injected into every arm (tests / smoke checks).
+    pub deterministic_responses: Option<Vec<String>>,
+    /// Fixed token usage reported by the scripted backend (tests only).
+    pub deterministic_usage_per_call: Option<ModelUsage>,
+    /// Seconds each arm sweep waits for in-flight tasks after a cancel signal.
+    pub cancel_deadline_secs: u64,
+    /// Install OS signal handlers (disable in tests to avoid handler conflicts).
+    pub install_os_signal_handlers: bool,
+}
+
+// ── Internal state (matrix.json) ─────────────────────────────────────────────
+
+/// Persisted state of a single arm.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArmState {
+    Pending,
+    Running,
+    Complete,
+    SkippedBudget,
+    NotStarted,
+    Cancelled,
+}
+
+impl ArmState {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Complete => "complete",
+            Self::SkippedBudget => "skipped_budget",
+            Self::NotStarted => "not_started",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ArmStatus {
+    name: String,
+    model: String,
+    state: ArmState,
+    sweep_dir: String,
+    total_cost_usd: f64,
+    resolved: usize,
+    submitted: usize,
+}
+
+/// Written to `{output}/matrix.json` before any arm runs, updated after each.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MatrixState {
+    artifact_kind: String,
+    config_path: String,
+    instance_ids: Vec<String>,
+    filter_spec: FilterSpec,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cost_limit_usd: Option<f64>,
+    arms: Vec<ArmStatus>,
+}
+
+// ── Output summary ────────────────────────────────────────────────────────────
+
+/// One row in the ranked matrix summary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArmSummaryRow {
+    pub rank: usize,
+    pub name: String,
+    pub model: String,
+    pub state: String,
+    pub resolved: usize,
+    pub resolved_rate: f64,
+    pub total_cost_usd: f64,
+    pub cost_per_resolved_usd: f64,
+    /// Resolved-rate difference from rank-1 arm, in percentage points.
+    pub delta_resolved_rate_pp: f64,
+    pub delta_cost_per_resolved_usd: f64,
+}
+
+/// Returned by `run`; also written to `{output}/matrix-summary.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MatrixSummary {
+    pub arms: Vec<ArmSummaryRow>,
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Validate arm definitions before running.
+///
+/// Rules: at least one arm, all names non-empty, no path separators, unique.
+pub fn validate_arms(arms: &[ArmDef]) -> Result<(), Error> {
+    if arms.is_empty() {
+        return Err(Error::Config(ConfigError::Invalid(
+            "matrix manifest must have at least one arm".into(),
+        )));
+    }
+
+    for arm in arms {
+        if arm.name.is_empty() {
+            return Err(Error::Config(ConfigError::Invalid(
+                "arm name cannot be empty".into(),
+            )));
+        }
+        if arm.name.contains('/') || arm.name.contains('\\') || arm.name.contains("..") {
+            return Err(Error::Config(ConfigError::Invalid(format!(
+                "arm name {:?} must not contain path separators or `..`",
+                arm.name
+            ))));
+        }
+    }
+
+    let mut seen: HashSet<&str> = HashSet::new();
+    for arm in arms {
+        if !seen.insert(arm.name.as_str()) {
+            return Err(Error::Config(ConfigError::Invalid(format!(
+                "duplicate arm name: {:?}",
+                arm.name
+            ))));
+        }
+    }
+
+    Ok(())
+}
+
+/// Run the full matrix experiment and return a ranked summary.
+pub async fn run(args: MatrixArgs) -> Result<MatrixSummary, Error> {
+    // Load and validate manifest.
+    let manifest_text = std::fs::read_to_string(&args.config_path)?;
+    let manifest: MatrixManifest = toml::from_str(&manifest_text)
+        .map_err(|e| Error::Config(ConfigError::Invalid(format!("matrix manifest: {e}"))))?;
+    validate_arms(&manifest.arms)?;
+
+    // Resolve the shared instance list once (before any arm runs).
+    let (dataset_bytes, _dataset_meta) =
+        crate::run::dataset::resolve_dataset(&args.dataset_source, &args.dataset_cache_dir)?;
+    let all_instances = load_dataset_from_bytes_pub(&dataset_bytes)?;
+    let (selected_instances, filter_spec) = apply_subset(
+        all_instances,
+        &ApplySubsetParams {
+            instance_ids_arg: args.instance_ids.as_deref(),
+            limit: args.limit,
+            sample: args.sample,
+            seed: args.seed,
+            stratify_by: args.stratify_by,
+            stratify_mode: args.stratify_mode,
+        },
+    )?;
+
+    let instance_ids: Vec<String> =
+        selected_instances.iter().map(|i| i.instance_id.clone()).collect();
+    let instance_ids_csv = instance_ids.join(",");
+
+    std::fs::create_dir_all(&args.output_dir)?;
+    let state_path = args.output_dir.join("matrix.json");
+
+    // Load or create matrix state.
+    let mut state = if args.resume && state_path.exists() {
+        let text = std::fs::read_to_string(&state_path)?;
+        serde_json::from_str::<MatrixState>(&text)?
+    } else {
+        MatrixState {
+            artifact_kind: "matrix".into(),
+            config_path: args.config_path.display().to_string(),
+            instance_ids: instance_ids.clone(),
+            filter_spec,
+            cost_limit_usd: args.sweep_cost_limit_usd,
+            arms: manifest
+                .arms
+                .iter()
+                .map(|arm| ArmStatus {
+                    name: arm.name.clone(),
+                    model: arm.model.clone(),
+                    state: ArmState::Pending,
+                    sweep_dir: args.output_dir.join(&arm.name).display().to_string(),
+                    total_cost_usd: 0.0,
+                    resolved: 0,
+                    submitted: 0,
+                })
+                .collect(),
+        }
+    };
+    write_matrix_state(&state_path, &state)?;
+
+    // Cumulative cost starts from arms already complete (resume scenario).
+    let mut cumulative_cost: f64 = state
+        .arms
+        .iter()
+        .filter(|a| a.state == ArmState::Complete)
+        .map(|a| a.total_cost_usd)
+        .sum();
+
+    for i in 0..manifest.arms.len() {
+        // Skip arms that are already in a terminal state.
+        match state.arms[i].state {
+            ArmState::Complete | ArmState::SkippedBudget => continue,
+            _ => {}
+        }
+
+        // Budget guard: mark remaining arms skipped when limit is exhausted.
+        if let Some(limit) = args.sweep_cost_limit_usd {
+            if cumulative_cost >= limit {
+                state.arms[i].state = ArmState::SkippedBudget;
+                write_matrix_state(&state_path, &state)?;
+                continue;
+            }
+        }
+
+        let arm_def = &manifest.arms[i];
+        let arm_sweep_dir = args.output_dir.join(&arm_def.name);
+        std::fs::create_dir_all(&arm_sweep_dir)?;
+
+        state.arms[i].state = ArmState::Running;
+        write_matrix_state(&state_path, &state)?;
+
+        let arm_results =
+            run_arm(arm_def, &arm_sweep_dir, &instance_ids_csv, &args).await?;
+
+        let resolved: usize = arm_results
+            .instances
+            .iter()
+            .map(|r| r.resolved_count as usize)
+            .sum();
+
+        cumulative_cost += arm_results.estimated_cost_usd;
+        state.arms[i].state = ArmState::Complete;
+        state.arms[i].total_cost_usd = arm_results.estimated_cost_usd;
+        state.arms[i].submitted = arm_results.submitted;
+        state.arms[i].resolved = resolved;
+
+        write_matrix_state(&state_path, &state)?;
+    }
+
+    // Build and persist summary.
+    let summary = build_summary(&state);
+
+    let summary_json = serde_json::to_string_pretty(&summary)?;
+    atomic_write(&args.output_dir.join("matrix-summary.json"), summary_json.as_bytes())?;
+
+    let summary_txt = render_summary_text(&summary, &state);
+    atomic_write(
+        &args.output_dir.join("matrix-summary.txt"),
+        summary_txt.as_bytes(),
+    )?;
+
+    Ok(summary)
+}
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+async fn run_arm(
+    arm: &ArmDef,
+    arm_sweep_dir: &Path,
+    instance_ids_csv: &str,
+    matrix_args: &MatrixArgs,
+) -> Result<crate::run::swebench::SweepResults, Error> {
+    let mut cfg = Config::defaults().map_err(Error::Config)?;
+    cfg.root.model.name.clone_from(&arm.model);
+    cfg.root.agent.step_limit = arm.step_limit.unwrap_or(cfg.root.agent.step_limit);
+    if let Some(budget) = arm.per_task_budget_usd {
+        cfg.root.agent.per_task_budget_usd = Some(budget);
+    }
+    if let Some(ref prompt_file) = arm.prompt_file {
+        let overlay = Config::load(prompt_file).map_err(Error::Config)?;
+        cfg.root.agent = overlay.root.agent;
+        cfg.root.model = overlay.root.model;
+    }
+
+    let arm_args = crate::run::swebench::SwebenchArgs {
+        dataset_source: matrix_args.dataset_source.clone(),
+        dataset_cache_dir: matrix_args.dataset_cache_dir.clone(),
+        output_dir: arm_sweep_dir.to_path_buf(),
+        parallel: matrix_args.parallel,
+        config: cfg,
+        reruns: 1,
+        resume: false,
+        cost_limit_usd: None,
+        task_timeout_secs: None,
+        instance_ids: Some(instance_ids_csv.to_owned()),
+        limit: None,
+        sample: None,
+        seed: None,
+        stratify_by: None,
+        stratify_mode: StratifyMode::Proportional,
+        max_retries: 0,
+        retry_on: None,
+        retry_backoff_base_ms: 1000,
+        retry_backoff_cap_s: 60,
+        retry_on_resume: false,
+        deterministic_responses: matrix_args.deterministic_responses.clone(),
+        deterministic_usage_per_call: matrix_args.deterministic_usage_per_call.clone(),
+        config_overlay_paths: vec![],
+        dry_run: false,
+        skip_preflight: matrix_args.skip_preflight,
+        preflight_format: "text".into(),
+        skip_model_probe: matrix_args.skip_model_probe,
+        preflight_check_timeout_s: 30,
+        preflight_total_timeout_s: 120,
+        preflight_mode: "sweep".into(),
+        skip_patch_validation: false,
+        max_rpm: None,
+        max_input_tpm: None,
+        cancel_deadline_secs: matrix_args.cancel_deadline_secs,
+        install_os_signal_handlers: matrix_args.install_os_signal_handlers,
+        cancellation_signals: None,
+        github_pr: None,
+        reproduced_from: None,
+        abort_on_systemic_failure: false,
+        systemic_failure_min_samples: 5,
+        systemic_failure_share_pct: 80,
+    };
+
+    crate::run::swebench::run(arm_args).await
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn build_summary(state: &MatrixState) -> MatrixSummary {
+    let n = state.instance_ids.len();
+
+    let mut rows: Vec<ArmSummaryRow> = state
+        .arms
+        .iter()
+        .map(|arm| {
+            let resolved_rate = if n > 0 {
+                arm.resolved as f64 / n as f64
+            } else {
+                0.0
+            };
+            let cost_per_resolved = if arm.resolved > 0 {
+                arm.total_cost_usd / arm.resolved as f64
+            } else {
+                0.0
+            };
+            ArmSummaryRow {
+                rank: 0, // assigned after sort
+                name: arm.name.clone(),
+                model: arm.model.clone(),
+                state: arm.state.as_str().to_owned(),
+                resolved: arm.resolved,
+                resolved_rate,
+                total_cost_usd: arm.total_cost_usd,
+                cost_per_resolved_usd: cost_per_resolved,
+                delta_resolved_rate_pp: 0.0,
+                delta_cost_per_resolved_usd: 0.0,
+            }
+        })
+        .collect();
+
+    // Rank: complete arms by resolved_rate descending, then by lower cost.
+    // Non-complete arms go after all complete arms.
+    rows.sort_by(|a, b| {
+        let a_complete = a.state == "complete";
+        let b_complete = b.state == "complete";
+        match (a_complete, b_complete) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => b
+                .resolved_rate
+                .partial_cmp(&a.resolved_rate)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(
+                    a.total_cost_usd
+                        .partial_cmp(&b.total_cost_usd)
+                        .unwrap_or(std::cmp::Ordering::Equal),
+                ),
+        }
+    });
+
+    // Assign contiguous ranks starting at 1.
+    for (i, row) in rows.iter_mut().enumerate() {
+        row.rank = i + 1;
+    }
+
+    // Compute deltas relative to rank-1 arm.
+    if let Some(best) = rows.first().cloned() {
+        for row in rows.iter_mut().skip(1) {
+            row.delta_resolved_rate_pp = (row.resolved_rate - best.resolved_rate) * 100.0;
+            row.delta_cost_per_resolved_usd =
+                row.cost_per_resolved_usd - best.cost_per_resolved_usd;
+        }
+    }
+
+    MatrixSummary { arms: rows }
+}
+
+fn render_summary_text(summary: &MatrixSummary, state: &MatrixState) -> String {
+    let n = state.instance_ids.len();
+    let mut s = String::from("=== bench matrix summary ===\n\n");
+    let _ = writeln!(
+        s,
+        "{:<4} {:<24} {:<24} {:<14} {:>8} {:>10} {:>10}",
+        "Rank", "Name", "Model", "State", "Resolved", "Rate%", "Cost($)"
+    );
+    s.push_str(&"-".repeat(100));
+    s.push('\n');
+
+    for row in &summary.arms {
+        let rate_pct = if n > 0 {
+            format!("{:.1}", row.resolved_rate * 100.0)
+        } else {
+            "N/A".into()
+        };
+        let _ = writeln!(
+            s,
+            "{:<4} {:<24} {:<24} {:<14} {:>8} {:>10} {:>10.4}",
+            row.rank,
+            row.name,
+            row.model,
+            row.state,
+            row.resolved,
+            rate_pct,
+            row.total_cost_usd
+        );
+    }
+    s
+}
+
+fn write_matrix_state(path: &Path, state: &MatrixState) -> Result<(), Error> {
+    let json = serde_json::to_string_pretty(state)?;
+    atomic_write(path, json.as_bytes())
+}
+
+fn atomic_write(path: &Path, data: &[u8]) -> Result<(), Error> {
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, data)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}

--- a/src/run/matrix.rs
+++ b/src/run/matrix.rs
@@ -202,6 +202,7 @@ pub fn validate_arms(arms: &[ArmDef]) -> Result<(), Error> {
 }
 
 /// Run the full matrix experiment and return a ranked summary.
+#[allow(clippy::too_many_lines)]
 pub async fn run(args: MatrixArgs) -> Result<MatrixSummary, Error> {
     // Load and validate manifest.
     let manifest_text = std::fs::read_to_string(&args.config_path)?;
@@ -225,8 +226,10 @@ pub async fn run(args: MatrixArgs) -> Result<MatrixSummary, Error> {
         },
     )?;
 
-    let instance_ids: Vec<String> =
-        selected_instances.iter().map(|i| i.instance_id.clone()).collect();
+    let instance_ids: Vec<String> = selected_instances
+        .iter()
+        .map(|i| i.instance_id.clone())
+        .collect();
     let instance_ids_csv = instance_ids.join(",");
 
     std::fs::create_dir_all(&args.output_dir)?;
@@ -291,8 +294,7 @@ pub async fn run(args: MatrixArgs) -> Result<MatrixSummary, Error> {
         state.arms[i].state = ArmState::Running;
         write_matrix_state(&state_path, &state)?;
 
-        let arm_results =
-            run_arm(arm_def, &arm_sweep_dir, &instance_ids_csv, &args).await?;
+        let arm_results = run_arm(arm_def, &arm_sweep_dir, &instance_ids_csv, &args).await?;
 
         let resolved: usize = arm_results
             .instances
@@ -313,7 +315,10 @@ pub async fn run(args: MatrixArgs) -> Result<MatrixSummary, Error> {
     let summary = build_summary(&state);
 
     let summary_json = serde_json::to_string_pretty(&summary)?;
-    atomic_write(&args.output_dir.join("matrix-summary.json"), summary_json.as_bytes())?;
+    atomic_write(
+        &args.output_dir.join("matrix-summary.json"),
+        summary_json.as_bytes(),
+    )?;
 
     let summary_txt = render_summary_text(&summary, &state);
     atomic_write(
@@ -481,13 +486,7 @@ fn render_summary_text(summary: &MatrixSummary, state: &MatrixState) -> String {
         let _ = writeln!(
             s,
             "{:<4} {:<24} {:<24} {:<14} {:>8} {:>10} {:>10.4}",
-            row.rank,
-            row.name,
-            row.model,
-            row.state,
-            row.resolved,
-            rate_pct,
-            row.total_cost_usd
+            row.rank, row.name, row.model, row.state, row.resolved, rate_pct, row.total_cost_usd
         );
     }
     s

--- a/src/run/matrix.rs
+++ b/src/run/matrix.rs
@@ -247,6 +247,28 @@ pub async fn run(args: MatrixArgs) -> Result<MatrixSummary, Error> {
         .map(|i| i.instance_id.clone())
         .collect();
 
+    if args.matrix_parallelism == 0 {
+        return Err(Error::Config(ConfigError::Invalid(
+            "--matrix-parallelism must be at least 1".into(),
+        )));
+    }
+
+    // With parallelism > 1 and a budget cap, up to `matrix_parallelism` arms
+    // can be in-flight simultaneously against the same pre-completion
+    // `cumulative_cost`, so the ceiling may be overrun by that many arms before
+    // any completion updates the running total.  The effective overshoot is
+    // bounded to one arm's cost per slot, not per sweep.
+    if args.matrix_parallelism > 1 && args.sweep_cost_limit_usd.is_some() {
+        tracing::warn!(
+            matrix_parallelism = args.matrix_parallelism,
+            "bench matrix: --sweep-cost-limit-usd with --matrix-parallelism > 1 \
+             enforces the shared budget against completed-arm costs only; \
+             up to {} arms may be in flight simultaneously before the ceiling \
+             is re-checked",
+            args.matrix_parallelism,
+        );
+    }
+
     std::fs::create_dir_all(&args.output_dir)?;
     let state_path = args.output_dir.join("matrix.json");
 
@@ -330,7 +352,15 @@ pub async fn run(args: MatrixArgs) -> Result<MatrixSummary, Error> {
 
     loop {
         // Fill available parallelism slots with new arms.
-        while !cancelled && join_set.len() < args.matrix_parallelism {
+        // When a budget cap is active, only launch one new arm per cycle so
+        // that `cumulative_cost` is updated between launches and the ceiling
+        // is not overrun by more than one arm's cost.
+        let fill_limit = if args.sweep_cost_limit_usd.is_some() {
+            join_set.len().saturating_add(1)
+        } else {
+            args.matrix_parallelism
+        };
+        while !cancelled && join_set.len() < fill_limit {
             // Advance past arms already in a terminal state (resume or prior iteration).
             while next_to_launch < manifest.arms.len()
                 && matches!(

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -11,6 +11,7 @@ pub mod frontier;
 pub mod github_pr;
 pub mod hello_world;
 pub mod inspect;
+pub mod matrix;
 pub mod mini;
 pub mod patch_stats;
 pub mod rate_limit;

--- a/tests/bench_matrix.rs
+++ b/tests/bench_matrix.rs
@@ -6,6 +6,7 @@
 
 #![allow(clippy::unwrap_used)]
 
+use std::fmt::Write as _;
 use std::path::Path;
 use std::process::Command;
 
@@ -21,10 +22,13 @@ use support::binary_path;
 
 fn minimal_dataset(dir: &Path, instances: &[&str]) -> std::path::PathBuf {
     let path = dir.join("dataset.jsonl");
-    let content: String = instances
-        .iter()
-        .map(|id| format!("{{\"instance_id\":\"{id}\",\"problem_statement\":\"fix it\"}}\n"))
-        .collect();
+    let content = instances.iter().fold(String::new(), |mut acc, id| {
+        let _ = writeln!(
+            acc,
+            "{{\"instance_id\":\"{id}\",\"problem_statement\":\"fix it\"}}"
+        );
+        acc
+    });
     std::fs::write(&path, content).unwrap();
     path
 }
@@ -32,12 +36,13 @@ fn minimal_dataset(dir: &Path, instances: &[&str]) -> std::path::PathBuf {
 /// Write a matrix.toml with each arm having `step_limit = 1` for fast tests.
 fn write_matrix_toml(dir: &Path, arms: &[(&str, &str)]) -> std::path::PathBuf {
     let path = dir.join("matrix.toml");
-    let content: String = arms
-        .iter()
-        .map(|(name, model)| {
-            format!("[[arm]]\nname = \"{name}\"\nmodel = \"{model}\"\nstep_limit = 1\n\n")
-        })
-        .collect();
+    let content = arms.iter().fold(String::new(), |mut acc, (name, model)| {
+        let _ = write!(
+            acc,
+            "[[arm]]\nname = \"{name}\"\nmodel = \"{model}\"\nstep_limit = 1\n\n"
+        );
+        acc
+    });
     std::fs::write(&path, &content).unwrap();
     path
 }
@@ -96,8 +101,14 @@ fn cli_matrix_help_shows_required_flags() {
         .unwrap();
 
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("--config"), "expected --config in help:\n{stdout}");
-    assert!(stdout.contains("--output"), "expected --output in help:\n{stdout}");
+    assert!(
+        stdout.contains("--config"),
+        "expected --config in help:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--output"),
+        "expected --output in help:\n{stdout}"
+    );
     assert!(
         stdout.contains("--dataset-path"),
         "expected --dataset-path in help:\n{stdout}"
@@ -110,20 +121,42 @@ fn cli_matrix_help_shows_required_flags() {
         stdout.contains("--matrix-parallelism"),
         "expected --matrix-parallelism in help:\n{stdout}"
     );
-    assert!(stdout.contains("--resume"), "expected --resume in help:\n{stdout}");
-    assert!(stdout.contains("--limit"), "expected --limit in help:\n{stdout}");
-    assert!(stdout.contains("--sample"), "expected --sample in help:\n{stdout}");
-    assert!(stdout.contains("--seed"), "expected --seed in help:\n{stdout}");
+    assert!(
+        stdout.contains("--resume"),
+        "expected --resume in help:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--limit"),
+        "expected --limit in help:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--sample"),
+        "expected --sample in help:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--seed"),
+        "expected --seed in help:\n{stdout}"
+    );
 }
 
 #[test]
 fn cli_matrix_requires_config_flag() {
     let output = Command::new(binary_path())
-        .args(["bench", "matrix", "--dataset-path", "x.jsonl", "--output", "/tmp/out"])
+        .args([
+            "bench",
+            "matrix",
+            "--dataset-path",
+            "x.jsonl",
+            "--output",
+            "/tmp/out",
+        ])
         .output()
         .unwrap();
 
-    assert!(!output.status.success(), "bench matrix without --config should fail");
+    assert!(
+        !output.status.success(),
+        "bench matrix without --config should fail"
+    );
 }
 
 #[test]
@@ -143,7 +176,10 @@ fn cli_matrix_requires_dataset_flag() {
         .output()
         .unwrap();
 
-    assert!(!output.status.success(), "bench matrix without --dataset-path should fail");
+    assert!(
+        !output.status.success(),
+        "bench matrix without --dataset-path should fail"
+    );
 }
 
 // ── Unit: manifest parsing ────────────────────────────────────────────────────
@@ -178,16 +214,21 @@ extra_args = ["--skip-patch-validation"]
     assert_eq!(arm.model, "claude-sonnet-4-6");
     assert_eq!(arm.step_limit, Some(30));
     assert_eq!(arm.per_task_budget_usd, Some(0.50));
-    assert_eq!(arm.prompt_file.as_deref().unwrap().to_str().unwrap(), "/path/to/prompt.toml");
+    assert_eq!(
+        arm.prompt_file.as_deref().unwrap().to_str().unwrap(),
+        "/path/to/prompt.toml"
+    );
     assert_eq!(arm.extra_args, vec!["--skip-patch-validation"]);
 }
 
 #[test]
 fn manifest_parses_multiple_arms() {
-    let content: String = [("a", "model-a"), ("b", "model-b"), ("c", "model-c")]
+    let content = [("a", "model-a"), ("b", "model-b"), ("c", "model-c")]
         .iter()
-        .map(|(n, m)| format!("[[arm]]\nname = \"{n}\"\nmodel = \"{m}\"\n\n"))
-        .collect();
+        .fold(String::new(), |mut acc, (n, m)| {
+            let _ = write!(acc, "[[arm]]\nname = \"{n}\"\nmodel = \"{m}\"\n\n");
+            acc
+        });
     let manifest: MatrixManifest = toml::from_str(&content).unwrap();
     assert_eq!(manifest.arms.len(), 3);
     assert_eq!(manifest.arms[0].name, "a");
@@ -201,8 +242,16 @@ fn manifest_parses_multiple_arms() {
 fn validate_arms_accepts_unique_names() {
     use rust_swe_agent::run::matrix::validate_arms;
     let arms = vec![
-        ArmDef { name: "alpha".into(), model: "m1".into(), ..ArmDef::default() },
-        ArmDef { name: "beta".into(), model: "m2".into(), ..ArmDef::default() },
+        ArmDef {
+            name: "alpha".into(),
+            model: "m1".into(),
+            ..ArmDef::default()
+        },
+        ArmDef {
+            name: "beta".into(),
+            model: "m2".into(),
+            ..ArmDef::default()
+        },
     ];
     assert!(validate_arms(&arms).is_ok());
 }
@@ -211,19 +260,37 @@ fn validate_arms_accepts_unique_names() {
 fn validate_arms_rejects_duplicate_names() {
     use rust_swe_agent::run::matrix::validate_arms;
     let arms = vec![
-        ArmDef { name: "same".into(), model: "m1".into(), ..ArmDef::default() },
-        ArmDef { name: "same".into(), model: "m2".into(), ..ArmDef::default() },
+        ArmDef {
+            name: "same".into(),
+            model: "m1".into(),
+            ..ArmDef::default()
+        },
+        ArmDef {
+            name: "same".into(),
+            model: "m2".into(),
+            ..ArmDef::default()
+        },
     ];
     let err = validate_arms(&arms).unwrap_err();
     let msg = err.to_string();
-    assert!(msg.contains("same"), "error should name the duplicate: {err}");
-    assert!(msg.contains("duplicate"), "error should say duplicate: {err}");
+    assert!(
+        msg.contains("same"),
+        "error should name the duplicate: {err}"
+    );
+    assert!(
+        msg.contains("duplicate"),
+        "error should say duplicate: {err}"
+    );
 }
 
 #[test]
 fn validate_arms_rejects_empty_name() {
     use rust_swe_agent::run::matrix::validate_arms;
-    let arms = vec![ArmDef { name: "".into(), model: "m1".into(), ..ArmDef::default() }];
+    let arms = vec![ArmDef {
+        name: String::new(),
+        model: "m1".into(),
+        ..ArmDef::default()
+    }];
     let err = validate_arms(&arms).unwrap_err();
     let msg = err.to_string();
     assert!(msg.contains("empty") || msg.contains("name"), "{err}");
@@ -233,7 +300,11 @@ fn validate_arms_rejects_empty_name() {
 fn validate_arms_rejects_name_with_path_separator() {
     use rust_swe_agent::run::matrix::validate_arms;
     for bad_name in ["/evil", "arm/../attack", "arm\\win"] {
-        let arms = vec![ArmDef { name: bad_name.into(), model: "m".into(), ..ArmDef::default() }];
+        let arms = vec![ArmDef {
+            name: bad_name.into(),
+            model: "m".into(),
+            ..ArmDef::default()
+        }];
         let err = validate_arms(&arms).unwrap_err();
         assert!(
             err.to_string().contains("name"),
@@ -256,16 +327,24 @@ fn validate_arms_rejects_empty_arm_list() {
 async fn matrix_run_creates_per_arm_dirs_and_results() {
     let tmp = tempfile::tempdir().unwrap();
     let dataset = minimal_dataset(tmp.path(), &["inst-1", "inst-2"]);
-    let config =
-        write_matrix_toml(tmp.path(), &[("arm-a", "deterministic"), ("arm-b", "deterministic")]);
+    let config = write_matrix_toml(
+        tmp.path(),
+        &[("arm-a", "deterministic"), ("arm-b", "deterministic")],
+    );
     let output = tmp.path().join("out");
 
     let args = default_matrix_args(config, dataset, output.clone());
     let summary = matrix_run(args).await.unwrap();
 
     // Per-arm directories exist with results.json.
-    assert!(output.join("arm-a").join("results.json").exists(), "arm-a/results.json must exist");
-    assert!(output.join("arm-b").join("results.json").exists(), "arm-b/results.json must exist");
+    assert!(
+        output.join("arm-a").join("results.json").exists(),
+        "arm-a/results.json must exist"
+    );
+    assert!(
+        output.join("arm-b").join("results.json").exists(),
+        "arm-b/results.json must exist"
+    );
 
     // matrix.json exists and records the instance list.
     let matrix_json_path = output.join("matrix.json");
@@ -273,7 +352,11 @@ async fn matrix_run_creates_per_arm_dirs_and_results() {
     let matrix_json: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&matrix_json_path).unwrap()).unwrap();
     let instance_ids = matrix_json["instance_ids"].as_array().unwrap();
-    assert_eq!(instance_ids.len(), 2, "matrix.json should record both instances");
+    assert_eq!(
+        instance_ids.len(),
+        2,
+        "matrix.json should record both instances"
+    );
     assert!(
         instance_ids.iter().any(|v| v == "inst-1"),
         "instance_ids should contain inst-1"
@@ -283,21 +366,35 @@ async fn matrix_run_creates_per_arm_dirs_and_results() {
         "instance_ids should contain inst-2"
     );
 
-    assert!(output.join("matrix-summary.json").exists(), "matrix-summary.json must exist");
-    assert!(output.join("matrix-summary.txt").exists(), "matrix-summary.txt must exist");
+    assert!(
+        output.join("matrix-summary.json").exists(),
+        "matrix-summary.json must exist"
+    );
+    assert!(
+        output.join("matrix-summary.txt").exists(),
+        "matrix-summary.txt must exist"
+    );
 
     assert_eq!(summary.arms.len(), 2);
     let names: Vec<&str> = summary.arms.iter().map(|a| a.name.as_str()).collect();
-    assert!(names.contains(&"arm-a"), "summary should include arm-a: {names:?}");
-    assert!(names.contains(&"arm-b"), "summary should include arm-b: {names:?}");
+    assert!(
+        names.contains(&"arm-a"),
+        "summary should include arm-a: {names:?}"
+    );
+    assert!(
+        names.contains(&"arm-b"),
+        "summary should include arm-b: {names:?}"
+    );
 }
 
 #[tokio::test]
 async fn matrix_all_arms_see_the_same_instances() {
     let tmp = tempfile::tempdir().unwrap();
     let dataset = minimal_dataset(tmp.path(), &["inst-1", "inst-2", "inst-3"]);
-    let config =
-        write_matrix_toml(tmp.path(), &[("arm-a", "deterministic"), ("arm-b", "deterministic")]);
+    let config = write_matrix_toml(
+        tmp.path(),
+        &[("arm-a", "deterministic"), ("arm-b", "deterministic")],
+    );
     let output = tmp.path().join("out");
 
     // limit=2 so we can verify the limit is applied once and shared.
@@ -323,7 +420,10 @@ async fn matrix_all_arms_see_the_same_instances() {
     let a_ids = load_ids("arm-a");
     let b_ids = load_ids("arm-b");
 
-    assert_eq!(a_ids, b_ids, "both arms must run against the same instance set");
+    assert_eq!(
+        a_ids, b_ids,
+        "both arms must run against the same instance set"
+    );
     assert_eq!(a_ids.len(), 2, "limit=2 should select exactly 2 instances");
 }
 
@@ -333,8 +433,7 @@ async fn matrix_budget_limit_skips_arms_that_exceed_it() {
     let dataset = minimal_dataset(tmp.path(), &["inst-1"]);
 
     // Arms with step_limit=1 → exactly one model call each.
-    let config_str =
-        "[[arm]]\nname = \"arm-first\"\nmodel = \"deterministic\"\nstep_limit = 1\n\n\
+    let config_str = "[[arm]]\nname = \"arm-first\"\nmodel = \"deterministic\"\nstep_limit = 1\n\n\
          [[arm]]\nname = \"arm-skipped\"\nmodel = \"deterministic\"\nstep_limit = 1\n";
     let config = tmp.path().join("matrix.toml");
     std::fs::write(&config, config_str).unwrap();
@@ -354,17 +453,20 @@ async fn matrix_budget_limit_skips_arms_that_exceed_it() {
 
     let summary = matrix_run(args).await.unwrap();
 
-    let skipped = summary.arms.iter().find(|a| a.name == "arm-skipped").unwrap();
+    let skipped = summary
+        .arms
+        .iter()
+        .find(|a| a.name == "arm-skipped")
+        .unwrap();
     assert_eq!(
         skipped.state, "skipped_budget",
         "arm-skipped should be skipped_budget when budget exhausted: {summary:?}"
     );
 
     // matrix.json records the arm state.
-    let matrix_json: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(output.join("matrix.json")).unwrap(),
-    )
-    .unwrap();
+    let matrix_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(output.join("matrix.json")).unwrap())
+            .unwrap();
     let arm_states: Vec<(String, String)> = matrix_json["arms"]
         .as_array()
         .unwrap()
@@ -384,8 +486,13 @@ async fn matrix_budget_limit_skips_arms_that_exceed_it() {
 async fn matrix_resume_skips_complete_arms() {
     let tmp = tempfile::tempdir().unwrap();
     let dataset = minimal_dataset(tmp.path(), &["inst-1"]);
-    let config =
-        write_matrix_toml(tmp.path(), &[("arm-done", "deterministic"), ("arm-pending", "deterministic")]);
+    let config = write_matrix_toml(
+        tmp.path(),
+        &[
+            ("arm-done", "deterministic"),
+            ("arm-pending", "deterministic"),
+        ],
+    );
     let output = tmp.path().join("out");
 
     // First run: complete both arms.
@@ -424,8 +531,10 @@ async fn matrix_resume_skips_complete_arms() {
 async fn matrix_summary_rows_are_ranked_contiguously_from_one() {
     let tmp = tempfile::tempdir().unwrap();
     let dataset = minimal_dataset(tmp.path(), &["inst-1"]);
-    let config =
-        write_matrix_toml(tmp.path(), &[("arm-a", "deterministic"), ("arm-b", "deterministic")]);
+    let config = write_matrix_toml(
+        tmp.path(),
+        &[("arm-a", "deterministic"), ("arm-b", "deterministic")],
+    );
     let output = tmp.path().join("out");
 
     let args = default_matrix_args(config, dataset, output.clone());
@@ -433,7 +542,10 @@ async fn matrix_summary_rows_are_ranked_contiguously_from_one() {
 
     let ranks: Vec<usize> = summary.arms.iter().map(|a| a.rank).collect();
     let expected: Vec<usize> = (1..=summary.arms.len()).collect();
-    assert_eq!(ranks, expected, "ranks must be contiguous starting from 1: {ranks:?}");
+    assert_eq!(
+        ranks, expected,
+        "ranks must be contiguous starting from 1: {ranks:?}"
+    );
 }
 
 #[tokio::test]
@@ -446,10 +558,9 @@ async fn matrix_summary_json_is_well_formed() {
     let args = default_matrix_args(config, dataset, output.clone());
     matrix_run(args).await.unwrap();
 
-    let json: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(output.join("matrix-summary.json")).unwrap(),
-    )
-    .unwrap();
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(output.join("matrix-summary.json")).unwrap())
+            .unwrap();
     let arms = json["arms"].as_array().unwrap();
     assert_eq!(arms.len(), 1);
     assert_eq!(arms[0]["name"], "arm-x");
@@ -486,7 +597,10 @@ async fn matrix_instance_list_is_deterministic_for_same_seed() {
         run_ids.push(ids);
     }
 
-    assert_eq!(run_ids[0], run_ids[1], "same seed must produce same instance list");
+    assert_eq!(
+        run_ids[0], run_ids[1],
+        "same seed must produce same instance list"
+    );
 }
 
 // ── Integration: matrix.json structure ───────────────────────────────────────
@@ -524,8 +638,14 @@ async fn matrix_arm_dirs_are_nested_inside_output() {
     let args = default_matrix_args(config, dataset, output.clone());
     matrix_run(args).await.unwrap();
 
-    assert!(output.join("arm-one").is_dir(), "arm-one must be a subdir of output");
-    assert!(output.join("arm-two").is_dir(), "arm-two must be a subdir of output");
+    assert!(
+        output.join("arm-one").is_dir(),
+        "arm-one must be a subdir of output"
+    );
+    assert!(
+        output.join("arm-two").is_dir(),
+        "arm-two must be a subdir of output"
+    );
     assert!(output.join("arm-one").join("results.json").exists());
     assert!(output.join("arm-two").join("results.json").exists());
 }

--- a/tests/bench_matrix.rs
+++ b/tests/bench_matrix.rs
@@ -1,0 +1,531 @@
+//! `bench matrix`: integration tests for the multi-arm experiment runner.
+//!
+//! Tests follow TDD RED→GREEN→REFACTOR per issue #162.
+//! Unit-level parsing/validation live in `src/run/matrix.rs`;
+//! these tests exercise the CLI binary and the public Rust API.
+
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+use rust_swe_agent::model::ModelUsage;
+use rust_swe_agent::run::dataset::DatasetSource;
+use rust_swe_agent::run::matrix::{ArmDef, MatrixArgs, MatrixManifest, run as matrix_run};
+use rust_swe_agent::run::swebench::StratifyMode;
+
+mod support;
+use support::binary_path;
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn minimal_dataset(dir: &Path, instances: &[&str]) -> std::path::PathBuf {
+    let path = dir.join("dataset.jsonl");
+    let content: String = instances
+        .iter()
+        .map(|id| format!("{{\"instance_id\":\"{id}\",\"problem_statement\":\"fix it\"}}\n"))
+        .collect();
+    std::fs::write(&path, content).unwrap();
+    path
+}
+
+/// Write a matrix.toml with each arm having `step_limit = 1` for fast tests.
+fn write_matrix_toml(dir: &Path, arms: &[(&str, &str)]) -> std::path::PathBuf {
+    let path = dir.join("matrix.toml");
+    let content: String = arms
+        .iter()
+        .map(|(name, model)| {
+            format!("[[arm]]\nname = \"{name}\"\nmodel = \"{model}\"\nstep_limit = 1\n\n")
+        })
+        .collect();
+    std::fs::write(&path, &content).unwrap();
+    path
+}
+
+fn default_matrix_args(
+    config_path: std::path::PathBuf,
+    dataset_path: std::path::PathBuf,
+    output_dir: std::path::PathBuf,
+) -> MatrixArgs {
+    MatrixArgs {
+        config_path,
+        dataset_source: DatasetSource::LocalPath(dataset_path),
+        dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
+        output_dir,
+        instance_ids: None,
+        limit: None,
+        sample: None,
+        seed: None,
+        stratify_by: None,
+        stratify_mode: StratifyMode::Proportional,
+        sweep_cost_limit_usd: None,
+        matrix_parallelism: 1,
+        resume: false,
+        parallel: 1,
+        skip_preflight: true,
+        skip_model_probe: true,
+        // Non-submit response: agent hits step_limit=1 cleanly.
+        deterministic_responses: Some(vec!["looking at the problem...".into()]),
+        deterministic_usage_per_call: None,
+        cancel_deadline_secs: 5,
+        install_os_signal_handlers: false,
+    }
+}
+
+// ── CLI smoke tests ───────────────────────────────────────────────────────────
+
+#[test]
+fn cli_help_includes_matrix_subcommand() {
+    let output = Command::new(binary_path())
+        .args(["bench", "--help"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("matrix"),
+        "bench --help should list the `matrix` subcommand, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn cli_matrix_help_shows_required_flags() {
+    let output = Command::new(binary_path())
+        .args(["bench", "matrix", "--help"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("--config"), "expected --config in help:\n{stdout}");
+    assert!(stdout.contains("--output"), "expected --output in help:\n{stdout}");
+    assert!(
+        stdout.contains("--dataset-path"),
+        "expected --dataset-path in help:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--sweep-cost-limit-usd"),
+        "expected --sweep-cost-limit-usd in help:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--matrix-parallelism"),
+        "expected --matrix-parallelism in help:\n{stdout}"
+    );
+    assert!(stdout.contains("--resume"), "expected --resume in help:\n{stdout}");
+    assert!(stdout.contains("--limit"), "expected --limit in help:\n{stdout}");
+    assert!(stdout.contains("--sample"), "expected --sample in help:\n{stdout}");
+    assert!(stdout.contains("--seed"), "expected --seed in help:\n{stdout}");
+}
+
+#[test]
+fn cli_matrix_requires_config_flag() {
+    let output = Command::new(binary_path())
+        .args(["bench", "matrix", "--dataset-path", "x.jsonl", "--output", "/tmp/out"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "bench matrix without --config should fail");
+}
+
+#[test]
+fn cli_matrix_requires_dataset_flag() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = write_matrix_toml(tmp.path(), &[("arm1", "claude-opus-4-7")]);
+
+    let output = Command::new(binary_path())
+        .args([
+            "bench",
+            "matrix",
+            "--config",
+            config.to_str().unwrap(),
+            "--output",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "bench matrix without --dataset-path should fail");
+}
+
+// ── Unit: manifest parsing ────────────────────────────────────────────────────
+
+#[test]
+fn manifest_parses_minimal_arm_definition() {
+    let toml_str = "[[arm]]\nname = \"baseline\"\nmodel = \"claude-opus-4-7\"\n";
+    let manifest: MatrixManifest = toml::from_str(toml_str).unwrap();
+    assert_eq!(manifest.arms.len(), 1);
+    assert_eq!(manifest.arms[0].name, "baseline");
+    assert_eq!(manifest.arms[0].model, "claude-opus-4-7");
+    assert!(manifest.arms[0].step_limit.is_none());
+    assert!(manifest.arms[0].per_task_budget_usd.is_none());
+    assert!(manifest.arms[0].prompt_file.is_none());
+    assert!(manifest.arms[0].extra_args.is_empty());
+}
+
+#[test]
+fn manifest_parses_arm_with_all_optional_fields() {
+    let toml_str = r#"
+[[arm]]
+name = "tuned"
+model = "claude-sonnet-4-6"
+step_limit = 30
+per_task_budget_usd = 0.50
+prompt_file = "/path/to/prompt.toml"
+extra_args = ["--skip-patch-validation"]
+"#;
+    let manifest: MatrixManifest = toml::from_str(toml_str).unwrap();
+    let arm = &manifest.arms[0];
+    assert_eq!(arm.name, "tuned");
+    assert_eq!(arm.model, "claude-sonnet-4-6");
+    assert_eq!(arm.step_limit, Some(30));
+    assert_eq!(arm.per_task_budget_usd, Some(0.50));
+    assert_eq!(arm.prompt_file.as_deref().unwrap().to_str().unwrap(), "/path/to/prompt.toml");
+    assert_eq!(arm.extra_args, vec!["--skip-patch-validation"]);
+}
+
+#[test]
+fn manifest_parses_multiple_arms() {
+    let content: String = [("a", "model-a"), ("b", "model-b"), ("c", "model-c")]
+        .iter()
+        .map(|(n, m)| format!("[[arm]]\nname = \"{n}\"\nmodel = \"{m}\"\n\n"))
+        .collect();
+    let manifest: MatrixManifest = toml::from_str(&content).unwrap();
+    assert_eq!(manifest.arms.len(), 3);
+    assert_eq!(manifest.arms[0].name, "a");
+    assert_eq!(manifest.arms[1].name, "b");
+    assert_eq!(manifest.arms[2].name, "c");
+}
+
+// ── Unit: arm validation ──────────────────────────────────────────────────────
+
+#[test]
+fn validate_arms_accepts_unique_names() {
+    use rust_swe_agent::run::matrix::validate_arms;
+    let arms = vec![
+        ArmDef { name: "alpha".into(), model: "m1".into(), ..ArmDef::default() },
+        ArmDef { name: "beta".into(), model: "m2".into(), ..ArmDef::default() },
+    ];
+    assert!(validate_arms(&arms).is_ok());
+}
+
+#[test]
+fn validate_arms_rejects_duplicate_names() {
+    use rust_swe_agent::run::matrix::validate_arms;
+    let arms = vec![
+        ArmDef { name: "same".into(), model: "m1".into(), ..ArmDef::default() },
+        ArmDef { name: "same".into(), model: "m2".into(), ..ArmDef::default() },
+    ];
+    let err = validate_arms(&arms).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("same"), "error should name the duplicate: {err}");
+    assert!(msg.contains("duplicate"), "error should say duplicate: {err}");
+}
+
+#[test]
+fn validate_arms_rejects_empty_name() {
+    use rust_swe_agent::run::matrix::validate_arms;
+    let arms = vec![ArmDef { name: "".into(), model: "m1".into(), ..ArmDef::default() }];
+    let err = validate_arms(&arms).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("empty") || msg.contains("name"), "{err}");
+}
+
+#[test]
+fn validate_arms_rejects_name_with_path_separator() {
+    use rust_swe_agent::run::matrix::validate_arms;
+    for bad_name in ["/evil", "arm/../attack", "arm\\win"] {
+        let arms = vec![ArmDef { name: bad_name.into(), model: "m".into(), ..ArmDef::default() }];
+        let err = validate_arms(&arms).unwrap_err();
+        assert!(
+            err.to_string().contains("name"),
+            "expected arm name validation error for `{bad_name}`, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn validate_arms_rejects_empty_arm_list() {
+    use rust_swe_agent::run::matrix::validate_arms;
+    let err = validate_arms(&[]).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("arm") || msg.contains("empty"), "{err}");
+}
+
+// ── Integration: matrix run ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn matrix_run_creates_per_arm_dirs_and_results() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dataset = minimal_dataset(tmp.path(), &["inst-1", "inst-2"]);
+    let config =
+        write_matrix_toml(tmp.path(), &[("arm-a", "deterministic"), ("arm-b", "deterministic")]);
+    let output = tmp.path().join("out");
+
+    let args = default_matrix_args(config, dataset, output.clone());
+    let summary = matrix_run(args).await.unwrap();
+
+    // Per-arm directories exist with results.json.
+    assert!(output.join("arm-a").join("results.json").exists(), "arm-a/results.json must exist");
+    assert!(output.join("arm-b").join("results.json").exists(), "arm-b/results.json must exist");
+
+    // matrix.json exists and records the instance list.
+    let matrix_json_path = output.join("matrix.json");
+    assert!(matrix_json_path.exists(), "matrix.json must exist");
+    let matrix_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&matrix_json_path).unwrap()).unwrap();
+    let instance_ids = matrix_json["instance_ids"].as_array().unwrap();
+    assert_eq!(instance_ids.len(), 2, "matrix.json should record both instances");
+    assert!(
+        instance_ids.iter().any(|v| v == "inst-1"),
+        "instance_ids should contain inst-1"
+    );
+    assert!(
+        instance_ids.iter().any(|v| v == "inst-2"),
+        "instance_ids should contain inst-2"
+    );
+
+    assert!(output.join("matrix-summary.json").exists(), "matrix-summary.json must exist");
+    assert!(output.join("matrix-summary.txt").exists(), "matrix-summary.txt must exist");
+
+    assert_eq!(summary.arms.len(), 2);
+    let names: Vec<&str> = summary.arms.iter().map(|a| a.name.as_str()).collect();
+    assert!(names.contains(&"arm-a"), "summary should include arm-a: {names:?}");
+    assert!(names.contains(&"arm-b"), "summary should include arm-b: {names:?}");
+}
+
+#[tokio::test]
+async fn matrix_all_arms_see_the_same_instances() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dataset = minimal_dataset(tmp.path(), &["inst-1", "inst-2", "inst-3"]);
+    let config =
+        write_matrix_toml(tmp.path(), &[("arm-a", "deterministic"), ("arm-b", "deterministic")]);
+    let output = tmp.path().join("out");
+
+    // limit=2 so we can verify the limit is applied once and shared.
+    let mut args = default_matrix_args(config, dataset, output.clone());
+    args.limit = Some(2);
+
+    matrix_run(args).await.unwrap();
+
+    let load_ids = |arm: &str| -> Vec<String> {
+        let path = output.join(arm).join("results.json");
+        let v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        let mut ids: Vec<String> = v["instances"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|i| i["instance_id"].as_str().unwrap().to_owned())
+            .collect();
+        ids.sort();
+        ids
+    };
+
+    let a_ids = load_ids("arm-a");
+    let b_ids = load_ids("arm-b");
+
+    assert_eq!(a_ids, b_ids, "both arms must run against the same instance set");
+    assert_eq!(a_ids.len(), 2, "limit=2 should select exactly 2 instances");
+}
+
+#[tokio::test]
+async fn matrix_budget_limit_skips_arms_that_exceed_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dataset = minimal_dataset(tmp.path(), &["inst-1"]);
+
+    // Arms with step_limit=1 → exactly one model call each.
+    let config_str =
+        "[[arm]]\nname = \"arm-first\"\nmodel = \"deterministic\"\nstep_limit = 1\n\n\
+         [[arm]]\nname = \"arm-skipped\"\nmodel = \"deterministic\"\nstep_limit = 1\n";
+    let config = tmp.path().join("matrix.toml");
+    std::fs::write(&config, config_str).unwrap();
+    let output = tmp.path().join("out");
+
+    let mut args = default_matrix_args(config, dataset, output.clone());
+    // 1M input tokens × $3/MTok = $3.00 per arm with step_limit=1 + 1 instance.
+    args.deterministic_usage_per_call = Some(ModelUsage {
+        input_tokens: 1_000_000,
+        output_tokens: 0,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+        cost_usd: None,
+    });
+    // Budget $2.00 < arm-first cost $3.00, so arm-skipped is skipped_budget.
+    args.sweep_cost_limit_usd = Some(2.0);
+
+    let summary = matrix_run(args).await.unwrap();
+
+    let skipped = summary.arms.iter().find(|a| a.name == "arm-skipped").unwrap();
+    assert_eq!(
+        skipped.state, "skipped_budget",
+        "arm-skipped should be skipped_budget when budget exhausted: {summary:?}"
+    );
+
+    // matrix.json records the arm state.
+    let matrix_json: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(output.join("matrix.json")).unwrap(),
+    )
+    .unwrap();
+    let arm_states: Vec<(String, String)> = matrix_json["arms"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|a| {
+            (
+                a["name"].as_str().unwrap().to_owned(),
+                a["state"].as_str().unwrap().to_owned(),
+            )
+        })
+        .collect();
+    let (_, skipped_state) = arm_states.iter().find(|(n, _)| n == "arm-skipped").unwrap();
+    assert_eq!(skipped_state, "skipped_budget");
+}
+
+#[tokio::test]
+async fn matrix_resume_skips_complete_arms() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dataset = minimal_dataset(tmp.path(), &["inst-1"]);
+    let config =
+        write_matrix_toml(tmp.path(), &[("arm-done", "deterministic"), ("arm-pending", "deterministic")]);
+    let output = tmp.path().join("out");
+
+    // First run: complete both arms.
+    let args = default_matrix_args(config.clone(), dataset.clone(), output.clone());
+    matrix_run(args).await.unwrap();
+
+    // Simulate a partial run: mark arm-pending as pending in matrix.json.
+    {
+        let state_path = output.join("matrix.json");
+        let mut state: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&state_path).unwrap()).unwrap();
+        for arm in state["arms"].as_array_mut().unwrap() {
+            if arm["name"] == "arm-pending" {
+                arm["state"] = serde_json::Value::String("pending".into());
+            }
+        }
+        std::fs::write(&state_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+    }
+    // Remove arm-pending's results to prove it will be re-run.
+    if output.join("arm-pending").exists() {
+        std::fs::remove_dir_all(output.join("arm-pending")).unwrap();
+    }
+
+    // Resume run: arm-done is skipped, arm-pending runs.
+    let mut args2 = default_matrix_args(config, dataset, output.clone());
+    args2.resume = true;
+    matrix_run(args2).await.unwrap();
+
+    assert!(
+        output.join("arm-pending").join("results.json").exists(),
+        "arm-pending should have been run on resume"
+    );
+}
+
+#[tokio::test]
+async fn matrix_summary_rows_are_ranked_contiguously_from_one() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dataset = minimal_dataset(tmp.path(), &["inst-1"]);
+    let config =
+        write_matrix_toml(tmp.path(), &[("arm-a", "deterministic"), ("arm-b", "deterministic")]);
+    let output = tmp.path().join("out");
+
+    let args = default_matrix_args(config, dataset, output.clone());
+    let summary = matrix_run(args).await.unwrap();
+
+    let ranks: Vec<usize> = summary.arms.iter().map(|a| a.rank).collect();
+    let expected: Vec<usize> = (1..=summary.arms.len()).collect();
+    assert_eq!(ranks, expected, "ranks must be contiguous starting from 1: {ranks:?}");
+}
+
+#[tokio::test]
+async fn matrix_summary_json_is_well_formed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dataset = minimal_dataset(tmp.path(), &["inst-1", "inst-2"]);
+    let config = write_matrix_toml(tmp.path(), &[("arm-x", "deterministic")]);
+    let output = tmp.path().join("out");
+
+    let args = default_matrix_args(config, dataset, output.clone());
+    matrix_run(args).await.unwrap();
+
+    let json: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(output.join("matrix-summary.json")).unwrap(),
+    )
+    .unwrap();
+    let arms = json["arms"].as_array().unwrap();
+    assert_eq!(arms.len(), 1);
+    assert_eq!(arms[0]["name"], "arm-x");
+    assert!(arms[0]["rank"].is_number());
+    assert!(arms[0]["resolved_rate"].is_number());
+    assert!(arms[0]["total_cost_usd"].is_number());
+    assert!(arms[0]["state"].is_string());
+}
+
+#[tokio::test]
+async fn matrix_instance_list_is_deterministic_for_same_seed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dataset = minimal_dataset(tmp.path(), &["inst-a", "inst-b", "inst-c"]);
+
+    let mut run_ids = Vec::new();
+    for run in 0..2 {
+        let config = write_matrix_toml(tmp.path(), &[("arm1", "deterministic")]);
+        let output = tmp.path().join(format!("run-{run}"));
+        let mut args = default_matrix_args(config, dataset.clone(), output.clone());
+        args.sample = Some(2);
+        args.seed = Some(42);
+        matrix_run(args).await.unwrap();
+
+        let path = output.join("matrix.json");
+        let v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        let mut ids: Vec<String> = v["instance_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|i| i.as_str().unwrap().to_owned())
+            .collect();
+        ids.sort();
+        run_ids.push(ids);
+    }
+
+    assert_eq!(run_ids[0], run_ids[1], "same seed must produce same instance list");
+}
+
+// ── Integration: matrix.json structure ───────────────────────────────────────
+
+#[tokio::test]
+async fn matrix_json_has_correct_artifact_kind() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dataset = minimal_dataset(tmp.path(), &["inst-1"]);
+    let config = write_matrix_toml(tmp.path(), &[("arm1", "deterministic")]);
+    let output = tmp.path().join("out");
+
+    let args = default_matrix_args(config, dataset, output.clone());
+    matrix_run(args).await.unwrap();
+
+    let state_path = output.join("matrix.json");
+    assert!(state_path.exists());
+    let state: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&state_path).unwrap()).unwrap();
+    assert_eq!(state["artifact_kind"], "matrix");
+    assert!(state["instance_ids"].is_array());
+    assert!(state["arms"].is_array());
+    assert!(state["filter_spec"].is_object());
+}
+
+#[tokio::test]
+async fn matrix_arm_dirs_are_nested_inside_output() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dataset = minimal_dataset(tmp.path(), &["inst-1"]);
+    let config = write_matrix_toml(
+        tmp.path(),
+        &[("arm-one", "deterministic"), ("arm-two", "deterministic")],
+    );
+    let output = tmp.path().join("out");
+
+    let args = default_matrix_args(config, dataset, output.clone());
+    matrix_run(args).await.unwrap();
+
+    assert!(output.join("arm-one").is_dir(), "arm-one must be a subdir of output");
+    assert!(output.join("arm-two").is_dir(), "arm-two must be a subdir of output");
+    assert!(output.join("arm-one").join("results.json").exists());
+    assert!(output.join("arm-two").join("results.json").exists());
+}

--- a/tests/bench_matrix.rs
+++ b/tests/bench_matrix.rs
@@ -388,6 +388,28 @@ async fn matrix_run_creates_per_arm_dirs_and_results() {
 }
 
 #[tokio::test]
+async fn matrix_parallelism_zero_returns_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let dataset = minimal_dataset(dir.path(), &["inst-1"]);
+    let config = write_matrix_toml(dir.path(), &[("arm-a", "scripted")]);
+    let output = dir.path().join("out");
+
+    let mut args = default_matrix_args(config, dataset, output);
+    args.matrix_parallelism = 0;
+
+    let result = matrix_run(args).await;
+    assert!(
+        result.is_err(),
+        "matrix_parallelism=0 should return an error, got Ok"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("matrix-parallelism"),
+        "error should mention --matrix-parallelism, got: {msg}"
+    );
+}
+
+#[tokio::test]
 async fn matrix_all_arms_see_the_same_instances() {
     let tmp = tempfile::tempdir().unwrap();
     let dataset = minimal_dataset(tmp.path(), &["inst-1", "inst-2", "inst-3"]);


### PR DESCRIPTION
## Summary

Implements the `bench matrix` subcommand, a new feature that runs multiple sweep arms against the same deterministically-selected instance set to enable direct comparison of different model/config combinations. This addresses issue #162 with comprehensive integration tests, CLI integration, and full documentation.

## Key Changes

- **New module `src/run/matrix.rs`**: Core matrix runner implementation
  - `MatrixManifest` and `ArmDef` types for parsing TOML arm definitions
  - `MatrixArgs` struct for runtime configuration
  - `validate_arms()` function enforcing unique, non-empty, path-safe arm names
  - `run()` async function orchestrating the multi-arm sweep with shared instance selection
  - Budget enforcement: arms are marked `skipped_budget` when cumulative cost exceeds the limit
  - Resume support: loads existing `matrix.json` and skips terminal-state arms
  - Summary generation with ranking by resolved rate and cost metrics

- **CLI integration** (`src/cli/args.rs` and `src/cli/mod.rs`):
  - New `MatrixCmd` struct with flags for config, dataset source, output, budget limits, parallelism, and sampling
  - `bench_matrix()` handler that resolves dataset sources and invokes the matrix runner
  - Support for both local JSONL datasets and named SWE-bench aliases

- **Comprehensive test suite** (`tests/bench_matrix.rs`):
  - CLI smoke tests: help text, required flags, validation
  - Manifest parsing tests: minimal/full arm definitions, multiple arms
  - Arm validation tests: duplicate detection, path separator rejection, empty list rejection
  - Integration tests: per-arm directory creation, instance set consistency across arms, budget limit enforcement, resume behavior, deterministic sampling, summary ranking
  - Output artifact validation: `matrix.json` structure, `matrix-summary.json` well-formedness

- **Documentation** (`docs/spec-matrix.md`):
  - Complete CLI reference with all flags and defaults
  - TOML manifest format specification
  - Output artifact schemas and arm state definitions
  - Budget enforcement and resume behavior details
  - Instance set consistency guarantees

- **Output artifacts**:
  - `matrix.json`: machine-readable state written before each arm and updated after completion
  - `matrix-summary.json`: ranked summary with resolved rates, costs, and deltas relative to best arm
  - `matrix-summary.txt`: human-readable ranked table
  - Per-arm directories with standard sweep results

## Implementation Details

- Instance selection is performed once before any arm runs, ensuring all arms evaluate identical workloads
- Budget tracking is cumulative across arms; the check fires before each arm starts
- Arms are ranked by resolved rate (descending), with ties broken by lower total cost
- Non-complete arms appear after all complete arms in rankings
- Atomic writes prevent partial state corruption
- Resume mode re-resolves the instance set to maintain reproducibility even after crashes
- Graceful abort (Ctrl-C) allows in-flight tasks to complete within a deadline before marking arms as cancelled

https://claude.ai/code/session_01Ryj9TgsNtXfcwnKMNkCTXi