### PR TITLE
Add `bench watch` command for live single-instance trajectory following

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ a valid trajectory in hand:
   and secret handling guidance. Start here before tuning a sweep.
 - [`bench tail`](docs/spec-tail.md): live aggregate progress, cost burn, ETA,
   and failure mix for running SWE-bench sweeps.
+- [`bench watch`](docs/spec-watch.md): attach to a single in-flight instance
+  and stream its turns live; redaction-safe, NDJSON-pipeable.
 - [`bench evaluator-selftest`](docs/spec-evaluator-selftest.md): zero-cost
   preflight that verifies the evaluator pipeline against gold patches before
   launching a paid sweep. Run after switching dataset, evaluator image, or machine.

--- a/docs/spec-watch.md
+++ b/docs/spec-watch.md
@@ -1,0 +1,132 @@
+# `bench watch` — Live Single-Instance Trajectory Follower
+
+`bench watch` attaches to a single in-flight sweep instance and streams its turns to stdout as they are written to disk, in the same human-readable format used by `bench inspect`.
+
+## Command
+
+```
+bench watch \
+  --sweep <DIR> \
+  --instance <ID> \
+  [--wait-secs N]     # default 30
+  [--stall-secs N]    # default 120
+  [--full]
+  [--max-bytes N]
+  [--ndjson]
+```
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--sweep <DIR>` | required | Sweep output directory produced by `bench swebench`. |
+| `--instance <ID>` | required | Instance id to follow. |
+| `--wait-secs <N>` | `30` | Seconds to wait for the trajectory file to appear. Set to `0` to fail immediately if not found. |
+| `--stall-secs <N>` | `120` | After this many seconds of no new turns, print a stall warning and keep following. |
+| `--full` | off | Disable stdout/stderr truncation. |
+| `--max-bytes <N>` | `4096` | Override the per-observation truncation threshold in bytes. Ignored when `--full` is set. |
+| `--ndjson` | off | Emit one newline-delimited JSON object per turn instead of human-readable text. |
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Instance reached a terminal outcome (`submitted`, `errored`, `cancelled`, `timed_out`). |
+| `1` | Trajectory file not found after `--wait-secs`. |
+| `2` | Sweep directory does not exist or is invalid. |
+| `130` | Interrupted by SIGINT (Ctrl-C). |
+
+## Waiting for the file
+
+When `bench watch` is invoked before the worker has started the instance, it waits up to `--wait-secs` for the trajectory file to appear. A progress line is printed to stderr at most every 5 seconds:
+
+```
+[watch] waiting for trajectory file for `django-1234`...
+```
+
+Set `--wait-secs 0` to fail immediately if the file is not present.
+
+## Stall detection
+
+If no new turns appear for `--stall-secs` seconds after the last observed turn, a warning is printed to stderr:
+
+```
+[stalled: no new turns in 120s]
+```
+
+`bench watch` continues following the file — it does not exit on a stall, since the worker may recover.
+
+## Redaction
+
+All output passes through the same redactor used by `bench inspect`. Secret-shaped content (GitHub tokens, private keys, bearer tokens, environment API keys) is replaced with deterministic redaction markers before reaching stdout.
+
+## NDJSON mode
+
+With `--ndjson`, each turn is emitted as a single JSON object followed by a newline. The process flushes stdout after every line, making it suitable for piping to `jq` or other stream processors.
+
+### Schema
+
+```json
+{
+  "schema_version": "watch-1.0",
+  "instance_id":    "django-1234",
+  "turn_index":     0,
+  "role":           "assistant",
+  "message":        "I will start by reading the test file.",
+  "bash":           null,
+  "exit_code":      null,
+  "stdout":         null,
+  "stderr":         null
+}
+```
+
+Fields present per `role`:
+
+| `role` | Fields present |
+|--------|---------------|
+| `assistant` | `message` |
+| `bash` | `bash`, `exit_code`, `stdout`, `stderr` |
+
+Optional fields are omitted when `null`.
+
+### Round-trip guarantee
+
+Every NDJSON line is valid JSON and can be parsed by `serde_json`. The `schema_version` field is stamped on every object.
+
+## Operator recipes
+
+### Watch one instance while `bench tail` is running in another terminal
+
+```bash
+# Terminal 1: aggregate sweep progress
+bench tail --sweep ./runs/my-sweep
+
+# Terminal 2: follow a specific instance
+bench watch --sweep ./runs/my-sweep --instance django__django-1234
+```
+
+### Pipe NDJSON to `jq` to filter assistant turns
+
+```bash
+bench watch --sweep ./runs/my-sweep \
+            --instance astropy__astropy-9999 \
+            --ndjson \
+  | jq 'select(.role == "assistant") | .message'
+```
+
+### Fail fast if the file isn't ready yet
+
+```bash
+bench watch --sweep ./runs/my-sweep \
+            --instance my-instance \
+            --wait-secs 0
+# exits 1 immediately if trajectory file not found
+```
+
+## Relation to other bench commands
+
+| Command | Zoom level | Status |
+|---------|-----------|--------|
+| `bench tail` | Sweep-wide aggregate | Live |
+| `bench watch` | Single instance | Live |
+| `bench inspect` | Single instance | Post-mortem (completed trajectory) |

--- a/docs/spec-watch.md
+++ b/docs/spec-watch.md
@@ -8,6 +8,7 @@
 bench watch \
   --sweep <DIR> \
   --instance <ID> \
+  [--run-index N]     # default 1
   [--wait-secs N]     # default 30
   [--stall-secs N]    # default 120
   [--full]
@@ -21,6 +22,7 @@ bench watch \
 |------|---------|-------------|
 | `--sweep <DIR>` | required | Sweep output directory produced by `bench swebench`. |
 | `--instance <ID>` | required | Instance id to follow. |
+| `--run-index <N>` | `1` | Run slot to follow. Use `2`, `3`, … for sweeps started with `--reruns`. |
 | `--wait-secs <N>` | `30` | Seconds to wait for the trajectory file to appear. Set to `0` to fail immediately if not found. |
 | `--stall-secs <N>` | `120` | After this many seconds of no new turns, print a stall warning and keep following. |
 | `--full` | off | Disable stdout/stderr truncation. |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1067,6 +1067,10 @@ pub struct WatchCmd {
     #[arg(long)]
     pub instance: String,
 
+    /// Run slot to follow (default 1). Use 2, 3, … for `--reruns` sweeps.
+    #[arg(long, default_value_t = 1)]
+    pub run_index: u32,
+
     /// Seconds to wait for the trajectory file to appear (0 = fail immediately if not found).
     #[arg(long, default_value_t = 30)]
     pub wait_secs: u64,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -319,6 +319,8 @@ pub enum BenchCmd {
     Inspect(InspectCmd),
     /// Tail live aggregate progress for a running sweep directory.
     Tail(TailCmd),
+    /// Attach to a single in-flight instance and stream its turns live.
+    Watch(WatchCmd),
     /// Cluster unresolved sweep failures into ranked actionable groups.
     Triage(TriageCmd),
     /// Aggregate shell-command frequency and cost by outcome bucket.
@@ -1052,6 +1054,38 @@ pub struct TailCmd {
     /// Output format: `text` (default) or `json`.
     #[arg(long, default_value = "text")]
     pub format: String,
+}
+
+/// `bench watch` — attach to a single in-flight instance and stream turns live.
+#[derive(Debug, Args)]
+pub struct WatchCmd {
+    /// Sweep output directory produced by `bench swebench`.
+    #[arg(long)]
+    pub sweep: PathBuf,
+
+    /// Instance id to watch.
+    #[arg(long)]
+    pub instance: String,
+
+    /// Seconds to wait for the trajectory file to appear (0 = fail immediately if not found).
+    #[arg(long, default_value_t = 30)]
+    pub wait_secs: u64,
+
+    /// Seconds of no new turns before printing a stall warning (keeps following).
+    #[arg(long, default_value_t = 120)]
+    pub stall_secs: u64,
+
+    /// Disable stdout/stderr truncation.
+    #[arg(long, default_value_t = false)]
+    pub full: bool,
+
+    /// Truncation threshold in bytes (default 4096). Ignored when `--full` is set.
+    #[arg(long)]
+    pub max_bytes: Option<usize>,
+
+    /// Emit one newline-delimited JSON object per turn instead of human-readable text.
+    #[arg(long, default_value_t = false)]
+    pub ndjson: bool,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2329,6 +2329,7 @@ async fn bench_watch(w: args::WatchCmd) -> Result<(), Error> {
     crate::run::watch::run(&crate::run::watch::WatchArgs {
         sweep: w.sweep,
         instance: w.instance,
+        run_index: w.run_index,
         wait_secs: w.wait_secs,
         stall_secs: w.stall_secs,
         full: w.full,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -88,6 +88,9 @@ pub async fn run() -> Result<(), Error> {
             cmd: args::BenchCmd::Tail(t),
         } => bench_tail(t).await,
         Command::Bench {
+            cmd: args::BenchCmd::Watch(w),
+        } => bench_watch(w).await,
+        Command::Bench {
             cmd: args::BenchCmd::Triage(t),
         } => bench_triage(t),
         Command::Bench {
@@ -2320,6 +2323,19 @@ async fn bench_tail(t: args::TailCmd) -> Result<(), Error> {
         }
         tokio::time::sleep(Duration::from_millis(t.interval_ms)).await;
     }
+}
+
+async fn bench_watch(w: args::WatchCmd) -> Result<(), Error> {
+    crate::run::watch::run(&crate::run::watch::WatchArgs {
+        sweep: w.sweep,
+        instance: w.instance,
+        wait_secs: w.wait_secs,
+        stall_secs: w.stall_secs,
+        full: w.full,
+        max_bytes: w.max_bytes,
+        ndjson: w.ndjson,
+    })
+    .await
 }
 
 fn parse_env_kind(kind: &str) -> Result<crate::config::EnvKind, Error> {

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -421,6 +421,14 @@ fn compute_latency_share(
 }
 
 fn build_inspect_steps(traj: &Trajectory, full: bool) -> Vec<InspectStep> {
+    build_inspect_steps_with_max(traj, full, TRUNCATE_MAX_BYTES)
+}
+
+pub(crate) fn build_inspect_steps_with_max(
+    traj: &Trajectory,
+    full: bool,
+    max_bytes: usize,
+) -> Vec<InspectStep> {
     let mut steps = Vec::new();
     for (msg_idx, msg) in traj.messages.iter().enumerate() {
         let current_index = steps.len();
@@ -470,9 +478,9 @@ fn build_inspect_steps(traj: &Trajectory, full: bool) -> Vec<InspectStep> {
             None
         };
         let (stdout, stdout_note, stdout_truncated) =
-            maybe_truncate(&run_result.stdout, full, current_index);
+            maybe_truncate(&run_result.stdout, full, max_bytes, current_index);
         let (stderr, stderr_note, stderr_truncated) =
-            maybe_truncate(&run_result.stderr, full, current_index);
+            maybe_truncate(&run_result.stderr, full, max_bytes, current_index);
         let mut note_parts = Vec::new();
         if let Some(n) = stdout_note {
             note_parts.push(format!("stdout: {n}"));
@@ -718,50 +726,59 @@ fn render_instance_text(report: &InspectReport) -> String {
     }
 
     for step in &report.steps {
-        let header = format!("[step {}] {}", step.index, step.role);
-        if color {
-            let _ = writeln!(s, "\n\x1b[1;36m{header}\x1b[0m");
-        } else {
-            let _ = writeln!(s, "\n{header}");
-        }
+        s.push_str(&render_step_text(step, color));
+    }
+    s
+}
 
-        if let Some(msg) = &step.message {
-            s.push_str(msg);
-            if !msg.ends_with('\n') {
-                s.push('\n');
-            }
-            continue;
-        }
+/// Render a single inspect step to a human-readable string.
+///
+/// `color` enables ANSI colour codes for the step header.
+pub(crate) fn render_step_text(step: &InspectStep, color: bool) -> String {
+    let mut s = String::new();
+    let header = format!("[step {}] {}", step.index, step.role);
+    if color {
+        let _ = writeln!(s, "\n\x1b[1;36m{header}\x1b[0m");
+    } else {
+        let _ = writeln!(s, "\n{header}");
+    }
 
-        if let Some(cmd) = &step.bash {
-            let _ = writeln!(s, "$ {cmd}");
+    if let Some(msg) = &step.message {
+        s.push_str(msg);
+        if !msg.ends_with('\n') {
+            s.push('\n');
         }
-        if let Some(code) = step.exit_code {
-            let _ = writeln!(s, "exit_code: {code}");
-        }
-        if step.history_elided {
-            let marker = step
-                .as_sent_marker
-                .as_deref()
-                .unwrap_or("[elision marker unavailable]");
-            let _ = writeln!(s, "[as-sent to model] {marker}");
-            if step.stdout.as_ref().is_some_and(|o| !o.is_empty()) {
-                let _ = writeln!(s, "[as-recorded stdout]");
-                if let Some(out) = &step.stdout {
-                    let _ = writeln!(s, "{out}");
-                }
+        return s;
+    }
+
+    if let Some(cmd) = &step.bash {
+        let _ = writeln!(s, "$ {cmd}");
+    }
+    if let Some(code) = step.exit_code {
+        let _ = writeln!(s, "exit_code: {code}");
+    }
+    if step.history_elided {
+        let marker = step
+            .as_sent_marker
+            .as_deref()
+            .unwrap_or("[elision marker unavailable]");
+        let _ = writeln!(s, "[as-sent to model] {marker}");
+        if step.stdout.as_ref().is_some_and(|o| !o.is_empty()) {
+            let _ = writeln!(s, "[as-recorded stdout]");
+            if let Some(out) = &step.stdout {
+                let _ = writeln!(s, "{out}");
             }
-        } else if let Some(out) = &step.stdout {
-            let _ = writeln!(s, "stdout:\n{out}");
         }
-        if let Some(err) = &step.stderr {
-            if !err.is_empty() {
-                let _ = writeln!(s, "stderr:\n{err}");
-            }
+    } else if let Some(out) = &step.stdout {
+        let _ = writeln!(s, "stdout:\n{out}");
+    }
+    if let Some(err) = &step.stderr {
+        if !err.is_empty() {
+            let _ = writeln!(s, "stderr:\n{err}");
         }
-        if let Some(note) = &step.truncation_note {
-            let _ = writeln!(s, "… {note}");
-        }
+    }
+    if let Some(note) = &step.truncation_note {
+        let _ = writeln!(s, "… {note}");
     }
     s
 }
@@ -830,12 +847,17 @@ fn infer_bash_from_previous_assistant(traj: &Trajectory, msg_idx: usize) -> Opti
         .and_then(|a| (a != "__SUBMIT__").then(|| a.clone()))
 }
 
-fn maybe_truncate(text: &str, full: bool, step_index: usize) -> (String, Option<String>, bool) {
+fn maybe_truncate(
+    text: &str,
+    full: bool,
+    max_bytes: usize,
+    step_index: usize,
+) -> (String, Option<String>, bool) {
     if full {
         return (text.to_owned(), None, false);
     }
     let line_count = text.lines().count();
-    if text.len() <= TRUNCATE_MAX_BYTES && line_count <= TRUNCATE_MAX_LINES {
+    if text.len() <= max_bytes && line_count <= TRUNCATE_MAX_LINES {
         return (text.to_owned(), None, false);
     }
 
@@ -843,10 +865,10 @@ fn maybe_truncate(text: &str, full: bool, step_index: usize) -> (String, Option<
     let mut consumed_bytes = 0usize;
     let mut shown_lines = 0usize;
     for line in text.split_inclusive('\n') {
-        if shown_lines >= TRUNCATE_MAX_LINES || consumed_bytes >= TRUNCATE_MAX_BYTES {
+        if shown_lines >= TRUNCATE_MAX_LINES || consumed_bytes >= max_bytes {
             break;
         }
-        let remaining = TRUNCATE_MAX_BYTES - consumed_bytes;
+        let remaining = max_bytes - consumed_bytes;
         let head = utf8_prefix_within_bytes(line, remaining);
         if head.is_empty() {
             break;
@@ -1009,7 +1031,10 @@ fn failure_label(c: FailureCategory) -> &'static str {
     }
 }
 
-fn redact_trajectory_for_inspect(trajectory: &mut Trajectory, redactor: &Redactor) -> bool {
+pub(crate) fn redact_trajectory_for_inspect(
+    trajectory: &mut Trajectory,
+    redactor: &Redactor,
+) -> bool {
     let mut redacted = false;
     if let Some(task) = &mut trajectory.info.task {
         let outcome = redactor.redact_text(task, surface::INSPECT);

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -26,5 +26,5 @@ pub mod retry;
 pub mod swebench;
 pub mod tail;
 pub mod trajectory_diff;
-pub mod watch;
 pub mod triage;
+pub mod watch;

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -26,4 +26,5 @@ pub mod retry;
 pub mod swebench;
 pub mod tail;
 pub mod trajectory_diff;
+pub mod watch;
 pub mod triage;

--- a/src/run/watch.rs
+++ b/src/run/watch.rs
@@ -1,0 +1,221 @@
+//! `bench watch`: follow a single in-flight trajectory instance live.
+
+use std::io::{IsTerminal as _, Write as StdWrite};
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+
+use crate::error::Error;
+use crate::redaction::Redactor;
+use crate::run::inspect::{
+    build_inspect_steps_with_max, redact_trajectory_for_inspect, render_step_text,
+    resolve_trajectory_path,
+};
+use crate::trajectory::{Trajectory, exit_reason};
+
+const DEFAULT_MAX_BYTES: usize = 4 * 1024;
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+const WAIT_PROGRESS_INTERVAL: Duration = Duration::from_secs(5);
+const NDJSON_SCHEMA_VERSION: &str = "watch-1.0";
+
+pub struct WatchArgs {
+    pub sweep: PathBuf,
+    pub instance: String,
+    pub wait_secs: u64,
+    pub stall_secs: u64,
+    pub full: bool,
+    pub max_bytes: Option<usize>,
+    pub ndjson: bool,
+}
+
+#[derive(Serialize)]
+struct WatchTurnEvent<'a> {
+    schema_version: &'static str,
+    instance_id: &'a str,
+    turn_index: usize,
+    role: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bash: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stdout: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stderr: Option<&'a str>,
+}
+
+pub async fn run(args: &WatchArgs) -> Result<(), Error> {
+    if !args.sweep.exists() {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "watch: sweep directory does not exist: {}",
+            args.sweep.display()
+        ))));
+    }
+
+    let max_bytes = args.max_bytes.unwrap_or(DEFAULT_MAX_BYTES);
+    let wait_deadline = Instant::now() + Duration::from_secs(args.wait_secs);
+    let stall_duration = Duration::from_secs(args.stall_secs);
+    let color = !args.ndjson && std::io::stdout().is_terminal();
+    let redactor = Redactor::default_enabled();
+
+    let mut stdout = std::io::stdout();
+    let mut emitted_steps: usize = 0;
+    let mut last_new_turn_at: Option<Instant> = None;
+    let mut stall_warned = false;
+    let mut last_wait_progress_at = Instant::now();
+    let mut file_found = false;
+
+    loop {
+        let traj_path = resolve_trajectory_path(&args.sweep, &args.instance);
+
+        if traj_path.is_none() && !file_found {
+            if Instant::now() >= wait_deadline {
+                return Err(Error::Trajectory(format!(
+                    "watch: trajectory file for instance `{}` not found after {} second(s)",
+                    args.instance, args.wait_secs
+                )));
+            }
+            if last_wait_progress_at.elapsed() >= WAIT_PROGRESS_INTERVAL {
+                eprintln!(
+                    "[watch] waiting for trajectory file for `{}`...",
+                    args.instance
+                );
+                last_wait_progress_at = Instant::now();
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+            continue;
+        }
+
+        let Some(traj_path) = traj_path else {
+            tokio::time::sleep(POLL_INTERVAL).await;
+            continue;
+        };
+
+        file_found = true;
+
+        let text = match std::fs::read_to_string(&traj_path) {
+            Ok(t) => t,
+            Err(_) => {
+                tokio::time::sleep(POLL_INTERVAL).await;
+                continue;
+            }
+        };
+
+        let mut traj: Trajectory = match serde_json::from_str(&text) {
+            Ok(t) => t,
+            Err(_) => {
+                tokio::time::sleep(POLL_INTERVAL).await;
+                continue;
+            }
+        };
+
+        redact_trajectory_for_inspect(&mut traj, &redactor);
+
+        let steps = build_inspect_steps_with_max(&traj, args.full, max_bytes);
+
+        if steps.len() > emitted_steps {
+            let new_steps = &steps[emitted_steps..];
+            for step in new_steps {
+                if args.ndjson {
+                    let event = WatchTurnEvent {
+                        schema_version: NDJSON_SCHEMA_VERSION,
+                        instance_id: &args.instance,
+                        turn_index: step.index,
+                        role: &step.role,
+                        message: step.message.as_deref(),
+                        bash: step.bash.as_deref(),
+                        exit_code: step.exit_code,
+                        stdout: step.stdout.as_deref(),
+                        stderr: step.stderr.as_deref(),
+                    };
+                    let line = serde_json::to_string(&event)?;
+                    writeln!(stdout, "{line}")?;
+                    stdout.flush()?;
+                } else {
+                    let rendered = render_step_text(step, color);
+                    write!(stdout, "{rendered}")?;
+                    stdout.flush()?;
+                }
+            }
+            emitted_steps = steps.len();
+            last_new_turn_at = Some(Instant::now());
+            stall_warned = false;
+        } else if let Some(last_turn) = last_new_turn_at {
+            if !stall_warned && last_turn.elapsed() >= stall_duration {
+                let secs = last_turn.elapsed().as_secs();
+                eprintln!("[stalled: no new turns in {secs}s]");
+                stall_warned = true;
+            }
+        }
+
+        if is_terminal_outcome(&traj) {
+            if !args.ndjson {
+                let traj_outcome = traj.info.outcome.as_deref().unwrap_or("?");
+                let cost = traj
+                    .info
+                    .total_cost_usd
+                    .map_or_else(|| "?".into(), |c| format!("{c:.4}"));
+                let steps_count = traj.info.steps.unwrap_or(0);
+                writeln!(
+                    stdout,
+                    "\n[watch] instance `{}` complete: outcome={} steps={} cost_usd={}",
+                    args.instance, traj_outcome, steps_count, cost
+                )?;
+                stdout.flush()?;
+            }
+            return Ok(());
+        }
+
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+fn is_terminal_outcome(traj: &Trajectory) -> bool {
+    traj.info.outcome.is_some()
+        || traj.info.exit_reason.as_deref() == Some(exit_reason::CANCELLED)
+        || traj.info.exit_reason.as_deref() == Some(exit_reason::WALLCLOCK_TIMEOUT)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use crate::trajectory::outcome;
+
+    #[test]
+    fn terminal_when_outcome_submitted() {
+        let mut traj = Trajectory::new();
+        traj.info.outcome = Some(outcome::SUBMITTED.into());
+        assert!(is_terminal_outcome(&traj));
+    }
+
+    #[test]
+    fn terminal_when_outcome_error() {
+        let mut traj = Trajectory::new();
+        traj.info.outcome = Some(outcome::ERROR.into());
+        assert!(is_terminal_outcome(&traj));
+    }
+
+    #[test]
+    fn not_terminal_when_no_outcome() {
+        let traj = Trajectory::new();
+        assert!(!is_terminal_outcome(&traj));
+    }
+
+    #[test]
+    fn terminal_when_exit_reason_cancelled() {
+        let mut traj = Trajectory::new();
+        traj.info.exit_reason = Some(exit_reason::CANCELLED.into());
+        assert!(is_terminal_outcome(&traj));
+    }
+
+    #[test]
+    fn terminal_when_exit_reason_wallclock_timeout() {
+        let mut traj = Trajectory::new();
+        traj.info.exit_reason = Some(exit_reason::WALLCLOCK_TIMEOUT.into());
+        assert!(is_terminal_outcome(&traj));
+    }
+}

--- a/src/run/watch.rs
+++ b/src/run/watch.rs
@@ -48,9 +48,9 @@ struct WatchTurnEvent<'a> {
 }
 
 pub async fn run(args: &WatchArgs) -> Result<(), Error> {
-    if !args.sweep.exists() {
+    if !args.sweep.is_dir() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "watch: sweep directory does not exist: {}",
+            "watch: sweep path is not a directory: {}",
             args.sweep.display()
         ))));
     }

--- a/src/run/watch.rs
+++ b/src/run/watch.rs
@@ -99,10 +99,7 @@ pub async fn run(args: &WatchArgs) -> Result<(), Error> {
         }
 
         // Skip read if file size is unchanged (avoids O(N) read every poll).
-        let current_len = tokio::fs::metadata(&traj_path)
-            .await
-            .map(|m| m.len())
-            .unwrap_or(0);
+        let current_len = tokio::fs::metadata(&traj_path).await.map_or(0, |m| m.len());
         if current_len == last_file_len && emitted_steps > 0 {
             maybe_warn_stall(last_activity_at.as_ref(), &mut stall_warned, stall_duration);
             tokio::time::sleep(POLL_INTERVAL).await;

--- a/src/run/watch.rs
+++ b/src/run/watch.rs
@@ -101,9 +101,10 @@ pub async fn run(args: &WatchArgs) -> Result<(), Error> {
 
         // Skip read when both size and mtime are unchanged (avoids O(N) read every poll).
         // When mtime is unavailable (rare filesystems) we always re-read for correctness.
-        let meta = tokio::fs::metadata(&traj_path).await.ok();
-        let current_len = meta.as_ref().map_or(0, |m| m.len());
-        let current_mtime = meta.as_ref().and_then(|m| m.modified().ok());
+        let (current_len, current_mtime) = match tokio::fs::metadata(&traj_path).await {
+            Ok(m) => (m.len(), m.modified().ok()),
+            Err(_) => (0, None),
+        };
         let skippable = emitted_steps > 0
             && current_len == last_file_len
             && current_mtime.is_some()
@@ -146,20 +147,7 @@ pub async fn run(args: &WatchArgs) -> Result<(), Error> {
         }
 
         if is_terminal_outcome(&traj) {
-            if !args.ndjson {
-                let traj_outcome = traj.info.outcome.as_deref().unwrap_or("?");
-                let cost = traj
-                    .info
-                    .total_cost_usd
-                    .map_or_else(|| "?".into(), |c| format!("{c:.4}"));
-                let steps_count = traj.info.steps.unwrap_or(0);
-                writeln!(
-                    stdout,
-                    "\n[watch] instance `{}` complete: outcome={} steps={} cost_usd={}",
-                    args.instance, traj_outcome, steps_count, cost
-                )?;
-                stdout.flush()?;
-            }
+            print_completion_summary(args, &traj, &mut stdout)?;
             return Ok(());
         }
 
@@ -186,6 +174,29 @@ fn resolve_watch_path(sweep: &Path, instance_id: &str, run_index: u32) -> Option
         }
     }
     None
+}
+
+fn print_completion_summary(
+    args: &WatchArgs,
+    traj: &Trajectory,
+    stdout: &mut std::io::Stdout,
+) -> Result<(), Error> {
+    if args.ndjson {
+        return Ok(());
+    }
+    let outcome = traj.info.outcome.as_deref().unwrap_or("?");
+    let cost = traj
+        .info
+        .total_cost_usd
+        .map_or_else(|| "?".into(), |c| format!("{c:.4}"));
+    let steps = traj.info.steps.unwrap_or(0);
+    writeln!(
+        stdout,
+        "\n[watch] instance `{}` complete: outcome={} steps={} cost_usd={}",
+        args.instance, outcome, steps, cost
+    )?;
+    stdout.flush()?;
+    Ok(())
 }
 
 fn emit_new_steps(

--- a/src/run/watch.rs
+++ b/src/run/watch.rs
@@ -9,10 +9,10 @@ use serde::Serialize;
 use crate::error::Error;
 use crate::redaction::Redactor;
 use crate::run::inspect::{
-    build_inspect_steps_with_max, redact_trajectory_for_inspect, render_step_text,
+    InspectStep, build_inspect_steps_with_max, redact_trajectory_for_inspect, render_step_text,
     resolve_trajectory_path,
 };
-use crate::trajectory::{Trajectory, exit_reason};
+use crate::trajectory::Trajectory;
 
 const DEFAULT_MAX_BYTES: usize = 4 * 1024;
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -63,15 +63,18 @@ pub async fn run(args: &WatchArgs) -> Result<(), Error> {
 
     let mut stdout = std::io::stdout();
     let mut emitted_steps: usize = 0;
-    let mut last_new_turn_at: Option<Instant> = None;
+    let mut last_activity_at: Option<Instant> = None;
     let mut stall_warned = false;
     let mut last_wait_progress_at = Instant::now();
-    let mut file_found = false;
+    let mut cached_path: Option<PathBuf> = None;
+    let mut last_file_len: u64 = 0;
 
     loop {
-        let traj_path = resolve_trajectory_path(&args.sweep, &args.instance);
+        let traj_path = cached_path
+            .clone()
+            .or_else(|| resolve_trajectory_path(&args.sweep, &args.instance));
 
-        if traj_path.is_none() && !file_found {
+        let Some(traj_path) = traj_path else {
             if Instant::now() >= wait_deadline {
                 return Err(Error::Trajectory(format!(
                     "watch: trajectory file for instance `{}` not found after {} second(s)",
@@ -87,68 +90,53 @@ pub async fn run(args: &WatchArgs) -> Result<(), Error> {
             }
             tokio::time::sleep(POLL_INTERVAL).await;
             continue;
+        };
+
+        // Initialize activity timer and cache path on first discovery.
+        if cached_path.is_none() {
+            cached_path = Some(traj_path.clone());
+            last_activity_at = Some(Instant::now());
         }
 
-        let Some(traj_path) = traj_path else {
+        // Skip read if file size is unchanged (avoids O(N) read every poll).
+        let current_len = tokio::fs::metadata(&traj_path)
+            .await
+            .map(|m| m.len())
+            .unwrap_or(0);
+        if current_len == last_file_len && emitted_steps > 0 {
+            maybe_warn_stall(last_activity_at.as_ref(), &mut stall_warned, stall_duration);
+            tokio::time::sleep(POLL_INTERVAL).await;
+            continue;
+        }
+
+        let Ok(text) = tokio::fs::read_to_string(&traj_path).await else {
+            maybe_warn_stall(last_activity_at.as_ref(), &mut stall_warned, stall_duration);
             tokio::time::sleep(POLL_INTERVAL).await;
             continue;
         };
 
-        file_found = true;
-
-        let text = match std::fs::read_to_string(&traj_path) {
-            Ok(t) => t,
-            Err(_) => {
-                tokio::time::sleep(POLL_INTERVAL).await;
-                continue;
-            }
+        let Ok(mut traj) = serde_json::from_str::<Trajectory>(&text) else {
+            maybe_warn_stall(last_activity_at.as_ref(), &mut stall_warned, stall_duration);
+            tokio::time::sleep(POLL_INTERVAL).await;
+            continue;
         };
 
-        let mut traj: Trajectory = match serde_json::from_str(&text) {
-            Ok(t) => t,
-            Err(_) => {
-                tokio::time::sleep(POLL_INTERVAL).await;
-                continue;
-            }
-        };
-
+        last_file_len = current_len;
         redact_trajectory_for_inspect(&mut traj, &redactor);
-
         let steps = build_inspect_steps_with_max(&traj, args.full, max_bytes);
 
+        // Handle the case where the file was rewritten with fewer steps (worker restart).
+        if steps.len() < emitted_steps {
+            emitted_steps = 0;
+        }
+
         if steps.len() > emitted_steps {
-            let new_steps = &steps[emitted_steps..];
-            for step in new_steps {
-                if args.ndjson {
-                    let event = WatchTurnEvent {
-                        schema_version: NDJSON_SCHEMA_VERSION,
-                        instance_id: &args.instance,
-                        turn_index: step.index,
-                        role: &step.role,
-                        message: step.message.as_deref(),
-                        bash: step.bash.as_deref(),
-                        exit_code: step.exit_code,
-                        stdout: step.stdout.as_deref(),
-                        stderr: step.stderr.as_deref(),
-                    };
-                    let line = serde_json::to_string(&event)?;
-                    writeln!(stdout, "{line}")?;
-                    stdout.flush()?;
-                } else {
-                    let rendered = render_step_text(step, color);
-                    write!(stdout, "{rendered}")?;
-                    stdout.flush()?;
-                }
-            }
+            emit_new_steps(&steps[emitted_steps..], args, &mut stdout, color)?;
             emitted_steps = steps.len();
-            last_new_turn_at = Some(Instant::now());
+            last_activity_at = Some(Instant::now());
             stall_warned = false;
-        } else if let Some(last_turn) = last_new_turn_at {
-            if !stall_warned && last_turn.elapsed() >= stall_duration {
-                let secs = last_turn.elapsed().as_secs();
-                eprintln!("[stalled: no new turns in {secs}s]");
-                stall_warned = true;
-            }
+        } else {
+            maybe_warn_stall(last_activity_at.as_ref(), &mut stall_warned, stall_duration);
         }
 
         if is_terminal_outcome(&traj) {
@@ -173,10 +161,45 @@ pub async fn run(args: &WatchArgs) -> Result<(), Error> {
     }
 }
 
+fn emit_new_steps(
+    steps: &[InspectStep],
+    args: &WatchArgs,
+    stdout: &mut std::io::Stdout,
+    color: bool,
+) -> Result<(), Error> {
+    for step in steps {
+        if args.ndjson {
+            let event = WatchTurnEvent {
+                schema_version: NDJSON_SCHEMA_VERSION,
+                instance_id: &args.instance,
+                turn_index: step.index,
+                role: &step.role,
+                message: step.message.as_deref(),
+                bash: step.bash.as_deref(),
+                exit_code: step.exit_code,
+                stdout: step.stdout.as_deref(),
+                stderr: step.stderr.as_deref(),
+            };
+            let line = serde_json::to_string(&event)?;
+            writeln!(stdout, "{line}")?;
+        } else {
+            write!(stdout, "{}", render_step_text(step, color))?;
+        }
+        stdout.flush()?;
+    }
+    Ok(())
+}
+
+fn maybe_warn_stall(last_activity: Option<&Instant>, stall_warned: &mut bool, duration: Duration) {
+    let Some(last) = last_activity else { return };
+    if !*stall_warned && last.elapsed() >= duration {
+        eprintln!("[stalled: no new turns in {}s]", last.elapsed().as_secs());
+        *stall_warned = true;
+    }
+}
+
 fn is_terminal_outcome(traj: &Trajectory) -> bool {
-    traj.info.outcome.is_some()
-        || traj.info.exit_reason.as_deref() == Some(exit_reason::CANCELLED)
-        || traj.info.exit_reason.as_deref() == Some(exit_reason::WALLCLOCK_TIMEOUT)
+    traj.info.outcome.is_some() || traj.info.exit_reason.is_some()
 }
 
 #[cfg(test)]
@@ -200,22 +223,23 @@ mod tests {
     }
 
     #[test]
-    fn not_terminal_when_no_outcome() {
+    fn not_terminal_when_no_outcome_and_no_exit_reason() {
         let traj = Trajectory::new();
         assert!(!is_terminal_outcome(&traj));
     }
 
     #[test]
-    fn terminal_when_exit_reason_cancelled() {
+    fn terminal_when_any_exit_reason_set() {
         let mut traj = Trajectory::new();
-        traj.info.exit_reason = Some(exit_reason::CANCELLED.into());
+        traj.info.exit_reason = Some("any_reason".into());
         assert!(is_terminal_outcome(&traj));
     }
 
     #[test]
-    fn terminal_when_exit_reason_wallclock_timeout() {
+    fn terminal_when_outcome_and_exit_reason_both_set() {
         let mut traj = Trajectory::new();
-        traj.info.exit_reason = Some(exit_reason::WALLCLOCK_TIMEOUT.into());
+        traj.info.outcome = Some(outcome::SUBMITTED.into());
+        traj.info.exit_reason = Some("cancelled".into());
         assert!(is_terminal_outcome(&traj));
     }
 }

--- a/src/run/watch.rs
+++ b/src/run/watch.rs
@@ -1,8 +1,8 @@
 //! `bench watch`: follow a single in-flight trajectory instance live.
 
 use std::io::{IsTerminal as _, Write as StdWrite};
-use std::path::PathBuf;
-use std::time::{Duration, Instant};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant, SystemTime};
 
 use serde::Serialize;
 
@@ -10,7 +10,6 @@ use crate::error::Error;
 use crate::redaction::Redactor;
 use crate::run::inspect::{
     InspectStep, build_inspect_steps_with_max, redact_trajectory_for_inspect, render_step_text,
-    resolve_trajectory_path,
 };
 use crate::trajectory::Trajectory;
 
@@ -22,6 +21,7 @@ const NDJSON_SCHEMA_VERSION: &str = "watch-1.0";
 pub struct WatchArgs {
     pub sweep: PathBuf,
     pub instance: String,
+    pub run_index: u32,
     pub wait_secs: u64,
     pub stall_secs: u64,
     pub full: bool,
@@ -68,17 +68,18 @@ pub async fn run(args: &WatchArgs) -> Result<(), Error> {
     let mut last_wait_progress_at = Instant::now();
     let mut cached_path: Option<PathBuf> = None;
     let mut last_file_len: u64 = 0;
+    let mut last_file_mtime: Option<SystemTime> = None;
 
     loop {
         let traj_path = cached_path
             .clone()
-            .or_else(|| resolve_trajectory_path(&args.sweep, &args.instance));
+            .or_else(|| resolve_watch_path(&args.sweep, &args.instance, args.run_index));
 
         let Some(traj_path) = traj_path else {
             if Instant::now() >= wait_deadline {
                 return Err(Error::Trajectory(format!(
-                    "watch: trajectory file for instance `{}` not found after {} second(s)",
-                    args.instance, args.wait_secs
+                    "watch: trajectory file for instance `{}` (run {}) not found after {} second(s)",
+                    args.instance, args.run_index, args.wait_secs
                 )));
             }
             if last_wait_progress_at.elapsed() >= WAIT_PROGRESS_INTERVAL {
@@ -98,9 +99,16 @@ pub async fn run(args: &WatchArgs) -> Result<(), Error> {
             last_activity_at = Some(Instant::now());
         }
 
-        // Skip read if file size is unchanged (avoids O(N) read every poll).
-        let current_len = tokio::fs::metadata(&traj_path).await.map_or(0, |m| m.len());
-        if current_len == last_file_len && emitted_steps > 0 {
+        // Skip read when both size and mtime are unchanged (avoids O(N) read every poll).
+        // When mtime is unavailable (rare filesystems) we always re-read for correctness.
+        let meta = tokio::fs::metadata(&traj_path).await.ok();
+        let current_len = meta.as_ref().map_or(0, |m| m.len());
+        let current_mtime = meta.as_ref().and_then(|m| m.modified().ok());
+        let skippable = emitted_steps > 0
+            && current_len == last_file_len
+            && current_mtime.is_some()
+            && current_mtime == last_file_mtime;
+        if skippable {
             maybe_warn_stall(last_activity_at.as_ref(), &mut stall_warned, stall_duration);
             tokio::time::sleep(POLL_INTERVAL).await;
             continue;
@@ -119,6 +127,7 @@ pub async fn run(args: &WatchArgs) -> Result<(), Error> {
         };
 
         last_file_len = current_len;
+        last_file_mtime = current_mtime;
         redact_trajectory_for_inspect(&mut traj, &redactor);
         let steps = build_inspect_steps_with_max(&traj, args.full, max_bytes);
 
@@ -156,6 +165,27 @@ pub async fn run(args: &WatchArgs) -> Result<(), Error> {
 
         tokio::time::sleep(POLL_INTERVAL).await;
     }
+}
+
+/// Resolve the trajectory file path for a watched instance.
+///
+/// For run_index > 1, only the nested `<sweep>/<instance>/run-N.traj.json` path is
+/// checked. For run_index == 1 the legacy flat layout is also accepted so that
+/// hello-world and pre-rerun sweep outputs work without a `--run-index` flag.
+fn resolve_watch_path(sweep: &Path, instance_id: &str, run_index: u32) -> Option<PathBuf> {
+    let nested = sweep
+        .join(instance_id)
+        .join(format!("run-{run_index}.traj.json"));
+    if nested.exists() {
+        return Some(nested);
+    }
+    if run_index == 1 {
+        let flat = sweep.join(format!("{instance_id}.traj.json"));
+        if flat.exists() {
+            return Some(flat);
+        }
+    }
+    None
 }
 
 fn emit_new_steps(
@@ -238,5 +268,41 @@ mod tests {
         traj.info.outcome = Some(outcome::SUBMITTED.into());
         traj.info.exit_reason = Some("cancelled".into());
         assert!(is_terminal_outcome(&traj));
+    }
+
+    #[test]
+    fn resolve_watch_path_finds_nested_run1() {
+        let dir = tempfile::tempdir().unwrap();
+        let instance_dir = dir.path().join("my-instance");
+        std::fs::create_dir_all(&instance_dir).unwrap();
+        std::fs::write(instance_dir.join("run-1.traj.json"), "{}").unwrap();
+        let p = resolve_watch_path(dir.path(), "my-instance", 1).unwrap();
+        assert!(p.ends_with("run-1.traj.json"));
+    }
+
+    #[test]
+    fn resolve_watch_path_finds_flat_for_run1() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("my-instance.traj.json"), "{}").unwrap();
+        let p = resolve_watch_path(dir.path(), "my-instance", 1).unwrap();
+        assert!(p.ends_with("my-instance.traj.json"));
+    }
+
+    #[test]
+    fn resolve_watch_path_finds_run2() {
+        let dir = tempfile::tempdir().unwrap();
+        let instance_dir = dir.path().join("my-instance");
+        std::fs::create_dir_all(&instance_dir).unwrap();
+        std::fs::write(instance_dir.join("run-2.traj.json"), "{}").unwrap();
+        let p = resolve_watch_path(dir.path(), "my-instance", 2).unwrap();
+        assert!(p.ends_with("run-2.traj.json"));
+    }
+
+    #[test]
+    fn resolve_watch_path_ignores_flat_for_run2() {
+        let dir = tempfile::tempdir().unwrap();
+        // Only flat file exists — run_index=2 should not find it
+        std::fs::write(dir.path().join("my-instance.traj.json"), "{}").unwrap();
+        assert!(resolve_watch_path(dir.path(), "my-instance", 2).is_none());
     }
 }

--- a/tests/bench_watch.rs
+++ b/tests/bench_watch.rs
@@ -295,6 +295,29 @@ fn invalid_sweep_dir_exits_2() {
     );
 }
 
+// Test: --sweep pointing at a file (not a directory) exits 2
+#[test]
+fn sweep_is_file_not_dir_exits_2() {
+    let file = tempfile::NamedTempFile::new().unwrap();
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "watch",
+            "--sweep",
+            file.path().to_str().unwrap(),
+            "--instance",
+            "some-instance",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected exit 2 when sweep is a file, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 // Test (e): Stall warning fires after --stall-secs and watch keeps following
 #[test]
 fn stall_warning_fires_and_watch_keeps_following() {

--- a/tests/bench_watch.rs
+++ b/tests/bench_watch.rs
@@ -211,7 +211,10 @@ fn ndjson_mode_produces_valid_ndjson() {
         );
         found_turn = true;
     }
-    assert!(found_turn, "expected at least one NDJSON turn line, stdout: {stdout}");
+    assert!(
+        found_turn,
+        "expected at least one NDJSON turn line, stdout: {stdout}"
+    );
 }
 
 // Test (d): Redaction strips a planted secret token before stdout

--- a/tests/bench_watch.rs
+++ b/tests/bench_watch.rs
@@ -1,0 +1,229 @@
+//! `bench watch`: live single-instance trajectory follower.
+
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+use rust_swe_agent::trajectory::{Trajectory, outcome};
+
+mod support;
+use support::binary_path;
+
+fn write_traj(dir: &Path, instance_id: &str, outcome_val: Option<&str>) {
+    let mut t = Trajectory::new();
+    t.info.model_name = Some("test-model".into());
+    t.info.outcome = outcome_val.map(str::to_owned);
+
+    let mut asst = rust_swe_agent::model::Message::assistant("```bash\necho hello\n```");
+    asst.extra.actions = Some(vec!["echo hello".into()]);
+    t.record_message(&asst);
+
+    let mut obs = rust_swe_agent::model::Message::user("output");
+    obs.extra.other.insert(
+        "run_result".into(),
+        serde_json::json!({
+            "stdout": "hello\n",
+            "stderr": "",
+            "exit_code": 0,
+            "timed_out": false
+        }),
+    );
+    t.record_message(&obs);
+
+    std::fs::write(
+        dir.join(format!("{instance_id}.traj.json")),
+        serde_json::to_string_pretty(&t).unwrap(),
+    )
+    .unwrap();
+}
+
+// Test (b): --wait-secs=0 against a missing file exits 1
+#[test]
+fn wait_secs_zero_missing_file_exits_1() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "watch",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+            "--instance",
+            "nonexistent-instance",
+            "--wait-secs",
+            "0",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "expected exit 1 for missing file, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// Test (a): Complete trajectory exits 0 and shows turn content
+#[test]
+fn complete_trajectory_exits_0_with_turns() {
+    let dir = tempfile::tempdir().unwrap();
+    write_traj(dir.path(), "my-instance", Some(outcome::SUBMITTED));
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "watch",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+            "--instance",
+            "my-instance",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "expected exit 0 for complete trajectory, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Should contain turn output from the assistant step
+    assert!(
+        stdout.contains("assistant") || stdout.contains("step"),
+        "expected turn output in stdout, got: {stdout}"
+    );
+    // Should contain the final summary
+    assert!(
+        stdout.contains("complete") || stdout.contains("submitted"),
+        "expected completion summary in stdout, got: {stdout}"
+    );
+}
+
+// Test (c): --ndjson mode produces valid NDJSON that round-trips through serde_json
+#[test]
+fn ndjson_mode_produces_valid_ndjson() {
+    let dir = tempfile::tempdir().unwrap();
+    write_traj(dir.path(), "ndjson-instance", Some(outcome::SUBMITTED));
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "watch",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+            "--instance",
+            "ndjson-instance",
+            "--ndjson",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "expected exit 0 in ndjson mode, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let mut found_turn = false;
+    for line in stdout.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let parsed: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("invalid JSON line: {e}\nline: {line}"));
+        assert!(
+            parsed.get("schema_version").is_some(),
+            "missing schema_version field in: {line}"
+        );
+        assert!(
+            parsed.get("turn_index").is_some(),
+            "missing turn_index field in: {line}"
+        );
+        assert!(
+            parsed.get("role").is_some(),
+            "missing role field in: {line}"
+        );
+        found_turn = true;
+    }
+    assert!(found_turn, "expected at least one NDJSON turn line, stdout: {stdout}");
+}
+
+// Test (d): Redaction strips a planted secret token before stdout
+#[test]
+fn redaction_strips_secret_from_stdout() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let mut t = Trajectory::new();
+    t.info.model_name = Some("test-model".into());
+    t.info.outcome = Some(outcome::SUBMITTED.into());
+
+    let mut asst = rust_swe_agent::model::Message::assistant("```bash\necho test\n```");
+    asst.extra.actions = Some(vec!["echo test".into()]);
+    t.record_message(&asst);
+
+    let mut obs = rust_swe_agent::model::Message::user("output");
+    obs.extra.other.insert(
+        "run_result".into(),
+        serde_json::json!({
+            "stdout": "ghp_SECRETTOKEN12345678901234567890AB output",
+            "stderr": "",
+            "exit_code": 0,
+            "timed_out": false
+        }),
+    );
+    t.record_message(&obs);
+
+    std::fs::write(
+        dir.path().join("secret-instance.traj.json"),
+        serde_json::to_string_pretty(&t).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "watch",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+            "--instance",
+            "secret-instance",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "expected exit 0, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("ghp_SECRETTOKEN12345678901234567890AB"),
+        "secret token should be redacted from stdout, but found in: {stdout}"
+    );
+}
+
+// Test (e): Invalid sweep directory exits 2
+#[test]
+fn invalid_sweep_dir_exits_2() {
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "watch",
+            "--sweep",
+            "/nonexistent/path/does/not/exist",
+            "--instance",
+            "some-instance",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected exit 2 for invalid sweep dir, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/tests/bench_watch.rs
+++ b/tests/bench_watch.rs
@@ -318,6 +318,96 @@ fn sweep_is_file_not_dir_exits_2() {
     );
 }
 
+// Test: --run-index 2 attaches to the correct run slot
+#[test]
+fn run_index_2_reads_correct_slot() {
+    let dir = tempfile::tempdir().unwrap();
+    let instance_id = "rerun-instance";
+    let instance_dir = dir.path().join(instance_id);
+    std::fs::create_dir_all(&instance_dir).unwrap();
+
+    // Write run-1 as already-complete with a different outcome to ensure
+    // bench watch selects run-2 and not run-1.
+    write_traj(dir.path(), instance_id, None);
+    // write_traj writes to <sweep>/<id>.traj.json (flat); also write a nested run-1
+    std::fs::write(
+        instance_dir.join("run-1.traj.json"),
+        serde_json::to_string_pretty(&{
+            let mut t = rust_swe_agent::trajectory::Trajectory::new();
+            t.info.outcome = Some(rust_swe_agent::trajectory::outcome::SUBMITTED.into());
+            t
+        })
+        .unwrap(),
+    )
+    .unwrap();
+    // run-2: complete trajectory with a unique assistant message
+    let mut t2 = rust_swe_agent::trajectory::Trajectory::new();
+    t2.info.outcome = Some(rust_swe_agent::trajectory::outcome::SUBMITTED.into());
+    let mut asst = rust_swe_agent::model::Message::assistant("run-two-unique-content");
+    asst.extra.actions = Some(vec!["echo run2".into()]);
+    t2.record_message(&asst);
+    std::fs::write(
+        instance_dir.join("run-2.traj.json"),
+        serde_json::to_string_pretty(&t2).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "watch",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+            "--instance",
+            instance_id,
+            "--run-index",
+            "2",
+            "--wait-secs",
+            "0",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "expected exit 0 for run-index 2, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("run-two-unique-content"),
+        "expected run-2 content in stdout, got: {stdout}"
+    );
+}
+
+// Test: --run-index N for missing slot exits 1 when --wait-secs 0
+#[test]
+fn run_index_missing_slot_exits_1() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "watch",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+            "--instance",
+            "some-instance",
+            "--run-index",
+            "3",
+            "--wait-secs",
+            "0",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "expected exit 1 for missing run-3 slot, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 // Test (e): Stall warning fires after --stall-secs and watch keeps following
 #[test]
 fn stall_warning_fires_and_watch_keeps_following() {

--- a/tests/bench_watch.rs
+++ b/tests/bench_watch.rs
@@ -3,7 +3,8 @@
 #![allow(clippy::unwrap_used)]
 
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::Duration;
 
 use rust_swe_agent::trajectory::{Trajectory, outcome};
 
@@ -63,7 +64,72 @@ fn wait_secs_zero_missing_file_exits_1() {
     );
 }
 
-// Test (a): Complete trajectory exits 0 and shows turn content
+// Test (a): Attach to a trajectory being written by a test harness; observe turns in order
+#[test]
+fn streams_turns_from_in_flight_trajectory() {
+    let dir = tempfile::tempdir().unwrap();
+    let instance_id = "streaming-instance";
+    let traj_path = dir.path().join(format!("{instance_id}.traj.json"));
+
+    // Write an initial non-terminal trajectory with one turn (still in-flight)
+    {
+        let mut t = Trajectory::new();
+        let mut asst = rust_swe_agent::model::Message::assistant("turn-one-content");
+        asst.extra.actions = Some(vec!["echo turn1".into()]);
+        t.record_message(&asst);
+        std::fs::write(&traj_path, serde_json::to_string_pretty(&t).unwrap()).unwrap();
+    }
+
+    // Start bench watch in background
+    let child = Command::new(binary_path())
+        .args([
+            "bench",
+            "watch",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+            "--instance",
+            instance_id,
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Let watch read and print the first turn
+    std::thread::sleep(Duration::from_millis(400));
+
+    // Write a second turn and mark terminal — simulates the worker finishing
+    {
+        let mut t = Trajectory::new();
+        t.info.outcome = Some(outcome::SUBMITTED.into());
+        let mut asst1 = rust_swe_agent::model::Message::assistant("turn-one-content");
+        asst1.extra.actions = Some(vec!["echo turn1".into()]);
+        t.record_message(&asst1);
+        let mut asst2 = rust_swe_agent::model::Message::assistant("turn-two-content");
+        asst2.extra.actions = Some(vec!["echo turn2".into()]);
+        t.record_message(&asst2);
+        std::fs::write(&traj_path, serde_json::to_string_pretty(&t).unwrap()).unwrap();
+    }
+
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "expected exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("turn-one-content"),
+        "expected turn 1 in stdout, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("turn-two-content"),
+        "expected turn 2 in stdout, got: {stdout}"
+    );
+}
+
+// Test (a) also: complete pre-written trajectory exits 0 and shows turns
 #[test]
 fn complete_trajectory_exits_0_with_turns() {
     let dir = tempfile::tempdir().unwrap();
@@ -88,12 +154,10 @@ fn complete_trajectory_exits_0_with_turns() {
         String::from_utf8_lossy(&out.stderr)
     );
     let stdout = String::from_utf8_lossy(&out.stdout);
-    // Should contain turn output from the assistant step
     assert!(
         stdout.contains("assistant") || stdout.contains("step"),
         "expected turn output in stdout, got: {stdout}"
     );
-    // Should contain the final summary
     assert!(
         stdout.contains("complete") || stdout.contains("submitted"),
         "expected completion summary in stdout, got: {stdout}"
@@ -206,7 +270,7 @@ fn redaction_strips_secret_from_stdout() {
     );
 }
 
-// Test (e): Invalid sweep directory exits 2
+// Test: Invalid sweep directory exits 2
 #[test]
 fn invalid_sweep_dir_exits_2() {
     let out = Command::new(binary_path())
@@ -225,5 +289,59 @@ fn invalid_sweep_dir_exits_2() {
         Some(2),
         "expected exit 2 for invalid sweep dir, stderr: {}",
         String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// Test (e): Stall warning fires after --stall-secs and watch keeps following
+#[test]
+fn stall_warning_fires_and_watch_keeps_following() {
+    let dir = tempfile::tempdir().unwrap();
+    let instance_id = "stall-instance";
+
+    // Write an in-flight (non-terminal) trajectory with one turn
+    let mut t = Trajectory::new();
+    let mut asst = rust_swe_agent::model::Message::assistant("initial turn");
+    asst.extra.actions = Some(vec!["echo hi".into()]);
+    t.record_message(&asst);
+    std::fs::write(
+        dir.path().join(format!("{instance_id}.traj.json")),
+        serde_json::to_string_pretty(&t).unwrap(),
+    )
+    .unwrap();
+
+    // Start bench watch with stall-secs=1
+    let mut child = Command::new(binary_path())
+        .args([
+            "bench",
+            "watch",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+            "--instance",
+            instance_id,
+            "--stall-secs",
+            "1",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Wait long enough for the stall to fire (stall-secs=1, wait 2.5s)
+    std::thread::sleep(Duration::from_millis(2500));
+
+    // Watch should still be running — stall must not cause an exit
+    assert!(
+        child.try_wait().unwrap().is_none(),
+        "bench watch should still be running after a stall — stall must not exit"
+    );
+
+    // Kill the process and collect output
+    child.kill().unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("[stalled:"),
+        "expected stall warning in stderr, got: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary

This PR introduces the `bench watch` command, a new live monitoring tool that attaches to a single in-flight sweep instance and streams its turns to stdout as they are written to disk. This complements the existing `bench tail` (sweep-wide aggregate) and `bench inspect` (post-mortem single instance) commands.

## Key Changes

- **New `bench watch` command** (`src/run/watch.rs`): 
  - Polls a trajectory file at regular intervals and emits new turns as they appear
  - Supports human-readable text output (reusing `bench inspect` rendering) and NDJSON streaming modes
  - Implements file-waiting logic with configurable timeout (`--wait-secs`, default 30s)
  - Detects stalls (no new turns for `--stall-secs`, default 120s) and warns without exiting
  - Applies redaction to all output using the same redactor as `bench inspect`
  - Exits with code 0 on terminal outcome, 1 on file not found, 2 on invalid sweep directory

- **CLI integration** (`src/cli/args.rs`, `src/cli/mod.rs`):
  - Added `WatchCmd` struct with flags: `--sweep`, `--instance`, `--wait-secs`, `--stall-secs`, `--full`, `--max-bytes`, `--ndjson`
  - Wired command into the main CLI dispatcher

- **Refactored `bench inspect` internals** (`src/run/inspect.rs`):
  - Extracted `build_inspect_steps_with_max()` to allow custom truncation thresholds (used by `watch`)
  - Extracted `render_step_text()` to render individual steps (reused by `watch` for both text and NDJSON modes)
  - Made `redact_trajectory_for_inspect()` public for use by `watch`
  - Updated `maybe_truncate()` signature to accept configurable `max_bytes` parameter

- **Comprehensive test suite** (`tests/bench_watch.rs`):
  - Tests for file waiting and timeout behavior
  - Tests for streaming turns from in-flight trajectories
  - Tests for complete pre-written trajectories
  - NDJSON output validation (schema, round-trip JSON parsing)
  - Redaction verification (secret token stripping)
  - Invalid sweep directory handling
  - Stall warning detection

- **Documentation** (`docs/spec-watch.md`):
  - Complete specification including command syntax, flags, exit codes
  - Waiting and stall detection behavior
  - NDJSON schema and round-trip guarantees
  - Operator recipes and relation to other bench commands

- **README update**: Added reference to `bench watch` in the command overview

## Implementation Details

- Uses async polling with 100ms intervals to check for file updates
- Tracks emitted steps to only output new turns on each poll cycle
- Maintains stall detection state separately from file-waiting state
- NDJSON mode flushes stdout after every line for stream processing compatibility
- Reuses existing trajectory inspection and redaction infrastructure to maintain consistency with `bench inspect`

https://claude.ai/code/session_01DTDMj9jsLcDsXeQeWGSRDo