### PR TITLE
🎻 Bard: Documentation expansion for key modules

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -351,15 +351,29 @@ fn ceil_char_boundary(input: &str, idx: usize) -> usize {
     i
 }
 
+/// The standard implementation of the SWE agent loop.
+///
+/// `DefaultAgent` drives the state machine by orchestrating the conversation
+/// between the LLM and the local environment. It manages prompt formatting,
+/// cache optimization, cost tracking, security boundaries, and telemetry logging.
 pub struct DefaultAgent {
+    /// The global runtime configuration governing this agent's limits and behavior.
     pub config: Config,
+    /// The inference backend used to generate actions.
     pub model: Arc<dyn Model>,
+    /// The sandboxed environment where shell commands and file operations execute.
     pub env: Box<dyn Environment>,
+    /// Formats the context and observations into the target model's preferred syntax.
     pub renderer: Arc<Renderer>,
+    /// The conversation transcript maintained over the lifecycle of the task.
     pub history: Vec<Message>,
+    /// The persistent append-only log of all actions, observations, and telemetry.
     pub trajectory: Trajectory,
+    /// The number of completed model-action-observation cycles.
     pub steps: u32,
+    /// The cumulative spend across all API calls in this run.
     pub total_cost_usd: f64,
+    /// Where the cost accounting information was sourced from.
     pub actual_cost_source: Option<CostSource>,
     /// Wall-clock start, used to compute `duration_secs` on terminate.
     pub started_at_instant: Instant,
@@ -379,9 +393,13 @@ pub struct DefaultAgent {
     /// Real-time event sink. Defaults to `NullSink` so non-streaming
     /// callers pay no cost beyond a vtable call.
     pub stream: Arc<dyn StreamSink>,
+    /// Scrubbing engine that prevents secrets from leaking into logs or external traces.
     pub redactor: Redactor,
+    /// An optional async interrupt switch used to abort execution gracefully.
     pub cancellation: Option<CancellationToken>,
+    /// The security layer enforcing permission rules against model-generated shell commands.
     pub policy_engine: PolicyEngine,
+    /// The collection of capabilities that the model is allowed to invoke.
     pub tool_registry: ToolRegistry,
     raw_task: String,
     test_command_patterns: Vec<TestCommandPattern>,
@@ -397,21 +415,34 @@ pub struct DefaultAgent {
     stagnation_detector: Option<StagnationDetector>,
 }
 
+/// Constructs a [`DefaultAgent`] with its necessary dependencies and environment constraints.
+///
+/// Ensures that telemetry, secrets redaction, and policy enforcement are properly
+/// bound before the agent loop begins.
 pub struct DefaultAgentBuilder {
+    /// The runtime configuration profile.
     pub config: Config,
+    /// The language model backend.
     pub model: Arc<dyn Model>,
+    /// The sandboxed environment.
     pub env: Box<dyn Environment>,
+    /// The objective the agent is attempting to solve.
     pub task: String,
+    /// Optional supplementary context appended to the system prompt.
     pub extra_context: Option<String>,
+    /// The renderer translating internal state into model prompts.
     pub renderer: Option<Arc<Renderer>>,
+    /// The telemetry stream for realtime observability.
     pub stream: Option<Arc<dyn StreamSink>>,
 }
 
 impl DefaultAgentBuilder {
+    /// Assembles the `DefaultAgent` using standard built-in tools.
     pub fn build(self) -> Result<DefaultAgent, Error> {
         self.build_with_tool_providers(Vec::new())
     }
 
+    /// Assembles the `DefaultAgent` while injecting external tool providers (like MCPs).
     #[allow(clippy::too_many_lines)]
     pub fn build_with_tool_providers(
         self,
@@ -1333,6 +1364,9 @@ impl Agent for DefaultAgent {
 }
 
 impl DefaultAgent {
+    /// Injects a strict wallclock deadline. If the loop exceeds this duration,
+    /// it terminates immediately. Used primarily during high-throughput parallel sweeps
+    /// to prevent runaway agent loops from blocking CI.
     pub fn set_wallclock_deadline(&mut self, timeout: Duration) {
         self.wallclock_deadline = Some(WallclockDeadline {
             deadline: Instant::now() + timeout,
@@ -1526,6 +1560,8 @@ impl DefaultAgent {
         }
     }
 
+    /// Transitions the agent state machine into a wallclock-timeout state.
+    /// This writes the final metadata and flushes the trajectory cleanly.
     pub fn finalize_wallclock_timeout(&mut self, timeout: Duration) {
         self.trajectory.info.exit_reason = Some(exit_reason::WALLCLOCK_TIMEOUT.into());
         self.trajectory.info.failure_category = Some(FailureCategory::WallclockTimeout);
@@ -1572,6 +1608,8 @@ impl DefaultAgent {
         })
     }
 
+    /// Transitions the agent state machine into a cancelled state.
+    /// This handles user-initiated SIGINT/SIGTERM terminations safely.
     pub fn finalize_cancelled(&mut self) {
         self.trajectory.info.exit_reason = Some(exit_reason::CANCELLED.into());
         self.trajectory.info.failure_category = None;

--- a/src/agent/interactive.rs
+++ b/src/agent/interactive.rs
@@ -9,16 +9,24 @@ use async_trait::async_trait;
 use super::{Agent, DefaultAgent, ExitReason, StepOutcome};
 use crate::error::Error;
 
+/// A wrapper around `DefaultAgent` that injects terminal interactivity.
+///
+/// Use this when driving the agent from a human-attended CLI rather than
+/// an automated batch sweep.
 pub struct InteractiveAgent {
+    /// The wrapped standard agent loop.
     pub inner: DefaultAgent,
+    /// If true, automatic prompting for human review of commands is skipped.
     pub yolo: bool,
 }
 
 impl InteractiveAgent {
+    /// Wraps an existing `DefaultAgent` to add CLI interactivity.
     pub fn new(inner: DefaultAgent, yolo: bool) -> Self {
         Self { inner, yolo }
     }
 
+    /// Generates a human-readable one-line status summary of the agent's progress.
     pub fn status_line(&self) -> String {
         let cache_str = if self.inner.model.supports_explicit_cache() {
             "cache:explicit"

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -40,21 +40,43 @@ pub use parse::{
 #[derive(Debug, Clone)]
 pub enum ExitReason {
     /// The agent explicitly decided to submit a final answer.
-    Submitted { final_output: String },
+    Submitted {
+        /// The text of the final answer submitted by the agent.
+        final_output: String,
+    },
     /// The agent reached its configured maximum number of allowed steps.
-    StepLimit { limit: u32 },
+    StepLimit {
+        /// The configured step limit that was reached.
+        limit: u32,
+    },
     /// The agent exceeded its configured maximum spend.
-    CostLimit { limit_usd: f64, spent_usd: f64 },
+    CostLimit {
+        /// The maximum allowed cost in USD.
+        limit_usd: f64,
+        /// The actual cost spent in USD.
+        spent_usd: f64,
+    },
     /// The agent's per-task USD budget was exhausted mid-loop.
-    BudgetExhausted { limit_usd: f64, spent_usd: f64 },
+    BudgetExhausted {
+        /// The maximum allowed budget in USD.
+        limit_usd: f64,
+        /// The actual cost spent in USD.
+        spent_usd: f64,
+    },
     /// A human explicitly cancelled the run.
     UserInterrupt,
     /// The LLM backend refused to complete the prompt (e.g. safety filters).
-    ModelRefusal { reason: String },
+    ModelRefusal {
+        /// The reason for refusal provided by the model backend.
+        reason: String,
+    },
     /// The agent was halted because it repeated the same action K times in W steps.
     AgentStagnation {
+        /// The hash of the action that was repeated.
         action_hash: String,
+        /// The number of times the action was repeated.
         count: u32,
+        /// The window of steps over which the repetition occurred.
         window: u32,
     },
     /// The prompt could not be compacted to fit within `history_max_input_tokens`

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -15,7 +15,9 @@ use thiserror::Error;
 /// contract. Major bumps are breaking; minor bumps must remain additive.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ArtifactSchemaVersion {
+    /// Incremented for breaking changes.
     pub major: u16,
+    /// Incremented for additive, backwards-compatible fields.
     pub minor: u16,
 }
 
@@ -83,7 +85,9 @@ impl fmt::Display for ArtifactKind {
 /// Standard top-level artifact metadata fields.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ArtifactHeader {
+    /// Identifies the file format and its intended consumer.
     pub artifact_kind: ArtifactKind,
+    /// The structural version attached to the artifact.
     pub schema_version: ArtifactSchemaVersion,
 }
 
@@ -118,9 +122,13 @@ impl CompatibilityClass {
 /// Result of classifying a specific artifact payload.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArtifactCompatibility {
+    /// The declared kind found during parsing.
     pub kind: ArtifactKind,
+    /// The declared version found during parsing (if present).
     pub version: Option<ArtifactSchemaVersion>,
+    /// How the current executable should handle this artifact.
     pub class: CompatibilityClass,
+    /// Any warnings generated during evaluation (e.g. forward-compatibility warnings).
     pub warnings: Vec<String>,
 }
 
@@ -135,25 +143,41 @@ impl ArtifactCompatibility {
     }
 }
 
+/// Represents errors that occur when deserializing or validating an artifact's header.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum ArtifactSchemaError {
+    /// The artifact's declared kind did not match the expected type for the current operation.
     #[error("{path}: artifact kind mismatch: expected {expected}, found {found}")]
     KindMismatch {
+        /// The file path of the artifact that failed validation.
         path: String,
+        /// The expected artifact kind.
         expected: ArtifactKind,
+        /// The actual artifact kind found in the header.
         found: ArtifactKind,
     },
+    /// The artifact was written by a newer, incompatible version of the binary.
     #[error(
         "{path}: unsupported future artifact schema for {kind}: version {version}; this binary supports major {supported_major}. Re-run with a newer rust-swe-agent."
     )]
     UnsupportedFuture {
+        /// The file path of the artifact.
         path: String,
+        /// The artifact kind.
         kind: ArtifactKind,
+        /// The future version found.
         version: ArtifactSchemaVersion,
+        /// The max major version this binary understands.
         supported_major: u16,
     },
+    /// The artifact metadata header could not be parsed.
     #[error("{path}: malformed artifact schema header: {message}")]
-    MalformedHeader { path: String, message: String },
+    MalformedHeader {
+        /// The file path of the artifact.
+        path: String,
+        /// Underlying parser error details.
+        message: String,
+    },
 }
 
 /// Classify a decoded JSON artifact against the expected artifact family.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -26,6 +26,7 @@ pub struct Cli {
     pub log: String,
 }
 
+/// The top-level commands available in the CLI.
 #[derive(Debug, Subcommand)]
 #[allow(clippy::large_enum_variant)]
 pub enum Command {

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,19 +1,66 @@
-//! Newtype IDs. Keeps `TaskId` from being accidentally passed where a
-//! `ContainerId` is expected.
+//! Core identifiers that maintain type boundaries across the system.
+//!
+//! In a complex agent environment, passing around raw strings and integers is a recipe
+//! for subtle bugs. The ids module provides strongly-typed wrappers (Newtypes)
+//! that ensure a `TaskId` cannot be accidentally swapped with a `ContainerId`, and
+//! an index like `StepIdx` is always distinct from other numeric values.
+//!
+//! ## Examples
+//!
+//! ```
+//! use rust_swe_agent::ids::{ContainerId, TaskId, StepIdx};
+//!
+//! let task = TaskId::new("issue-42");
+//! let container = ContainerId::from("docker-abc");
+//! let initial_step = StepIdx::zero();
+//!
+//! assert_eq!(task.as_str(), "issue-42");
+//! assert_eq!(initial_step.get(), 0);
+//! ```
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
 macro_rules! string_id {
-    ($name:ident) => {
+    ($name:ident, $doc:expr, $example:expr) => {
+        #[doc = $doc]
+        #[doc = ""]
+        #[doc = "## Examples"]
+        #[doc = ""]
+        #[doc = "```"]
+        #[doc = $example]
+        #[doc = "```"]
         #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
         #[serde(transparent)]
         pub struct $name(pub String);
 
         impl $name {
+            /// Wraps an underlying string-like value into this strong type.
+            ///
+            /// This exists to cleanly convert from `&str` or `String` into the domain-specific ID.
+            ///
+            /// ## Examples
+            ///
+            /// ```
+            /// use rust_swe_agent::ids::TaskId;
+            /// let id = TaskId::new("my-task-123");
+            /// ```
             pub fn new(s: impl Into<String>) -> Self {
                 Self(s.into())
             }
+
+            /// Exposes the inner string representation.
+            ///
+            /// Useful when interfacing with external systems (like Docker or logging)
+            /// that require a primitive string reference.
+            ///
+            /// ## Examples
+            ///
+            /// ```
+            /// use rust_swe_agent::ids::TaskId;
+            /// let id = TaskId::new("my-task-123");
+            /// assert_eq!(id.as_str(), "my-task-123");
+            /// ```
             pub fn as_str(&self) -> &str {
                 &self.0
             }
@@ -39,21 +86,83 @@ macro_rules! string_id {
     };
 }
 
-string_id!(ContainerId);
-string_id!(TaskId);
+string_id!(
+    ContainerId,
+    "A unique identifier for a sandboxed execution environment.",
+    "use rust_swe_agent::ids::ContainerId;\nlet id = ContainerId::new(\"docker-container-xyz\");\nassert_eq!(id.as_str(), \"docker-container-xyz\");"
+);
 
+string_id!(
+    TaskId,
+    "A unique identifier for a specific problem instance or issue.",
+    "use rust_swe_agent::ids::TaskId;\nlet id = TaskId::new(\"django-1234\");\nassert_eq!(id.as_str(), \"django-1234\");"
+);
+
+/// A zero-based index tracking the sequence of actions taken by an agent.
+///
+/// The `StepIdx` provides a safe, monotonically increasing counter used to align
+/// trajectory recordings, state transitions, and cost tracking. It prevents
+/// accidental arithmetic operations that might invalidate the sequential order.
+///
+/// ## Examples
+///
+/// ```
+/// use rust_swe_agent::ids::StepIdx;
+///
+/// let first = StepIdx::zero();
+/// let second = first.next();
+/// assert_eq!(second.get(), 1);
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct StepIdx(pub u32);
 
 impl StepIdx {
+    /// Initializes a fresh step index starting at zero.
+    ///
+    /// This exists to establish the beginning of an agent's lifecycle securely.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use rust_swe_agent::ids::StepIdx;
+    /// let start = StepIdx::zero();
+    /// assert_eq!(start.get(), 0);
+    /// ```
     pub const fn zero() -> Self {
         Self(0)
     }
+
+    /// Advances the counter by one, capping at the maximum value of `u32`.
+    ///
+    /// The saturating addition ensures that a runaway loop does not cause a panic
+    /// from integer overflow, allowing the system to halt gracefully.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use rust_swe_agent::ids::StepIdx;
+    /// let current = StepIdx::zero();
+    /// let advanced = current.next();
+    /// assert_eq!(advanced.get(), 1);
+    /// ```
     #[must_use]
     pub const fn next(self) -> Self {
         Self(self.0.saturating_add(1))
     }
+
+    /// Retrieves the raw underlying integer value.
+    ///
+    /// Essential for formatting outputs, logging, or interacting with legacy systems
+    /// that require raw numeric indexes.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use rust_swe_agent::ids::StepIdx;
+    /// let step = StepIdx::zero();
+    /// assert_eq!(step.get(), 0);
+    /// ```
     pub const fn get(self) -> u32 {
         self.0
     }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -21,12 +21,17 @@ pub use deterministic::DeterministicModel;
 pub use fallback::FallbackModel;
 pub use litellm::{AnthropicBackend, LitellmBackend};
 
+/// The role associated with a message in a conversation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
+    /// High-level instructions that set the behavior of the assistant.
     System,
+    /// Messages from the user or environment.
     User,
+    /// Responses from the assistant itself.
     Assistant,
+    /// Results returned from executing a tool call.
     Tool,
 }
 

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -50,6 +50,7 @@ impl Default for PolicyCfg {
 
 // ── Policy profiles ───────────────────────────────────────────────────────────
 
+/// Security profile level governing command execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PolicyProfile {
     /// Block the built-in dangerous-command corpus; allow everything else.

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -14,13 +14,22 @@ use sha2::{Digest, Sha256};
 use crate::config::RedactionCfg;
 use crate::stream::{StreamEvent, StreamSink};
 
+/// Defines target surfaces where text might be exported or persisted,
+/// allowing the redactor to optionally tune behavior per output medium.
 pub mod surface {
+    /// Surface for storing full trajectory logs on disk.
     pub const TRAJECTORY: &str = "trajectory";
+    /// Surface for sending environment observations back to the LLM.
     pub const MODEL_OBSERVATION: &str = "model_observation";
+    /// Surface for realtime API/web streaming.
     pub const STREAM: &str = "stream";
+    /// Surface for the local CLI debug inspector.
     pub const INSPECT: &str = "inspect";
+    /// Surface for generic external text export.
     pub const EXPORT: &str = "export";
+    /// Surface for the final generated git patch diff.
     pub const PATCH_SUBMISSION: &str = "patch_submission";
+    /// Surface for writing summary comments to GitHub pull requests.
     pub const GITHUB_COMMENT: &str = "github_comment";
 }
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -35,10 +35,13 @@ pub struct SkillRegistry {
     manifests: Vec<SkillManifest>,
 }
 
+/// Indicates how a specific skill was selected for inclusion in the context.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SkillActivationReason {
+    /// The skill was explicitly named in the agent's instructions or task context.
     ExplicitMention,
+    /// The skill was automatically selected based on heuristics (like repository patterns).
     AutoMatch,
 }
 


### PR DESCRIPTION
📖 Chapter: Documenting core agents, artifacts, models, and boundaries.
🔦 Insight: Added missing `///` comments to explicitly clarify the purpose of various structs, enums, fields, and modules (like `ArtifactHeader`, `DefaultAgent`, `ExitReason`, etc.).
🧪 Example: Embedded executable doctests within `src/ids.rs` to showcase strongly-typed identifier creation.
🖼️ Preview: Documentation now renders completely without `-W missing_docs` warnings on these files.

---
*PR created automatically by Jules for task [14119613501071664367](https://jules.google.com/task/14119613501071664367) started by @madmax983*