### PR TITLE
Add `bench command-stats` subcommand for shell command analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ a valid trajectory in hand:
   pass@k, and compare regression gates.
 - [`bench triage`](docs/spec-triage.md): deterministic unresolved-failure
   clustering, ranked stdout tables, and the `triage.json` schema.
+- [`bench command-stats`](docs/spec-command-stats.md): shell-command frequency
+  and cost aggregated by outcome bucket, delta view for resolved-vs-unresolved
+  comparison, and the `command-stats.json` schema.
 - [`bench matrix`](docs/spec-matrix.md): multi-arm experiment runner — compare
   models or configs against the same instance set, shared budget enforcement,
   `matrix.json` state, ranked `matrix-summary.json`, and `--resume` support.

--- a/docs/spec-command-stats.md
+++ b/docs/spec-command-stats.md
@@ -1,0 +1,208 @@
+# `bench command-stats` Spec
+
+`bench command-stats` is a read-only post-processor for completed SWE-bench sweeps.
+It consumes the artifacts already written by `bench swebench` and optionally
+`bench evaluate`, extracts every bash command executed by the agent, aggregates
+command-frequency and cost metrics segmented by outcome bucket, writes
+`command-stats.json`, and prints a ranked table per bucket.
+
+It never re-runs instances and never calls a model provider.
+
+## CLI
+
+```bash
+rust-swe-agent bench command-stats --sweep runs/sweep
+```
+
+Options:
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--sweep <dir>` | required | Sweep directory containing `results.json`, optionally `evaluation.json`, and trajectory files. |
+| `--bucket resolved\|unresolved\|errored\|all` | unset | Restrict which outcome bucket's rows appear in non-"all" columns of the output. |
+| `--min-invocations <n>` | `1` | Hide command heads with fewer than `n` total invocations. Useful for suppressing long-tail noise. |
+| `--top <n>` | `15` | Number of ranked rows to print per outcome bucket in text mode. |
+| `--compare resolved-vs-unresolved` | unset | Append a delta table sorted by `(resolved_share − unresolved_share)` descending. |
+| `--filter <key>=<value>` | unset | Restrict the input set to instances matching the given filter (same syntax as `bench inspect --filter`). Example: `failure_category=model_parse`. |
+| `--format text\|json` | `text` | Text table or full JSON report on stdout. `command-stats.json` is written in both modes. |
+
+Exit behavior:
+
+- `0`: aggregation completed, even when the sweep contains failures.
+- Non-zero: missing or unreadable `results.json`, malformed JSON, or invalid CLI flags.
+
+## Head-extraction rules
+
+For every assistant turn with `actions`, each action string is decomposed into
+one or more **command heads** — the normalized first token of each pipeline
+segment, with common shell prefixes stripped.
+
+### Prefix stripping (applied left to right until the actual command is found)
+
+| Prefix | Example | Stripped to |
+| --- | --- | --- |
+| `sudo` | `sudo apt-get install python3` | `apt-get` |
+| `time` | `time cargo test` | `cargo` |
+| `env VAR=val ...` | `env RUST_LOG=debug cargo build` | `cargo` |
+| Bare `VAR=val` assignments | `RUST_LOG=debug cargo build` | `cargo` |
+
+Multiple prefixes are chained: `sudo time env A=1 pytest -x` → `pytest`.
+
+### Pipeline decomposition
+
+`|` splits a command into segments; each segment's head is extracted
+independently. `||` (logical OR) is **not** treated as a pipeline delimiter.
+
+| Command | Heads |
+| --- | --- |
+| `cat file.txt \| grep error \| sort -u` | `["cat", "grep", "sort"]` |
+| `false \|\| true` | `["false"]` |
+| `grep 'def test' .` | `["grep"]` |
+
+### Edge cases
+
+- Empty or whitespace-only commands produce no heads.
+- Commands whose entire content is prefix tokens (e.g., `sudo`) produce no heads.
+
+## Output schema
+
+### `command-stats.json`
+
+```json
+{
+  "sweep": "<path to sweep directory>",
+  "generated_at": "<ISO-8601 UTC timestamp>",
+  "totals": {
+    "trajectories": <int>,
+    "bash_steps": <int>,
+    "unique_command_heads": <int>
+  },
+  "by_outcome": {
+    "<resolved|unresolved|errored|all>": [
+      {
+        "command_head": "<str>",
+        "instance_count": <int>,
+        "invocation_count": <int>,
+        "mean_calls_per_instance": <float>,
+        "nonzero_exit_rate": <float>,
+        "attributed_cost_usd": <float>
+      }
+    ]
+  },
+  "comparisons": [
+    {
+      "name": "resolved-vs-unresolved",
+      "rows": [
+        {
+          "command_head": "<str>",
+          "resolved_share": <float>,
+          "unresolved_share": <float>,
+          "delta": <float>
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Field definitions:**
+
+| Field | Meaning |
+| --- | --- |
+| `command_head` | Normalized first token after prefix stripping, per the rules above. |
+| `instance_count` | Number of distinct instances (trajectories) that used this command at least once. |
+| `invocation_count` | Total number of times this command head was invoked across all instances in the bucket. |
+| `mean_calls_per_instance` | `invocation_count / instance_count`. |
+| `nonzero_exit_rate` | Fraction of invocations whose immediately following observation reported a non-zero exit code. `0.0` when all exits were zero; `1.0` when all were non-zero. |
+| `attributed_cost_usd` | Sum of the model-call cost (`extra.cost`) for every assistant turn that produced an invocation of this command. When an assistant turn produces multiple commands, the full turn cost is attributed to each. |
+| `resolved_share` | Fraction of all resolved-bucket invocations accounted for by this command. |
+| `unresolved_share` | Fraction of all unresolved-bucket invocations accounted for by this command. |
+| `delta` | `resolved_share − unresolved_share`. Positive values indicate commands more common in resolved runs. |
+
+`comparisons` is omitted from the JSON when `--compare` is not passed.
+
+Rows within each bucket are sorted by `invocation_count` descending, then
+alphabetically by `command_head` for determinism. Delta rows are sorted by
+`delta` descending.
+
+### Determinism
+
+Running `bench command-stats` twice on the same sweep directory produces
+byte-identical `command-stats.json` files (modulo `generated_at`). Row
+ordering is fully determined by the sort keys above; no hash-map iteration
+order leaks into the output.
+
+## Outcome bucket classification
+
+| Bucket | Criterion |
+| --- | --- |
+| `resolved` | Instance appears in `evaluation.json` with `resolved: true`. |
+| `errored` | Instance has `outcome: "error"` in `results.json` and is not in the resolved set. |
+| `unresolved` | All other instances (e.g., `step_limit_reached`, `budget_exhausted`). |
+| `all` | All instances regardless of outcome. |
+
+When `evaluation.json` is absent, no instance is classified as resolved.
+
+## Worked example
+
+Given a sweep at `runs/sweep/` with three instances:
+
+```
+runs/sweep/
+  results.json
+  evaluation.json
+  resolved-1.traj.json   # submitted, evaluation resolved: true
+  unresolved-1.traj.json # step_limit_reached
+  errored-1.traj.json    # outcome: error, failure_category: model_parse
+```
+
+Running:
+
+```bash
+rust-swe-agent bench command-stats \
+  --sweep runs/sweep \
+  --compare resolved-vs-unresolved \
+  --top 5
+```
+
+Produces stdout similar to:
+
+```
+=== bench command-stats ===
+Sweep: runs/sweep
+Trajectories: 3  bash_steps: 8  unique_command_heads: 4
+
+--- Outcome: resolved ---
+╭──────┬──────────────┬────────────────┬──────────────────┬──────────────────────┬───────────────────┬─────────────────────╮
+│ rank │ command_head │ instance_count │ invocation_count │ mean_calls/instance  │ nonzero_exit_rate │ attributed_cost_usd │
+├──────┼──────────────┼────────────────┼──────────────────┼──────────────────────┼───────────────────┼─────────────────────┤
+│ 1    │ cat          │ 1              │ 2                │ 2.00                 │ 0.000             │ 0.020000            │
+│ 2    │ grep         │ 1              │ 1                │ 1.00                 │ 0.000             │ 0.010000            │
+│ 3    │ pytest       │ 1              │ 1                │ 1.00                 │ 0.000             │ 0.020000            │
+╰──────┴──────────────┴────────────────┴──────────────────┴──────────────────────┴───────────────────┴─────────────────────╯
+
+--- Outcome: unresolved ---
+...
+
+--- Comparison: resolved-vs-unresolved ---
+╭──────────────┬────────────────┬──────────────────┬─────────╮
+│ command_head │ resolved_share │ unresolved_share │ delta   │
+├──────────────┼────────────────┼──────────────────┼─────────┤
+│ pytest       │ 0.2500         │ 0.0000           │ 0.2500  │
+│ cat          │ 0.5000         │ 0.6667           │ -0.1667 │
+│ grep         │ 0.2500         │ 0.3333           │ -0.0833 │
+╰──────────────┴────────────────┴──────────────────┴─────────╯
+```
+
+The `pytest` row has a positive delta (+0.25) because it only appears in
+resolved runs. This is the signal an operator needs to form a prompt hypothesis:
+"encourage the agent to run `pytest` before submitting."
+
+The JSON artifact is also written to `runs/sweep/command-stats.json`.
+
+## Fixture sweep
+
+A reference fixture sweep is checked in at
+`tests/fixtures/command_stats/sweep/`. It contains three instances spanning
+resolved, unresolved, and errored outcomes, and is used by the regression tests
+in `tests/bench_command_stats.rs`.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -284,6 +284,8 @@ pub enum BenchCmd {
     Tail(TailCmd),
     /// Cluster unresolved sweep failures into ranked actionable groups.
     Triage(TriageCmd),
+    /// Aggregate shell-command frequency and cost by outcome bucket.
+    CommandStats(CommandStatsCmd),
     /// Pareto frontier across multiple sweep runs: ASCII chart + JSON dataset.
     Frontier(FrontierCmd),
     /// Replay a saved sweep from its manifest and report reproducibility.
@@ -921,6 +923,40 @@ pub struct TriageCmd {
     /// Number of ranked clusters to print in text mode.
     #[arg(long, default_value_t = 10)]
     pub top: usize,
+
+    /// Output format: `text` (default) or `json`.
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
+#[derive(Debug, Args)]
+pub struct CommandStatsCmd {
+    /// Completed sweep directory produced by `bench swebench`.
+    #[arg(long)]
+    pub sweep: PathBuf,
+
+    /// Restrict output to one outcome bucket: `resolved`, `unresolved`,
+    /// `errored`, or `all`.
+    #[arg(long)]
+    pub bucket: Option<String>,
+
+    /// Hide commands with fewer than N total invocations (default: 1).
+    #[arg(long, default_value_t = 1)]
+    pub min_invocations: usize,
+
+    /// Number of top rows by invocation count to print per bucket (default: 15).
+    #[arg(long, default_value_t = 15)]
+    pub top: usize,
+
+    /// Emit a delta table comparing two outcome buckets.
+    /// Currently only `resolved-vs-unresolved` is supported.
+    #[arg(long)]
+    pub compare: Option<String>,
+
+    /// Filter instances using the same syntax as `bench inspect --filter`.
+    /// Example: `failure_category=model_parse`.
+    #[arg(long)]
+    pub filter: Option<String>,
 
     /// Output format: `text` (default) or `json`.
     #[arg(long, default_value = "text")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -91,6 +91,9 @@ pub async fn run() -> Result<(), Error> {
             cmd: args::BenchCmd::Triage(t),
         } => bench_triage(t),
         Command::Bench {
+            cmd: args::BenchCmd::CommandStats(c),
+        } => bench_command_stats(c),
+        Command::Bench {
             cmd: args::BenchCmd::Frontier(f),
         } => bench_frontier(f),
         Command::Bench {
@@ -1436,6 +1439,35 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
     Ok(())
 }
 
+fn bench_command_stats(c: args::CommandStatsCmd) -> Result<(), Error> {
+    let format = match c.format.as_str() {
+        "text" => CommandStatsFormat::Text,
+        "json" => CommandStatsFormat::Json,
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "unknown --format `{other}` (expected `text` or `json`)"
+            ))));
+        }
+    };
+    let report = crate::run::command_stats::run(&crate::run::command_stats::CommandStatsArgs {
+        sweep_dir: c.sweep,
+        bucket: c.bucket,
+        min_invocations: c.min_invocations,
+        top: c.top,
+        compare: c.compare,
+        filter: c.filter,
+    })?;
+    match format {
+        CommandStatsFormat::Text => {
+            print!("{}", crate::run::command_stats::render_text(&report, c.top));
+        }
+        CommandStatsFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+    }
+    Ok(())
+}
+
 fn bench_triage(t: args::TriageCmd) -> Result<(), Error> {
     let format = match t.format.as_str() {
         "text" => TriageFormat::Text,
@@ -1613,6 +1645,12 @@ enum TailFormat {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TriageFormat {
+    Text,
+    Json,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CommandStatsFormat {
     Text,
     Json,
 }

--- a/src/run/command_stats.rs
+++ b/src/run/command_stats.rs
@@ -149,7 +149,24 @@ pub fn render_text(report: &CommandStatsReport, top: usize) -> String {
     out
 }
 
+const VALID_BUCKETS: &[&str] = &["resolved", "unresolved", "errored", "all"];
+
 fn build_report(args: &CommandStatsArgs) -> Result<CommandStatsReport, Error> {
+    if let Some(b) = &args.bucket {
+        if !VALID_BUCKETS.contains(&b.as_str()) {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "command-stats: unknown --bucket `{b}`; valid values: resolved, unresolved, errored, all"
+            ))));
+        }
+    }
+    if let Some(c) = &args.compare {
+        if c != "resolved-vs-unresolved" {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "command-stats: unknown --compare `{c}`; valid values: resolved-vs-unresolved"
+            ))));
+        }
+    }
+
     let sweep = load_sweep(&args.sweep_dir)?;
     let evaluation = load_evaluation_results_checked(&args.sweep_dir)?;
 
@@ -182,18 +199,17 @@ fn build_report(args: &CommandStatsArgs) -> Result<CommandStatsReport, Error> {
         instance_buckets.push((id, bucket));
     }
 
-    // Collect bash steps from all trajectories
+    // Collect bash steps from all trajectories (including multiple runs per instance)
     let mut all_steps: Vec<BashStep> = Vec::new();
     for (instance_id, bucket) in &instance_buckets {
         let instance = &sweep.instances[instance_id];
-        let Some(trajectory_path) = resolve_trajectory_path(&args.sweep_dir, instance_id) else {
-            continue;
-        };
-        let Ok(trajectory) = load_trajectory(&trajectory_path) else {
-            continue;
-        };
-        let steps = extract_steps_from_trajectory(&trajectory, instance_id, bucket, instance);
-        all_steps.extend(steps);
+        for trajectory_path in resolve_trajectory_paths(&args.sweep_dir, instance_id) {
+            let Ok(trajectory) = load_trajectory(&trajectory_path) else {
+                continue;
+            };
+            let steps = extract_steps_from_trajectory(&trajectory, instance_id, bucket, instance);
+            all_steps.extend(steps);
+        }
     }
 
     // Bucket filter: when set, restrict which steps contribute to each outcome bucket
@@ -208,9 +224,8 @@ fn build_report(args: &CommandStatsArgs) -> Result<CommandStatsReport, Error> {
             .iter()
             .filter(|s| {
                 let in_bucket = bucket_name == "all" || s.bucket == bucket_name;
-                let in_filter = active_bucket.map_or(true, |fb| {
-                    fb == "all" || fb == bucket_name || fb == s.bucket
-                });
+                let in_filter = active_bucket
+                    .is_none_or(|fb| fb == "all" || fb == bucket_name || fb == s.bucket);
                 in_bucket && in_filter
             })
             .collect();
@@ -493,6 +508,9 @@ fn extract_steps_from_trajectory(
             .map(|rr| rr.exit_code);
 
         for action in actions {
+            if action == "__SUBMIT__" {
+                continue;
+            }
             for head in extract_command_heads(action) {
                 steps.push(BashStep {
                     command_head: head,
@@ -602,23 +620,46 @@ fn load_trajectory(path: &Path) -> Result<Trajectory, Error> {
     serde_json::from_value(value).map_err(Into::into)
 }
 
-fn resolve_trajectory_path(sweep: &Path, instance_id: &str) -> Option<PathBuf> {
+fn resolve_trajectory_paths(sweep: &Path, instance_id: &str) -> Vec<PathBuf> {
+    // Nested single-trajectory format (legacy / hello-world)
     let nested = sweep.join(instance_id).join("trajectory.json");
     if nested.exists() {
-        return Some(nested);
+        return vec![nested];
     }
-    let nested_run = sweep.join(instance_id).join("run-1.traj.json");
-    if nested_run.exists() {
-        return Some(nested_run);
+
+    // Nested multi-run format: run-1.traj.json, run-2.traj.json, …
+    let instance_dir = sweep.join(instance_id);
+    if instance_dir.is_dir() {
+        let mut run_paths = Vec::new();
+        let mut n = 1usize;
+        loop {
+            let p = instance_dir.join(format!("run-{n}.traj.json"));
+            if !p.exists() {
+                break;
+            }
+            run_paths.push(p);
+            n += 1;
+        }
+        if !run_paths.is_empty() {
+            return run_paths;
+        }
     }
+
+    // Flat layout: <sweep>/<instance_id>.traj.json
     let flat = sweep.join(format!("{instance_id}.traj.json"));
     if flat.exists() {
-        return Some(flat);
+        return vec![flat];
     }
+
+    // Bundled layout: <sweep>/trajectories/<instance_id>.traj.json
     let bundled = sweep
         .join("trajectories")
         .join(format!("{instance_id}.traj.json"));
-    bundled.exists().then_some(bundled)
+    if bundled.exists() {
+        vec![bundled]
+    } else {
+        vec![]
+    }
 }
 
 fn utc_now_iso8601() -> String {

--- a/src/run/command_stats.rs
+++ b/src/run/command_stats.rs
@@ -84,9 +84,7 @@ pub fn render_text(report: &CommandStatsReport, top: usize) -> String {
     let _ = writeln!(
         out,
         "Trajectories: {}  bash_steps: {}  unique_command_heads: {}",
-        report.totals.trajectories,
-        report.totals.bash_steps,
-        report.totals.unique_command_heads
+        report.totals.trajectories, report.totals.bash_steps, report.totals.unique_command_heads
     );
     out.push('\n');
 
@@ -424,8 +422,7 @@ fn matches_filter(
 ) -> Result<bool, Error> {
     let Some((key, value)) = filter.split_once('=') else {
         return Err(Error::Config(crate::error::ConfigError::Invalid(
-            "command-stats: --filter expects key=value (e.g. failure_category=model_parse)"
-                .into(),
+            "command-stats: --filter expects key=value (e.g. failure_category=model_parse)".into(),
         )));
     };
     let (key, value) = (key.trim(), value.trim());
@@ -439,9 +436,9 @@ fn matches_filter(
             let expected = value == "true";
             Ok(resolved == Some(expected))
         }
-        "failure_category" => Ok(instance.failure_category.is_some_and(|fc| {
-            failure_category_label(fc) == value
-        })),
+        "failure_category" => Ok(instance
+            .failure_category
+            .is_some_and(|fc| failure_category_label(fc) == value)),
         other => Err(Error::Config(crate::error::ConfigError::Invalid(format!(
             "command-stats: unsupported filter key `{other}`; supported: `resolved`, `failure_category`"
         )))),
@@ -571,10 +568,7 @@ fn extract_segment_head(segment: &str) -> String {
         if token == "env" {
             i += 1;
             // Skip VAR=val tokens after `env`
-            while i < tokens.len()
-                && tokens[i].contains('=')
-                && !tokens[i].starts_with('-')
-            {
+            while i < tokens.len() && tokens[i].contains('=') && !tokens[i].starts_with('-') {
                 i += 1;
             }
             continue;

--- a/src/run/command_stats.rs
+++ b/src/run/command_stats.rs
@@ -252,7 +252,16 @@ fn build_report(args: &CommandStatsArgs) -> Result<CommandStatsReport, Error> {
         unique_command_heads,
     };
 
-    let comparisons = build_comparisons(args, &by_outcome);
+    // Pre-filter totals: count invocations per bucket from all_steps so that
+    // --min-invocations doesn't shrink the denominator used for share calculations.
+    let resolved_total_all: usize = all_steps.iter().filter(|s| s.bucket == "resolved").count();
+    let unresolved_total_all: usize = all_steps
+        .iter()
+        .filter(|s| s.bucket == "unresolved")
+        .count();
+
+    let comparisons =
+        build_comparisons(args, &by_outcome, resolved_total_all, unresolved_total_all);
 
     Ok(CommandStatsReport {
         sweep: args.sweep_dir.display().to_string(),
@@ -266,6 +275,8 @@ fn build_report(args: &CommandStatsArgs) -> Result<CommandStatsReport, Error> {
 fn build_comparisons(
     args: &CommandStatsArgs,
     by_outcome: &BTreeMap<String, Vec<CommandStatRow>>,
+    resolved_total: usize,
+    unresolved_total: usize,
 ) -> Vec<CommandStatsComparison> {
     let Some(compare) = &args.compare else {
         return Vec::new();
@@ -279,16 +290,20 @@ fn build_comparisons(
     let Some(unresolved_rows) = by_outcome.get("unresolved") else {
         return Vec::new();
     };
-    vec![build_resolved_vs_unresolved(resolved_rows, unresolved_rows)]
+    vec![build_resolved_vs_unresolved(
+        resolved_rows,
+        unresolved_rows,
+        resolved_total,
+        unresolved_total,
+    )]
 }
 
 fn build_resolved_vs_unresolved(
     resolved_rows: &[CommandStatRow],
     unresolved_rows: &[CommandStatRow],
+    resolved_total: usize,
+    unresolved_total: usize,
 ) -> CommandStatsComparison {
-    let resolved_total: usize = resolved_rows.iter().map(|r| r.invocation_count).sum();
-    let unresolved_total: usize = unresolved_rows.iter().map(|r| r.invocation_count).sum();
-
     let all_heads: BTreeSet<&str> = resolved_rows
         .iter()
         .map(|r| r.command_head.as_str())

--- a/src/run/command_stats.rs
+++ b/src/run/command_stats.rs
@@ -174,8 +174,9 @@ fn build_report(args: &CommandStatsArgs) -> Result<CommandStatsReport, Error> {
     sorted_ids.sort();
     for id in sorted_ids {
         let instance = &sweep.instances[&id];
+        let is_resolved = resolved_set.contains(&id);
         if let Some(filter) = &args.filter {
-            if !matches_filter(instance, filter) {
+            if !matches_filter(instance, Some(is_resolved), filter)? {
                 continue;
             }
         }
@@ -416,15 +417,34 @@ fn classify_outcome(
     OutcomeBucket::Unresolved
 }
 
-fn matches_filter(instance: &InstanceResult, filter: &str) -> bool {
+fn matches_filter(
+    instance: &InstanceResult,
+    resolved: Option<bool>,
+    filter: &str,
+) -> Result<bool, Error> {
     let Some((key, value)) = filter.split_once('=') else {
-        return true;
+        return Err(Error::Config(crate::error::ConfigError::Invalid(
+            "command-stats: --filter expects key=value (e.g. failure_category=model_parse)"
+                .into(),
+        )));
     };
-    match key.trim() {
-        "failure_category" => instance.failure_category.is_some_and(|fc| {
-            failure_category_label(fc) == value.trim()
-        }),
-        _ => true,
+    let (key, value) = (key.trim(), value.trim());
+    match key {
+        "resolved" => {
+            if value != "true" && value != "false" {
+                return Err(Error::Config(crate::error::ConfigError::Invalid(
+                    "command-stats: resolved filter must be `true` or `false`".into(),
+                )));
+            }
+            let expected = value == "true";
+            Ok(resolved == Some(expected))
+        }
+        "failure_category" => Ok(instance.failure_category.is_some_and(|fc| {
+            failure_category_label(fc) == value
+        })),
+        other => Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "command-stats: unsupported filter key `{other}`; supported: `resolved`, `failure_category`"
+        )))),
     }
 }
 

--- a/src/run/command_stats.rs
+++ b/src/run/command_stats.rs
@@ -1,0 +1,640 @@
+//! `bench command-stats`: surface shell-command behavior by outcome bucket.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::artifact::{ArtifactKind, classify_json_value};
+use crate::env::RunResult;
+use crate::error::Error;
+use crate::run::compare::{load_evaluation_results_checked, load_sweep};
+use crate::run::swebench::InstanceResult;
+use crate::trajectory::{FailureCategory, Trajectory};
+
+#[derive(Debug, Clone)]
+pub struct CommandStatsArgs {
+    pub sweep_dir: PathBuf,
+    pub bucket: Option<String>,
+    pub min_invocations: usize,
+    pub top: usize,
+    pub compare: Option<String>,
+    pub filter: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandStatRow {
+    pub command_head: String,
+    pub instance_count: usize,
+    pub invocation_count: usize,
+    pub mean_calls_per_instance: f64,
+    pub nonzero_exit_rate: f64,
+    pub attributed_cost_usd: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandStatsTotals {
+    pub trajectories: usize,
+    pub bash_steps: usize,
+    pub unique_command_heads: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandStatsDelta {
+    pub command_head: String,
+    pub resolved_share: f64,
+    pub unresolved_share: f64,
+    pub delta: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandStatsComparison {
+    pub name: String,
+    pub rows: Vec<CommandStatsDelta>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandStatsReport {
+    pub sweep: String,
+    pub generated_at: String,
+    pub totals: CommandStatsTotals,
+    pub by_outcome: BTreeMap<String, Vec<CommandStatRow>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comparisons: Vec<CommandStatsComparison>,
+}
+
+pub fn run(args: &CommandStatsArgs) -> Result<CommandStatsReport, Error> {
+    let mut report = build_report(args)?;
+    report.generated_at = utc_now_iso8601();
+    let output_path = args.sweep_dir.join("command-stats.json");
+    let file = std::fs::File::create(output_path)?;
+    serde_json::to_writer_pretty(file, &report)?;
+    Ok(report)
+}
+
+pub fn render_text(report: &CommandStatsReport, top: usize) -> String {
+    use comfy_table::Table;
+    use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+    use comfy_table::presets::UTF8_FULL;
+
+    let mut out = String::new();
+    out.push_str("\n=== bench command-stats ===\n");
+    let _ = writeln!(out, "Sweep: {}", report.sweep);
+    let _ = writeln!(
+        out,
+        "Trajectories: {}  bash_steps: {}  unique_command_heads: {}",
+        report.totals.trajectories,
+        report.totals.bash_steps,
+        report.totals.unique_command_heads
+    );
+    out.push('\n');
+
+    for (bucket, rows) in &report.by_outcome {
+        let _ = writeln!(out, "--- Outcome: {bucket} ---");
+        let mut table = Table::new();
+        table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec![
+                "rank",
+                "command_head",
+                "instance_count",
+                "invocation_count",
+                "mean_calls/instance",
+                "nonzero_exit_rate",
+                "attributed_cost_usd",
+            ]);
+
+        for (idx, row) in rows.iter().take(top).enumerate() {
+            table.add_row(vec![
+                (idx + 1).to_string(),
+                row.command_head.clone(),
+                row.instance_count.to_string(),
+                row.invocation_count.to_string(),
+                format!("{:.2}", row.mean_calls_per_instance),
+                format!("{:.3}", row.nonzero_exit_rate),
+                format!("{:.6}", row.attributed_cost_usd),
+            ]);
+        }
+
+        out.push_str(&table.to_string());
+        out.push('\n');
+    }
+
+    for comparison in &report.comparisons {
+        let _ = writeln!(out, "--- Comparison: {} ---", comparison.name);
+        let mut table = Table::new();
+        table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec![
+                "command_head",
+                "resolved_share",
+                "unresolved_share",
+                "delta",
+            ]);
+
+        for row in &comparison.rows {
+            table.add_row(vec![
+                row.command_head.clone(),
+                format!("{:.4}", row.resolved_share),
+                format!("{:.4}", row.unresolved_share),
+                format!("{:.4}", row.delta),
+            ]);
+        }
+
+        out.push_str(&table.to_string());
+        out.push('\n');
+    }
+
+    out
+}
+
+fn build_report(args: &CommandStatsArgs) -> Result<CommandStatsReport, Error> {
+    let sweep = load_sweep(&args.sweep_dir)?;
+    let evaluation = load_evaluation_results_checked(&args.sweep_dir)?;
+
+    // Build resolved-instance set from evaluation (keyed by instance_id)
+    let resolved_set: HashSet<String> = evaluation
+        .as_ref()
+        .map(|ev| {
+            ev.results
+                .instances
+                .iter()
+                .filter(|i| i.resolved)
+                .map(|i| i.instance_id.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Classify each instance by outcome bucket, applying the optional filter
+    let mut instance_buckets: Vec<(String, OutcomeBucket)> = Vec::new();
+    let mut sorted_ids: Vec<String> = sweep.instances.keys().cloned().collect();
+    sorted_ids.sort();
+    for id in sorted_ids {
+        let instance = &sweep.instances[&id];
+        if let Some(filter) = &args.filter {
+            if !matches_filter(instance, filter) {
+                continue;
+            }
+        }
+        let bucket = classify_outcome(&id, instance, &resolved_set);
+        instance_buckets.push((id, bucket));
+    }
+
+    // Collect bash steps from all trajectories
+    let mut all_steps: Vec<BashStep> = Vec::new();
+    for (instance_id, bucket) in &instance_buckets {
+        let instance = &sweep.instances[instance_id];
+        let Some(trajectory_path) = resolve_trajectory_path(&args.sweep_dir, instance_id) else {
+            continue;
+        };
+        let Ok(trajectory) = load_trajectory(&trajectory_path) else {
+            continue;
+        };
+        let steps = extract_steps_from_trajectory(&trajectory, instance_id, bucket, instance);
+        all_steps.extend(steps);
+    }
+
+    // Bucket filter: when set, restrict which steps contribute to each outcome bucket
+    let active_bucket = args.bucket.as_deref();
+
+    // Aggregate rows per outcome bucket
+    let bucket_names = ["resolved", "unresolved", "errored", "all"];
+    let mut by_outcome: BTreeMap<String, Vec<CommandStatRow>> = BTreeMap::new();
+    for &bucket_name in &bucket_names {
+        // Skip this bucket entirely when filtering to a different bucket (non-"all" filter)
+        let step_subset: Vec<&BashStep> = all_steps
+            .iter()
+            .filter(|s| {
+                let in_bucket = bucket_name == "all" || s.bucket == bucket_name;
+                let in_filter = active_bucket.map_or(true, |fb| {
+                    fb == "all" || fb == bucket_name || fb == s.bucket
+                });
+                in_bucket && in_filter
+            })
+            .collect();
+
+        let mut rows = aggregate_rows(step_subset.iter().copied());
+        rows.retain(|r| r.invocation_count >= args.min_invocations);
+        rows.sort_by(|a, b| {
+            b.invocation_count
+                .cmp(&a.invocation_count)
+                .then_with(|| a.command_head.cmp(&b.command_head))
+        });
+        by_outcome.insert(bucket_name.to_owned(), rows);
+    }
+
+    // Totals over all steps (unfiltered by bucket, but filtered by instance filter)
+    let total_bash_steps = all_steps.len();
+    let unique_heads: HashSet<&str> = all_steps.iter().map(|s| s.command_head.as_str()).collect();
+    let unique_command_heads = unique_heads.len();
+    let trajectories = instance_buckets.len();
+
+    let totals = CommandStatsTotals {
+        trajectories,
+        bash_steps: total_bash_steps,
+        unique_command_heads,
+    };
+
+    let comparisons = build_comparisons(args, &by_outcome);
+
+    Ok(CommandStatsReport {
+        sweep: args.sweep_dir.display().to_string(),
+        generated_at: String::new(),
+        totals,
+        by_outcome,
+        comparisons,
+    })
+}
+
+fn build_comparisons(
+    args: &CommandStatsArgs,
+    by_outcome: &BTreeMap<String, Vec<CommandStatRow>>,
+) -> Vec<CommandStatsComparison> {
+    let Some(compare) = &args.compare else {
+        return Vec::new();
+    };
+    if compare != "resolved-vs-unresolved" {
+        return Vec::new();
+    }
+    let Some(resolved_rows) = by_outcome.get("resolved") else {
+        return Vec::new();
+    };
+    let Some(unresolved_rows) = by_outcome.get("unresolved") else {
+        return Vec::new();
+    };
+    vec![build_resolved_vs_unresolved(resolved_rows, unresolved_rows)]
+}
+
+fn build_resolved_vs_unresolved(
+    resolved_rows: &[CommandStatRow],
+    unresolved_rows: &[CommandStatRow],
+) -> CommandStatsComparison {
+    let resolved_total: usize = resolved_rows.iter().map(|r| r.invocation_count).sum();
+    let unresolved_total: usize = unresolved_rows.iter().map(|r| r.invocation_count).sum();
+
+    let all_heads: BTreeSet<&str> = resolved_rows
+        .iter()
+        .map(|r| r.command_head.as_str())
+        .chain(unresolved_rows.iter().map(|r| r.command_head.as_str()))
+        .collect();
+
+    let mut deltas: Vec<CommandStatsDelta> = all_heads
+        .iter()
+        .map(|&head| {
+            let r_count = resolved_rows
+                .iter()
+                .find(|r| r.command_head == head)
+                .map_or(0, |r| r.invocation_count);
+            let u_count = unresolved_rows
+                .iter()
+                .find(|r| r.command_head == head)
+                .map_or(0, |r| r.invocation_count);
+            #[allow(clippy::cast_precision_loss)]
+            let r_share = if resolved_total > 0 {
+                r_count as f64 / resolved_total as f64
+            } else {
+                0.0
+            };
+            #[allow(clippy::cast_precision_loss)]
+            let u_share = if unresolved_total > 0 {
+                u_count as f64 / unresolved_total as f64
+            } else {
+                0.0
+            };
+            CommandStatsDelta {
+                command_head: head.to_owned(),
+                resolved_share: r_share,
+                unresolved_share: u_share,
+                delta: r_share - u_share,
+            }
+        })
+        .collect();
+
+    deltas.sort_by(|a, b| {
+        b.delta
+            .total_cmp(&a.delta)
+            .then_with(|| a.command_head.cmp(&b.command_head))
+    });
+
+    CommandStatsComparison {
+        name: "resolved-vs-unresolved".to_owned(),
+        rows: deltas,
+    }
+}
+
+// ── internal types ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct BashStep {
+    command_head: String,
+    instance_id: String,
+    bucket: String,
+    exit_code: Option<i32>,
+    cost_usd: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum OutcomeBucket {
+    Resolved,
+    Unresolved,
+    Errored,
+}
+
+impl OutcomeBucket {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Resolved => "resolved",
+            Self::Unresolved => "unresolved",
+            Self::Errored => "errored",
+        }
+    }
+}
+
+// ── aggregation ───────────────────────────────────────────────────────────────
+
+fn aggregate_rows<'a, I>(steps: I) -> Vec<CommandStatRow>
+where
+    I: Iterator<Item = &'a BashStep>,
+{
+    let mut by_head: BTreeMap<String, Vec<&'a BashStep>> = BTreeMap::new();
+    for step in steps {
+        by_head
+            .entry(step.command_head.clone())
+            .or_default()
+            .push(step);
+    }
+
+    by_head
+        .into_iter()
+        .map(|(head, steps)| {
+            let invocation_count = steps.len();
+            let unique_instances: HashSet<&str> =
+                steps.iter().map(|s| s.instance_id.as_str()).collect();
+            let instance_count = unique_instances.len();
+            #[allow(clippy::cast_precision_loss)]
+            let mean_calls_per_instance = invocation_count as f64 / instance_count as f64;
+            let nonzero_exits = steps
+                .iter()
+                .filter(|s| s.exit_code.is_some_and(|c| c != 0))
+                .count();
+            let exits_known = steps.iter().filter(|s| s.exit_code.is_some()).count();
+            #[allow(clippy::cast_precision_loss)]
+            let nonzero_exit_rate = if exits_known > 0 {
+                nonzero_exits as f64 / exits_known as f64
+            } else {
+                0.0
+            };
+            let attributed_cost_usd: f64 = steps.iter().map(|s| s.cost_usd).sum();
+            CommandStatRow {
+                command_head: head,
+                instance_count,
+                invocation_count,
+                mean_calls_per_instance,
+                nonzero_exit_rate,
+                attributed_cost_usd,
+            }
+        })
+        .collect()
+}
+
+// ── classification ────────────────────────────────────────────────────────────
+
+fn classify_outcome(
+    instance_id: &str,
+    instance: &InstanceResult,
+    resolved_set: &HashSet<String>,
+) -> OutcomeBucket {
+    if resolved_set.contains(instance_id) {
+        return OutcomeBucket::Resolved;
+    }
+    if instance.outcome.as_deref() == Some(crate::trajectory::outcome::ERROR) {
+        return OutcomeBucket::Errored;
+    }
+    OutcomeBucket::Unresolved
+}
+
+fn matches_filter(instance: &InstanceResult, filter: &str) -> bool {
+    let Some((key, value)) = filter.split_once('=') else {
+        return true;
+    };
+    match key.trim() {
+        "failure_category" => instance.failure_category.is_some_and(|fc| {
+            failure_category_label(fc) == value.trim()
+        }),
+        _ => true,
+    }
+}
+
+fn failure_category_label(c: FailureCategory) -> &'static str {
+    match c {
+        FailureCategory::EnvSetup => "env_setup",
+        FailureCategory::ModelApi => "model_api",
+        FailureCategory::ModelParse => "model_parse",
+        FailureCategory::StepLimit => "step_limit",
+        FailureCategory::CostLimit => "cost_limit",
+        FailureCategory::BudgetExhausted => "budget_exhausted",
+        FailureCategory::WallclockTimeout => "wallclock_timeout",
+        FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::AgentStagnation => "agent_stagnation",
+        FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
+        FailureCategory::PatchEmpty => "patch_empty",
+        FailureCategory::SecretLeakDetected => "secret_leak_detected",
+        FailureCategory::Unknown => "unknown",
+    }
+}
+
+// ── step extraction ───────────────────────────────────────────────────────────
+
+fn extract_steps_from_trajectory(
+    trajectory: &Trajectory,
+    instance_id: &str,
+    bucket: &OutcomeBucket,
+    _instance: &InstanceResult,
+) -> Vec<BashStep> {
+    let mut steps = Vec::new();
+    let bucket_str = bucket.as_str().to_owned();
+    let messages = &trajectory.messages;
+
+    for (i, msg) in messages.iter().enumerate() {
+        if msg.role != "assistant" {
+            continue;
+        }
+        let Some(actions) = &msg.extra.actions else {
+            continue;
+        };
+        let cost = msg.extra.cost.unwrap_or(0.0);
+
+        // Find the exit code from the next user observation message
+        let exit_code = messages[i + 1..]
+            .iter()
+            .find(|m| m.role == "user")
+            .and_then(|m| m.extra.other.get("run_result"))
+            .and_then(|v| serde_json::from_value::<RunResult>(v.clone()).ok())
+            .map(|rr| rr.exit_code);
+
+        for action in actions {
+            for head in extract_command_heads(action) {
+                steps.push(BashStep {
+                    command_head: head,
+                    instance_id: instance_id.to_owned(),
+                    bucket: bucket_str.clone(),
+                    exit_code,
+                    cost_usd: cost,
+                });
+            }
+        }
+    }
+
+    steps
+}
+
+// ── head extraction (public for unit tests) ───────────────────────────────────
+
+/// Extract the normalized command head(s) from a bash command string.
+///
+/// Handles:
+/// - Pipelines: `a | b | c` → `["a", "b", "c"]` (not `||`)
+/// - Leading `sudo` prefix stripped
+/// - Leading `time` prefix stripped
+/// - Leading `env VAR=val ...` prefix stripped
+/// - Leading bare `VAR=val` environment assignments stripped
+pub fn extract_command_heads(command: &str) -> Vec<String> {
+    let command = command.trim();
+    if command.is_empty() {
+        return Vec::new();
+    }
+    split_pipeline(command)
+        .into_iter()
+        .filter_map(|segment| {
+            let head = extract_segment_head(segment.trim());
+            if head.is_empty() { None } else { Some(head) }
+        })
+        .collect()
+}
+
+/// Split on `|` but not `||`.
+fn split_pipeline(command: &str) -> Vec<&str> {
+    let mut segments: Vec<&str> = Vec::new();
+    let bytes = command.as_bytes();
+    let mut start = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'|' && i + 1 < bytes.len() && bytes[i + 1] == b'|' {
+            // logical OR — stop splitting here; treat the rest as one segment
+            break;
+        }
+        if bytes[i] == b'|' {
+            segments.push(&command[start..i]);
+            start = i + 1;
+        }
+        i += 1;
+    }
+    segments.push(&command[start..]);
+    segments
+}
+
+/// Extract the command head from one pipeline segment, stripping prefixes.
+fn extract_segment_head(segment: &str) -> String {
+    let tokens: Vec<&str> = segment.split_whitespace().collect();
+    let mut i = 0;
+    while i < tokens.len() {
+        let token = tokens[i];
+
+        if token == "sudo" || token == "time" {
+            i += 1;
+            continue;
+        }
+
+        if token == "env" {
+            i += 1;
+            // Skip VAR=val tokens after `env`
+            while i < tokens.len()
+                && tokens[i].contains('=')
+                && !tokens[i].starts_with('-')
+            {
+                i += 1;
+            }
+            continue;
+        }
+
+        // Bare VAR=val assignment: identifier before `=`
+        if let Some(eq) = token.find('=') {
+            let var = &token[..eq];
+            if !var.is_empty()
+                && !var.starts_with('-')
+                && !var.starts_with('/')
+                && var.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+            {
+                i += 1;
+                continue;
+            }
+        }
+
+        return token.to_owned();
+    }
+    String::new()
+}
+
+// ── trajectory loading (mirrors triage.rs) ────────────────────────────────────
+
+fn load_trajectory(path: &Path) -> Result<Trajectory, Error> {
+    let text = std::fs::read_to_string(path)?;
+    let value: serde_json::Value = serde_json::from_str(&text)?;
+    classify_json_value(&value, ArtifactKind::Trajectory, path.display().to_string())
+        .map_err(|err| Error::Trajectory(err.to_string()))?;
+    serde_json::from_value(value).map_err(Into::into)
+}
+
+fn resolve_trajectory_path(sweep: &Path, instance_id: &str) -> Option<PathBuf> {
+    let nested = sweep.join(instance_id).join("trajectory.json");
+    if nested.exists() {
+        return Some(nested);
+    }
+    let nested_run = sweep.join(instance_id).join("run-1.traj.json");
+    if nested_run.exists() {
+        return Some(nested_run);
+    }
+    let flat = sweep.join(format!("{instance_id}.traj.json"));
+    if flat.exists() {
+        return Some(flat);
+    }
+    let bundled = sweep
+        .join("trajectories")
+        .join(format!("{instance_id}.traj.json"));
+    bundled.exists().then_some(bundled)
+}
+
+fn utc_now_iso8601() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_pipeline_handles_logical_or() {
+        let segs = split_pipeline("false || true");
+        // The `||` causes us to stop splitting; "false " is the first and only segment
+        assert_eq!(segs.len(), 1, "|| should not create a pipeline split");
+    }
+
+    #[test]
+    fn extract_heads_pipeline_three_segments() {
+        assert_eq!(
+            extract_command_heads("cat f | grep x | sort"),
+            vec!["cat", "grep", "sort"]
+        );
+    }
+
+    #[test]
+    fn extract_heads_strips_nested_prefixes() {
+        assert_eq!(
+            extract_command_heads("sudo time env A=1 pytest -x"),
+            vec!["pytest"]
+        );
+    }
+}

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod bundle;
 pub mod calibrate;
+pub mod command_stats;
 pub mod compare;
 pub mod dataset;
 pub mod evaluate;

--- a/tests/bench_command_stats.rs
+++ b/tests/bench_command_stats.rs
@@ -1,6 +1,6 @@
 //! `bench command-stats`: surface shell-command behavior by outcome.
 
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)]
 
 use std::path::Path;
 use std::process::Command;
@@ -294,9 +294,7 @@ fn cli_rows_ordered_by_invocation_count_descending() {
         let curr = all_rows[i]["invocation_count"].as_u64().unwrap();
         assert!(
             prev >= curr,
-            "rows should be sorted by invocation_count descending: {} before {}",
-            prev,
-            curr
+            "rows should be sorted by invocation_count descending: {prev} before {curr}"
         );
     }
 
@@ -376,8 +374,7 @@ fn cli_min_invocations_hides_low_frequency_commands() {
     for row in all_rows {
         assert!(
             row["invocation_count"].as_u64().unwrap() >= 3,
-            "all rows should have >= 3 invocations, got {:?}",
-            row
+            "all rows should have >= 3 invocations, got {row:?}"
         );
     }
 }

--- a/tests/bench_command_stats.rs
+++ b/tests/bench_command_stats.rs
@@ -1,6 +1,6 @@
 //! `bench command-stats`: surface shell-command behavior by outcome.
 
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::path::Path;
 use std::process::Command;
@@ -20,7 +20,10 @@ fn head_extraction_simple_command() {
 
 #[test]
 fn head_extraction_strips_sudo() {
-    assert_eq!(extract_command_heads("sudo apt-get install python3"), vec!["apt-get"]);
+    assert_eq!(
+        extract_command_heads("sudo apt-get install python3"),
+        vec!["apt-get"]
+    );
 }
 
 #[test]
@@ -30,12 +33,18 @@ fn head_extraction_strips_time() {
 
 #[test]
 fn head_extraction_strips_env_prefix() {
-    assert_eq!(extract_command_heads("env RUST_LOG=debug cargo build"), vec!["cargo"]);
+    assert_eq!(
+        extract_command_heads("env RUST_LOG=debug cargo build"),
+        vec!["cargo"]
+    );
 }
 
 #[test]
 fn head_extraction_strips_inline_var_assignment() {
-    assert_eq!(extract_command_heads("RUST_LOG=debug cargo build"), vec!["cargo"]);
+    assert_eq!(
+        extract_command_heads("RUST_LOG=debug cargo build"),
+        vec!["cargo"]
+    );
 }
 
 #[test]
@@ -160,15 +169,22 @@ fn cli_writes_command_stats_json_artifact() {
         report["totals"]["bash_steps"].as_u64().unwrap() > 0,
         "should have bash steps"
     );
-    assert!(
-        report["totals"]["unique_command_heads"].as_u64().unwrap() > 0
-    );
+    assert!(report["totals"]["unique_command_heads"].as_u64().unwrap() > 0);
 
     // by_outcome buckets
     let by_outcome = report["by_outcome"].as_object().unwrap();
-    assert!(by_outcome.contains_key("resolved"), "resolved bucket required");
-    assert!(by_outcome.contains_key("unresolved"), "unresolved bucket required");
-    assert!(by_outcome.contains_key("errored"), "errored bucket required");
+    assert!(
+        by_outcome.contains_key("resolved"),
+        "resolved bucket required"
+    );
+    assert!(
+        by_outcome.contains_key("unresolved"),
+        "unresolved bucket required"
+    );
+    assert!(
+        by_outcome.contains_key("errored"),
+        "errored bucket required"
+    );
     assert!(by_outcome.contains_key("all"), "all bucket required");
 }
 
@@ -226,11 +242,20 @@ fn cli_row_fields_have_correct_types() {
 
     // Check resolved bucket rows
     let resolved_rows = report["by_outcome"]["resolved"].as_array().unwrap();
-    assert!(!resolved_rows.is_empty(), "resolved bucket should have rows");
+    assert!(
+        !resolved_rows.is_empty(),
+        "resolved bucket should have rows"
+    );
     let row = &resolved_rows[0];
-    assert!(row["command_head"].is_string(), "command_head must be string");
+    assert!(
+        row["command_head"].is_string(),
+        "command_head must be string"
+    );
     assert!(row["instance_count"].is_u64(), "instance_count must be int");
-    assert!(row["invocation_count"].is_u64(), "invocation_count must be int");
+    assert!(
+        row["invocation_count"].is_u64(),
+        "invocation_count must be int"
+    );
     assert!(row["mean_calls_per_instance"].is_f64() || row["mean_calls_per_instance"].is_u64());
     assert!(row["nonzero_exit_rate"].is_f64() || row["nonzero_exit_rate"].is_u64());
     assert!(row["attributed_cost_usd"].is_f64() || row["attributed_cost_usd"].is_u64());
@@ -276,7 +301,10 @@ fn cli_rows_ordered_by_invocation_count_descending() {
     }
 
     // cat should be first (most invocations: 4 total across all instances)
-    assert_eq!(all_rows[0]["command_head"], "cat", "cat has most invocations");
+    assert_eq!(
+        all_rows[0]["command_head"], "cat",
+        "cat has most invocations"
+    );
 }
 
 #[test]
@@ -475,14 +503,12 @@ fn cli_output_is_deterministic_except_generated_at() {
     copy_command_stats_fixture(sweep.path());
 
     let first = run_command_stats_json(sweep.path());
-    let first_file =
-        std::fs::read_to_string(sweep.path().join("command-stats.json")).unwrap();
+    let first_file = std::fs::read_to_string(sweep.path().join("command-stats.json")).unwrap();
 
     std::thread::sleep(Duration::from_secs(1));
 
     let second = run_command_stats_json(sweep.path());
-    let second_file =
-        std::fs::read_to_string(sweep.path().join("command-stats.json")).unwrap();
+    let second_file = std::fs::read_to_string(sweep.path().join("command-stats.json")).unwrap();
 
     assert_eq!(
         redact_generated_at(&first),
@@ -659,7 +685,8 @@ fn cli_json_output_matches_golden_snapshot_byte_for_byte() {
     let golden_pretty = serde_json::to_string_pretty(&golden).unwrap();
 
     assert_eq!(
-        actual_pretty, golden_pretty,
+        actual_pretty,
+        golden_pretty,
         "JSON output does not match golden snapshot.\n\
          If the change is intentional, update tests/fixtures/command_stats/golden-command-stats.json.\n\
          Diff (actual vs golden):\n{}\n",
@@ -823,8 +850,7 @@ fn cli_filter_resolved_bad_value_exits_nonzero() {
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 fn copy_command_stats_fixture(dir: &Path) {
-    let fixture =
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/command_stats/sweep");
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/command_stats/sweep");
     copy_dir(&fixture, dir);
 }
 

--- a/tests/bench_command_stats.rs
+++ b/tests/bench_command_stats.rs
@@ -615,6 +615,211 @@ fn cli_nonzero_exit_rate_reflects_failed_commands() {
     );
 }
 
+// ── golden snapshot regression test ──────────────────────────────────────────
+
+#[test]
+fn cli_json_output_matches_golden_snapshot_byte_for_byte() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--compare",
+            "resolved-vs-unresolved",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench command-stats failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let mut actual: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // Zero out the two fields that legitimately vary between runs
+    actual["sweep"] = serde_json::json!("");
+    actual["generated_at"] = serde_json::json!("");
+
+    let golden_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/command_stats/golden-command-stats.json");
+    let golden: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&golden_path).unwrap()).unwrap();
+
+    let actual_pretty = serde_json::to_string_pretty(&actual).unwrap();
+    let golden_pretty = serde_json::to_string_pretty(&golden).unwrap();
+
+    assert_eq!(
+        actual_pretty, golden_pretty,
+        "JSON output does not match golden snapshot.\n\
+         If the change is intentional, update tests/fixtures/command_stats/golden-command-stats.json.\n\
+         Diff (actual vs golden):\n{}\n",
+        diff_strings(&actual_pretty, &golden_pretty)
+    );
+}
+
+fn diff_strings(actual: &str, expected: &str) -> String {
+    actual
+        .lines()
+        .zip(expected.lines())
+        .enumerate()
+        .filter(|(_, (a, e))| a != e)
+        .take(20)
+        .map(|(i, (a, e))| format!("line {}: actual={a:?} expected={e:?}", i + 1))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// ── --filter resolved= tests ──────────────────────────────────────────────────
+
+#[test]
+fn cli_filter_resolved_true_restricts_to_resolved_instances() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--filter",
+            "resolved=true",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "command-stats --filter resolved=true failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // Only resolved-1 is in scope, so totals.trajectories == 1
+    assert_eq!(
+        report["totals"]["trajectories"], 1,
+        "only resolved-1 should be in scope with resolved=true"
+    );
+    // pytest only appears in resolved-1 — it must be present
+    let all_rows = report["by_outcome"]["all"].as_array().unwrap();
+    assert!(
+        all_rows.iter().any(|r| r["command_head"] == "pytest"),
+        "pytest should be present when filtering to resolved=true"
+    );
+}
+
+#[test]
+fn cli_filter_resolved_false_excludes_resolved_instances() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--filter",
+            "resolved=false",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "command-stats --filter resolved=false failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // unresolved-1 and errored-1 are in scope
+    assert_eq!(
+        report["totals"]["trajectories"], 2,
+        "unresolved-1 and errored-1 should be in scope with resolved=false"
+    );
+    // pytest only appears in resolved-1 — it must NOT be present
+    let all_rows = report["by_outcome"]["all"].as_array().unwrap();
+    assert!(
+        !all_rows.iter().any(|r| r["command_head"] == "pytest"),
+        "pytest should be absent when filtering to resolved=false"
+    );
+}
+
+#[test]
+fn cli_filter_invalid_key_exits_nonzero() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--filter",
+            "bogus_key=foo",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "unsupported filter key should cause non-zero exit"
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("unsupported filter key") || stderr.contains("bogus_key"),
+        "error message should mention the bad key: {stderr}"
+    );
+}
+
+#[test]
+fn cli_filter_resolved_bad_value_exits_nonzero() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--filter",
+            "resolved=maybe",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "resolved=<non-bool> should cause non-zero exit"
+    );
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 fn copy_command_stats_fixture(dir: &Path) {

--- a/tests/bench_command_stats.rs
+++ b/tests/bench_command_stats.rs
@@ -1,0 +1,684 @@
+//! `bench command-stats`: surface shell-command behavior by outcome.
+
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+mod support;
+use support::binary_path;
+
+// ── unit tests for head extraction (live in the library) ──────────────────────
+
+use rust_swe_agent::run::command_stats::extract_command_heads;
+
+#[test]
+fn head_extraction_simple_command() {
+    assert_eq!(extract_command_heads("ls -la"), vec!["ls"]);
+}
+
+#[test]
+fn head_extraction_strips_sudo() {
+    assert_eq!(extract_command_heads("sudo apt-get install python3"), vec!["apt-get"]);
+}
+
+#[test]
+fn head_extraction_strips_time() {
+    assert_eq!(extract_command_heads("time cargo test"), vec!["cargo"]);
+}
+
+#[test]
+fn head_extraction_strips_env_prefix() {
+    assert_eq!(extract_command_heads("env RUST_LOG=debug cargo build"), vec!["cargo"]);
+}
+
+#[test]
+fn head_extraction_strips_inline_var_assignment() {
+    assert_eq!(extract_command_heads("RUST_LOG=debug cargo build"), vec!["cargo"]);
+}
+
+#[test]
+fn head_extraction_decomposes_pipeline() {
+    let heads = extract_command_heads("cat file.txt | grep error | sort -u");
+    assert_eq!(heads, vec!["cat", "grep", "sort"]);
+}
+
+#[test]
+fn head_extraction_pipeline_not_logical_or() {
+    // `||` should not split into segments the way `|` does
+    let heads = extract_command_heads("false || true");
+    assert_eq!(heads, vec!["false"]);
+}
+
+#[test]
+fn head_extraction_empty_command_returns_empty() {
+    let heads = extract_command_heads("");
+    assert!(heads.is_empty(), "empty command should produce no heads");
+}
+
+#[test]
+fn head_extraction_whitespace_only_returns_empty() {
+    let heads = extract_command_heads("   ");
+    assert!(heads.is_empty());
+}
+
+#[test]
+fn head_extraction_quoted_args_dont_affect_head() {
+    assert_eq!(extract_command_heads("grep 'def test' ."), vec!["grep"]);
+}
+
+#[test]
+fn head_extraction_sudo_time_combined() {
+    assert_eq!(extract_command_heads("sudo time pytest -x"), vec!["pytest"]);
+}
+
+#[test]
+fn head_extraction_strips_multiple_env_vars() {
+    assert_eq!(
+        extract_command_heads("A=1 B=2 C=3 python script.py"),
+        vec!["python"]
+    );
+}
+
+// ── CLI integration tests ─────────────────────────────────────────────────────
+
+#[test]
+fn cli_produces_text_output_with_outcome_tables() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench command-stats failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("=== bench command-stats ==="), "{stdout}");
+    // Should show outcome buckets
+    assert!(stdout.contains("resolved"), "{stdout}");
+    assert!(stdout.contains("unresolved"), "{stdout}");
+    // Should show command names
+    assert!(stdout.contains("cat"), "{stdout}");
+    assert!(stdout.contains("grep"), "{stdout}");
+    assert!(stdout.contains("pytest"), "{stdout}");
+}
+
+#[test]
+fn cli_writes_command_stats_json_artifact() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench command-stats failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report_path = sweep.path().join("command-stats.json");
+    assert!(report_path.exists(), "command-stats.json should be written");
+
+    let report: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&report_path).unwrap()).unwrap();
+
+    // Top-level schema validation
+    assert!(report["sweep"].is_string(), "sweep field required");
+    assert!(report["generated_at"].is_string(), "generated_at required");
+    assert!(report["totals"].is_object(), "totals required");
+    assert!(report["by_outcome"].is_object(), "by_outcome required");
+
+    // Totals
+    assert_eq!(report["totals"]["trajectories"], 3);
+    assert!(
+        report["totals"]["bash_steps"].as_u64().unwrap() > 0,
+        "should have bash steps"
+    );
+    assert!(
+        report["totals"]["unique_command_heads"].as_u64().unwrap() > 0
+    );
+
+    // by_outcome buckets
+    let by_outcome = report["by_outcome"].as_object().unwrap();
+    assert!(by_outcome.contains_key("resolved"), "resolved bucket required");
+    assert!(by_outcome.contains_key("unresolved"), "unresolved bucket required");
+    assert!(by_outcome.contains_key("errored"), "errored bucket required");
+    assert!(by_outcome.contains_key("all"), "all bucket required");
+}
+
+#[test]
+fn cli_json_format_emits_valid_json_to_stdout() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench command-stats --format json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(report["by_outcome"].is_object());
+}
+
+#[test]
+fn cli_row_fields_have_correct_types() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    // Check resolved bucket rows
+    let resolved_rows = report["by_outcome"]["resolved"].as_array().unwrap();
+    assert!(!resolved_rows.is_empty(), "resolved bucket should have rows");
+    let row = &resolved_rows[0];
+    assert!(row["command_head"].is_string(), "command_head must be string");
+    assert!(row["instance_count"].is_u64(), "instance_count must be int");
+    assert!(row["invocation_count"].is_u64(), "invocation_count must be int");
+    assert!(row["mean_calls_per_instance"].is_f64() || row["mean_calls_per_instance"].is_u64());
+    assert!(row["nonzero_exit_rate"].is_f64() || row["nonzero_exit_rate"].is_u64());
+    assert!(row["attributed_cost_usd"].is_f64() || row["attributed_cost_usd"].is_u64());
+}
+
+#[test]
+fn cli_rows_ordered_by_invocation_count_descending() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    // unresolved-1 has 3 cat invocations (cat main.py, cat setup.py) and grep
+    // and resolved-1 has cat, grep, pytest
+    // In "all" bucket, cat appears most (resolved cat + unresolved 2x cat + errored cat = 4)
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let all_rows = report["by_outcome"]["all"].as_array().unwrap();
+    assert!(!all_rows.is_empty());
+
+    // Verify descending order
+    for i in 1..all_rows.len() {
+        let prev = all_rows[i - 1]["invocation_count"].as_u64().unwrap();
+        let curr = all_rows[i]["invocation_count"].as_u64().unwrap();
+        assert!(
+            prev >= curr,
+            "rows should be sorted by invocation_count descending: {} before {}",
+            prev,
+            curr
+        );
+    }
+
+    // cat should be first (most invocations: 4 total across all instances)
+    assert_eq!(all_rows[0]["command_head"], "cat", "cat has most invocations");
+}
+
+#[test]
+fn cli_bucket_filter_restricts_to_one_outcome() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--bucket",
+            "resolved",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench command-stats --bucket resolved failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // resolved-1 has cat, grep, pytest, (cat from pipeline too)
+    let resolved = report["by_outcome"]["resolved"].as_array().unwrap();
+    assert!(!resolved.is_empty());
+    // The unresolved bucket in filtered output should be empty (no unresolved steps when filtering to resolved)
+    let unresolved = report["by_outcome"]["unresolved"].as_array().unwrap();
+    assert!(
+        unresolved.is_empty(),
+        "unresolved bucket should be empty when --bucket resolved is set"
+    );
+}
+
+#[test]
+fn cli_min_invocations_hides_low_frequency_commands() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--min-invocations",
+            "3",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    // Only cat (4 invocations in "all") should pass the threshold of 3
+    let all_rows = report["by_outcome"]["all"].as_array().unwrap();
+    for row in all_rows {
+        assert!(
+            row["invocation_count"].as_u64().unwrap() >= 3,
+            "all rows should have >= 3 invocations, got {:?}",
+            row
+        );
+    }
+}
+
+#[test]
+fn cli_top_limits_printed_rows() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--top",
+            "1",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // With --top 1, we should see "cat" (most frequent) but not "pytest" (less frequent)
+    assert!(stdout.contains("cat"), "top-1 should include cat: {stdout}");
+}
+
+#[test]
+fn cli_compare_resolved_vs_unresolved_emits_delta_table() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--compare",
+            "resolved-vs-unresolved",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench command-stats --compare failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let comparisons = report["comparisons"].as_array().unwrap();
+    assert!(!comparisons.is_empty(), "comparisons should be present");
+    let comp = &comparisons[0];
+    assert_eq!(comp["name"], "resolved-vs-unresolved");
+    let rows = comp["rows"].as_array().unwrap();
+    assert!(!rows.is_empty());
+
+    // Each row must have the required fields
+    let row = &rows[0];
+    assert!(row["command_head"].is_string());
+    assert!(row["resolved_share"].is_f64() || row["resolved_share"].is_u64());
+    assert!(row["unresolved_share"].is_f64() || row["unresolved_share"].is_u64());
+    assert!(row["delta"].is_f64() || row["delta"].is_u64());
+
+    // Rows should be sorted by delta descending
+    for i in 1..rows.len() {
+        let prev = rows[i - 1]["delta"].as_f64().unwrap();
+        let curr = rows[i]["delta"].as_f64().unwrap();
+        assert!(
+            prev >= curr,
+            "delta rows should be sorted descending: {prev} before {curr}"
+        );
+    }
+
+    // pytest is only in resolved, so it should have a positive delta
+    let pytest_row = rows.iter().find(|r| r["command_head"] == "pytest");
+    if let Some(r) = pytest_row {
+        assert!(
+            r["delta"].as_f64().unwrap() > 0.0,
+            "pytest should have positive delta (only in resolved)"
+        );
+    }
+}
+
+#[test]
+fn cli_compare_text_output_includes_comparison_section() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--compare",
+            "resolved-vs-unresolved",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("resolved-vs-unresolved"),
+        "text output should show comparison section: {stdout}"
+    );
+}
+
+#[test]
+fn cli_output_is_deterministic_except_generated_at() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let first = run_command_stats_json(sweep.path());
+    let first_file =
+        std::fs::read_to_string(sweep.path().join("command-stats.json")).unwrap();
+
+    std::thread::sleep(Duration::from_secs(1));
+
+    let second = run_command_stats_json(sweep.path());
+    let second_file =
+        std::fs::read_to_string(sweep.path().join("command-stats.json")).unwrap();
+
+    assert_eq!(
+        redact_generated_at(&first),
+        redact_generated_at(&second),
+        "stdout JSON should be deterministic except generated_at"
+    );
+    assert_eq!(
+        redact_generated_at_text(&first_file),
+        redact_generated_at_text(&second_file),
+        "command-stats.json bytes should be deterministic except generated_at"
+    );
+}
+
+#[test]
+fn cli_exits_zero_on_success_regardless_of_failures() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "command-stats should exit 0 even when sweep has failures"
+    );
+}
+
+#[test]
+fn cli_exits_nonzero_when_sweep_dir_missing() {
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            "/tmp/nonexistent-sweep-dir-xyz-command-stats",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "command-stats should fail when sweep dir is missing"
+    );
+}
+
+#[test]
+fn cli_works_without_evaluation_json() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+    // Remove evaluation.json — should still work, treating everything as unresolved/errored
+    std::fs::remove_file(sweep.path().join("evaluation.json")).unwrap();
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "command-stats should work without evaluation.json\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn cli_nonzero_exit_rate_reflects_failed_commands() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_command_stats_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    // In unresolved-1, all 3 commands exit with code 1
+    // In the unresolved bucket, cat exits with code 1 both times → nonzero_exit_rate=1.0
+    let unresolved_rows = report["by_outcome"]["unresolved"].as_array().unwrap();
+    let cat_row = unresolved_rows
+        .iter()
+        .find(|r| r["command_head"] == "cat")
+        .expect("cat should be in unresolved bucket");
+    let rate = cat_row["nonzero_exit_rate"].as_f64().unwrap();
+    assert_eq!(
+        rate, 1.0,
+        "cat in unresolved bucket always exits with code 1"
+    );
+
+    // In resolved-1, cat exits with code 0 → nonzero_exit_rate=0.0
+    let resolved_rows = report["by_outcome"]["resolved"].as_array().unwrap();
+    let cat_resolved = resolved_rows
+        .iter()
+        .find(|r| r["command_head"] == "cat")
+        .expect("cat should be in resolved bucket");
+    let resolved_rate = cat_resolved["nonzero_exit_rate"].as_f64().unwrap();
+    assert_eq!(
+        resolved_rate, 0.0,
+        "cat in resolved bucket always exits with code 0"
+    );
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn copy_command_stats_fixture(dir: &Path) {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/command_stats/sweep");
+    copy_dir(&fixture, dir);
+}
+
+fn copy_dir(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        let target = dst.join(entry.file_name());
+        if path.is_dir() {
+            copy_dir(&path, &target);
+        } else {
+            std::fs::copy(&path, &target).unwrap();
+        }
+    }
+}
+
+fn run_command_stats_json(sweep: &Path) -> serde_json::Value {
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "command-stats",
+            "--sweep",
+            sweep.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "bench command-stats failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+fn redact_generated_at(value: &serde_json::Value) -> serde_json::Value {
+    let mut redacted = value.clone();
+    redacted["generated_at"] = serde_json::json!("<generated_at>");
+    redacted
+}
+
+fn redact_generated_at_text(text: &str) -> String {
+    text.lines()
+        .map(|line| {
+            if line.trim_start().starts_with("\"generated_at\":") {
+                let indent_len = line.len() - line.trim_start().len();
+                format!(
+                    "{}\"generated_at\": \"<generated_at>\",",
+                    " ".repeat(indent_len)
+                )
+            } else {
+                line.to_owned()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/tests/fixtures/command_stats/golden-command-stats.json
+++ b/tests/fixtures/command_stats/golden-command-stats.json
@@ -1,0 +1,116 @@
+{
+  "sweep": "",
+  "generated_at": "",
+  "totals": {
+    "trajectories": 3,
+    "bash_steps": 9,
+    "unique_command_heads": 3
+  },
+  "by_outcome": {
+    "all": [
+      {
+        "command_head": "cat",
+        "instance_count": 3,
+        "invocation_count": 5,
+        "mean_calls_per_instance": 1.6666666666666667,
+        "nonzero_exit_rate": 0.6,
+        "attributed_cost_usd": 0.05
+      },
+      {
+        "command_head": "grep",
+        "instance_count": 2,
+        "invocation_count": 3,
+        "mean_calls_per_instance": 1.5,
+        "nonzero_exit_rate": 0.3333333333333333,
+        "attributed_cost_usd": 0.03
+      },
+      {
+        "command_head": "pytest",
+        "instance_count": 1,
+        "invocation_count": 1,
+        "mean_calls_per_instance": 1.0,
+        "nonzero_exit_rate": 0.0,
+        "attributed_cost_usd": 0.02
+      }
+    ],
+    "errored": [
+      {
+        "command_head": "cat",
+        "instance_count": 1,
+        "invocation_count": 1,
+        "mean_calls_per_instance": 1.0,
+        "nonzero_exit_rate": 1.0,
+        "attributed_cost_usd": 0.01
+      }
+    ],
+    "resolved": [
+      {
+        "command_head": "cat",
+        "instance_count": 1,
+        "invocation_count": 2,
+        "mean_calls_per_instance": 2.0,
+        "nonzero_exit_rate": 0.0,
+        "attributed_cost_usd": 0.02
+      },
+      {
+        "command_head": "grep",
+        "instance_count": 1,
+        "invocation_count": 2,
+        "mean_calls_per_instance": 2.0,
+        "nonzero_exit_rate": 0.0,
+        "attributed_cost_usd": 0.02
+      },
+      {
+        "command_head": "pytest",
+        "instance_count": 1,
+        "invocation_count": 1,
+        "mean_calls_per_instance": 1.0,
+        "nonzero_exit_rate": 0.0,
+        "attributed_cost_usd": 0.02
+      }
+    ],
+    "unresolved": [
+      {
+        "command_head": "cat",
+        "instance_count": 1,
+        "invocation_count": 2,
+        "mean_calls_per_instance": 2.0,
+        "nonzero_exit_rate": 1.0,
+        "attributed_cost_usd": 0.02
+      },
+      {
+        "command_head": "grep",
+        "instance_count": 1,
+        "invocation_count": 1,
+        "mean_calls_per_instance": 1.0,
+        "nonzero_exit_rate": 1.0,
+        "attributed_cost_usd": 0.01
+      }
+    ]
+  },
+  "comparisons": [
+    {
+      "name": "resolved-vs-unresolved",
+      "rows": [
+        {
+          "command_head": "pytest",
+          "resolved_share": 0.2,
+          "unresolved_share": 0.0,
+          "delta": 0.2
+        },
+        {
+          "command_head": "grep",
+          "resolved_share": 0.4,
+          "unresolved_share": 0.3333333333333333,
+          "delta": 0.06666666666666671
+        },
+        {
+          "command_head": "cat",
+          "resolved_share": 0.4,
+          "unresolved_share": 0.6666666666666666,
+          "delta": -0.2666666666666666
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/command_stats/sweep/errored-1.traj.json
+++ b/tests/fixtures/command_stats/sweep/errored-1.traj.json
@@ -1,0 +1,37 @@
+{
+  "trajectory_format": "mini-swe-agent-1.2",
+  "artifact_kind": "trajectory",
+  "schema_version": {"major": 1, "minor": 4},
+  "info": {
+    "task": "errored-1",
+    "model_name": "fixture-model",
+    "outcome": "error",
+    "failure_category": "model_parse",
+    "total_cost_usd": 0.01,
+    "steps": 1,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Let me start.",
+      "extra": {
+        "actions": ["cat README.md"],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "README not found",
+      "extra": {
+        "run_result": {
+          "stdout": "",
+          "stderr": "cat: README.md: No such file or directory",
+          "exit_code": 1,
+          "timed_out": false
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/command_stats/sweep/evaluation.json
+++ b/tests/fixtures/command_stats/sweep/evaluation.json
@@ -1,0 +1,24 @@
+{
+  "instances": [
+    {
+      "instance_id": "resolved-1",
+      "resolved": true,
+      "runs": 1,
+      "resolved_count": 1,
+      "pass_at_1": true,
+      "tests_passed": [],
+      "tests_failed": [],
+      "eval_exit_reason": "resolved"
+    },
+    {
+      "instance_id": "unresolved-1",
+      "resolved": false,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_passed": [],
+      "tests_failed": [],
+      "eval_exit_reason": "unresolved"
+    }
+  ]
+}

--- a/tests/fixtures/command_stats/sweep/resolved-1.traj.json
+++ b/tests/fixtures/command_stats/sweep/resolved-1.traj.json
@@ -1,0 +1,96 @@
+{
+  "trajectory_format": "mini-swe-agent-1.2",
+  "artifact_kind": "trajectory",
+  "schema_version": {"major": 1, "minor": 4},
+  "info": {
+    "task": "resolved-1",
+    "model_name": "fixture-model",
+    "outcome": "submitted",
+    "total_cost_usd": 0.05,
+    "steps": 4,
+    "test_invocations": [],
+    "tests_run_before_submit": true
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Let me look at the code first.",
+      "extra": {
+        "actions": ["cat README.md"],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "# Project README\nThis is a test project.",
+      "extra": {
+        "run_result": {
+          "stdout": "# Project README\nThis is a test project.",
+          "stderr": "",
+          "exit_code": 0,
+          "timed_out": false
+        }
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Let me search for the bug.",
+      "extra": {
+        "actions": ["grep -r 'def test' ."],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "tests/test_main.py:def test_foo():",
+      "extra": {
+        "run_result": {
+          "stdout": "tests/test_main.py:def test_foo():",
+          "stderr": "",
+          "exit_code": 0,
+          "timed_out": false
+        }
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Now run the tests.",
+      "extra": {
+        "actions": ["pytest tests/"],
+        "cost": 0.02
+      }
+    },
+    {
+      "role": "user",
+      "content": "1 passed",
+      "extra": {
+        "run_result": {
+          "stdout": "1 passed",
+          "stderr": "",
+          "exit_code": 0,
+          "timed_out": false
+        }
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Let me apply the fix and verify.",
+      "extra": {
+        "actions": ["cat solution.py | grep -c def"],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "3",
+      "extra": {
+        "run_result": {
+          "stdout": "3",
+          "stderr": "",
+          "exit_code": 0,
+          "timed_out": false
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/command_stats/sweep/results.json
+++ b/tests/fixtures/command_stats/sweep/results.json
@@ -1,0 +1,48 @@
+{
+  "artifact_kind": "sweep_results",
+  "schema_version": {
+    "major": 1,
+    "minor": 4
+  },
+  "total": 3,
+  "submitted": 1,
+  "skipped": 0,
+  "errored": 1,
+  "total_cost_usd": 0.09,
+  "instances": [
+    {
+      "instance_id": "resolved-1",
+      "exit_reason": "submitted",
+      "outcome": "submitted",
+      "cost_usd": 0.05,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 1,
+      "pass_at_1": true,
+      "tests_run_before_submit": true
+    },
+    {
+      "instance_id": "unresolved-1",
+      "exit_reason": "step_limit_reached",
+      "outcome": "step_limit_reached",
+      "cost_usd": 0.03,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    },
+    {
+      "instance_id": "errored-1",
+      "exit_reason": "error",
+      "outcome": "error",
+      "failure_category": "model_parse",
+      "cost_usd": 0.01,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    }
+  ]
+}

--- a/tests/fixtures/command_stats/sweep/unresolved-1.traj.json
+++ b/tests/fixtures/command_stats/sweep/unresolved-1.traj.json
@@ -1,0 +1,76 @@
+{
+  "trajectory_format": "mini-swe-agent-1.2",
+  "artifact_kind": "trajectory",
+  "schema_version": {"major": 1, "minor": 4},
+  "info": {
+    "task": "unresolved-1",
+    "model_name": "fixture-model",
+    "outcome": "step_limit_reached",
+    "total_cost_usd": 0.03,
+    "steps": 3,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Let me look at the files.",
+      "extra": {
+        "actions": ["cat main.py"],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "cat: main.py: No such file or directory",
+      "extra": {
+        "run_result": {
+          "stdout": "",
+          "stderr": "cat: main.py: No such file or directory",
+          "exit_code": 1,
+          "timed_out": false
+        }
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Let me find the file.",
+      "extra": {
+        "actions": ["grep -r 'def main' ."],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "",
+      "extra": {
+        "run_result": {
+          "stdout": "",
+          "stderr": "",
+          "exit_code": 1,
+          "timed_out": false
+        }
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Try listing files.",
+      "extra": {
+        "actions": ["cat setup.py"],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "cat: setup.py: No such file or directory",
+      "extra": {
+        "run_result": {
+          "stdout": "",
+          "stderr": "cat: setup.py: No such file or directory",
+          "exit_code": 1,
+          "timed_out": false
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR introduces a new `bench command-stats` subcommand that analyzes shell command execution patterns across completed SWE-bench sweeps. It extracts, aggregates, and reports command frequency and cost metrics segmented by outcome bucket (resolved, unresolved, errored).

## Key Changes

- **New subcommand**: `bench command-stats` reads completed sweep artifacts and generates command statistics without re-running instances or calling model providers
- **Command head extraction**: Implements robust parsing of bash commands with support for:
  - Prefix stripping (sudo, time, env, variable assignments)
  - Pipeline decomposition (splits on `|` but not `||`)
  - Quoted argument handling
- **Outcome bucketing**: Classifies instances as resolved, unresolved, or errored based on evaluation results
- **Aggregation metrics**: Per-command statistics including:
  - Instance count (distinct trajectories using the command)
  - Invocation count (total executions)
  - Mean calls per instance
  - Nonzero exit rate
  - Attributed cost in USD
- **Filtering and sorting**: Supports `--bucket`, `--min-invocations`, `--top`, and `--filter` options to customize output
- **Comparison mode**: `--compare resolved-vs-unresolved` generates delta analysis showing command usage differences between outcome buckets
- **Output formats**: Text tables (via comfy_table) and JSON with deterministic output (except timestamps)
- **Artifact generation**: Writes `command-stats.json` to the sweep directory in both text and JSON output modes

## Implementation Details

- Command head extraction is unit-tested with 11 test cases covering edge cases (empty commands, quoted args, multiple prefixes, pipelines)
- Integration tests validate CLI behavior, JSON schema, filtering, sorting, and comparison features using fixture data
- Trajectory loading handles missing evaluation.json gracefully
- Exit codes reflect aggregation success (0) even when sweep contains failures; non-zero only for missing/malformed input
- Rows are sorted by invocation count descending, with secondary sort by command name for determinism
- Cost attribution sums the `extra.cost` field from assistant turns that produced each command

## Files Modified

- `src/cli/mod.rs`: Added `bench_command_stats` handler
- `src/cli/args.rs`: Added `CommandStatsCmd` struct with CLI options
- `src/run/mod.rs`: Exported new `command_stats` module
- `README.md`: Added reference to new subcommand spec

## Files Added

- `src/run/command_stats.rs`: Core implementation (660 lines)
- `docs/spec-command-stats.md`: Full specification and schema documentation
- `tests/bench_command_stats.rs`: Comprehensive test suite (889 lines)
- Test fixtures: sweep directory with 3 sample trajectories and evaluation results

https://claude.ai/code/session_01UFnTDrjykcbUyVGQ1pZefT