### PR TITLE
⚒️ Forge: Extract duplicated config override logic in CLI module

### DIFF
--- a/clippy.log
+++ b/clippy.log
@@ -1,1 +1,0 @@
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.33s

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,2 @@
+1. **Analyze comment:** The user suggests replacing the `apply_config_overrides!` macro with a trait-based approach. We should define a `ConfigOverrides` trait that both `args::MiniCmd` and `args::SwebenchCmd` implement, and then have a function apply the overrides.
+2. **Review codebase:** Let's look at `src/cli/args.rs` and `src/cli/mod.rs` to see how to implement this trait.

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,47 @@
+If we use a trait we can define the `apply_config_overrides` function:
+```rust
+fn apply_config_overrides(cfg: &mut Config, cmd: &impl ConfigOverrides) -> Result<(), Error> {
+    cfg.root.model.name = cmd.model().to_owned();
+    cfg.root.agent.step_limit = cmd.step_limit();
+    if let Some(v) = cmd.observation_max_bytes() {
+        cfg.root.agent.observation_max_bytes = v;
+    }
+    if let Some(v) = cmd.observation_head_ratio() {
+        validate_observation_head_ratio(v)?;
+        cfg.root.agent.observation_head_ratio = v;
+    }
+    if let Some(kind) = cmd.env() {
+        cfg.root.environment.kind = parse_env_kind(kind.as_str())?;
+    }
+    if let Some(img) = cmd.docker_image() {
+        cfg.root.environment.docker_image = Some(img.clone());
+    }
+    if let Some(v) = cmd.per_task_budget_usd() {
+        cfg.root.agent.per_task_budget_usd = Some(v);
+    }
+    if cmd.hide_budget_from_agent() {
+        cfg.root.agent.hide_budget_from_agent = true;
+    }
+    if let Some(v) = cmd.detect_stagnation() {
+        cfg.root.agent.detect_stagnation = v;
+    }
+    if let Some(v) = cmd.stagnation_repeat_threshold() {
+        cfg.root.agent.stagnation_repeat_threshold = v;
+    }
+    if let Some(v) = cmd.stagnation_window() {
+        cfg.root.agent.stagnation_window = v;
+    }
+    if let Some(v) = cmd.history_max_input_tokens() {
+        cfg.root.agent.history_max_input_tokens = Some(v);
+    }
+    if let Some(v) = cmd.history_keep_last_observations() {
+        cfg.root.agent.history_keep_last_observations = Some(v);
+    }
+    apply_mcp_server_overrides(cfg, cmd.mcp_servers())?;
+    Ok(())
+}
+```
+
+Wait, `clone_from` is better than `to_owned` since it can avoid allocating if the buffer is big enough, but here it's just setting from the struct initialization so `clone()` is fine or just `.into()`.
+
+Let's do this directly. We will write a python script to revert the previous change and apply the trait.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -127,46 +127,98 @@ fn init_logging(level: &str) {
         .try_init();
 }
 
-macro_rules! apply_config_overrides {
-    ($cfg:expr, $cmd:expr) => {
-        $cfg.root.model.name.clone_from(&$cmd.model);
-        $cfg.root.agent.step_limit = $cmd.step_limit;
-        if let Some(v) = $cmd.observation_max_bytes {
-            $cfg.root.agent.observation_max_bytes = v;
-        }
-        if let Some(v) = $cmd.observation_head_ratio {
-            validate_observation_head_ratio(v)?;
-            $cfg.root.agent.observation_head_ratio = v;
-        }
-        if let Some(kind) = &$cmd.env {
-            $cfg.root.environment.kind = parse_env_kind(kind.as_str())?;
-        }
-        if let Some(img) = $cmd.docker_image.clone() {
-            $cfg.root.environment.docker_image = Some(img);
-        }
-        if let Some(v) = $cmd.per_task_budget_usd {
-            $cfg.root.agent.per_task_budget_usd = Some(v);
-        }
-        if $cmd.hide_budget_from_agent {
-            $cfg.root.agent.hide_budget_from_agent = true;
-        }
-        if let Some(v) = $cmd.detect_stagnation {
-            $cfg.root.agent.detect_stagnation = v;
-        }
-        if let Some(v) = $cmd.stagnation_repeat_threshold {
-            $cfg.root.agent.stagnation_repeat_threshold = v;
-        }
-        if let Some(v) = $cmd.stagnation_window {
-            $cfg.root.agent.stagnation_window = v;
-        }
-        if let Some(v) = $cmd.history_max_input_tokens {
-            $cfg.root.agent.history_max_input_tokens = Some(v);
-        }
-        if let Some(v) = $cmd.history_keep_last_observations {
-            $cfg.root.agent.history_keep_last_observations = Some(v);
-        }
-        apply_mcp_server_overrides(&mut $cfg, &$cmd.mcp_servers)?;
-    };
+
+
+trait ConfigOverrides {
+    fn model(&self) -> &str;
+    fn step_limit(&self) -> u32;
+    fn observation_max_bytes(&self) -> Option<usize>;
+    fn observation_head_ratio(&self) -> Option<f64>;
+    fn env(&self) -> Option<&String>;
+    fn docker_image(&self) -> Option<&String>;
+    fn per_task_budget_usd(&self) -> Option<f64>;
+    fn hide_budget_from_agent(&self) -> bool;
+    fn detect_stagnation(&self) -> Option<bool>;
+    fn stagnation_repeat_threshold(&self) -> Option<u32>;
+    fn stagnation_window(&self) -> Option<u32>;
+    fn history_max_input_tokens(&self) -> Option<u64>;
+    fn history_keep_last_observations(&self) -> Option<usize>;
+    fn mcp_servers(&self) -> &[String];
+}
+
+impl ConfigOverrides for args::MiniCmd {
+    fn model(&self) -> &str { &self.model }
+    fn step_limit(&self) -> u32 { self.step_limit }
+    fn observation_max_bytes(&self) -> Option<usize> { self.observation_max_bytes }
+    fn observation_head_ratio(&self) -> Option<f64> { self.observation_head_ratio }
+    fn env(&self) -> Option<&String> { self.env.as_ref() }
+    fn docker_image(&self) -> Option<&String> { self.docker_image.as_ref() }
+    fn per_task_budget_usd(&self) -> Option<f64> { self.per_task_budget_usd }
+    fn hide_budget_from_agent(&self) -> bool { self.hide_budget_from_agent }
+    fn detect_stagnation(&self) -> Option<bool> { self.detect_stagnation }
+    fn stagnation_repeat_threshold(&self) -> Option<u32> { self.stagnation_repeat_threshold }
+    fn stagnation_window(&self) -> Option<u32> { self.stagnation_window }
+    fn history_max_input_tokens(&self) -> Option<u64> { self.history_max_input_tokens }
+    fn history_keep_last_observations(&self) -> Option<usize> { self.history_keep_last_observations }
+    fn mcp_servers(&self) -> &[String] { &self.mcp_servers }
+}
+
+impl ConfigOverrides for args::SwebenchCmd {
+    fn model(&self) -> &str { &self.model }
+    fn step_limit(&self) -> u32 { self.step_limit }
+    fn observation_max_bytes(&self) -> Option<usize> { self.observation_max_bytes }
+    fn observation_head_ratio(&self) -> Option<f64> { self.observation_head_ratio }
+    fn env(&self) -> Option<&String> { self.env.as_ref() }
+    fn docker_image(&self) -> Option<&String> { self.docker_image.as_ref() }
+    fn per_task_budget_usd(&self) -> Option<f64> { self.per_task_budget_usd }
+    fn hide_budget_from_agent(&self) -> bool { self.hide_budget_from_agent }
+    fn detect_stagnation(&self) -> Option<bool> { self.detect_stagnation }
+    fn stagnation_repeat_threshold(&self) -> Option<u32> { self.stagnation_repeat_threshold }
+    fn stagnation_window(&self) -> Option<u32> { self.stagnation_window }
+    fn history_max_input_tokens(&self) -> Option<u64> { self.history_max_input_tokens }
+    fn history_keep_last_observations(&self) -> Option<usize> { self.history_keep_last_observations }
+    fn mcp_servers(&self) -> &[String] { &self.mcp_servers }
+}
+
+fn apply_config_overrides(cfg: &mut Config, cmd: &impl ConfigOverrides) -> Result<(), Error> {
+    cfg.root.model.name = cmd.model().to_owned();
+    cfg.root.agent.step_limit = cmd.step_limit();
+    if let Some(v) = cmd.observation_max_bytes() {
+        cfg.root.agent.observation_max_bytes = v;
+    }
+    if let Some(v) = cmd.observation_head_ratio() {
+        validate_observation_head_ratio(v)?;
+        cfg.root.agent.observation_head_ratio = v;
+    }
+    if let Some(kind) = cmd.env() {
+        cfg.root.environment.kind = parse_env_kind(kind.as_str())?;
+    }
+    if let Some(img) = cmd.docker_image() {
+        cfg.root.environment.docker_image = Some(img.clone());
+    }
+    if let Some(v) = cmd.per_task_budget_usd() {
+        cfg.root.agent.per_task_budget_usd = Some(v);
+    }
+    if cmd.hide_budget_from_agent() {
+        cfg.root.agent.hide_budget_from_agent = true;
+    }
+    if let Some(v) = cmd.detect_stagnation() {
+        cfg.root.agent.detect_stagnation = v;
+    }
+    if let Some(v) = cmd.stagnation_repeat_threshold() {
+        cfg.root.agent.stagnation_repeat_threshold = v;
+    }
+    if let Some(v) = cmd.stagnation_window() {
+        cfg.root.agent.stagnation_window = v;
+    }
+    if let Some(v) = cmd.history_max_input_tokens() {
+        cfg.root.agent.history_max_input_tokens = Some(v);
+    }
+    if let Some(v) = cmd.history_keep_last_observations() {
+        cfg.root.agent.history_keep_last_observations = Some(v);
+    }
+    apply_mcp_server_overrides(cfg, cmd.mcp_servers())?;
+    Ok(())
 }
 
 async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
@@ -174,7 +226,7 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         Some(p) => Config::load(p)?,
         None => Config::defaults()?,
     };
-    apply_config_overrides!(cfg, m);
+    apply_config_overrides(&mut cfg, &m)?;
 
     let trajectory_name = m
         .trajectory_name
@@ -512,7 +564,7 @@ fn swebench_config_from_cmd(s: &args::SwebenchCmd) -> Result<Config, Error> {
         Some(p) => Config::load(p)?,
         None => Config::defaults()?,
     };
-    apply_config_overrides!(cfg, s);
+    apply_config_overrides(&mut cfg, s)?;
     Ok(cfg)
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -127,48 +127,54 @@ fn init_logging(level: &str) {
         .try_init();
 }
 
+macro_rules! apply_config_overrides {
+    ($cfg:expr, $cmd:expr) => {
+        $cfg.root.model.name.clone_from(&$cmd.model);
+        $cfg.root.agent.step_limit = $cmd.step_limit;
+        if let Some(v) = $cmd.observation_max_bytes {
+            $cfg.root.agent.observation_max_bytes = v;
+        }
+        if let Some(v) = $cmd.observation_head_ratio {
+            validate_observation_head_ratio(v)?;
+            $cfg.root.agent.observation_head_ratio = v;
+        }
+        if let Some(kind) = &$cmd.env {
+            $cfg.root.environment.kind = parse_env_kind(kind.as_str())?;
+        }
+        if let Some(img) = $cmd.docker_image.clone() {
+            $cfg.root.environment.docker_image = Some(img);
+        }
+        if let Some(v) = $cmd.per_task_budget_usd {
+            $cfg.root.agent.per_task_budget_usd = Some(v);
+        }
+        if $cmd.hide_budget_from_agent {
+            $cfg.root.agent.hide_budget_from_agent = true;
+        }
+        if let Some(v) = $cmd.detect_stagnation {
+            $cfg.root.agent.detect_stagnation = v;
+        }
+        if let Some(v) = $cmd.stagnation_repeat_threshold {
+            $cfg.root.agent.stagnation_repeat_threshold = v;
+        }
+        if let Some(v) = $cmd.stagnation_window {
+            $cfg.root.agent.stagnation_window = v;
+        }
+        if let Some(v) = $cmd.history_max_input_tokens {
+            $cfg.root.agent.history_max_input_tokens = Some(v);
+        }
+        if let Some(v) = $cmd.history_keep_last_observations {
+            $cfg.root.agent.history_keep_last_observations = Some(v);
+        }
+        apply_mcp_server_overrides(&mut $cfg, &$cmd.mcp_servers)?;
+    };
+}
+
 async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
     let mut cfg = match &m.config {
         Some(p) => Config::load(p)?,
         None => Config::defaults()?,
     };
-    cfg.root.model.name.clone_from(&m.model);
-    cfg.root.agent.step_limit = m.step_limit;
-    if let Some(v) = m.observation_max_bytes {
-        cfg.root.agent.observation_max_bytes = v;
-    }
-    if let Some(v) = m.observation_head_ratio {
-        validate_observation_head_ratio(v)?;
-        cfg.root.agent.observation_head_ratio = v;
-    }
-    if let Some(kind) = &m.env {
-        cfg.root.environment.kind = parse_env_kind(kind.as_str())?;
-    }
-    if let Some(img) = m.docker_image.clone() {
-        cfg.root.environment.docker_image = Some(img);
-    }
-    if let Some(v) = m.per_task_budget_usd {
-        cfg.root.agent.per_task_budget_usd = Some(v);
-    }
-    if m.hide_budget_from_agent {
-        cfg.root.agent.hide_budget_from_agent = true;
-    }
-    if let Some(v) = m.detect_stagnation {
-        cfg.root.agent.detect_stagnation = v;
-    }
-    if let Some(v) = m.stagnation_repeat_threshold {
-        cfg.root.agent.stagnation_repeat_threshold = v;
-    }
-    if let Some(v) = m.stagnation_window {
-        cfg.root.agent.stagnation_window = v;
-    }
-    if let Some(v) = m.history_max_input_tokens {
-        cfg.root.agent.history_max_input_tokens = Some(v);
-    }
-    if let Some(v) = m.history_keep_last_observations {
-        cfg.root.agent.history_keep_last_observations = Some(v);
-    }
-    apply_mcp_server_overrides(&mut cfg, &m.mcp_servers)?;
+    apply_config_overrides!(cfg, m);
 
     let trajectory_name = m
         .trajectory_name
@@ -506,43 +512,7 @@ fn swebench_config_from_cmd(s: &args::SwebenchCmd) -> Result<Config, Error> {
         Some(p) => Config::load(p)?,
         None => Config::defaults()?,
     };
-    cfg.root.model.name.clone_from(&s.model);
-    cfg.root.agent.step_limit = s.step_limit;
-    if let Some(v) = s.observation_max_bytes {
-        cfg.root.agent.observation_max_bytes = v;
-    }
-    if let Some(v) = s.observation_head_ratio {
-        validate_observation_head_ratio(v)?;
-        cfg.root.agent.observation_head_ratio = v;
-    }
-    if let Some(kind) = &s.env {
-        cfg.root.environment.kind = parse_env_kind(kind.as_str())?;
-    }
-    if let Some(img) = s.docker_image.clone() {
-        cfg.root.environment.docker_image = Some(img);
-    }
-    if let Some(v) = s.per_task_budget_usd {
-        cfg.root.agent.per_task_budget_usd = Some(v);
-    }
-    if s.hide_budget_from_agent {
-        cfg.root.agent.hide_budget_from_agent = true;
-    }
-    if let Some(v) = s.detect_stagnation {
-        cfg.root.agent.detect_stagnation = v;
-    }
-    if let Some(v) = s.stagnation_repeat_threshold {
-        cfg.root.agent.stagnation_repeat_threshold = v;
-    }
-    if let Some(v) = s.stagnation_window {
-        cfg.root.agent.stagnation_window = v;
-    }
-    if let Some(v) = s.history_max_input_tokens {
-        cfg.root.agent.history_max_input_tokens = Some(v);
-    }
-    if let Some(v) = s.history_keep_last_observations {
-        cfg.root.agent.history_keep_last_observations = Some(v);
-    }
-    apply_mcp_server_overrides(&mut cfg, &s.mcp_servers)?;
+    apply_config_overrides!(cfg, s);
     Ok(cfg)
 }
 


### PR DESCRIPTION
🚮 Smell: Duplicated configuration override boilerplate inside `mini_cmd` and `swebench_config_from_cmd` in `src/cli/mod.rs`. This violated DRY, inflated function length unnecessarily, and created an error-prone site for adding future CLI overrides.

✨ Solution: Extracted the duplicated logic into a declarative `apply_config_overrides!` macro. Replaced the ~35 lines of duplicate logic in both handler functions with a single macro invocation.

🧼 Benefit: Dramatically reduces cognitive load when reading the CLI entry points. Ensures overrides from CLI arguments to the shared Agent Config remain unified and bug-free going forward.

🛡️ Verification: Tests passed. No logic changed. Compiled cleanly with `-- -D warnings`.

---
*PR created automatically by Jules for task [3170860610577496375](https://jules.google.com/task/3170860610577496375) started by @madmax983*