### PR TITLE
Implement history bounding to limit model-visible prompt size

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -133,7 +133,7 @@ fn elide_history_for_model(
     max_input_tokens: Option<u64>,
 ) -> ElisionInfo {
     let no_cap = keep_last_observations.is_none() && max_input_tokens.is_none();
-    if no_cap || history.len() <= 2 {
+    if no_cap {
         return ElisionInfo {
             prompt: history.to_vec(),
             elided: Vec::new(),
@@ -141,12 +141,25 @@ fn elide_history_for_model(
         };
     }
 
-    let obs_indices = observation_indices(history);
     let max_bytes = max_input_tokens.map(|t| {
         usize::try_from(t)
             .unwrap_or(usize::MAX)
             .saturating_mul(BYTES_PER_TOKEN)
     });
+
+    // With only system + instance messages there is nothing to elide. Still
+    // check whether those fixed messages already exceed the token cap.
+    if history.len() <= 2 {
+        let compaction_failed = max_bytes
+            .is_some_and(|limit| history.iter().map(|m| m.content.len()).sum::<usize>() > limit);
+        return ElisionInfo {
+            prompt: history.to_vec(),
+            elided: Vec::new(),
+            compaction_failed,
+        };
+    }
+
+    let obs_indices = observation_indices(history);
 
     if obs_indices.len() <= 1 {
         // No elidable candidates. Still check the budget: if the fixed prompt

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -42,6 +42,8 @@ use crate::trajectory::{
 
 const MAX_TOOL_HOOK_ENV_VALUE_BYTES: usize = 1024;
 const WALLCLOCK_WARNING_BEFORE_SECS: u64 = 30;
+/// Bytes-per-token approximation used when a live tokenizer is unavailable.
+const BYTES_PER_TOKEN: usize = 4;
 
 #[derive(Debug, Clone)]
 struct WallclockDeadline {
@@ -67,6 +69,143 @@ struct TruncateResult {
     text: String,
     bytes_omitted: usize,
     truncated: bool,
+}
+
+/// Output of `elide_history_for_model`.
+#[derive(Debug, Clone)]
+struct ElisionInfo {
+    /// History to pass to the model (with elision markers substituted).
+    prompt: Vec<Message>,
+    /// `(history_index, original_byte_len)` for each elided observation.
+    /// Used to retroactively update trajectory records.
+    elided: Vec<(usize, usize)>,
+    /// True when even eliding all candidates leaves the prompt over budget.
+    compaction_failed: bool,
+}
+
+/// Build a short, stable elision marker for an observation.
+///
+/// `obs_number` is the 0-based index of the observation among all User/Tool
+/// messages after the instance prompt (used for human-readable labelling).
+/// `bytes` is the original content size.
+fn elision_marker(obs_number: usize, bytes: usize) -> String {
+    format!("[history-elided: step {obs_number} observation, {bytes} bytes]")
+}
+
+/// Returns the indices of all User/Tool messages in `history` at position ≥ 2
+/// (i.e., everything after the system prompt and user instance message).
+fn observation_indices(history: &[Message]) -> Vec<usize> {
+    (2..history.len())
+        .filter(|&i| matches!(history[i].role, Role::User | Role::Tool))
+        .collect()
+}
+
+/// Build the model-visible history, eliding stale observations per config.
+///
+/// Protected (never elided):
+/// - `history[0]`: system prompt
+/// - `history[1]`: user instance / task message
+/// - The last User/Tool message (most recent observation)
+/// - The last Assistant message (most recent assistant turn, if any)
+///
+/// Candidates for elision are all other User/Tool messages, oldest first.
+///
+/// When both `keep_last_observations` and `max_input_tokens` are set, the rule
+/// that elides more observations wins.
+fn elide_history_for_model(
+    history: &[Message],
+    keep_last_observations: Option<usize>,
+    max_input_tokens: Option<u64>,
+) -> ElisionInfo {
+    let no_cap = keep_last_observations.is_none() && max_input_tokens.is_none();
+    if no_cap || history.len() <= 2 {
+        return ElisionInfo {
+            prompt: history.to_vec(),
+            elided: Vec::new(),
+            compaction_failed: false,
+        };
+    }
+
+    let obs_indices = observation_indices(history);
+    if obs_indices.len() <= 1 {
+        // Nothing to elide: only one (protected) observation.
+        return ElisionInfo {
+            prompt: history.to_vec(),
+            elided: Vec::new(),
+            compaction_failed: false,
+        };
+    }
+
+    // The last observation is always protected. Candidates are the rest (oldest first).
+    let candidate_count = obs_indices.len() - 1;
+
+    // How many to elide by the keep_last rule.
+    let elide_by_count = if let Some(keep) = keep_last_observations {
+        // Keep the last `keep` observations total (including the protected one).
+        // Among candidates, keep = keep.saturating_sub(1).
+        let keep_among = keep.saturating_sub(1);
+        candidate_count.saturating_sub(keep_among)
+    } else {
+        0
+    };
+
+    // How many to elide by the token-budget rule (oldest first, until under cap).
+    let elide_by_tokens = if let Some(max_tokens) = max_input_tokens {
+        let max_bytes = (max_tokens as usize).saturating_mul(BYTES_PER_TOKEN);
+        let mut total: usize = history.iter().map(|m| m.content.len()).sum();
+        let mut count = 0usize;
+        for (obs_num, &hist_idx) in obs_indices[..candidate_count].iter().enumerate() {
+            if total <= max_bytes {
+                break;
+            }
+            let orig = history[hist_idx].content.len();
+            let marker_len = elision_marker(obs_num, orig).len();
+            total = total.saturating_sub(orig).saturating_add(marker_len);
+            count += 1;
+        }
+        count
+    } else {
+        0
+    };
+
+    let elide_count = elide_by_count.max(elide_by_tokens);
+
+    // Compaction failure: even with ALL candidates elided, still over budget.
+    let compaction_failed = if let Some(max_tokens) = max_input_tokens {
+        let max_bytes = (max_tokens as usize).saturating_mul(BYTES_PER_TOKEN);
+        let min_total: usize = history
+            .iter()
+            .enumerate()
+            .map(|(i, m)| {
+                if let Some(pos) = obs_indices[..candidate_count].iter().position(|&idx| idx == i) {
+                    elision_marker(pos, m.content.len()).len()
+                } else {
+                    m.content.len()
+                }
+            })
+            .sum();
+        min_total > max_bytes
+    } else {
+        false
+    };
+
+    // Build the elided prompt.
+    let mut prompt = history.to_vec();
+    let mut elided = Vec::new();
+    for (obs_num, &hist_idx) in obs_indices[..candidate_count].iter().enumerate() {
+        if obs_num >= elide_count {
+            break;
+        }
+        let orig_len = history[hist_idx].content.len();
+        prompt[hist_idx].content = elision_marker(obs_num, orig_len);
+        elided.push((hist_idx, orig_len));
+    }
+
+    ElisionInfo {
+        prompt,
+        elided,
+        compaction_failed,
+    }
 }
 
 #[allow(
@@ -514,7 +653,41 @@ impl Agent for DefaultAgent {
         // 2. Retag cache hints (one line; backend handles capping).
         retag_cache_hints(&mut self.history);
 
-        // 3. model.query.
+        // 2.5. Elide stale observations from the model-visible prompt per
+        //      history_max_input_tokens / history_keep_last_observations config.
+        //      The full content is kept in self.history and the trajectory.
+        let elision = elide_history_for_model(
+            &self.history,
+            self.config.root.agent.history_keep_last_observations,
+            self.config.root.agent.history_max_input_tokens,
+        );
+        if elision.compaction_failed {
+            self.trajectory.info.exit_reason = Some("history_compaction_failed".into());
+            self.trajectory.info.failure_category =
+                Some(FailureCategory::HistoryCompactionFailed);
+            self.trajectory.info.steps = Some(self.steps);
+            self.finalize_run_metadata(outcome::ERROR);
+            self.emit_run_ended(
+                "history_compaction_failed",
+                Some(FailureCategory::HistoryCompactionFailed),
+                None,
+            );
+            return Ok(StepOutcome::Terminate(ExitReason::HistoryCompactionFailed));
+        }
+        // Retroactively mark elided observations in the trajectory.
+        for (hist_idx, orig_bytes) in &elision.elided {
+            if let Some(rec) = self.trajectory.messages.get_mut(*hist_idx) {
+                rec.extra
+                    .other
+                    .insert("history_elided".into(), serde_json::Value::Bool(true));
+                rec.extra.other.insert(
+                    "history_bytes_elided".into(),
+                    serde_json::json!(*orig_bytes as u64),
+                );
+            }
+        }
+
+        // 3. model.query (using the elided prompt, not the raw history).
         let opts = QueryOpts {
             temperature: self.config.root.model.temperature,
             max_tokens: Some(self.config.root.model.max_tokens),
@@ -528,7 +701,7 @@ impl Agent for DefaultAgent {
         let model_query_start = Instant::now();
         let query_result = query_model_until_cancelled(
             self.model.as_ref(),
-            &self.history,
+            &elision.prompt,
             &opts,
             self.cancellation.clone(),
         )
@@ -2514,5 +2687,97 @@ mod tests {
             agent.trajectory.info.failure_category,
             Some(FailureCategory::BudgetExhausted)
         );
+    }
+
+    // ── elide_history_for_model unit tests ───────────────────────────────────
+
+    fn make_history(obs_payloads: &[&str]) -> Vec<Message> {
+        let mut h = vec![
+            Message::system("system"),
+            Message::user("instance"),
+        ];
+        for payload in obs_payloads {
+            h.push(Message::assistant("```bash\necho x\n```"));
+            h.push(Message::user(payload.to_string()));
+        }
+        h
+    }
+
+    #[test]
+    fn elide_no_cap_returns_unchanged() {
+        let h = make_history(&["obs0", "obs1", "obs2"]);
+        let info = elide_history_for_model(&h, None, None);
+        assert_eq!(info.elided.len(), 0);
+        assert!(!info.compaction_failed);
+        assert_eq!(info.prompt.len(), h.len());
+    }
+
+    #[test]
+    fn elide_keep_last_1_elides_all_but_latest() {
+        let h = make_history(&["obs0", "obs1", "obs2"]);
+        let info = elide_history_for_model(&h, Some(1), None);
+        // obs0 and obs1 should be replaced; obs2 (last) stays intact.
+        assert_eq!(info.elided.len(), 2, "expected 2 elided observations");
+        assert!(info.prompt[3].content.contains("[history-elided:"));
+        assert!(info.prompt[5].content.contains("[history-elided:"));
+        assert!(info.prompt[7].content.contains("obs2"), "last obs must be intact");
+        assert!(!info.compaction_failed);
+    }
+
+    #[test]
+    fn elide_keep_last_preserves_system_and_instance() {
+        let h = make_history(&["obs0", "obs1"]);
+        let info = elide_history_for_model(&h, Some(1), None);
+        assert_eq!(info.prompt[0].content, "system");
+        assert_eq!(info.prompt[1].content, "instance");
+    }
+
+    #[test]
+    fn elide_marker_contains_step_number_and_bytes() {
+        let payload = "x".repeat(500);
+        let h = make_history(&[&payload, "recent"]);
+        let info = elide_history_for_model(&h, Some(1), None);
+        let marker = &info.prompt[3].content;
+        assert!(
+            marker.contains("[history-elided: step 0 observation, 500 bytes]"),
+            "unexpected marker: {marker}"
+        );
+    }
+
+    #[test]
+    fn elide_both_flags_compose_more_aggressive_wins() {
+        // 5 observations, each 200 bytes.
+        let obs: Vec<String> = (0..5).map(|i| format!("obs{i}{}", "x".repeat(196))).collect();
+        let obs_refs: Vec<&str> = obs.iter().map(String::as_str).collect();
+        let h = make_history(&obs_refs);
+
+        // keep_last=4 alone would elide 1 candidate.
+        // max_tokens set tight enough to elide more.
+        // Total = sys+inst+5*asst+5*obs ≈ 6+8+5*18+5*200 = ~1114 bytes
+        // With max_tokens=100 → max_bytes=400, we need to elide many obs.
+        let info = elide_history_for_model(&h, Some(4), Some(100));
+        assert!(
+            info.elided.len() > 1,
+            "token cap should force more elision than keep_last=4 alone; got {}",
+            info.elided.len()
+        );
+    }
+
+    #[test]
+    fn elide_compaction_failed_when_irreducible() {
+        let h = make_history(&["obs0", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"]);
+        // Even with obs0 elided, the fixed content won't fit in 5 bytes.
+        let info = elide_history_for_model(&h, None, Some(1)); // 1 token = 4 bytes
+        assert!(info.compaction_failed);
+    }
+
+    #[test]
+    fn elide_single_observation_never_elided() {
+        let h = make_history(&["only-obs"]);
+        let info = elide_history_for_model(&h, Some(0), None);
+        // With keep_last=0 we'd like to elide everything, but the single obs
+        // is the "last" (protected). Nothing to elide.
+        assert_eq!(info.elided.len(), 0);
+        assert!(!info.compaction_failed);
     }
 }

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -151,7 +151,9 @@ fn elide_history_for_model(
 
     // How many to elide by the token-budget rule (oldest first, until under cap).
     let elide_by_tokens = if let Some(max_tokens) = max_input_tokens {
-        let max_bytes = (max_tokens as usize).saturating_mul(BYTES_PER_TOKEN);
+        let max_bytes = usize::try_from(max_tokens)
+            .unwrap_or(usize::MAX)
+            .saturating_mul(BYTES_PER_TOKEN);
         let mut total: usize = history.iter().map(|m| m.content.len()).sum();
         let mut count = 0usize;
         for (obs_num, &hist_idx) in obs_indices[..candidate_count].iter().enumerate() {
@@ -172,12 +174,17 @@ fn elide_history_for_model(
 
     // Compaction failure: even with ALL candidates elided, still over budget.
     let compaction_failed = if let Some(max_tokens) = max_input_tokens {
-        let max_bytes = (max_tokens as usize).saturating_mul(BYTES_PER_TOKEN);
+        let max_bytes = usize::try_from(max_tokens)
+            .unwrap_or(usize::MAX)
+            .saturating_mul(BYTES_PER_TOKEN);
         let min_total: usize = history
             .iter()
             .enumerate()
             .map(|(i, m)| {
-                if let Some(pos) = obs_indices[..candidate_count].iter().position(|&idx| idx == i) {
+                if let Some(pos) = obs_indices[..candidate_count]
+                    .iter()
+                    .position(|&idx| idx == i)
+                {
                     elision_marker(pos, m.content.len()).len()
                 } else {
                     m.content.len()
@@ -663,8 +670,7 @@ impl Agent for DefaultAgent {
         );
         if elision.compaction_failed {
             self.trajectory.info.exit_reason = Some("history_compaction_failed".into());
-            self.trajectory.info.failure_category =
-                Some(FailureCategory::HistoryCompactionFailed);
+            self.trajectory.info.failure_category = Some(FailureCategory::HistoryCompactionFailed);
             self.trajectory.info.steps = Some(self.steps);
             self.finalize_run_metadata(outcome::ERROR);
             self.emit_run_ended(
@@ -2700,10 +2706,7 @@ mod tests {
     // ── elide_history_for_model unit tests ───────────────────────────────────
 
     fn make_history(obs_payloads: &[&str]) -> Vec<Message> {
-        let mut h = vec![
-            Message::system("system"),
-            Message::user("instance"),
-        ];
+        let mut h = vec![Message::system("system"), Message::user("instance")];
         for payload in obs_payloads {
             h.push(Message::assistant("```bash\necho x\n```"));
             h.push(Message::user(payload.to_string()));
@@ -2728,7 +2731,10 @@ mod tests {
         assert_eq!(info.elided.len(), 2, "expected 2 elided observations");
         assert!(info.prompt[3].content.contains("[history-elided:"));
         assert!(info.prompt[5].content.contains("[history-elided:"));
-        assert!(info.prompt[7].content.contains("obs2"), "last obs must be intact");
+        assert!(
+            info.prompt[7].content.contains("obs2"),
+            "last obs must be intact"
+        );
         assert!(!info.compaction_failed);
     }
 
@@ -2755,7 +2761,9 @@ mod tests {
     #[test]
     fn elide_both_flags_compose_more_aggressive_wins() {
         // 5 observations, each 200 bytes.
-        let obs: Vec<String> = (0..5).map(|i| format!("obs{i}{}", "x".repeat(196))).collect();
+        let obs: Vec<String> = (0..5)
+            .map(|i| format!("obs{i}{}", "x".repeat(196)))
+            .collect();
         let obs_refs: Vec<&str> = obs.iter().map(String::as_str).collect();
         let h = make_history(&obs_refs);
 
@@ -2773,7 +2781,10 @@ mod tests {
 
     #[test]
     fn elide_compaction_failed_when_irreducible() {
-        let h = make_history(&["obs0", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"]);
+        let h = make_history(&[
+            "obs0",
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        ]);
         // Even with obs0 elided, the fixed content won't fit in 5 bytes.
         let info = elide_history_for_model(&h, None, Some(1)); // 1 token = 4 bytes
         assert!(info.compaction_failed);

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -675,14 +675,22 @@ impl Agent for DefaultAgent {
             return Ok(StepOutcome::Terminate(ExitReason::HistoryCompactionFailed));
         }
         // Retroactively mark elided observations in the trajectory.
+        // We also store the marker text so bench-inspect can reconstruct
+        // "as-sent-to-model" view without re-running elision logic.
         for (hist_idx, orig_bytes) in &elision.elided {
             if let Some(rec) = self.trajectory.messages.get_mut(*hist_idx) {
+                // The elided prompt slice at hist_idx holds the marker.
+                let marker = elision.prompt[*hist_idx].content.clone();
                 rec.extra
                     .other
                     .insert("history_elided".into(), serde_json::Value::Bool(true));
                 rec.extra.other.insert(
                     "history_bytes_elided".into(),
                     serde_json::json!(*orig_bytes as u64),
+                );
+                rec.extra.other.insert(
+                    "history_elision_marker".into(),
+                    serde_json::Value::String(marker),
                 );
             }
         }

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -94,9 +94,21 @@ fn elision_marker(obs_number: usize, bytes: usize) -> String {
 
 /// Returns the indices of all User/Tool messages in `history` at position ≥ 2
 /// (i.e., everything after the system prompt and user instance message).
+/// Harness advisory messages (marked `harness_advisory: true`) are excluded so
+/// they are never selected as elision candidates or as the protected last
+/// observation.
 fn observation_indices(history: &[Message]) -> Vec<usize> {
     (2..history.len())
-        .filter(|&i| matches!(history[i].role, Role::User | Role::Tool))
+        .filter(|&i| {
+            let m = &history[i];
+            matches!(m.role, Role::User | Role::Tool)
+                && !m
+                    .extra
+                    .other
+                    .get("harness_advisory")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false)
+        })
         .collect()
 }
 
@@ -109,9 +121,12 @@ fn observation_indices(history: &[Message]) -> Vec<usize> {
 /// - The last Assistant message (most recent assistant turn, if any)
 ///
 /// Candidates for elision are all other User/Tool messages, oldest first.
+/// Harness advisory messages (e.g. wallclock warnings) are excluded from the
+/// candidate set so they cannot displace real tool results.
 ///
 /// When both `keep_last_observations` and `max_input_tokens` are set, the rule
 /// that elides more observations wins.
+#[allow(clippy::too_many_lines)]
 fn elide_history_for_model(
     history: &[Message],
     keep_last_observations: Option<usize>,
@@ -179,10 +194,12 @@ fn elide_history_for_model(
                     met_at = count;
                 }
             }
-            // `total` is now the size after all candidates are replaced — the
-            // minimum the budget-based pass can achieve.
+            // compaction_failed only when no prefix of candidates ever fit the
+            // budget.  A later iteration can push total back above the limit if
+            // a tiny observation is replaced by a longer marker, but met_at
+            // already identifies a valid elision count.
             let elide_needed = if met { met_at } else { count };
-            (elide_needed, total > limit)
+            (elide_needed, !met)
         }
     } else {
         (0, false)
@@ -1348,13 +1365,18 @@ impl DefaultAgent {
              work and submit now with COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT. Do not install \
              dependencies unless they are strictly required to produce the final patch."
         );
-        let msg = Message::user(
+        let mut msg = Message::user(
             self.redactor
                 .redact_text(&content, surface::MODEL_OBSERVATION)
                 .text,
         );
+        // Mark as harness advisory so elision treats it as a non-observation
+        // and never counts it as the protected "last observation".
+        msg.extra
+            .other
+            .insert("harness_advisory".into(), serde_json::Value::Bool(true));
         self.history.push(msg.clone());
-        let mut extra = MessageExtra::default();
+        let mut extra = msg.extra.clone();
         extra.other.insert(
             "wallclock_deadline_warning".into(),
             serde_json::Value::Bool(true),

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -127,74 +127,105 @@ fn elide_history_for_model(
     }
 
     let obs_indices = observation_indices(history);
+    let max_bytes = max_input_tokens.map(|t| {
+        usize::try_from(t)
+            .unwrap_or(usize::MAX)
+            .saturating_mul(BYTES_PER_TOKEN)
+    });
+
     if obs_indices.len() <= 1 {
-        // Nothing to elide: only one (protected) observation.
+        // No elidable candidates. Still check the budget: if the fixed prompt
+        // (system + instance + single protected observation) already exceeds the
+        // cap there is nothing we can do to fix it.
+        let compaction_failed = max_bytes
+            .is_some_and(|limit| history.iter().map(|m| m.content.len()).sum::<usize>() > limit);
         return ElisionInfo {
             prompt: history.to_vec(),
             elided: Vec::new(),
-            compaction_failed: false,
+            compaction_failed,
         };
     }
 
     // The last observation is always protected. Candidates are the rest (oldest first).
     let candidate_count = obs_indices.len() - 1;
 
-    // How many to elide by the keep_last rule.
+    // Count-based minimum elisions from keep_last_observations.
     let elide_by_count = if let Some(keep) = keep_last_observations {
-        // Keep the last `keep` observations total (including the protected one).
-        // Among candidates, keep = keep.saturating_sub(1).
-        let keep_among = keep.saturating_sub(1);
-        candidate_count.saturating_sub(keep_among)
+        candidate_count.saturating_sub(keep.saturating_sub(1))
     } else {
         0
     };
 
-    // How many to elide by the token-budget rule (oldest first, until under cap).
-    let elide_by_tokens = if let Some(max_tokens) = max_input_tokens {
-        let max_bytes = usize::try_from(max_tokens)
-            .unwrap_or(usize::MAX)
-            .saturating_mul(BYTES_PER_TOKEN);
-        let mut total: usize = history.iter().map(|m| m.content.len()).sum();
-        let mut count = 0usize;
-        for (obs_num, &hist_idx) in obs_indices[..candidate_count].iter().enumerate() {
-            if total <= max_bytes {
-                break;
-            }
-            let orig = history[hist_idx].content.len();
-            let marker_len = elision_marker(obs_num, orig).len();
-            total = total.saturating_sub(orig).saturating_add(marker_len);
-            count += 1;
-        }
-        count
-    } else {
-        0
-    };
-
-    let elide_count = elide_by_count.max(elide_by_tokens);
-
-    // Compaction failure: even with ALL candidates elided, still over budget.
-    let compaction_failed = if let Some(max_tokens) = max_input_tokens {
-        let max_bytes = usize::try_from(max_tokens)
-            .unwrap_or(usize::MAX)
-            .saturating_mul(BYTES_PER_TOKEN);
-        let min_total: usize = history
-            .iter()
-            .enumerate()
-            .map(|(i, m)| {
-                if let Some(pos) = obs_indices[..candidate_count]
-                    .iter()
-                    .position(|&idx| idx == i)
-                {
-                    elision_marker(pos, m.content.len()).len()
-                } else {
-                    m.content.len()
+    // Token-budget: single O(N) pass through ALL candidates.
+    // Continues past the break-even point so the final `total` equals the
+    // minimum achievable prompt size — used for compaction_failed detection.
+    let (elide_by_tokens, compaction_failed_full) = if let Some(limit) = max_bytes {
+        let initial_total: usize = history.iter().map(|m| m.content.len()).sum();
+        if initial_total <= limit {
+            // Already under budget; no token-based elisions needed.
+            (0, false)
+        } else {
+            let mut total = initial_total;
+            let mut count = 0usize;
+            let mut met = false;
+            let mut met_at = 0usize;
+            for (obs_num, &hist_idx) in obs_indices[..candidate_count].iter().enumerate() {
+                let orig = history[hist_idx].content.len();
+                let marker_len = elision_marker(obs_num, orig).len();
+                total = total.saturating_sub(orig).saturating_add(marker_len);
+                count += 1;
+                if !met && total <= limit {
+                    met = true;
+                    met_at = count;
                 }
-            })
-            .sum();
-        min_total > max_bytes
+            }
+            // `total` is now the size after all candidates are replaced — the
+            // minimum the budget-based pass can achieve.
+            let elide_needed = if met { met_at } else { count };
+            (elide_needed, total > limit)
+        }
     } else {
-        false
+        (0, false)
     };
+
+    let mut elide_count = elide_by_count.max(elide_by_tokens);
+    let mut compaction_failed = compaction_failed_full;
+
+    // When count-based elision is more aggressive and a token budget is active,
+    // the extra marker replacements can inflate the prompt (markers can be longer
+    // than very short observations). Re-verify the actual size and extend
+    // elide_count toward candidate_count until the prompt fits or all candidates
+    // are exhausted.
+    if !compaction_failed {
+        if let Some(limit) = max_bytes {
+            if elide_count > elide_by_tokens {
+                let mut actual: usize = history
+                    .iter()
+                    .enumerate()
+                    .map(|(i, m)| {
+                        if let Some(pos) = obs_indices[..candidate_count]
+                            .iter()
+                            .position(|&idx| idx == i)
+                        {
+                            if pos < elide_count {
+                                return elision_marker(pos, m.content.len()).len();
+                            }
+                        }
+                        m.content.len()
+                    })
+                    .sum();
+                while actual > limit && elide_count < candidate_count {
+                    let pos = elide_count;
+                    let hist_idx = obs_indices[pos];
+                    let orig = history[hist_idx].content.len();
+                    let marker_len = elision_marker(pos, orig).len();
+                    actual = actual.saturating_sub(orig).saturating_add(marker_len);
+                    elide_count += 1;
+                }
+                compaction_failed = actual > limit;
+            }
+        }
+    }
 
     // Build the elided prompt.
     let mut prompt = history.to_vec();
@@ -799,8 +830,10 @@ impl Agent for DefaultAgent {
         //   2. Normalize (strip the per-run salt hash) — produces stable markers
         //      like [REDACTED:kind:size].  Used only to compute a run-independent
         //      fingerprint hash; NOT stored in the trajectory.
-        let redacted_history: Vec<crate::model::Message> = self
-            .history
+        // Fingerprint the elided prompt (what the model actually received), not
+        // self.history, so replay with the same config reproduces the same hash.
+        let redacted_history: Vec<crate::model::Message> = elision
+            .prompt
             .iter()
             .map(|m| {
                 let mut m2 = m.clone();
@@ -2798,5 +2831,41 @@ mod tests {
         // is the "last" (protected). Nothing to elide.
         assert_eq!(info.elided.len(), 0);
         assert!(!info.compaction_failed);
+    }
+
+    #[test]
+    fn elide_single_observation_compaction_failed_when_over_budget() {
+        // Only one observation (protected) but it's already over the 1-token budget.
+        let h = make_history(&["xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"]);
+        let info = elide_history_for_model(&h, None, Some(1)); // 1 token = 4 bytes
+        // Nothing to elide, but prompt exceeds budget → compaction_failed.
+        assert_eq!(info.elided.len(), 0);
+        assert!(info.compaction_failed);
+    }
+
+    #[test]
+    fn elide_count_inflation_handled_by_budget() {
+        // 3 observations each 5 bytes. Markers are longer (~45 bytes each).
+        // keep_last=1 would elide 2 candidates; those replacements inflate the prompt.
+        // With a tight budget (say 100 bytes), the function must extend elide_count
+        // until under budget or declare compaction_failed.
+        let obs: Vec<String> = (0..3).map(|i| format!("obs{i}")).collect();
+        let obs_refs: Vec<&str> = obs.iter().map(String::as_str).collect();
+        let h = make_history(&obs_refs);
+        // Budget = 10 tokens = 40 bytes. System+instance ≈ 20 bytes, each obs 4 bytes.
+        // Without elision total ≈ 36 bytes (under budget). But keep_last=1 forces
+        // eliding 2 obs with markers (~45 bytes each), inflating to ~130 bytes.
+        // The function should extend past keep_last to minimize, or report failure.
+        let info = elide_history_for_model(&h, Some(1), Some(10));
+        // Even with all candidates elided the markers inflate the prompt, so
+        // compaction_failed should be set if min achievable > budget.
+        let total_with_all_elided: usize = info.prompt.iter().map(|m| m.content.len()).sum();
+        let max_bytes = 10 * BYTES_PER_TOKEN;
+        assert!(
+            total_with_all_elided <= max_bytes || info.compaction_failed,
+            "either prompt fits or compaction_failed must be set; \
+             total={total_with_all_elided} max={max_bytes} failed={}",
+            info.compaction_failed
+        );
     }
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -57,6 +57,9 @@ pub enum ExitReason {
         count: u32,
         window: u32,
     },
+    /// The prompt could not be compacted to fit within `history_max_input_tokens`
+    /// even after eliding all eligible older observations.
+    HistoryCompactionFailed,
 }
 
 impl ExitReason {
@@ -82,6 +85,7 @@ impl ExitReason {
             Self::UserInterrupt => "user_interrupt",
             Self::ModelRefusal { .. } => "model_refusal",
             Self::AgentStagnation { .. } => "agent_stagnation",
+            Self::HistoryCompactionFailed => "history_compaction_failed",
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -205,6 +205,18 @@ pub struct MiniCmd {
     #[arg(long)]
     pub stagnation_window: Option<u32>,
 
+    /// Token budget for the model-visible prompt. Older tool observations are
+    /// elided oldest-first when the projected input would exceed this value.
+    /// Default: unset (no cap). Overrides the config-file value when set.
+    #[arg(long)]
+    pub history_max_input_tokens: Option<u64>,
+
+    /// Keep only the last N tool observations in the model-visible prompt.
+    /// Older ones are replaced with a short elision marker. Default: unset.
+    /// Overrides the config-file value when set.
+    #[arg(long)]
+    pub history_keep_last_observations: Option<usize>,
+
     #[command(flatten)]
     pub github_pr: MiniGithubPrArgs,
 }
@@ -810,6 +822,18 @@ pub struct SwebenchCmd {
     /// Overrides the config-file value when set. Schema default: 8.
     #[arg(long)]
     pub stagnation_window: Option<u32>,
+
+    /// Token budget for the model-visible prompt. Older tool observations are
+    /// elided oldest-first when the projected input would exceed this value.
+    /// Default: unset (no cap). Overrides the config-file value when set.
+    #[arg(long)]
+    pub history_max_input_tokens: Option<u64>,
+
+    /// Keep only the last N tool observations in the model-visible prompt.
+    /// Older ones are replaced with a short elision marker. Default: unset.
+    /// Overrides the config-file value when set.
+    #[arg(long)]
+    pub history_keep_last_observations: Option<usize>,
 
     #[command(flatten)]
     pub github_pr: SwebenchGithubPrArgs,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -273,6 +273,18 @@ pub struct ReplayCmd {
     /// step in the drift report. Excess is replaced with `[truncated]`.
     #[arg(long, default_value_t = crate::run::replay::DEFAULT_DRIFT_CAP_BYTES)]
     pub drift_cap_bytes: usize,
+
+    /// Token budget for the model-visible prompt (same as the run-time flag).
+    /// Required when replaying a trajectory produced with this bound so the
+    /// elided prompts match and fingerprint comparison succeeds.
+    #[arg(long)]
+    pub history_max_input_tokens: Option<u64>,
+
+    /// Keep only the last N observations in the model-visible prompt (same as
+    /// the run-time flag). Required when replaying a trajectory produced with
+    /// this bound so fingerprint comparison succeeds.
+    #[arg(long)]
+    pub history_keep_last_observations: Option<usize>,
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -999,6 +999,10 @@ fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
     if let Some(latency) = &eval.latency_summary {
         print!("{}", crate::run::evaluate::render_latency_summary(latency));
     }
+    let elision_text = crate::run::evaluate::render_elision_stats(&eval.behavioral);
+    if !elision_text.is_empty() {
+        print!("{elision_text}");
+    }
     if let Some(prov) = &eval.provenance {
         println!(
             "evaluator_provenance: backend={} subset={} split={}",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -162,6 +162,12 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
     if let Some(v) = m.stagnation_window {
         cfg.root.agent.stagnation_window = v;
     }
+    if let Some(v) = m.history_max_input_tokens {
+        cfg.root.agent.history_max_input_tokens = Some(v);
+    }
+    if let Some(v) = m.history_keep_last_observations {
+        cfg.root.agent.history_keep_last_observations = Some(v);
+    }
     apply_mcp_server_overrides(&mut cfg, &m.mcp_servers)?;
 
     let trajectory_name = m
@@ -523,6 +529,12 @@ fn swebench_config_from_cmd(s: &args::SwebenchCmd) -> Result<Config, Error> {
     }
     if let Some(v) = s.stagnation_window {
         cfg.root.agent.stagnation_window = v;
+    }
+    if let Some(v) = s.history_max_input_tokens {
+        cfg.root.agent.history_max_input_tokens = Some(v);
+    }
+    if let Some(v) = s.history_keep_last_observations {
+        cfg.root.agent.history_keep_last_observations = Some(v);
     }
     apply_mcp_server_overrides(&mut cfg, &s.mcp_servers)?;
     Ok(cfg)
@@ -1998,6 +2010,8 @@ mod tests {
             detect_stagnation: None,
             stagnation_repeat_threshold: None,
             stagnation_window: None,
+            history_max_input_tokens: None,
+            history_keep_last_observations: None,
             mcp_servers: Vec::new(),
             config: None,
             env: None,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -234,6 +234,12 @@ async fn replay_cmd(r: args::ReplayCmd) -> Result<(), Error> {
     if let Some(img) = r.docker_image.clone() {
         cfg.root.environment.docker_image = Some(img);
     }
+    if let Some(v) = r.history_max_input_tokens {
+        cfg.root.agent.history_max_input_tokens = Some(v);
+    }
+    if let Some(v) = r.history_keep_last_observations {
+        cfg.root.agent.history_keep_last_observations = Some(v);
+    }
 
     let args = crate::run::replay::ReplayArgs {
         trajectory_path: r.trajectory_path,

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -75,6 +75,22 @@ pub struct AgentCfg {
     /// Must be >= `stagnation_repeat_threshold`. Default: 8.
     #[serde(default = "default_stagnation_window")]
     pub stagnation_window: u32,
+    /// Token budget for the prompt sent to the model on each turn. When the
+    /// projected input exceeds this value, older tool observations are elided
+    /// oldest-first until the projection fits. Default: `None` (no cap).
+    ///
+    /// Uses a byte-based approximation (1 token ≈ 4 bytes) when a live
+    /// tokenizer is unavailable.
+    #[serde(default)]
+    pub history_max_input_tokens: Option<u64>,
+    /// Keep only the last N tool observations in the model-visible prompt.
+    /// Older observations are replaced with a short elision marker. Default:
+    /// `None` (keep all).
+    ///
+    /// When both `history_max_input_tokens` and `history_keep_last_observations`
+    /// are set, whichever elides more observations wins.
+    #[serde(default)]
+    pub history_keep_last_observations: Option<usize>,
 }
 
 fn default_step_limit() -> u32 {

--- a/src/run/command_stats.rs
+++ b/src/run/command_stats.rs
@@ -489,6 +489,7 @@ fn failure_category_label(c: FailureCategory) -> &'static str {
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
         FailureCategory::SecretLeakDetected => "secret_leak_detected",
+        FailureCategory::HistoryCompactionFailed => "history_compaction_failed",
         FailureCategory::Unknown => "unknown",
     }
 }

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -2358,6 +2358,7 @@ fn failure_label(cat: FailureCategory) -> &'static str {
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
         FailureCategory::SecretLeakDetected => "secret_leak_detected",
+        FailureCategory::HistoryCompactionFailed => "history_compaction_failed",
         FailureCategory::Unknown => "unknown",
     }
 }

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -1315,7 +1315,12 @@ fn build_elision_stats(
         let path = if path.exists() {
             path
         } else {
-            sweep_dir.join(format!("{}.traj.json", slot.instance_id))
+            // Fallbacks: flat layout then bundled-archive layout.
+            let flat = sweep_dir.join(format!("{}.traj.json", slot.instance_id));
+            let bundled = sweep_dir
+                .join("trajectories")
+                .join(format!("{}.traj.json", slot.instance_id));
+            if flat.exists() { flat } else { bundled }
         };
         let Ok(text) = std::fs::read_to_string(&path) else {
             continue;

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -1309,8 +1309,7 @@ fn build_elision_stats<S: std::hash::BuildHasher>(
         if result.failure_category == Some(FailureCategory::HistoryCompactionFailed) {
             compaction_failed += 1;
         }
-        let Some(path) =
-            crate::run::inspect::resolve_trajectory_path(sweep_dir, instance_id)
+        let Some(path) = crate::run::inspect::resolve_trajectory_path(sweep_dir, instance_id)
         else {
             continue;
         };
@@ -1326,7 +1325,7 @@ fn build_elision_stats<S: std::hash::BuildHasher>(
                 .extra
                 .other
                 .get("history_elided")
-                .and_then(|v| v.as_bool())
+                .and_then(serde_json::Value::as_bool)
                 .unwrap_or(false);
             if elided {
                 any_elided = true;
@@ -1334,7 +1333,7 @@ fn build_elision_stats<S: std::hash::BuildHasher>(
                     .extra
                     .other
                     .get("history_bytes_elided")
-                    .and_then(|v| v.as_u64())
+                    .and_then(serde_json::Value::as_u64)
                 {
                     bytes_elided_total = bytes_elided_total.saturating_add(bytes);
                 }

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -244,6 +244,15 @@ pub struct BehavioralMetrics {
     pub tests_run_before_submit_rate: f64,
     pub resolved_rate_when_tests_run: f64,
     pub resolved_rate_when_tests_skipped: f64,
+    /// Number of instances where at least one observation was elided.
+    #[serde(default)]
+    pub history_elision_instances: usize,
+    /// Sum of `history_bytes_elided` across all elided observations in the sweep.
+    #[serde(default)]
+    pub history_bytes_elided_total: u64,
+    /// Number of instances that exited with `history_compaction_failed`.
+    #[serde(default)]
+    pub history_compaction_failed: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -384,6 +393,11 @@ pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
     );
     attach_patch_stats(&mut eval, args, &resolved_by_run)?;
     eval.behavioral = build_behavioral_metrics(&eval.instances, &results);
+    let (elision_instances, bytes_elided_total, compaction_failed) =
+        build_elision_stats(&args.sweep_dir, &results);
+    eval.behavioral.history_elision_instances = elision_instances;
+    eval.behavioral.history_bytes_elided_total = bytes_elided_total;
+    eval.behavioral.history_compaction_failed = compaction_failed;
     eval.breakdown = build_breakdown(
         &eval.instances,
         &results,
@@ -1277,7 +1291,60 @@ fn build_behavioral_metrics(
         tests_run_before_submit_rate: pct(tests_run, submitted),
         resolved_rate_when_tests_run: pct(resolved_with_tests, tests_run),
         resolved_rate_when_tests_skipped: pct(resolved_tests_skipped, tests_skipped),
+        ..BehavioralMetrics::default()
     }
+}
+
+/// Scan trajectory files for elision metadata produced by history-bounding.
+/// Returns (elision_instances, bytes_elided_total, compaction_failed_count).
+fn build_elision_stats<S: std::hash::BuildHasher>(
+    sweep_dir: &Path,
+    results: &HashMap<String, InstanceResult, S>,
+) -> (usize, u64, usize) {
+    let mut elision_instances = 0usize;
+    let mut bytes_elided_total = 0u64;
+    let mut compaction_failed = 0usize;
+
+    for (instance_id, result) in results {
+        if result.failure_category == Some(FailureCategory::HistoryCompactionFailed) {
+            compaction_failed += 1;
+        }
+        let Some(path) =
+            crate::run::inspect::resolve_trajectory_path(sweep_dir, instance_id)
+        else {
+            continue;
+        };
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(traj) = serde_json::from_str::<crate::trajectory::Trajectory>(&text) else {
+            continue;
+        };
+        let mut any_elided = false;
+        for msg in &traj.messages {
+            let elided = msg
+                .extra
+                .other
+                .get("history_elided")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if elided {
+                any_elided = true;
+                if let Some(bytes) = msg
+                    .extra
+                    .other
+                    .get("history_bytes_elided")
+                    .and_then(|v| v.as_u64())
+                {
+                    bytes_elided_total = bytes_elided_total.saturating_add(bytes);
+                }
+            }
+        }
+        if any_elided {
+            elision_instances += 1;
+        }
+    }
+    (elision_instances, bytes_elided_total, compaction_failed)
 }
 
 fn normalize_single_run_metrics(row: &mut InstanceEvaluation, runs: u32) {
@@ -1822,6 +1889,32 @@ pub fn render_cost_attribution_table(rows: &[CostAttributionBucket]) -> String {
             row.bucket, row.n, row.total_usd, row.mean_usd, row.share_pct
         );
     }
+    out
+}
+
+/// Render the elision stats from `BehavioralMetrics` if any elision occurred.
+/// Returns an empty string when no history bounding was active.
+#[must_use]
+pub fn render_elision_stats(behavioral: &BehavioralMetrics) -> String {
+    if behavioral.history_elision_instances == 0 && behavioral.history_compaction_failed == 0 {
+        return String::new();
+    }
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "history_elision_instances: {}",
+        behavioral.history_elision_instances
+    );
+    let _ = writeln!(
+        out,
+        "history_bytes_elided_total: {}",
+        behavioral.history_bytes_elided_total
+    );
+    let _ = writeln!(
+        out,
+        "history_compaction_failed: {}",
+        behavioral.history_compaction_failed
+    );
     out
 }
 

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -93,7 +93,7 @@ pub struct SourceReportEntry {
 pub const COST_ATTRIBUTION_RESOLVED_BUCKET: &str = "resolved";
 pub const COST_ATTRIBUTION_UNCATEGORIZED_BUCKET: &str = "uncategorized";
 pub const COST_ATTRIBUTION_TOTAL_BUCKET: &str = "TOTAL";
-pub const ALL_FAILURE_CATEGORIES: [FailureCategory; 12] = [
+pub const ALL_FAILURE_CATEGORIES: [FailureCategory; 13] = [
     FailureCategory::EnvSetup,
     FailureCategory::ModelApi,
     FailureCategory::ModelParse,
@@ -105,6 +105,7 @@ pub const ALL_FAILURE_CATEGORIES: [FailureCategory; 12] = [
     FailureCategory::PatchApplyInvalid,
     FailureCategory::PatchEmpty,
     FailureCategory::SecretLeakDetected,
+    FailureCategory::HistoryCompactionFailed,
     FailureCategory::Unknown,
 ];
 
@@ -1627,6 +1628,7 @@ pub fn failure_label(cat: FailureCategory) -> &'static str {
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
         FailureCategory::SecretLeakDetected => "secret_leak_detected",
+        FailureCategory::HistoryCompactionFailed => "history_compaction_failed",
         FailureCategory::Unknown => "unknown",
     }
 }

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -393,8 +393,9 @@ pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
     );
     attach_patch_stats(&mut eval, args, &resolved_by_run)?;
     eval.behavioral = build_behavioral_metrics(&eval.instances, &results);
+    let run_slots = load_run_slots(&args.sweep_dir, &results)?;
     let (elision_instances, bytes_elided_total, compaction_failed) =
-        build_elision_stats(&args.sweep_dir, &results);
+        build_elision_stats(&args.sweep_dir, &run_slots, &results);
     eval.behavioral.history_elision_instances = elision_instances;
     eval.behavioral.history_bytes_elided_total = bytes_elided_total;
     eval.behavioral.history_compaction_failed = compaction_failed;
@@ -404,7 +405,6 @@ pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
         &args.breakdown,
         model_name.as_deref(),
     );
-    let run_slots = load_run_slots(&args.sweep_dir, &results)?;
     if args.cost_attribution {
         eval.cost_attribution = build_cost_attribution_from_run_slots(
             &run_slots,
@@ -1296,22 +1296,27 @@ fn build_behavioral_metrics(
 }
 
 /// Scan trajectory files for elision metadata produced by history-bounding.
-/// Returns (elision_instances, bytes_elided_total, compaction_failed_count).
+/// Iterates all run slots (handles reruns) to count instances with elision and
+/// aggregate bytes. Returns (elision_instances, bytes_elided_total, compaction_failed_count).
 fn build_elision_stats<S: std::hash::BuildHasher>(
     sweep_dir: &Path,
+    run_slots: &[crate::run::compare::LoadedRunSlot],
     results: &HashMap<String, InstanceResult, S>,
 ) -> (usize, u64, usize) {
-    let mut elision_instances = 0usize;
-    let mut bytes_elided_total = 0u64;
-    let mut compaction_failed = 0usize;
+    let compaction_failed = results
+        .values()
+        .filter(|r| r.failure_category == Some(FailureCategory::HistoryCompactionFailed))
+        .count();
 
-    for (instance_id, result) in results {
-        if result.failure_category == Some(FailureCategory::HistoryCompactionFailed) {
-            compaction_failed += 1;
-        }
-        let Some(path) = crate::run::inspect::resolve_trajectory_path(sweep_dir, instance_id)
-        else {
-            continue;
+    let mut elision_instance_set = std::collections::HashSet::<String>::new();
+    let mut bytes_elided_total = 0u64;
+
+    for slot in run_slots {
+        let path = swebench::trajectory_path_for_run(sweep_dir, &slot.instance_id, slot.run_index);
+        let path = if path.exists() {
+            path
+        } else {
+            sweep_dir.join(format!("{}.traj.json", slot.instance_id))
         };
         let Ok(text) = std::fs::read_to_string(&path) else {
             continue;
@@ -1340,10 +1345,14 @@ fn build_elision_stats<S: std::hash::BuildHasher>(
             }
         }
         if any_elided {
-            elision_instances += 1;
+            elision_instance_set.insert(slot.instance_id.clone());
         }
     }
-    (elision_instances, bytes_elided_total, compaction_failed)
+    (
+        elision_instance_set.len(),
+        bytes_elided_total,
+        compaction_failed,
+    )
 }
 
 fn normalize_single_run_metrics(row: &mut InstanceEvaluation, runs: u32) {
@@ -2945,12 +2954,74 @@ mod tests {
             ]
         });
         std::fs::write(
-            instance_a.join("trajectory.json"),
+            instance_a.join("run-1.traj.json"),
             serde_json::to_string(&traj_a).unwrap(),
         )
         .unwrap();
 
         // Instance b: history_compaction_failed
+        let run_slots = vec![
+            crate::run::compare::LoadedRunSlot {
+                instance_id: "inst-a".to_owned(),
+                run_index: 1,
+                result: InstanceResult {
+                    instance_id: "inst-a".into(),
+                    exit_reason: "submitted".into(),
+                    outcome: Some(outcome::SUBMITTED.into()),
+                    failure_category: None,
+                    steps: None,
+                    cost_usd: None,
+                    prompt_tokens: None,
+                    cache_read_tokens: None,
+                    cache_creation_tokens: None,
+                    completion_tokens: None,
+                    duration_secs: None,
+                    error: None,
+                    github_pr_error: None,
+                    patch_present: true,
+                    non_empty_patch: true,
+                    attempts: 1,
+                    retry_reasons: vec![],
+                    runs: 0,
+                    resolved_count: 0,
+                    pass_at_1: false,
+                    tests_run_before_submit: false,
+                    last_tests_passed: None,
+                    fallback_count: None,
+                    final_model: None,
+                },
+            },
+            crate::run::compare::LoadedRunSlot {
+                instance_id: "inst-b".to_owned(),
+                run_index: 1,
+                result: InstanceResult {
+                    instance_id: "inst-b".into(),
+                    exit_reason: "history_compaction_failed".into(),
+                    outcome: Some("error".into()),
+                    failure_category: Some(FailureCategory::HistoryCompactionFailed),
+                    steps: None,
+                    cost_usd: None,
+                    prompt_tokens: None,
+                    cache_read_tokens: None,
+                    cache_creation_tokens: None,
+                    completion_tokens: None,
+                    duration_secs: None,
+                    error: None,
+                    github_pr_error: None,
+                    patch_present: false,
+                    non_empty_patch: false,
+                    attempts: 1,
+                    retry_reasons: vec![],
+                    runs: 0,
+                    resolved_count: 0,
+                    pass_at_1: false,
+                    tests_run_before_submit: false,
+                    last_tests_passed: None,
+                    fallback_count: None,
+                    final_model: None,
+                },
+            },
+        ];
         let results: HashMap<String, InstanceResult> = [
             (
                 "inst-a".to_owned(),
@@ -3014,7 +3085,8 @@ mod tests {
         .into_iter()
         .collect();
 
-        let (instances, bytes, compaction_failed) = build_elision_stats(sweep, &results);
+        let (instances, bytes, compaction_failed) =
+            build_elision_stats(sweep, &run_slots, &results);
         assert_eq!(instances, 1, "one instance should be elided");
         assert_eq!(bytes, 500, "should total 500 bytes elided");
         assert_eq!(compaction_failed, 1, "one compaction_failed instance");

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -2887,4 +2887,136 @@ mod tests {
         assert!(cmd.contains("dev"), "got: {cmd}");
         assert!(cmd.contains("test-run"), "got: {cmd}");
     }
+
+    #[test]
+    fn render_elision_stats_empty_when_no_elision() {
+        let behavioral = BehavioralMetrics::default();
+        assert!(
+            render_elision_stats(&behavioral).is_empty(),
+            "should be empty when no elision occurred"
+        );
+    }
+
+    #[test]
+    fn render_elision_stats_shows_counts_when_nonzero() {
+        let behavioral = BehavioralMetrics {
+            history_elision_instances: 3,
+            history_bytes_elided_total: 12_345,
+            history_compaction_failed: 1,
+            ..BehavioralMetrics::default()
+        };
+        let text = render_elision_stats(&behavioral);
+        assert!(
+            text.contains("history_elision_instances: 3"),
+            "missing instances count: {text}"
+        );
+        assert!(
+            text.contains("history_bytes_elided_total: 12345"),
+            "missing bytes total: {text}"
+        );
+        assert!(
+            text.contains("history_compaction_failed: 1"),
+            "missing compaction_failed count: {text}"
+        );
+    }
+
+    #[test]
+    fn build_elision_stats_counts_from_trajectory_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let sweep = dir.path();
+        // Instance a: one elided message → counts toward instances + bytes
+        let instance_a = sweep.join("inst-a");
+        std::fs::create_dir_all(&instance_a).unwrap();
+        let traj_a = serde_json::json!({
+            "trajectory_format": "mini-swe-agent-1.1",
+            "artifact_kind": "trajectory",
+            "schema_version": {"major": 1, "minor": 1},
+            "info": {},
+            "messages": [
+                {"role": "assistant", "content": "cmd"},
+                {
+                    "role": "user",
+                    "content": "full content",
+                    "extra": {
+                        "history_elided": true,
+                        "history_bytes_elided": 500_u64
+                    }
+                }
+            ]
+        });
+        std::fs::write(
+            instance_a.join("trajectory.json"),
+            serde_json::to_string(&traj_a).unwrap(),
+        )
+        .unwrap();
+
+        // Instance b: history_compaction_failed
+        let results: HashMap<String, InstanceResult> = [
+            (
+                "inst-a".to_owned(),
+                InstanceResult {
+                    instance_id: "inst-a".into(),
+                    exit_reason: "submitted".into(),
+                    outcome: Some(outcome::SUBMITTED.into()),
+                    failure_category: None,
+                    steps: None,
+                    cost_usd: None,
+                    prompt_tokens: None,
+                    cache_read_tokens: None,
+                    cache_creation_tokens: None,
+                    completion_tokens: None,
+                    duration_secs: None,
+                    error: None,
+                    github_pr_error: None,
+                    patch_present: true,
+                    non_empty_patch: true,
+                    attempts: 1,
+                    retry_reasons: vec![],
+                    runs: 0,
+                    resolved_count: 0,
+                    pass_at_1: false,
+                    tests_run_before_submit: false,
+                    last_tests_passed: None,
+                    fallback_count: None,
+                    final_model: None,
+                },
+            ),
+            (
+                "inst-b".to_owned(),
+                InstanceResult {
+                    instance_id: "inst-b".into(),
+                    exit_reason: "history_compaction_failed".into(),
+                    outcome: Some("error".into()),
+                    failure_category: Some(FailureCategory::HistoryCompactionFailed),
+                    steps: None,
+                    cost_usd: None,
+                    prompt_tokens: None,
+                    cache_read_tokens: None,
+                    cache_creation_tokens: None,
+                    completion_tokens: None,
+                    duration_secs: None,
+                    error: None,
+                    github_pr_error: None,
+                    patch_present: false,
+                    non_empty_patch: false,
+                    attempts: 1,
+                    retry_reasons: vec![],
+                    runs: 0,
+                    resolved_count: 0,
+                    pass_at_1: false,
+                    tests_run_before_submit: false,
+                    last_tests_passed: None,
+                    fallback_count: None,
+                    final_model: None,
+                },
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        let (instances, bytes, compaction_failed) = build_elision_stats(sweep, &results);
+        assert_eq!(instances, 1, "one instance should be elided");
+        assert_eq!(bytes, 500, "should total 500 bytes elided");
+        assert_eq!(compaction_failed, 1, "one compaction_failed instance");
+    }
 }

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -2963,8 +2963,7 @@ mod tests {
             instance_id: id.into(),
             exit_reason: cat
                 .as_ref()
-                .map(|c| format!("{c:?}").to_lowercase())
-                .unwrap_or_else(|| "submitted".into()),
+                .map_or_else(|| "submitted".into(), |c| format!("{c:?}").to_lowercase()),
             outcome: Some(
                 if cat.is_some() {
                     "error"

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -1315,12 +1315,19 @@ fn build_elision_stats(
         let path = if path.exists() {
             path
         } else {
-            // Fallbacks: flat layout then bundled-archive layout.
+            // Fallbacks in priority order: nested legacy, flat, bundled-archive.
+            let nested = sweep_dir.join(&slot.instance_id).join("trajectory.json");
             let flat = sweep_dir.join(format!("{}.traj.json", slot.instance_id));
             let bundled = sweep_dir
                 .join("trajectories")
                 .join(format!("{}.traj.json", slot.instance_id));
-            if flat.exists() { flat } else { bundled }
+            if nested.exists() {
+                nested
+            } else if flat.exists() {
+                flat
+            } else {
+                bundled
+            }
         };
         let Ok(text) = std::fs::read_to_string(&path) else {
             continue;

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -395,7 +395,7 @@ pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
     eval.behavioral = build_behavioral_metrics(&eval.instances, &results);
     let run_slots = load_run_slots(&args.sweep_dir, &results)?;
     let (elision_instances, bytes_elided_total, compaction_failed) =
-        build_elision_stats(&args.sweep_dir, &run_slots, &results);
+        build_elision_stats(&args.sweep_dir, &run_slots);
     eval.behavioral.history_elision_instances = elision_instances;
     eval.behavioral.history_bytes_elided_total = bytes_elided_total;
     eval.behavioral.history_compaction_failed = compaction_failed;
@@ -1298,14 +1298,13 @@ fn build_behavioral_metrics(
 /// Scan trajectory files for elision metadata produced by history-bounding.
 /// Iterates all run slots (handles reruns) to count instances with elision and
 /// aggregate bytes. Returns (elision_instances, bytes_elided_total, compaction_failed_count).
-fn build_elision_stats<S: std::hash::BuildHasher>(
+fn build_elision_stats(
     sweep_dir: &Path,
     run_slots: &[crate::run::compare::LoadedRunSlot],
-    results: &HashMap<String, InstanceResult, S>,
 ) -> (usize, u64, usize) {
-    let compaction_failed = results
-        .values()
-        .filter(|r| r.failure_category == Some(FailureCategory::HistoryCompactionFailed))
+    let compaction_failed = run_slots
+        .iter()
+        .filter(|s| s.result.failure_category == Some(FailureCategory::HistoryCompactionFailed))
         .count();
 
     let mut elision_instance_set = std::collections::HashSet::<String>::new();
@@ -2959,134 +2958,56 @@ mod tests {
         )
         .unwrap();
 
-        // Instance b: history_compaction_failed
+        // Instance b: history_compaction_failed — result lives in the slot
+        let make_result = |id: &str, cat: Option<FailureCategory>| InstanceResult {
+            instance_id: id.into(),
+            exit_reason: cat
+                .as_ref()
+                .map(|c| format!("{c:?}").to_lowercase())
+                .unwrap_or_else(|| "submitted".into()),
+            outcome: Some(
+                if cat.is_some() {
+                    "error"
+                } else {
+                    outcome::SUBMITTED
+                }
+                .into(),
+            ),
+            failure_category: cat,
+            steps: None,
+            cost_usd: None,
+            prompt_tokens: None,
+            cache_read_tokens: None,
+            cache_creation_tokens: None,
+            completion_tokens: None,
+            duration_secs: None,
+            error: None,
+            github_pr_error: None,
+            patch_present: cat.is_none(),
+            non_empty_patch: cat.is_none(),
+            attempts: 1,
+            retry_reasons: vec![],
+            runs: 0,
+            resolved_count: 0,
+            pass_at_1: false,
+            tests_run_before_submit: false,
+            last_tests_passed: None,
+            fallback_count: None,
+            final_model: None,
+        };
         let run_slots = vec![
             crate::run::compare::LoadedRunSlot {
                 instance_id: "inst-a".to_owned(),
                 run_index: 1,
-                result: InstanceResult {
-                    instance_id: "inst-a".into(),
-                    exit_reason: "submitted".into(),
-                    outcome: Some(outcome::SUBMITTED.into()),
-                    failure_category: None,
-                    steps: None,
-                    cost_usd: None,
-                    prompt_tokens: None,
-                    cache_read_tokens: None,
-                    cache_creation_tokens: None,
-                    completion_tokens: None,
-                    duration_secs: None,
-                    error: None,
-                    github_pr_error: None,
-                    patch_present: true,
-                    non_empty_patch: true,
-                    attempts: 1,
-                    retry_reasons: vec![],
-                    runs: 0,
-                    resolved_count: 0,
-                    pass_at_1: false,
-                    tests_run_before_submit: false,
-                    last_tests_passed: None,
-                    fallback_count: None,
-                    final_model: None,
-                },
+                result: make_result("inst-a", None),
             },
             crate::run::compare::LoadedRunSlot {
                 instance_id: "inst-b".to_owned(),
                 run_index: 1,
-                result: InstanceResult {
-                    instance_id: "inst-b".into(),
-                    exit_reason: "history_compaction_failed".into(),
-                    outcome: Some("error".into()),
-                    failure_category: Some(FailureCategory::HistoryCompactionFailed),
-                    steps: None,
-                    cost_usd: None,
-                    prompt_tokens: None,
-                    cache_read_tokens: None,
-                    cache_creation_tokens: None,
-                    completion_tokens: None,
-                    duration_secs: None,
-                    error: None,
-                    github_pr_error: None,
-                    patch_present: false,
-                    non_empty_patch: false,
-                    attempts: 1,
-                    retry_reasons: vec![],
-                    runs: 0,
-                    resolved_count: 0,
-                    pass_at_1: false,
-                    tests_run_before_submit: false,
-                    last_tests_passed: None,
-                    fallback_count: None,
-                    final_model: None,
-                },
+                result: make_result("inst-b", Some(FailureCategory::HistoryCompactionFailed)),
             },
         ];
-        let results: HashMap<String, InstanceResult> = [
-            (
-                "inst-a".to_owned(),
-                InstanceResult {
-                    instance_id: "inst-a".into(),
-                    exit_reason: "submitted".into(),
-                    outcome: Some(outcome::SUBMITTED.into()),
-                    failure_category: None,
-                    steps: None,
-                    cost_usd: None,
-                    prompt_tokens: None,
-                    cache_read_tokens: None,
-                    cache_creation_tokens: None,
-                    completion_tokens: None,
-                    duration_secs: None,
-                    error: None,
-                    github_pr_error: None,
-                    patch_present: true,
-                    non_empty_patch: true,
-                    attempts: 1,
-                    retry_reasons: vec![],
-                    runs: 0,
-                    resolved_count: 0,
-                    pass_at_1: false,
-                    tests_run_before_submit: false,
-                    last_tests_passed: None,
-                    fallback_count: None,
-                    final_model: None,
-                },
-            ),
-            (
-                "inst-b".to_owned(),
-                InstanceResult {
-                    instance_id: "inst-b".into(),
-                    exit_reason: "history_compaction_failed".into(),
-                    outcome: Some("error".into()),
-                    failure_category: Some(FailureCategory::HistoryCompactionFailed),
-                    steps: None,
-                    cost_usd: None,
-                    prompt_tokens: None,
-                    cache_read_tokens: None,
-                    cache_creation_tokens: None,
-                    completion_tokens: None,
-                    duration_secs: None,
-                    error: None,
-                    github_pr_error: None,
-                    patch_present: false,
-                    non_empty_patch: false,
-                    attempts: 1,
-                    retry_reasons: vec![],
-                    runs: 0,
-                    resolved_count: 0,
-                    pass_at_1: false,
-                    tests_run_before_submit: false,
-                    last_tests_passed: None,
-                    fallback_count: None,
-                    final_model: None,
-                },
-            ),
-        ]
-        .into_iter()
-        .collect();
-
-        let (instances, bytes, compaction_failed) =
-            build_elision_stats(sweep, &run_slots, &results);
+        let (instances, bytes, compaction_failed) = build_elision_stats(sweep, &run_slots);
         assert_eq!(instances, 1, "one instance should be elided");
         assert_eq!(bytes, 500, "should total 500 bytes elided");
         assert_eq!(compaction_failed, 1, "one compaction_failed instance");

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -967,6 +967,7 @@ fn failure_label(c: FailureCategory) -> &'static str {
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
         FailureCategory::SecretLeakDetected => "secret_leak_detected",
+        FailureCategory::HistoryCompactionFailed => "history_compaction_failed",
         FailureCategory::Unknown => "unknown",
     }
 }

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -747,10 +747,12 @@ fn render_instance_text(report: &InspectReport) -> String {
             let _ = writeln!(s, "[as-sent to model] {marker}");
             if step.stdout.as_ref().is_some_and(|o| !o.is_empty()) {
                 let _ = writeln!(s, "[as-recorded stdout]");
+                if let Some(out) = &step.stdout {
+                    let _ = writeln!(s, "{out}");
+                }
             }
-        }
-        if let Some(out) = &step.stdout {
-            let _ = writeln!(s, "{out}");
+        } else if let Some(out) = &step.stdout {
+            let _ = writeln!(s, "stdout:\n{out}");
         }
         if let Some(err) = &step.stderr {
             if !err.is_empty() {

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -1167,4 +1167,130 @@ mod tests {
             panic!("expected Instance output");
         }
     }
+
+    #[test]
+    fn elided_step_renders_two_view() {
+        let dir = tempfile::tempdir().unwrap();
+        let instance_dir = dir.path().join("task-elided");
+        std::fs::create_dir_all(&instance_dir).unwrap();
+        let run_result = serde_json::json!({
+            "stdout": "full_observation_content",
+            "stderr": "",
+            "exit_code": 0,
+            "timed_out": false
+        });
+        let traj = serde_json::json!({
+            "trajectory_format": "mini-swe-agent-1.1",
+            "artifact_kind": "trajectory",
+            "schema_version": {"major": 1, "minor": 1},
+            "info": {},
+            "messages": [
+                {"role": "assistant", "content": "```bash\necho x\n```"},
+                {
+                    "role": "user",
+                    "content": "full_observation_content",
+                    "extra": {
+                        "run_result": run_result,
+                        "history_elided": true,
+                        "history_elision_marker": "[history-elided: step 0 observation, 23 bytes]",
+                        "history_bytes_elided": 23
+                    }
+                }
+            ]
+        });
+        std::fs::write(
+            instance_dir.join("trajectory.json"),
+            serde_json::to_string(&traj).unwrap(),
+        )
+        .unwrap();
+
+        let args = InspectArgs {
+            sweep: dir.path().to_path_buf(),
+            instance: Some("task-elided".into()),
+            filter: None,
+            full: false,
+        };
+        let output = run(&args).unwrap();
+        let text = render_text(&output);
+
+        assert!(
+            text.contains("[as-sent to model]"),
+            "elided step should show as-sent view:\n{text}"
+        );
+        assert!(
+            text.contains("[history-elided: step 0 observation"),
+            "elided step should include marker text:\n{text}"
+        );
+        assert!(
+            text.contains("[as-recorded stdout]"),
+            "elided step should show as-recorded label:\n{text}"
+        );
+        assert!(
+            text.contains("full_observation_content"),
+            "elided step should show full recorded content:\n{text}"
+        );
+
+        if let InspectOutput::Instance(report) = &output {
+            let elided_step = report.steps.iter().find(|s| s.history_elided);
+            assert!(elided_step.is_some(), "report must contain an elided step");
+            let step = elided_step.unwrap();
+            assert!(
+                step.as_sent_marker
+                    .as_deref()
+                    .unwrap_or("")
+                    .contains("[history-elided:"),
+                "as_sent_marker must contain the elision marker"
+            );
+        } else {
+            panic!("expected Instance output");
+        }
+    }
+
+    #[test]
+    fn elided_step_without_marker_shows_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let instance_dir = dir.path().join("task-no-marker");
+        std::fs::create_dir_all(&instance_dir).unwrap();
+        let run_result = serde_json::json!({
+            "stdout": "content",
+            "stderr": "",
+            "exit_code": 0,
+            "timed_out": false
+        });
+        let traj = serde_json::json!({
+            "trajectory_format": "mini-swe-agent-1.1",
+            "artifact_kind": "trajectory",
+            "schema_version": {"major": 1, "minor": 1},
+            "info": {},
+            "messages": [
+                {"role": "assistant", "content": "```bash\necho x\n```"},
+                {
+                    "role": "user",
+                    "content": "content",
+                    "extra": {
+                        "run_result": run_result,
+                        "history_elided": true
+                    }
+                }
+            ]
+        });
+        std::fs::write(
+            instance_dir.join("trajectory.json"),
+            serde_json::to_string(&traj).unwrap(),
+        )
+        .unwrap();
+
+        let args = InspectArgs {
+            sweep: dir.path().to_path_buf(),
+            instance: Some("task-no-marker".into()),
+            filter: None,
+            full: false,
+        };
+        let output = run(&args).unwrap();
+        let text = render_text(&output);
+        assert!(
+            text.contains("[elision marker unavailable]"),
+            "should show fallback when marker is absent:\n{text}"
+        );
+    }
 }

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -54,6 +54,12 @@ pub struct InspectStep {
     pub truncated: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub truncation_note: Option<String>,
+    /// True when this observation was elided from the model-visible prompt.
+    #[serde(default)]
+    pub history_elided: bool,
+    /// The marker text that was sent to the model in place of the full content.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub as_sent_marker: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -430,6 +436,8 @@ fn build_inspect_steps(traj: &Trajectory, full: bool) -> Vec<InspectStep> {
                 stderr: None,
                 truncated: false,
                 truncation_note: None,
+                history_elided: false,
+                as_sent_marker: None,
             });
             continue;
         }
@@ -446,6 +454,21 @@ fn build_inspect_steps(traj: &Trajectory, full: bool) -> Vec<InspectStep> {
             continue;
         };
         let bash = infer_bash_from_previous_assistant(traj, msg_idx);
+        let history_elided = msg
+            .extra
+            .other
+            .get("history_elided")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let as_sent_marker = if history_elided {
+            msg.extra
+                .other
+                .get("history_elision_marker")
+                .and_then(|v| v.as_str())
+                .map(str::to_owned)
+        } else {
+            None
+        };
         let (stdout, stdout_note, stdout_truncated) =
             maybe_truncate(&run_result.stdout, full, current_index);
         let (stderr, stderr_note, stderr_truncated) =
@@ -467,6 +490,8 @@ fn build_inspect_steps(traj: &Trajectory, full: bool) -> Vec<InspectStep> {
             stderr: Some(stderr),
             truncated: stdout_truncated || stderr_truncated,
             truncation_note: (!note_parts.is_empty()).then(|| note_parts.join("; ")),
+            history_elided,
+            as_sent_marker,
         });
     }
     steps
@@ -714,8 +739,18 @@ fn render_instance_text(report: &InspectReport) -> String {
         if let Some(code) = step.exit_code {
             let _ = writeln!(s, "exit_code: {code}");
         }
+        if step.history_elided {
+            let marker = step
+                .as_sent_marker
+                .as_deref()
+                .unwrap_or("[elision marker unavailable]");
+            let _ = writeln!(s, "[as-sent to model] {marker}");
+            if step.stdout.as_ref().is_some_and(|o| !o.is_empty()) {
+                let _ = writeln!(s, "[as-recorded stdout]");
+            }
+        }
         if let Some(out) = &step.stdout {
-            let _ = writeln!(s, "stdout:\n{out}");
+            let _ = writeln!(s, "{out}");
         }
         if let Some(err) = &step.stderr {
             if !err.is_empty() {

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -458,7 +458,7 @@ fn build_inspect_steps(traj: &Trajectory, full: bool) -> Vec<InspectStep> {
             .extra
             .other
             .get("history_elided")
-            .and_then(|v| v.as_bool())
+            .and_then(serde_json::Value::as_bool)
             .unwrap_or(false);
         let as_sent_marker = if history_elided {
             msg.extra

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -3805,6 +3805,7 @@ fn parse_failure_category_label(s: &str) -> Result<FailureCategory, Error> {
         "patch_empty" => Ok(FailureCategory::PatchEmpty),
         "secret_leak_detected" => Ok(FailureCategory::SecretLeakDetected),
         "agent_stagnation" => Ok(FailureCategory::AgentStagnation),
+        "history_compaction_failed" => Ok(FailureCategory::HistoryCompactionFailed),
         "unknown" => Ok(FailureCategory::Unknown),
         _ => Err(Error::Config(crate::error::ConfigError::Invalid(format!(
             "unknown retry category `{s}`"
@@ -4259,6 +4260,7 @@ fn failure_category_label(cat: FailureCategory) -> &'static str {
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
         FailureCategory::SecretLeakDetected => "secret_leak_detected",
+        FailureCategory::HistoryCompactionFailed => "history_compaction_failed",
         FailureCategory::Unknown => "unknown",
     }
 }

--- a/src/run/tail.rs
+++ b/src/run/tail.rs
@@ -982,6 +982,7 @@ fn failure_label(category: FailureCategory) -> &'static str {
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
         FailureCategory::SecretLeakDetected => "secret_leak_detected",
+        FailureCategory::HistoryCompactionFailed => "history_compaction_failed",
         FailureCategory::Unknown => "unknown",
     }
 }

--- a/src/run/trajectory_diff.rs
+++ b/src/run/trajectory_diff.rs
@@ -1053,6 +1053,7 @@ fn failure_label(category: FailureCategory) -> &'static str {
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
         FailureCategory::SecretLeakDetected => "secret_leak_detected",
+        FailureCategory::HistoryCompactionFailed => "history_compaction_failed",
         FailureCategory::Unknown => "unknown",
     }
 }

--- a/src/run/triage.rs
+++ b/src/run/triage.rs
@@ -587,6 +587,7 @@ fn failure_label(c: FailureCategory) -> &'static str {
         FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
         FailureCategory::PatchEmpty => "patch_empty",
         FailureCategory::SecretLeakDetected => "secret_leak_detected",
+        FailureCategory::HistoryCompactionFailed => "history_compaction_failed",
         FailureCategory::Unknown => "unknown",
     }
 }

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -149,6 +149,10 @@ pub enum FailureCategory {
     SecretLeakDetected,
     /// The agent repeated the same action without progress and was halted.
     AgentStagnation,
+    /// History could not be compacted to fit within `history_max_input_tokens`
+    /// even after eliding all older observations. The run is terminated rather
+    /// than sending an oversized prompt or triggering a provider context error.
+    HistoryCompactionFailed,
     /// An unknown or unclassified failure occurred.
     Unknown,
 }

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -153,7 +153,9 @@ pub enum FailureCategory {
     /// even after eliding all older observations. The run is terminated rather
     /// than sending an oversized prompt or triggering a provider context error.
     HistoryCompactionFailed,
-    /// An unknown or unclassified failure occurred.
+    /// An unknown or unclassified failure occurred, or a value produced by a
+    /// newer harness version that this reader does not recognise.
+    #[serde(other)]
     Unknown,
 }
 

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -172,7 +172,10 @@ impl FailureCategory {
     /// errors, or conditions already governed by other budget controls).
     #[must_use]
     pub fn is_actionable(self) -> bool {
-        matches!(self, Self::EnvSetup | Self::ModelApi)
+        matches!(
+            self,
+            Self::EnvSetup | Self::ModelApi | Self::HistoryCompactionFailed
+        )
     }
 }
 

--- a/tests/fixtures/artifact_schema/current/evaluation.json
+++ b/tests/fixtures/artifact_schema/current/evaluation.json
@@ -23,7 +23,10 @@
   "behavioral": {
     "tests_run_before_submit_rate": 0.0,
     "resolved_rate_when_tests_run": 0.0,
-    "resolved_rate_when_tests_skipped": 0.0
+    "resolved_rate_when_tests_skipped": 0.0,
+    "history_elision_instances": 0,
+    "history_bytes_elided_total": 0,
+    "history_compaction_failed": 0
   },
   "latency_summary": {
     "harness_overhead_ms": {"p50": 0, "p95": 0}

--- a/tests/history_bounding.rs
+++ b/tests/history_bounding.rs
@@ -1,0 +1,378 @@
+//! Tests for history bounding (issue #167).
+//!
+//! Verifies `history_keep_last_observations` and `history_max_input_tokens`
+//! elide old observations in the prompt while keeping the full content in the
+//! trajectory.
+
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rust_swe_agent::agent::default::DefaultAgentBuilder;
+use rust_swe_agent::error::EnvError;
+use rust_swe_agent::{
+    Agent, Config, DeterministicModel, Environment, ExitReason, FailureCategory, RunRequest,
+    RunResult,
+};
+
+/// An environment that always returns a fixed-size synthetic observation.
+struct SyntheticEnv {
+    stdout: String,
+}
+
+impl SyntheticEnv {
+    fn new_with_size(size_bytes: usize) -> Self {
+        Self {
+            stdout: "x".repeat(size_bytes),
+        }
+    }
+}
+
+#[async_trait]
+impl Environment for SyntheticEnv {
+    async fn run(&self, _req: RunRequest) -> Result<RunResult, EnvError> {
+        Ok(RunResult {
+            stdout: self.stdout.clone(),
+            stderr: String::new(),
+            exit_code: 0,
+            timed_out: false,
+        })
+    }
+}
+
+fn make_responses(n_bash: usize) -> Vec<String> {
+    let mut r: Vec<String> = (0..n_bash)
+        .map(|i| format!("```bash\necho step{i}\n```"))
+        .collect();
+    r.push("COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfinal\n```".into());
+    r
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 1 (RED): keep_last_observations elides older observations from the
+// model-visible prompt while keeping the full content in the trajectory.
+// ─────────────────────────────────────────────────────────────────────────────
+#[tokio::test]
+async fn keep_last_observations_elides_older_from_model_prompt() {
+    const N_BASH: usize = 5;
+    const KEEP: usize = 2;
+
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 20;
+    cfg.root.agent.history_keep_last_observations = Some(KEEP);
+    cfg.root.agent.observation_max_bytes = 64 * 1024;
+
+    let model = Arc::new(DeterministicModel::new(make_responses(N_BASH)));
+    let env: Box<dyn Environment> = Box::new(SyntheticEnv::new_with_size(1024));
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model: model.clone(),
+        env,
+        task: "test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+    assert!(
+        matches!(exit, ExitReason::Submitted { .. }),
+        "expected submitted, got {exit:?}"
+    );
+
+    let inputs = model.recorded_inputs();
+    let last_query = inputs.last().unwrap();
+
+    // The model prompt must contain elision markers for steps older than KEEP.
+    let elided_count = last_query
+        .iter()
+        .filter(|m| m.content.contains("[history-elided:"))
+        .count();
+
+    assert!(
+        elided_count >= N_BASH - KEEP - 1,
+        "expected at least {} elision markers in final prompt, got {}",
+        N_BASH - KEEP - 1,
+        elided_count,
+    );
+
+    // The most recent KEEP observations must be full (not markers).
+    let user_msgs: Vec<_> = last_query
+        .iter()
+        .filter(|m| {
+            matches!(
+                m.role,
+                rust_swe_agent::model::Role::User | rust_swe_agent::model::Role::Tool
+            )
+        })
+        .collect();
+
+    // The last KEEP user messages (excluding instance msg at front) should not
+    // be elision markers.
+    let recent: Vec<_> = user_msgs.iter().rev().take(KEEP).collect();
+    for msg in &recent {
+        assert!(
+            !msg.content.contains("[history-elided:"),
+            "a recent observation should not be elided: {}",
+            &msg.content[..msg.content.len().min(80)]
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 2 (RED): trajectory records the full, untruncated observation even when
+// the model only sees an elision marker. Steps that triggered elision carry
+// `history_elided: true` and a positive `history_bytes_elided`.
+// ─────────────────────────────────────────────────────────────────────────────
+#[tokio::test]
+async fn trajectory_records_full_content_and_elision_metadata() {
+    const N_BASH: usize = 4;
+    const KEEP: usize = 1;
+    const OBS_SIZE: usize = 500;
+
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 20;
+    cfg.root.agent.history_keep_last_observations = Some(KEEP);
+    cfg.root.agent.observation_max_bytes = 64 * 1024;
+
+    let model = Arc::new(DeterministicModel::new(make_responses(N_BASH)));
+    let env: Box<dyn Environment> = Box::new(SyntheticEnv::new_with_size(OBS_SIZE));
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    agent.run().await.unwrap();
+
+    let traj = &agent.trajectory;
+    // Trajectory must hold full content (no markers).
+    let obs_messages: Vec<_> = traj
+        .messages
+        .iter()
+        .filter(|m| m.role == "user")
+        .skip(1) // skip initial instance message
+        .collect();
+
+    for msg in &obs_messages {
+        assert!(
+            !msg.content.contains("[history-elided:"),
+            "trajectory should contain full content, got marker: {}",
+            &msg.content[..msg.content.len().min(80)]
+        );
+    }
+
+    // Steps that became elided in the model-visible prompt must have
+    // history_elided = true and history_bytes_elided > 0.
+    let elided_steps: Vec<_> = obs_messages
+        .iter()
+        .filter(|m| {
+            m.extra
+                .other
+                .get("history_elided")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+        })
+        .collect();
+
+    assert!(
+        elided_steps.len() >= N_BASH - KEEP,
+        "expected at least {} steps with history_elided=true, got {}",
+        N_BASH - KEEP,
+        elided_steps.len()
+    );
+
+    for step in &elided_steps {
+        let bytes_elided = step
+            .extra
+            .other
+            .get("history_bytes_elided")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        assert!(
+            bytes_elided > 0,
+            "history_bytes_elided must be > 0 on elided steps"
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 3 (RED): regression — with both flags unset, no elision markers appear.
+// ─────────────────────────────────────────────────────────────────────────────
+#[tokio::test]
+async fn no_elision_markers_when_flags_unset() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 20;
+    assert!(cfg.root.agent.history_keep_last_observations.is_none());
+    assert!(cfg.root.agent.history_max_input_tokens.is_none());
+
+    let model = Arc::new(DeterministicModel::new(make_responses(5)));
+    let env: Box<dyn Environment> = Box::new(SyntheticEnv::new_with_size(512));
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model: model.clone(),
+        env,
+        task: "test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    agent.run().await.unwrap();
+
+    for (qi, query) in model.recorded_inputs().iter().enumerate() {
+        for msg in query {
+            assert!(
+                !msg.content.contains("[history-elided:"),
+                "query {qi} unexpectedly contains an elision marker: {}",
+                &msg.content[..msg.content.len().min(80)]
+            );
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 4 (RED): history_max_input_tokens bounds the byte-length of the prompt
+// sent to the model (1 token ≈ 4 bytes approximation).
+// ─────────────────────────────────────────────────────────────────────────────
+#[tokio::test]
+async fn max_input_tokens_bounds_prompt_bytes() {
+    const N_BASH: usize = 8;
+    const OBS_BYTES: usize = 2048;
+    // Cap at 6000 tokens ≈ 24 000 bytes.
+    const MAX_TOKENS: u64 = 6_000;
+    const MAX_BYTES_APPROX: usize = (MAX_TOKENS as usize) * 4;
+
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 30;
+    cfg.root.agent.history_max_input_tokens = Some(MAX_TOKENS);
+    cfg.root.agent.observation_max_bytes = 64 * 1024;
+
+    let model = Arc::new(DeterministicModel::new(make_responses(N_BASH)));
+    let env: Box<dyn Environment> = Box::new(SyntheticEnv::new_with_size(OBS_BYTES));
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model: model.clone(),
+        env,
+        task: "test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    agent.run().await.unwrap();
+
+    for (qi, query) in model.recorded_inputs().iter().enumerate() {
+        let total_bytes: usize = query.iter().map(|m| m.content.len()).sum();
+        assert!(
+            total_bytes <= MAX_BYTES_APPROX,
+            "query {qi}: total bytes {total_bytes} exceeds cap {MAX_BYTES_APPROX}"
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 5 (RED): when even the most-recent single observation exceeds the cap,
+// the run exits with failure_category = history_compaction_failed.
+// ─────────────────────────────────────────────────────────────────────────────
+#[tokio::test]
+async fn history_compaction_failed_when_irreducible() {
+    // Tiny cap: 10 tokens ≈ 40 bytes. A 500-byte observation cannot fit.
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 20;
+    cfg.root.agent.history_max_input_tokens = Some(10);
+    cfg.root.agent.observation_max_bytes = 64 * 1024;
+
+    let model = Arc::new(DeterministicModel::new(make_responses(10)));
+    let env: Box<dyn Environment> = Box::new(SyntheticEnv::new_with_size(500));
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    let exit = agent.run().await.unwrap();
+
+    assert!(
+        !matches!(exit, ExitReason::Submitted { .. }),
+        "should not submit when cap is irreducibly too low"
+    );
+
+    assert_eq!(
+        agent.trajectory.info.failure_category,
+        Some(FailureCategory::HistoryCompactionFailed),
+        "expected failure_category = history_compaction_failed"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 6 (GREEN): when both flags are set, the more aggressive (more elision)
+// rule wins — the model sees fewer observations than keep_last alone would allow.
+// ─────────────────────────────────────────────────────────────────────────────
+#[tokio::test]
+async fn both_flags_compose_taking_more_aggressive() {
+    const N_BASH: usize = 6;
+    // Observations are 512 bytes each.
+    // keep_last=4 alone would elide 2 candidates (keep 4 total obs).
+    // With max_tokens=400 → max_bytes=1600:
+    //   sys+inst+assistants ≈ 200+100+6*25 = ~450 bytes
+    //   remaining budget for obs ≈ 1150 bytes → fits ~2 full observations
+    // So max_tokens forces ≥ 4 elisions, while keep_last=4 forces only 2.
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 20;
+    cfg.root.agent.history_keep_last_observations = Some(4);
+    cfg.root.agent.history_max_input_tokens = Some(400); // ~1600 bytes
+    cfg.root.agent.observation_max_bytes = 64 * 1024;
+
+    let model = Arc::new(DeterministicModel::new(make_responses(N_BASH)));
+    let env: Box<dyn Environment> = Box::new(SyntheticEnv::new_with_size(512));
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model: model.clone(),
+        env,
+        task: "test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+
+    agent.run().await.unwrap();
+
+    let inputs = model.recorded_inputs();
+    let last_query = inputs.last().unwrap();
+
+    // keep_last=4 alone would elide 2 out of 5 candidates.
+    // The token cap must force at least 3 elisions (strictly more than 2).
+    let elision_count = last_query
+        .iter()
+        .filter(|m| m.content.contains("[history-elided:"))
+        .count();
+
+    let keep_last_only_elision = N_BASH - 4; // = 2
+    assert!(
+        elision_count > keep_last_only_elision,
+        "token cap should force more elision than keep_last=4 alone; \
+         expected elision_count > {keep_last_only_elision}, got {elision_count}"
+    );
+}

--- a/tests/history_bounding.rs
+++ b/tests/history_bounding.rs
@@ -179,7 +179,7 @@ async fn trajectory_records_full_content_and_elision_metadata() {
             m.extra
                 .other
                 .get("history_elided")
-                .and_then(|v| v.as_bool())
+                .and_then(serde_json::Value::as_bool)
                 .unwrap_or(false)
         })
         .collect();
@@ -196,7 +196,7 @@ async fn trajectory_records_full_content_and_elision_metadata() {
             .extra
             .other
             .get("history_bytes_elided")
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .unwrap_or(0);
         assert!(
             bytes_elided > 0,
@@ -256,7 +256,7 @@ async fn max_input_tokens_bounds_prompt_bytes() {
     // Each 5 KB observation would grow the prompt well beyond this cap without
     // elision, so the history-bounding logic must kick in every step.
     const MAX_TOKENS: u64 = 8_000;
-    const MAX_BYTES_APPROX: usize = (MAX_TOKENS as usize) * 4;
+    const MAX_BYTES_APPROX: usize = 8_000 * 4; // MAX_TOKENS * 4 bytes-per-token approximation
 
     let mut cfg = Config::defaults().unwrap();
     cfg.root.agent.step_limit = 50;

--- a/tests/history_bounding.rs
+++ b/tests/history_bounding.rs
@@ -245,17 +245,21 @@ async fn no_elision_markers_when_flags_unset() {
 // ─────────────────────────────────────────────────────────────────────────────
 // Test 4 (RED): history_max_input_tokens bounds the byte-length of the prompt
 // sent to the model (1 token ≈ 4 bytes approximation).
+// Uses 30+ steps with 5 KB synthetic observations — the cap must hold for every
+// single query, not just the final one.
 // ─────────────────────────────────────────────────────────────────────────────
 #[tokio::test]
 async fn max_input_tokens_bounds_prompt_bytes() {
-    const N_BASH: usize = 8;
-    const OBS_BYTES: usize = 2048;
-    // Cap at 6000 tokens ≈ 24 000 bytes.
-    const MAX_TOKENS: u64 = 6_000;
+    const N_BASH: usize = 32;
+    const OBS_BYTES: usize = 5 * 1024; // 5 KB per observation
+    // Cap at 8 000 tokens ≈ 32 000 bytes.
+    // Each 5 KB observation would grow the prompt well beyond this cap without
+    // elision, so the history-bounding logic must kick in every step.
+    const MAX_TOKENS: u64 = 8_000;
     const MAX_BYTES_APPROX: usize = (MAX_TOKENS as usize) * 4;
 
     let mut cfg = Config::defaults().unwrap();
-    cfg.root.agent.step_limit = 30;
+    cfg.root.agent.step_limit = 50;
     cfg.root.agent.history_max_input_tokens = Some(MAX_TOKENS);
     cfg.root.agent.observation_max_bytes = 64 * 1024;
 
@@ -275,7 +279,16 @@ async fn max_input_tokens_bounds_prompt_bytes() {
 
     agent.run().await.unwrap();
 
-    for (qi, query) in model.recorded_inputs().iter().enumerate() {
+    let inputs = model.recorded_inputs();
+    // We ran 32 bash steps + 1 submit, so the model should have received at
+    // least 30 queries.
+    assert!(
+        inputs.len() >= 30,
+        "expected ≥30 model queries, got {}",
+        inputs.len()
+    );
+
+    for (qi, query) in inputs.iter().enumerate() {
         let total_bytes: usize = query.iter().map(|m| m.content.len()).sum();
         assert!(
             total_bytes <= MAX_BYTES_APPROX,


### PR DESCRIPTION
## Summary

This PR implements history bounding for the agent's conversation history, allowing the model-visible prompt to be capped by either observation count or token budget while preserving the full conversation in the trajectory. This addresses issue #167 and enables better control over context window usage.

## Key Changes

- **History elision logic** (`src/agent/default.rs`):
  - Added `elide_history_for_model()` function that replaces older observations with compact elision markers when either `history_keep_last_observations` or `history_max_input_tokens` limits are exceeded
  - Implements a byte-per-token approximation (1 token ≈ 4 bytes) for token budget calculations
  - Protects system prompt, instance message, and most recent observation from elision
  - When both limits are set, the more aggressive rule wins
  - Detects and reports `history_compaction_failed` when even maximum elision cannot fit the prompt within budget

- **Configuration** (`src/config/schema.rs`, `src/cli/args.rs`, `src/cli/mod.rs`):
  - Added `history_max_input_tokens` config option for token-based prompt budgeting
  - Added `history_keep_last_observations` config option for observation-count-based limiting
  - Both options are CLI-overridable via `--history-max-input-tokens` and `--history-keep-last-observations` flags

- **Trajectory metadata** (`src/agent/default.rs`, `src/run/inspect.rs`):
  - Retroactively marks elided observations in trajectory with:
    - `history_elided: true` flag
    - `history_bytes_elided` count (original byte length)
    - `history_elision_marker` (the marker text sent to model)
  - Allows reconstruction of "as-sent-to-model" view without re-running elision logic

- **Exit handling** (`src/agent/mod.rs`, `src/trajectory/mod.rs`):
  - Added `HistoryCompactionFailed` exit reason and failure category
  - Properly terminates runs when history cannot be compacted to fit budget

- **Evaluation metrics** (`src/run/evaluate.rs`):
  - Added `history_elision_instances` (count of instances with any elision)
  - Added `history_bytes_elided_total` (sum of all elided bytes in sweep)
  - Added `history_compaction_failed` (count of runs that failed due to irreducible history)
  - Added `render_elision_stats()` for reporting elision metrics

- **Comprehensive test suite** (`tests/history_bounding.rs`):
  - 6 integration tests covering elision behavior, trajectory preservation, token budgeting, and failure cases
  - 5 unit tests for the elision logic itself

## Notable Implementation Details

- Elision markers are stable and human-readable: `[history-elided: step N observation, M bytes]`
- The full observation content is always preserved in `self.history` and the trajectory; only the model-visible prompt is modified
- Observation indices are calculated relative to the instance message (position 1), making markers consistent across runs
- The implementation gracefully handles edge cases: single observations are never elided, and compaction failure is properly detected

https://claude.ai/code/session_01QyCj6cMUnaduRQfcdfwbcp