### PR TITLE
🔒 Warden: [security fix]

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -327,20 +327,28 @@ where
     (handle, buffer)
 }
 
+const MAX_PIPE_BUFFER_SIZE: usize = 16 * 1024 * 1024;
+
 async fn read_pipe_to_buffer<R>(mut pipe: R, buffer: Arc<Mutex<Vec<u8>>>) -> Result<(), EnvError>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut chunk = [0u8; 8192];
+    let mut remaining = MAX_PIPE_BUFFER_SIZE;
     loop {
+        if remaining == 0 {
+            return Ok(());
+        }
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {
             return Ok(());
         }
+        let take = std::cmp::min(n, remaining);
         buffer
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .extend_from_slice(&chunk[..n]);
+            .extend_from_slice(&chunk[..take]);
+        remaining = remaining.saturating_sub(take);
     }
 }
 

--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -232,20 +232,28 @@ where
     (handle, buffer)
 }
 
+const MAX_PIPE_BUFFER_SIZE: usize = 16 * 1024 * 1024;
+
 async fn read_pipe_to_buffer<R>(mut pipe: R, buffer: Arc<Mutex<Vec<u8>>>) -> Result<(), EnvError>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut chunk = [0u8; 8192];
+    let mut remaining = MAX_PIPE_BUFFER_SIZE;
     loop {
+        if remaining == 0 {
+            return Ok(());
+        }
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {
             return Ok(());
         }
+        let take = std::cmp::min(n, remaining);
         buffer
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .extend_from_slice(&chunk[..n]);
+            .extend_from_slice(&chunk[..take]);
+        remaining = remaining.saturating_sub(take);
     }
 }
 
@@ -522,6 +530,23 @@ mod tests {
         req.env.insert("RSA_TEST_VAR".into(), "from_test".into());
         let r = env.run(req).await.unwrap();
         assert_eq!(r.stdout.trim(), "from_test");
+    }
+
+    #[tokio::test]
+    async fn read_pipe_to_buffer_caps_memory() {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let mut pipe = tokio::io::repeat(b'A');
+        let task_buffer = Arc::clone(&buffer);
+        let _ = tokio::time::timeout(
+            Duration::from_millis(100),
+            read_pipe_to_buffer(&mut pipe, task_buffer),
+        )
+        .await;
+        let len = buffer
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len();
+        assert_eq!(len, MAX_PIPE_BUFFER_SIZE);
     }
 
     #[tokio::test]


### PR DESCRIPTION
🦠 Threat: Memory exhaustion (DoS) vulnerability due to unbounded reading of child process pipes in both `src/env/local.rs` and `src/env/docker.rs` via `read_pipe_to_buffer` function.
🛡️ Defense: Implemented capped readers for process pipes, applying a `MAX_PIPE_BUFFER_SIZE` of 16MB and tracking remaining allowed bytes with `saturating_sub`.
💥 Severity: High - Malicious or runaway tools could output infinite data to stdout/stderr causing OOM panics in the executor.
🧪 Verification: Added `read_pipe_to_buffer_caps_memory` test mimicking infinite stream via `tokio::io::repeat` to verify buffer is properly capped at 16MB without exhausting memory.

---
*PR created automatically by Jules for task [17665385604389548350](https://jules.google.com/task/17665385604389548350) started by @madmax983*