### PR TITLE
⚡ Bolt: Pre-allocate trajectory paths vector in bundle.rs

### DIFF
--- a/src/run/bundle.rs
+++ b/src/run/bundle.rs
@@ -1131,7 +1131,8 @@ fn find_trajectory_paths_for_bundle(
     }
     let runs = effective_runs_value(row);
     if runs > 1 {
-        let mut out = Vec::new();
+        // Pre-allocate the vector with exactly the required capacity to avoid reallocation
+        let mut out = Vec::with_capacity(runs as usize);
         for run_index in 1..=runs {
             let path = required_rerun_trajectory_path(sweep_dir, instance_id, run_index)?;
             out.push((path, format!("{instance_id}/run-{run_index}.traj.json")));


### PR DESCRIPTION
💡 What: Switched `Vec::new()` to `Vec::with_capacity(runs as usize)` in `find_trajectory_paths_for_bundle` inside `src/run/bundle.rs`.

🎯 Why: In the `runs > 1` loop, we know exactly how many elements will be pushed to the vector (exactly `runs` elements, from `1..=runs`). Pre-allocating the vector avoids unnecessary heap reallocations when collecting paths.

📊 Impact: Eliminates hidden heap reallocations during `Bundle` trajectory collection, avoiding dynamic memory growth on the hot path for tasks with multiple retry runs.

🔬 Measurement: Run `cargo bench` and the test suite (`cargo test`) to verify correctness and no regressions.

---
*PR created automatically by Jules for task [16491499359082512604](https://jules.google.com/task/16491499359082512604) started by @madmax983*