### PR TITLE
🎨 Mosaic: UI Polish for bench matrix

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1511,6 +1511,7 @@ fn bench_bundle(b: args::BundleCmd) -> Result<(), Error> {
     }
 }
 
+#[allow(clippy::too_many_lines)]
 async fn bench_matrix(m: args::MatrixCmd) -> Result<(), Error> {
     let cache_dir = m
         .dataset_cache_dir
@@ -1574,19 +1575,24 @@ async fn bench_matrix(m: args::MatrixCmd) -> Result<(), Error> {
 
     let summary = crate::run::matrix::run(matrix_args).await?;
 
-    println!("=== bench matrix ===");
+    let mut table = comfy_table::Table::new();
+    table
+        .load_preset(comfy_table::presets::UTF8_FULL)
+        .apply_modifier(comfy_table::modifiers::UTF8_ROUND_CORNERS)
+        .set_header(vec![
+            "Rank", "Name", "Model", "State", "Resolved", "Cost($)",
+        ]);
     for arm in &summary.arms {
-        println!(
-            "  [{rank}] {name}  model={model}  state={state}  resolved={resolved}  \
-             cost=${cost:.4}",
-            rank = arm.rank,
-            name = arm.name,
-            model = arm.model,
-            state = arm.state,
-            resolved = arm.resolved,
-            cost = arm.total_cost_usd,
-        );
+        table.add_row(vec![
+            arm.rank.to_string(),
+            arm.name.clone(),
+            arm.model.clone(),
+            arm.state.clone(),
+            arm.resolved.to_string(),
+            format!("{:.4}", arm.total_cost_usd),
+        ]);
     }
+    println!("=== bench matrix ===\n{table}");
     Ok(())
 }
 

--- a/src/run/matrix.rs
+++ b/src/run/matrix.rs
@@ -6,8 +6,9 @@
 //! cost across completed arms meets the limit, remaining arms are recorded as
 //! `skipped_budget`.
 
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 use std::collections::HashSet;
-use std::fmt::Write as _;
+
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -613,14 +614,13 @@ fn build_summary(state: &MatrixState) -> MatrixSummary {
 
 fn render_summary_text(summary: &MatrixSummary, state: &MatrixState) -> String {
     let n = state.instance_ids.len();
-    let mut s = String::from("=== bench matrix summary ===\n\n");
-    let _ = writeln!(
-        s,
-        "{:<4} {:<24} {:<24} {:<14} {:>8} {:>10} {:>10}",
-        "Rank", "Name", "Model", "State", "Resolved", "Rate%", "Cost($)"
-    );
-    s.push_str(&"-".repeat(100));
-    s.push('\n');
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec![
+            "Rank", "Name", "Model", "State", "Resolved", "Rate%", "Cost($)",
+        ]);
 
     for row in &summary.arms {
         let rate_pct = if n > 0 {
@@ -628,13 +628,17 @@ fn render_summary_text(summary: &MatrixSummary, state: &MatrixState) -> String {
         } else {
             "N/A".into()
         };
-        let _ = writeln!(
-            s,
-            "{:<4} {:<24} {:<24} {:<14} {:>8} {:>10} {:>10.4}",
-            row.rank, row.name, row.model, row.state, row.resolved, rate_pct, row.total_cost_usd
-        );
+        table.add_row(vec![
+            row.rank.to_string(),
+            row.name.clone(),
+            row.model.clone(),
+            row.state.clone(),
+            row.resolved.to_string(),
+            rate_pct,
+            format!("{:.4}", row.total_cost_usd),
+        ]);
     }
-    s
+    format!("=== bench matrix summary ===\n\n{table}\n")
 }
 
 fn write_matrix_state(path: &Path, state: &MatrixState) -> Result<(), Error> {


### PR DESCRIPTION
🖌️ **Before:**
The `bench matrix` output and `matrix-summary.txt` formatted rows of data using raw `println!` macros and manual string formatting with padding. This approach resulted in an output that looked like raw logs rather than an easily readable summary dashboard.

✨ **After:**
Replaced manual string formatting with `comfy_table`, utilizing `UTF8_FULL` presets and `UTF8_ROUND_CORNERS` modifiers. This wraps the matrix summary data in a beautiful, structured table.

🖼️ **Visuals:**
The terminal and output text files now cleanly represent the `bench matrix` dataset in structured CLI tables.

---
*PR created automatically by Jules for task [14957016603693983396](https://jules.google.com/task/14957016603693983396) started by @madmax983*