### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -183,6 +183,54 @@ mod tests {
     }
 
     #[test]
+    fn from_error_timeout_is_task_unsuccessful() {
+        assert_eq!(
+            ExitCode::from_error(&Error::Env(EnvError::Timeout(
+                std::time::Duration::from_secs(1)
+            ))),
+            ExitCode::TaskUnsuccessful
+        );
+    }
+
+    #[test]
+    fn from_error_unexpected_exit_is_task_unsuccessful() {
+        assert_eq!(
+            ExitCode::from_error(&Error::Env(EnvError::UnexpectedExit("1".into()))),
+            ExitCode::TaskUnsuccessful
+        );
+    }
+
+    #[test]
+    fn from_error_docker_daemon_unreachable_is_preflight_failure() {
+        assert_eq!(
+            ExitCode::from_error(&Error::Env(EnvError::DockerDaemonUnreachable(
+                "connection refused".into()
+            ))),
+            ExitCode::PreflightFailure
+        );
+    }
+
+    #[test]
+    fn from_error_container_start_failed_is_preflight_failure() {
+        assert_eq!(
+            ExitCode::from_error(&Error::Env(EnvError::ContainerStartFailed(
+                "image not found".into()
+            ))),
+            ExitCode::PreflightFailure
+        );
+    }
+
+    #[test]
+    fn from_error_env_io_is_task_unsuccessful() {
+        assert_eq!(
+            ExitCode::from_error(&Error::Env(EnvError::Io(std::io::Error::other(
+                "disk full"
+            )))),
+            ExitCode::TaskUnsuccessful
+        );
+    }
+
+    #[test]
     fn from_error_model_is_task_unsuccessful() {
         assert_eq!(
             ExitCode::from_error(&Error::Model(ModelError::Request("t/o".into()))),


### PR DESCRIPTION
🎯 Target: `ExitCode::from_error` in `src/exit_code.rs` (specifically the `EnvError` variants mapped via `ExitCode::from_env_error`).

💣 Risk: Several `EnvError` variants (e.g., orchestration failures, timeouts) were previously untested in the `ExitCode` mapping logic. If they were accidentally reassigned to a different outcome class or if new variants were added improperly, it could break automation reliant on exact CLI exit codes (e.g., `TaskUnsuccessful` vs `PreflightFailure`).

🧪 Strategy: Added specific test functions mapping each of the untested `EnvError` variants to their expected `ExitCode`. Following Sentry's correctness directive, this ensures each branch of the `match e { ... }` block in `from_env_error` is exercised by the test suite.

🔬 Verification: Run `cargo test -p rust_swe_agent --lib exit_code::tests`

---
*PR created automatically by Jules for task [9470969077499501563](https://jules.google.com/task/9470969077499501563) started by @madmax983*