### PR TITLE
Add failing test names and expected tests to bench inspect output

### DIFF
--- a/docs/spec-inspect.md
+++ b/docs/spec-inspect.md
@@ -10,6 +10,7 @@ instances in filter mode.
 rust-swe-agent bench inspect --sweep <dir> --instance <instance_id>
 rust-swe-agent bench inspect --sweep <dir> --instance <instance_id> --full
 rust-swe-agent bench inspect --sweep <dir> --instance <instance_id> --format json
+rust-swe-agent bench inspect --sweep <dir> --instance <instance_id> --show-expected
 rust-swe-agent bench inspect --sweep <dir> --filter resolved=false
 rust-swe-agent bench inspect --sweep <dir> --filter failure_category=step_limit
 rust-swe-agent bench inspect --diff <baseline.traj.json> <candidate.traj.json>
@@ -27,6 +28,8 @@ rust-swe-agent bench compare --baseline <dir> --candidate <dir> --emit-diff-scri
 * `--filter`: summary-table mode (`resolved=true|false` or `failure_category=<snake_case>`).
 * `--format`: `text` (default) or `json`.
 * `--full`: disable stdout/stderr truncation in transcript mode.
+* `--show-expected`: also print `PASS_TO_PASS` / `FAIL_TO_PASS` expected-test groupings read
+  from `<sweep>/dataset.jsonl`. Silently skipped when the file is absent.
 * `--diff`: compare two trajectory JSON files for the same `instance_id`.
 * `--show-noise`: in diff mode, include whitespace-only and timestamp-only differences.
 * `--inspect-diff`: compare sugar that resolves `<instance_id>.traj.json` or `<instance_id>/run-1.traj.json` inside both sweep directories.
@@ -49,6 +52,66 @@ Header fields:
 * `baseline_cost_usd` and `baseline_cost_model` when available
 * token totals (`prompt`, `completion`)
 * `resolved` when `evaluation.json` exists
+* `Failing tests` section when the instance is unresolved (see below)
+* `PASS_TO_PASS` / `FAIL_TO_PASS` sections when `--show-expected` is set
+
+### Failing tests section
+
+When the instance is **unresolved** and `evaluation.json` is present, a
+`Failing tests` section follows the `resolved` line:
+
+* When the evaluator reported individual test names:
+  ```
+  Failing tests (N):
+    tests/test_widgets.py::test_widget_render
+    tests/test_widgets.py::test_widget_init
+  ```
+* When test names are unavailable (evaluator error, timeout, build failure, etc.):
+  ```
+  Failing tests: <eval_error>
+  ```
+  The reason is taken from the `eval_exit_reason` field in `evaluation.json`,
+  or falls back to `failure_category` from the trajectory.
+
+When the instance is **resolved**, no `Failing tests` section is printed
+(silent on the happy path).
+
+### `--show-expected` sections
+
+When `--show-expected` is set and `<sweep>/dataset.jsonl` contains a record for
+the instance, two additional sections are printed:
+
+```
+PASS_TO_PASS (N):
+  tests/test_core.py::test_existing
+FAIL_TO_PASS (M):
+  tests/test_core.py::test_targeted
+```
+
+The lists are read directly from the `PASS_TO_PASS` and `FAIL_TO_PASS` arrays
+in the SWE-bench instance record. If `dataset.jsonl` is absent or has no
+matching record, both sections are silently omitted.
+
+### `failing_tests` JSON shape
+
+`--format json` includes a `failing_tests` field on the instance record when
+the instance is unresolved:
+
+```json
+{
+  "failing_tests": {
+    "tests": ["tests/test_widgets.py::test_widget_render"],
+    "source": "evaluator",
+    "reason": ""
+  }
+}
+```
+
+* `source`: `"evaluator"` when names come from evaluator output; `"unavailable"` otherwise.
+* `reason`: human-readable explanation when `source == "unavailable"`; empty string when `source == "evaluator"`.
+* `tests`: array of test names in the order reported by the evaluator; empty when `source == "unavailable"`.
+
+The `failing_tests` field is absent for resolved instances.
 
 Step rendering:
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1035,6 +1035,11 @@ pub struct InspectCmd {
     /// Disable stdout/stderr truncation in transcript mode.
     #[arg(long, default_value_t = false)]
     pub full: bool,
+
+    /// Also print PASS_TO_PASS / FAIL_TO_PASS expected-test groupings from the
+    /// sweep's dataset.jsonl (requires dataset.jsonl in the sweep directory).
+    #[arg(long, default_value_t = false)]
+    pub show_expected: bool,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1611,6 +1611,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         instance: i.instance,
         filter: i.filter,
         full: i.full,
+        show_expected: i.show_expected,
     })?;
     match format {
         crate::run::inspect::InspectFormat::Text => {

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -12,9 +12,9 @@ use crate::cost::CostSource;
 use crate::env::RunResult;
 use crate::error::Error;
 use crate::redaction::{Redactor, surface};
-use crate::run::evaluate::EvaluationResults;
+use crate::run::evaluate::{EvalExitReason, EvaluationResults};
 use crate::run::patch_stats::PatchStats;
-use crate::run::swebench::{InstanceResult, ProvenanceManifest};
+use crate::run::swebench::{InstanceResult, ProvenanceManifest, SweBenchInstance};
 use crate::trajectory::{
     FailureCategory, FallbackSummary, TokenUsage, Trajectory, VerificationResult,
 };
@@ -34,6 +34,26 @@ pub struct InspectArgs {
     pub instance: Option<String>,
     pub filter: Option<String>,
     pub full: bool,
+    /// When true, load PASS_TO_PASS / FAIL_TO_PASS from the sweep's dataset.jsonl
+    /// and add them to the report.
+    pub show_expected: bool,
+}
+
+/// Failing tests from the evaluator, or an explanation of why names are unavailable.
+#[derive(Debug, Clone, Serialize)]
+pub struct FailingTests {
+    pub tests: Vec<String>,
+    /// `"evaluator"` when names come from evaluator output; `"unavailable"` otherwise.
+    pub source: String,
+    /// Human-readable reason when `source == "unavailable"`. Empty otherwise.
+    pub reason: String,
+}
+
+/// Expected test groupings read from the SWE-bench instance record.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExpectedTests {
+    pub pass_to_pass: Vec<String>,
+    pub fail_to_pass: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -125,6 +145,14 @@ pub struct InspectReport {
     pub latency_share_pct: Option<LatencySharePct>,
     #[serde(default)]
     pub warnings: Vec<String>,
+    /// Failing tests from the evaluator, or a reason why names are unavailable.
+    /// `None` for resolved instances (silent on the happy path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failing_tests: Option<FailingTests>,
+    /// PASS_TO_PASS / FAIL_TO_PASS groupings from the SWE-bench instance record.
+    /// Populated only when `--show-expected` is set and the dataset is available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_tests: Option<ExpectedTests>,
     #[serde(default)]
     pub steps: Vec<InspectStep>,
 }
@@ -195,11 +223,17 @@ pub fn run(args: &InspectArgs) -> Result<InspectOutput, Error> {
 
     let instance_id = args.instance.clone().unwrap_or_default();
     let evaluation_overrides = load_evaluation_overrides(&args.sweep)?;
+    let dataset_instance = if args.show_expected {
+        load_dataset_instance(&args.sweep, &instance_id)
+    } else {
+        None
+    };
     let report = build_instance_report(
         &args.sweep,
         &instance_id,
         args.full,
         evaluation_overrides.as_ref(),
+        dataset_instance.as_ref(),
     )?;
     Ok(InspectOutput::Instance(Box::new(report)))
 }
@@ -240,6 +274,7 @@ fn build_instance_report(
     instance_id: &str,
     full: bool,
     evaluation_overrides: Option<&HashMap<String, EvaluationOverride>>,
+    dataset_instance: Option<&SweBenchInstance>,
 ) -> Result<InspectReport, Error> {
     let traj_path = resolve_trajectory_path(sweep, instance_id).ok_or_else(|| {
         Error::Trajectory(format!(
@@ -264,6 +299,10 @@ fn build_instance_report(
             warnings.push(format!(
                 "failed to parse trajectory as canonical schema: {err}; rendering minimal report"
             ));
+            let resolved = evaluation_overrides
+                .and_then(|m| m.get(instance_id))
+                .map(|value| value.resolved);
+            let eval_override = evaluation_overrides.and_then(|m| m.get(instance_id));
             return Ok(InspectReport {
                 sweep_dir: sweep.to_path_buf(),
                 instance_id: Some(instance_id.to_owned()),
@@ -280,12 +319,8 @@ fn build_instance_report(
                 cache_read_tokens: None,
                 cache_creation_tokens: None,
                 completion_tokens: None,
-                resolved: evaluation_overrides
-                    .and_then(|m| m.get(instance_id))
-                    .map(|value| value.resolved),
-                patch_stats: evaluation_overrides
-                    .and_then(|m| m.get(instance_id))
-                    .and_then(|value| value.patch_stats.clone()),
+                resolved,
+                patch_stats: eval_override.and_then(|value| value.patch_stats.clone()),
                 test_invocations_count: 0,
                 last_test_exit_code: None,
                 tests_run_before_submit: false,
@@ -298,6 +333,8 @@ fn build_instance_report(
                 harness_overhead_ms_total: None,
                 latency_share_pct: None,
                 warnings,
+                failing_tests: build_failing_tests(resolved, eval_override, None),
+                expected_tests: dataset_instance.map(extract_expected_tests),
                 steps: vec![],
             });
         }
@@ -328,6 +365,10 @@ fn build_instance_report(
     );
 
     let token_usage = traj.info.token_usage.as_ref();
+    let eval_override = evaluation_overrides.and_then(|m| m.get(instance_id));
+    let resolved = eval_override.map(|value| value.resolved);
+    let failing_tests = build_failing_tests(resolved, eval_override, traj.info.failure_category);
+    let expected_tests = dataset_instance.map(extract_expected_tests);
     Ok(InspectReport {
         sweep_dir: sweep.to_path_buf(),
         instance_id: Some(instance_id.to_owned()),
@@ -344,12 +385,8 @@ fn build_instance_report(
         cache_read_tokens: token_usage.map(|t| t.cache_read_tokens),
         cache_creation_tokens: token_usage.map(|t| t.cache_creation_tokens),
         completion_tokens: token_usage.map(|t| t.completion_tokens),
-        resolved: evaluation_overrides
-            .and_then(|m| m.get(instance_id))
-            .map(|value| value.resolved),
-        patch_stats: evaluation_overrides
-            .and_then(|m| m.get(instance_id))
-            .and_then(|value| value.patch_stats.clone()),
+        resolved,
+        patch_stats: eval_override.and_then(|value| value.patch_stats.clone()),
         test_invocations_count: traj.info.test_invocations.len(),
         last_test_exit_code: traj
             .info
@@ -366,6 +403,8 @@ fn build_instance_report(
         harness_overhead_ms_total,
         latency_share_pct,
         warnings,
+        failing_tests,
+        expected_tests,
         steps,
     })
 }
@@ -652,6 +691,26 @@ fn render_instance_text(report: &InspectReport) -> String {
     if let Some(r) = report.resolved {
         let _ = writeln!(s, "resolved:         {r}");
     }
+    if let Some(ft) = &report.failing_tests {
+        if ft.source == "evaluator" {
+            let _ = writeln!(s, "Failing tests ({}):", ft.tests.len());
+            for name in &ft.tests {
+                let _ = writeln!(s, "  {name}");
+            }
+        } else {
+            let _ = writeln!(s, "Failing tests: <{}>", ft.reason);
+        }
+    }
+    if let Some(et) = &report.expected_tests {
+        let _ = writeln!(s, "PASS_TO_PASS ({}):", et.pass_to_pass.len());
+        for name in &et.pass_to_pass {
+            let _ = writeln!(s, "  {name}");
+        }
+        let _ = writeln!(s, "FAIL_TO_PASS ({}):", et.fail_to_pass.len());
+        for name in &et.fail_to_pass {
+            let _ = writeln!(s, "  {name}");
+        }
+    }
     write_patch_stats_lines(&mut s, report.patch_stats.as_ref());
     let submitted_without_tests = report.outcome.as_deref()
         == Some(crate::trajectory::outcome::SUBMITTED)
@@ -930,6 +989,8 @@ pub(crate) fn resolve_trajectory_path(sweep: &Path, instance_id: &str) -> Option
 struct EvaluationOverride {
     resolved: bool,
     patch_stats: Option<PatchStats>,
+    tests_failed: Vec<String>,
+    eval_exit_reason: Option<EvalExitReason>,
 }
 
 fn load_evaluation_overrides(
@@ -957,11 +1018,96 @@ fn load_evaluation_overrides(
                     EvaluationOverride {
                         resolved: x.resolved,
                         patch_stats: x.patch_stats,
+                        tests_failed: x.tests_failed,
+                        eval_exit_reason: Some(x.eval_exit_reason),
                     },
                 )
             })
             .collect(),
     ))
+}
+
+fn build_failing_tests(
+    resolved: Option<bool>,
+    eval_override: Option<&EvaluationOverride>,
+    failure_category: Option<FailureCategory>,
+) -> Option<FailingTests> {
+    if resolved == Some(true) {
+        return None;
+    }
+    let Some(eval) = eval_override else {
+        return None;
+    };
+    if !eval.tests_failed.is_empty() {
+        return Some(FailingTests {
+            tests: eval.tests_failed.clone(),
+            source: "evaluator".into(),
+            reason: String::new(),
+        });
+    }
+    let reason = eval
+        .eval_exit_reason
+        .as_ref()
+        .map_or_else(
+            || {
+                failure_category
+                    .map_or_else(|| "unknown".into(), |c| failure_label(c).to_owned())
+            },
+            eval_exit_reason_label,
+        );
+    Some(FailingTests {
+        tests: vec![],
+        source: "unavailable".into(),
+        reason,
+    })
+}
+
+fn eval_exit_reason_label(reason: &EvalExitReason) -> String {
+    match reason {
+        EvalExitReason::Resolved => "resolved".into(),
+        EvalExitReason::Unresolved => "unresolved".into(),
+        EvalExitReason::PatchApplyFailed => "patch_apply_failed".into(),
+        EvalExitReason::EvalError => "eval_error".into(),
+        EvalExitReason::SkippedNoPatch => "skipped_no_patch".into(),
+    }
+}
+
+fn extract_expected_tests(inst: &SweBenchInstance) -> ExpectedTests {
+    let get_string_list = |key: &str| {
+        inst.other
+            .get(key)
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(str::to_owned))
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    ExpectedTests {
+        pass_to_pass: get_string_list("PASS_TO_PASS"),
+        fail_to_pass: get_string_list("FAIL_TO_PASS"),
+    }
+}
+
+fn load_dataset_instance(sweep: &Path, instance_id: &str) -> Option<SweBenchInstance> {
+    let dataset_path = sweep.join("dataset.jsonl");
+    if !dataset_path.exists() {
+        return None;
+    }
+    let text = std::fs::read_to_string(&dataset_path).ok()?;
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Ok(inst) = serde_json::from_str::<SweBenchInstance>(line) {
+            if inst.instance_id == instance_id {
+                return Some(inst);
+            }
+        }
+    }
+    None
 }
 
 #[derive(Debug, Clone)]
@@ -1135,6 +1281,7 @@ mod tests {
             instance: Some("task-a".into()),
             filter: None,
             full: false,
+            show_expected: false,
         };
         let output = run(&args).unwrap();
         let text = render_text(&output);
@@ -1178,6 +1325,7 @@ mod tests {
             instance: Some("task-b".into()),
             filter: None,
             full: false,
+            show_expected: false,
         };
         let output = run(&args).unwrap();
         if let InspectOutput::Instance(report) = &output {
@@ -1236,6 +1384,7 @@ mod tests {
             instance: Some("task-elided".into()),
             filter: None,
             full: false,
+            show_expected: false,
         };
         let output = run(&args).unwrap();
         let text = render_text(&output);
@@ -1312,6 +1461,7 @@ mod tests {
             instance: Some("task-no-marker".into()),
             filter: None,
             full: false,
+            show_expected: false,
         };
         let output = run(&args).unwrap();
         let text = render_text(&output);

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -367,7 +367,12 @@ fn build_instance_report(
     let token_usage = traj.info.token_usage.as_ref();
     let eval_override = evaluation_overrides.and_then(|m| m.get(instance_id));
     let resolved = eval_override.map(|value| value.resolved);
-    let failing_tests = build_failing_tests(resolved, eval_override, traj.info.failure_category);
+    let failing_tests =
+        redact_failing_tests(
+            build_failing_tests(resolved, eval_override, traj.info.failure_category),
+            &inspect_redactor,
+            &mut warnings,
+        );
     let expected_tests = dataset_instance.map(extract_expected_tests);
     Ok(InspectReport {
         sweep_dir: sweep.to_path_buf(),
@@ -1062,6 +1067,26 @@ fn build_failing_tests(
     })
 }
 
+fn redact_failing_tests(
+    failing_tests: Option<FailingTests>,
+    redactor: &Redactor,
+    warnings: &mut Vec<String>,
+) -> Option<FailingTests> {
+    let mut ft = failing_tests?;
+    let mut any_redacted = false;
+    for name in &mut ft.tests {
+        let outcome = redactor.redact_text(name, surface::INSPECT);
+        if outcome.redacted {
+            any_redacted = true;
+        }
+        *name = outcome.text;
+    }
+    if any_redacted {
+        warnings.push("bench inspect redacted secret-shaped content at view time".into());
+    }
+    Some(ft)
+}
+
 fn eval_exit_reason_label(reason: &EvalExitReason) -> String {
     match reason {
         EvalExitReason::Resolved => "resolved".into(),
@@ -1469,5 +1494,35 @@ mod tests {
             text.contains("[elision marker unavailable]"),
             "should show fallback when marker is absent:\n{text}"
         );
+    }
+
+    #[test]
+    fn build_failing_tests_falls_back_to_failure_category_when_eval_exit_reason_absent() {
+        let eval_override = EvaluationOverride {
+            resolved: false,
+            patch_stats: None,
+            tests_failed: vec![],
+            eval_exit_reason: None,
+        };
+        let ft = build_failing_tests(
+            Some(false),
+            Some(&eval_override),
+            Some(FailureCategory::WallclockTimeout),
+        );
+        let ft = ft.unwrap();
+        assert_eq!(ft.source, "unavailable");
+        assert_eq!(ft.reason, "wallclock_timeout");
+    }
+
+    #[test]
+    fn build_failing_tests_returns_none_for_resolved() {
+        let eval_override = EvaluationOverride {
+            resolved: true,
+            patch_stats: None,
+            tests_failed: vec!["tests/test.py::test_foo".into()],
+            eval_exit_reason: Some(crate::run::evaluate::EvalExitReason::Resolved),
+        };
+        let ft = build_failing_tests(Some(true), Some(&eval_override), None);
+        assert!(ft.is_none(), "resolved instances must return None");
     }
 }

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -1097,17 +1097,25 @@ fn eval_exit_reason_label(reason: &EvalExitReason) -> String {
 }
 
 fn extract_expected_tests(inst: &SweBenchInstance, redactor: &Redactor) -> ExpectedTests {
-    let get_string_list = |key: &str| {
-        inst.other
-            .get(key)
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str())
-                    .map(|s| redactor.redact_text(s, surface::INSPECT).text)
-                    .collect()
-            })
-            .unwrap_or_default()
+    let get_string_list = |key: &str| -> Vec<String> {
+        let Some(val) = inst.other.get(key) else {
+            return vec![];
+        };
+        // SWE-bench Hugging Face exports store these as a JSON-encoded string
+        // (e.g. "[\"test_a\", \"test_b\"]"). Accept both that form and a native
+        // JSON array so synthetic fixtures and real datasets both work.
+        let items: Vec<serde_json::Value> = if let Some(arr) = val.as_array() {
+            arr.clone()
+        } else if let Some(s) = val.as_str() {
+            serde_json::from_str(s).unwrap_or_default()
+        } else {
+            vec![]
+        };
+        items
+            .iter()
+            .filter_map(|v| v.as_str())
+            .map(|s| redactor.redact_text(s, surface::INSPECT).text)
+            .collect()
     };
     ExpectedTests {
         pass_to_pass: get_string_list("PASS_TO_PASS"),

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -303,6 +303,12 @@ fn build_instance_report(
                 .and_then(|m| m.get(instance_id))
                 .map(|value| value.resolved);
             let eval_override = evaluation_overrides.and_then(|m| m.get(instance_id));
+            let minimal_redactor = Redactor::default_enabled();
+            let failing_tests = redact_failing_tests(
+                build_failing_tests(resolved, eval_override, None),
+                &minimal_redactor,
+                &mut warnings,
+            );
             return Ok(InspectReport {
                 sweep_dir: sweep.to_path_buf(),
                 instance_id: Some(instance_id.to_owned()),
@@ -333,8 +339,9 @@ fn build_instance_report(
                 harness_overhead_ms_total: None,
                 latency_share_pct: None,
                 warnings,
-                failing_tests: build_failing_tests(resolved, eval_override, None),
-                expected_tests: dataset_instance.map(extract_expected_tests),
+                failing_tests,
+                expected_tests: dataset_instance
+                    .map(|inst| extract_expected_tests(inst, &minimal_redactor)),
                 steps: vec![],
             });
         }
@@ -367,13 +374,13 @@ fn build_instance_report(
     let token_usage = traj.info.token_usage.as_ref();
     let eval_override = evaluation_overrides.and_then(|m| m.get(instance_id));
     let resolved = eval_override.map(|value| value.resolved);
-    let failing_tests =
-        redact_failing_tests(
-            build_failing_tests(resolved, eval_override, traj.info.failure_category),
-            &inspect_redactor,
-            &mut warnings,
-        );
-    let expected_tests = dataset_instance.map(extract_expected_tests);
+    let failing_tests = redact_failing_tests(
+        build_failing_tests(resolved, eval_override, traj.info.failure_category),
+        &inspect_redactor,
+        &mut warnings,
+    );
+    let expected_tests =
+        dataset_instance.map(|inst| extract_expected_tests(inst, &inspect_redactor));
     Ok(InspectReport {
         sweep_dir: sweep.to_path_buf(),
         instance_id: Some(instance_id.to_owned()),
@@ -1040,9 +1047,7 @@ fn build_failing_tests(
     if resolved == Some(true) {
         return None;
     }
-    let Some(eval) = eval_override else {
-        return None;
-    };
+    let eval = eval_override?;
     if !eval.tests_failed.is_empty() {
         return Some(FailingTests {
             tests: eval.tests_failed.clone(),
@@ -1050,16 +1055,10 @@ fn build_failing_tests(
             reason: String::new(),
         });
     }
-    let reason = eval
-        .eval_exit_reason
-        .as_ref()
-        .map_or_else(
-            || {
-                failure_category
-                    .map_or_else(|| "unknown".into(), |c| failure_label(c).to_owned())
-            },
-            eval_exit_reason_label,
-        );
+    let reason = eval.eval_exit_reason.as_ref().map_or_else(
+        || failure_category.map_or_else(|| "unknown".into(), |c| failure_label(c).to_owned()),
+        eval_exit_reason_label,
+    );
     Some(FailingTests {
         tests: vec![],
         source: "unavailable".into(),
@@ -1097,14 +1096,15 @@ fn eval_exit_reason_label(reason: &EvalExitReason) -> String {
     }
 }
 
-fn extract_expected_tests(inst: &SweBenchInstance) -> ExpectedTests {
+fn extract_expected_tests(inst: &SweBenchInstance, redactor: &Redactor) -> ExpectedTests {
     let get_string_list = |key: &str| {
         inst.other
             .get(key)
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()
-                    .filter_map(|v| v.as_str().map(str::to_owned))
+                    .filter_map(|v| v.as_str())
+                    .map(|s| redactor.redact_text(s, surface::INSPECT).text)
                     .collect()
             })
             .unwrap_or_default()

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -1641,3 +1641,87 @@ fn failing_tests_json_shape_round_trips() {
     assert_eq!(back2["source"], "unavailable");
     assert_eq!(back2["reason"], "eval_error");
 }
+
+#[test]
+fn unresolved_with_patch_apply_failed_shows_reason() {
+    // eval_exit_reason other than eval_error is also surfaced as the reason.
+    let sweep = tempfile::tempdir().unwrap();
+    write_traj(sweep.path(), "my-instance", false);
+    std::fs::write(
+        sweep.path().join("evaluation.json"),
+        serde_json::json!({
+            "instances": [{
+                "instance_id": "my-instance",
+                "resolved": false,
+                "tests_passed": [],
+                "tests_failed": [],
+                "eval_exit_reason": "patch_apply_failed"
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "my-instance",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Failing tests: <patch_apply_failed>"),
+        "expected patch_apply_failed reason:\n{stdout}"
+    );
+}
+
+#[test]
+fn failing_test_names_are_redacted_at_view_time() {
+    // A secret-shaped string embedded in a test name should be redacted.
+    // The token uses a bracket delimiter so the regex \b word-boundary fires.
+    let secret = "ghp_0123456789ABCDEF0123456789ABCDEF0123";
+    let sweep = tempfile::tempdir().unwrap();
+    write_traj(sweep.path(), "my-instance", false);
+    std::fs::write(
+        sweep.path().join("evaluation.json"),
+        serde_json::json!({
+            "instances": [{
+                "instance_id": "my-instance",
+                "resolved": false,
+                "tests_passed": [],
+                "tests_failed": [format!("tests/test_core.py::test_secret[{secret}]")],
+                "eval_exit_reason": "unresolved"
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "my-instance",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains(secret),
+        "secret should be redacted from failing test name:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Failing tests"),
+        "Failing tests section should still appear:\n{stdout}"
+    );
+}

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -1413,10 +1413,10 @@ fn unresolved_with_evaluator_failures_shows_failing_tests() {
     // order must be preserved
     let render_pos = stdout
         .find("test_widget_render")
-        .expect("test_widget_render not found");
+        .unwrap_or_else(|| panic!("test_widget_render not found in:\n{stdout}"));
     let init_pos = stdout
         .find("test_widget_init")
-        .expect("test_widget_init not found");
+        .unwrap_or_else(|| panic!("test_widget_init not found in:\n{stdout}"));
     assert!(
         render_pos < init_pos,
         "test names should appear in evaluator-reported order"
@@ -1503,7 +1503,7 @@ fn json_format_includes_failing_tests_field() {
         .unwrap_or_else(|e| panic!("JSON parse failed: {e}\n{stdout}"));
     let ft = value
         .pointer("/failing_tests")
-        .expect("failing_tests missing from JSON output");
+        .unwrap_or_else(|| panic!("failing_tests missing from JSON output:\n{stdout}"));
     assert_eq!(
         ft["tests"],
         serde_json::json!(["tests/test_core.py::test_main"]),

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -1555,6 +1555,65 @@ fn json_format_resolved_instance_has_no_failing_tests_field() {
 }
 
 #[test]
+fn show_expected_parses_json_encoded_string_form() {
+    // SWE-bench Hugging Face exports store PASS_TO_PASS / FAIL_TO_PASS as
+    // a JSON-encoded string (e.g. "[\"test_a\"]") not a native JSON array.
+    // Verify --show-expected handles that form correctly.
+    let sweep = tempfile::tempdir().unwrap();
+    write_traj(sweep.path(), "my-instance", false);
+    std::fs::write(
+        sweep.path().join("evaluation.json"),
+        serde_json::json!({
+            "instances": [{
+                "instance_id": "my-instance",
+                "resolved": false,
+                "tests_passed": [],
+                "tests_failed": [],
+                "eval_exit_reason": "unresolved"
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    // Store PASS_TO_PASS / FAIL_TO_PASS as JSON-encoded strings (HF export format)
+    std::fs::write(
+        sweep.path().join("dataset.jsonl"),
+        serde_json::json!({
+            "instance_id": "my-instance",
+            "repo": "test/repo",
+            "PASS_TO_PASS": "[\"tests/test_core.py::test_existing\"]",
+            "FAIL_TO_PASS": "[\"tests/test_core.py::test_target\"]"
+        })
+        .to_string()
+            + "\n",
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "my-instance",
+            "--show-expected",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("tests/test_core.py::test_existing"),
+        "expected PASS_TO_PASS test from JSON-encoded string:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("tests/test_core.py::test_target"),
+        "expected FAIL_TO_PASS test from JSON-encoded string:\n{stdout}"
+    );
+}
+
+#[test]
 fn show_expected_renders_pass_to_pass_and_fail_to_pass() {
     let sweep = tempfile::tempdir().unwrap();
     write_traj(sweep.path(), "my-instance", false);

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -309,6 +309,7 @@ fn help_lists_inspect_subcommand_and_flags() {
         "--full",
         "--diff",
         "--show-noise",
+        "--show-expected",
     ] {
         assert!(stdout.contains(flag), "missing {flag} in:\n{stdout}");
     }
@@ -1320,4 +1321,323 @@ fn filter_mode_lists_matching_instances() {
     assert!(stdout.contains("│ instance_id ┆ outcome"), "{stdout}");
     assert!(stdout.contains("│ a           ┆ error"), "{stdout}");
     assert!(!stdout.contains("│ b           ┆ error"), "{stdout}");
+}
+
+// ── issue-175: failing-test names in bench inspect ────────────────────────────
+
+#[test]
+fn resolved_instance_has_no_failing_tests_section() {
+    let sweep = tempfile::tempdir().unwrap();
+    write_traj(sweep.path(), "my-instance", false);
+    std::fs::write(
+        sweep.path().join("evaluation.json"),
+        serde_json::json!({
+            "instances": [{
+                "instance_id": "my-instance",
+                "resolved": true,
+                "tests_passed": ["tests/test_widgets.py::test_render"],
+                "tests_failed": [],
+                "eval_exit_reason": "resolved"
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "my-instance",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("Failing tests"),
+        "resolved instance should not show Failing tests section:\n{stdout}"
+    );
+}
+
+#[test]
+fn unresolved_with_evaluator_failures_shows_failing_tests() {
+    let sweep = tempfile::tempdir().unwrap();
+    write_traj(sweep.path(), "my-instance", false);
+    std::fs::write(
+        sweep.path().join("evaluation.json"),
+        serde_json::json!({
+            "instances": [{
+                "instance_id": "my-instance",
+                "resolved": false,
+                "tests_passed": [],
+                "tests_failed": [
+                    "tests/test_widgets.py::test_widget_render",
+                    "tests/test_widgets.py::test_widget_init"
+                ],
+                "eval_exit_reason": "unresolved"
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "my-instance",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Failing tests (2):"),
+        "expected count header:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("tests/test_widgets.py::test_widget_render"),
+        "expected first test name:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("tests/test_widgets.py::test_widget_init"),
+        "expected second test name:\n{stdout}"
+    );
+    // order must be preserved
+    let render_pos = stdout
+        .find("test_widget_render")
+        .expect("test_widget_render not found");
+    let init_pos = stdout
+        .find("test_widget_init")
+        .expect("test_widget_init not found");
+    assert!(
+        render_pos < init_pos,
+        "test names should appear in evaluator-reported order"
+    );
+}
+
+#[test]
+fn unresolved_without_test_names_shows_reason_from_eval_exit_reason() {
+    let sweep = tempfile::tempdir().unwrap();
+    write_traj(sweep.path(), "my-instance", false);
+    std::fs::write(
+        sweep.path().join("evaluation.json"),
+        serde_json::json!({
+            "instances": [{
+                "instance_id": "my-instance",
+                "resolved": false,
+                "tests_passed": [],
+                "tests_failed": [],
+                "eval_exit_reason": "eval_error"
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "my-instance",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Failing tests: <"),
+        "expected unavailable reason format:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("eval_error"),
+        "expected eval_error reason in output:\n{stdout}"
+    );
+}
+
+#[test]
+fn json_format_includes_failing_tests_field() {
+    let sweep = tempfile::tempdir().unwrap();
+    write_traj(sweep.path(), "my-instance", false);
+    std::fs::write(
+        sweep.path().join("evaluation.json"),
+        serde_json::json!({
+            "instances": [{
+                "instance_id": "my-instance",
+                "resolved": false,
+                "tests_passed": [],
+                "tests_failed": ["tests/test_core.py::test_main"],
+                "eval_exit_reason": "unresolved"
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "my-instance",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let value: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("JSON parse failed: {e}\n{stdout}"));
+    let ft = value
+        .pointer("/failing_tests")
+        .expect("failing_tests missing from JSON output");
+    assert_eq!(
+        ft["tests"],
+        serde_json::json!(["tests/test_core.py::test_main"]),
+        "failing_tests.tests mismatch"
+    );
+    assert_eq!(ft["source"], "evaluator", "failing_tests.source mismatch");
+}
+
+#[test]
+fn json_format_resolved_instance_has_no_failing_tests_field() {
+    let sweep = tempfile::tempdir().unwrap();
+    write_traj(sweep.path(), "my-instance", false);
+    std::fs::write(
+        sweep.path().join("evaluation.json"),
+        serde_json::json!({
+            "instances": [{
+                "instance_id": "my-instance",
+                "resolved": true,
+                "tests_passed": ["tests/test_core.py::test_main"],
+                "tests_failed": [],
+                "eval_exit_reason": "resolved"
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "my-instance",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let value: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("JSON parse failed: {e}\n{stdout}"));
+    assert!(
+        value.pointer("/failing_tests").is_none(),
+        "resolved instance should not have failing_tests in JSON:\n{stdout}"
+    );
+}
+
+#[test]
+fn show_expected_renders_pass_to_pass_and_fail_to_pass() {
+    let sweep = tempfile::tempdir().unwrap();
+    write_traj(sweep.path(), "my-instance", false);
+    std::fs::write(
+        sweep.path().join("evaluation.json"),
+        serde_json::json!({
+            "instances": [{
+                "instance_id": "my-instance",
+                "resolved": false,
+                "tests_passed": [],
+                "tests_failed": ["tests/test_core.py::test_fail"],
+                "eval_exit_reason": "unresolved"
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    // Write a minimal dataset.jsonl with PASS_TO_PASS / FAIL_TO_PASS
+    std::fs::write(
+        sweep.path().join("dataset.jsonl"),
+        serde_json::json!({
+            "instance_id": "my-instance",
+            "repo": "test/repo",
+            "PASS_TO_PASS": ["tests/test_core.py::test_existing"],
+            "FAIL_TO_PASS": ["tests/test_core.py::test_fail"]
+        })
+        .to_string()
+            + "\n",
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "my-instance",
+            "--show-expected",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("PASS_TO_PASS"),
+        "expected PASS_TO_PASS section:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("FAIL_TO_PASS"),
+        "expected FAIL_TO_PASS section:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("tests/test_core.py::test_existing"),
+        "expected PASS_TO_PASS test:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("tests/test_core.py::test_fail"),
+        "expected FAIL_TO_PASS test:\n{stdout}"
+    );
+}
+
+#[test]
+fn failing_tests_json_shape_round_trips() {
+    // Verify the JSON schema documented in the spec: { tests, source, reason }
+    let ft = rust_swe_agent::run::inspect::FailingTests {
+        tests: vec!["tests/test_core.py::test_foo".into()],
+        source: "evaluator".into(),
+        reason: String::new(),
+    };
+    let json = serde_json::to_string(&ft).unwrap();
+    let back: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(back["tests"][0], "tests/test_core.py::test_foo");
+    assert_eq!(back["source"], "evaluator");
+
+    let ft_unavail = rust_swe_agent::run::inspect::FailingTests {
+        tests: vec![],
+        source: "unavailable".into(),
+        reason: "eval_error".into(),
+    };
+    let json2 = serde_json::to_string(&ft_unavail).unwrap();
+    let back2: serde_json::Value = serde_json::from_str(&json2).unwrap();
+    assert_eq!(back2["source"], "unavailable");
+    assert_eq!(back2["reason"], "eval_error");
 }

--- a/tests/evaluator_provenance.rs
+++ b/tests/evaluator_provenance.rs
@@ -726,6 +726,7 @@ fn inspect_summary_loads_provenance_from_evaluation_json() {
         instance: None,
         filter: Some("resolved=true".into()),
         full: false,
+        show_expected: false,
     };
 
     let output = rust_swe_agent::run::inspect::run(&args).unwrap();

--- a/tests/per_turn_latency.rs
+++ b/tests/per_turn_latency.rs
@@ -428,6 +428,7 @@ fn inspect_report_aggregates_stage_totals() {
         instance: Some("aa".into()),
         filter: None,
         full: true,
+        show_expected: false,
     };
     let out = rust_swe_agent::run::inspect::run(&args).unwrap();
     let report: &InspectReport = match &out {
@@ -468,6 +469,7 @@ fn legacy_trajectory_inspect_renders_latency_unknown() {
         instance: Some("legacy".into()),
         filter: None,
         full: true,
+        show_expected: false,
     };
     let out = rust_swe_agent::run::inspect::run(&args).unwrap();
     let text = render_text(&out);

--- a/tests/secret_redaction.rs
+++ b/tests/secret_redaction.rs
@@ -529,6 +529,7 @@ fn bench_inspect_redacts_legacy_raw_trajectory_and_warns() {
         instance: Some("legacy-raw".into()),
         filter: None,
         full: true,
+        show_expected: false,
     })
     .unwrap();
     let text = rust_swe_agent::run::inspect::render_text(&output);


### PR DESCRIPTION
## Summary

This PR adds support for displaying failing test names from the evaluator and expected test groupings (PASS_TO_PASS/FAIL_TO_PASS) in the `bench inspect` command output. It includes a new `--show-expected` flag and extends the JSON output schema to include failing test information.

## Key Changes

- **New `--show-expected` flag**: When set, loads and displays PASS_TO_PASS and FAIL_TO_PASS test groupings from the sweep's `dataset.jsonl` file
- **Failing tests section**: Added to text output for unresolved instances, showing either:
  - Individual test names reported by the evaluator (when available)
  - A reason code (eval_error, patch_apply_failed, etc.) when test names are unavailable
- **JSON schema extension**: Added `failing_tests` field to JSON output with structure `{ tests, source, reason }` where:
  - `source` is either "evaluator" or "unavailable"
  - `reason` contains human-readable explanation when source is "unavailable"
  - `tests` contains the list of failing test names in evaluator-reported order
- **Secret redaction**: Failing test names are redacted at view time to prevent accidental exposure of secrets embedded in test names
- **Graceful degradation**: Resolved instances silently omit the failing_tests section; missing dataset.jsonl is silently skipped

## Implementation Details

- Added `FailingTests` and `ExpectedTests` structs to represent the new data
- Extended `EvaluationOverride` to track `tests_failed` and `eval_exit_reason` from evaluation.json
- Implemented `build_failing_tests()` to construct the failing tests object with fallback logic (eval_exit_reason → failure_category → "unknown")
- Added `load_dataset_instance()` to parse dataset.jsonl and extract instance-specific test groupings
- Text rendering shows test counts and lists; JSON includes full structured data
- Updated all test cases to include the new `show_expected` parameter

https://claude.ai/code/session_01WF7iuJw1YGwYWkaYCaJQCy