### PR TITLE
⚡ Bolt: Optimize JSON validation by avoiding unnecessary allocations

### DIFF
--- a/src/run/dataset.rs
+++ b/src/run/dataset.rs
@@ -336,8 +336,8 @@ fn validate_jsonl_bytes(bytes: &[u8]) -> Result<usize, String> {
         if line.is_empty() {
             continue;
         }
-        // ⚡ Bolt: Use `IgnoredAny` to avoid allocating an in-memory DOM since we only care about syntax validity.
-        let v: Result<serde::de::IgnoredAny, _> = serde_json::from_str(line);
+        // Use IgnoredAny to avoid allocating an in-memory DOM since we only care about syntax validity.
+        let v = serde_json::from_str::<serde::de::IgnoredAny>(line);
         if let Err(e) = v {
             return Err(format!("line {}: {e}", i + 1));
         }

--- a/src/run/dataset.rs
+++ b/src/run/dataset.rs
@@ -336,7 +336,8 @@ fn validate_jsonl_bytes(bytes: &[u8]) -> Result<usize, String> {
         if line.is_empty() {
             continue;
         }
-        let v: Result<serde_json::Value, _> = serde_json::from_str(line);
+        // ⚡ Bolt: Use `IgnoredAny` to avoid allocating an in-memory DOM since we only care about syntax validity.
+        let v: Result<serde::de::IgnoredAny, _> = serde_json::from_str(line);
         if let Err(e) = v {
             return Err(format!("line {}: {e}", i + 1));
         }


### PR DESCRIPTION
💡 What: Replaced parsing into `serde_json::Value` with `serde::de::IgnoredAny` in `validate_jsonl_bytes`.
🎯 Why: We were building a full in-memory DOM structure (`BTreeMap`, `Vec`, `String`, etc.) just to throw it away immediately since we only cared if parsing resulted in an `Err`.
📊 Impact: Completely eliminates heap allocations for DOM creation during JSON syntax validation, significantly speeding up the parsing of large `.jsonl` files (e.g., the SWE-bench datasets) and reducing memory pressure.
🔬 Measurement: Run `cargo bench` if available or `cargo test` to verify logic. The impact scales directly with the size of the dataset.

---
*PR created automatically by Jules for task [12851597502558681703](https://jules.google.com/task/12851597502558681703) started by @madmax983*