### PR TITLE
🔒 Warden: [security fix] Fix unbounded memory exhaustion in pipe readers

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -327,20 +327,27 @@ where
     (handle, buffer)
 }
 
+const MAX_PIPE_BUFFER_SIZE: usize = 16 * 1024 * 1024;
+
 async fn read_pipe_to_buffer<R>(mut pipe: R, buffer: Arc<Mutex<Vec<u8>>>) -> Result<(), EnvError>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut chunk = [0u8; 8192];
+    let mut remaining = MAX_PIPE_BUFFER_SIZE;
     loop {
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {
             return Ok(());
         }
-        buffer
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .extend_from_slice(&chunk[..n]);
+        if remaining > 0 {
+            let to_add = std::cmp::min(n, remaining);
+            buffer
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .extend_from_slice(&chunk[..to_add]);
+            remaining = remaining.saturating_sub(to_add);
+        }
     }
 }
 
@@ -444,6 +451,24 @@ const _COMPILE_TIME_USED: Duration = Duration::from_secs(0);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    #[allow(clippy::unwrap_used)]
+    async fn read_pipe_to_buffer_respects_max_size() {
+        use std::sync::{Arc, Mutex};
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let mut reader = tokio::io::repeat(b'A');
+
+        let limit = super::MAX_PIPE_BUFFER_SIZE as u64 + 8192;
+        let mut limited_reader = tokio::io::AsyncReadExt::take(&mut reader, limit);
+
+        super::read_pipe_to_buffer(&mut limited_reader, Arc::clone(&buffer))
+            .await
+            .unwrap();
+
+        let len = buffer.lock().unwrap().len();
+        assert_eq!(len, super::MAX_PIPE_BUFFER_SIZE);
+    }
 
     fn test_env() -> DockerEnvironment {
         DockerEnvironment {

--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -232,20 +232,27 @@ where
     (handle, buffer)
 }
 
+const MAX_PIPE_BUFFER_SIZE: usize = 16 * 1024 * 1024;
+
 async fn read_pipe_to_buffer<R>(mut pipe: R, buffer: Arc<Mutex<Vec<u8>>>) -> Result<(), EnvError>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut chunk = [0u8; 8192];
+    let mut remaining = MAX_PIPE_BUFFER_SIZE;
     loop {
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {
             return Ok(());
         }
-        buffer
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .extend_from_slice(&chunk[..n]);
+        if remaining > 0 {
+            let to_add = std::cmp::min(n, remaining);
+            buffer
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .extend_from_slice(&chunk[..to_add]);
+            remaining = remaining.saturating_sub(to_add);
+        }
     }
 }
 
@@ -530,6 +537,24 @@ mod tests {
         let req = RunRequest::new(stdin_echo_command()).with_stdin("from stdin\n");
         let r = env.run(req).await.unwrap();
         assert_eq!(r.stdout.trim(), "from stdin");
+    }
+
+    #[tokio::test]
+    async fn read_pipe_to_buffer_respects_max_size() {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let mut reader = tokio::io::repeat(b'A');
+
+        // Take just enough to exceed MAX_PIPE_BUFFER_SIZE slightly,
+        // so we can test that it truncates and successfully returns
+        let limit = super::MAX_PIPE_BUFFER_SIZE as u64 + 8192;
+        let mut limited_reader = tokio::io::AsyncReadExt::take(&mut reader, limit);
+
+        super::read_pipe_to_buffer(&mut limited_reader, Arc::clone(&buffer))
+            .await
+            .unwrap();
+
+        let len = buffer.lock().unwrap().len();
+        assert_eq!(len, super::MAX_PIPE_BUFFER_SIZE);
     }
 
     #[tokio::test]


### PR DESCRIPTION
🦠 Threat: The `read_pipe_to_buffer` functions in `src/env/local.rs` and `src/env/docker.rs` unbounded read data into a `Vec<u8>`. A malicious or excessively verbose process could output an infinite amount of data to stdout or stderr, exhausting all available memory (DoS).
🛡️ Defense: Capped the reader using a `MAX_PIPE_BUFFER_SIZE` of 16MB and manual accumulators (`saturating_sub`). Once the limit is reached, it still reads but discards the excess data, draining the pipe gracefully without exhausting memory.
💥 Severity: High - an untrusted task or tool running amok could DoS the host agent.
🧪 Verification: Wrote `read_pipe_to_buffer_respects_max_size` unit tests using `tokio::io::repeat(b'A')` to verify graceful truncation.

---
*PR created automatically by Jules for task [17606181840583598159](https://jules.google.com/task/17606181840583598159) started by @madmax983*