### PR TITLE
Add paired McNemar significance testing to bench compare

### DIFF
--- a/docs/spec-significance.md
+++ b/docs/spec-significance.md
@@ -1,0 +1,145 @@
+# `bench compare` — Significance Testing
+
+`bench compare` computes a paired statistical significance test on the
+resolved-rate delta whenever two sweeps share at least one `instance_id`.
+The result is emitted in the JSON report as `resolved_rate_significance` and
+rendered as a single `Significance:` line in text output.
+
+## Why paired testing?
+
+`bench compare` already joins sweeps on `instance_id`. Pairing exploits the
+correlation between sweeps run on the same instances and provides far more
+power to detect real deltas than unpaired (two-proportion z-test) comparisons.
+A swing from 18% → 22% resolved on N≈50 is indistinguishable from noise with
+unpaired tests; paired McNemar makes that explicit.
+
+## Test: exact McNemar
+
+The chosen test is the **two-sided exact McNemar test** on the paired overlap
+subset.
+
+Define:
+- **n₀₁** (`pass_to_fail`): instances that passed in the baseline but failed in the candidate.
+- **n₁₀** (`fail_to_pass`): instances that failed in the baseline but passed in the candidate.
+- **n** = n₀₁ + n₁₀ (total discordant pairs).
+
+Under H₀ (no difference), each discordant pair is equally likely to go either
+direction, so the smaller count follows Binomial(n, 0.5). The two-sided
+p-value is:
+
+```
+p = 2 × Σ_{k=0}^{min(n₀₁,n₁₀)} C(n,k) × 0.5ⁿ, capped at 1.0
+```
+
+Computation is performed in log-space to avoid floating-point overflow for
+large n. The test is always exact (no chi-square approximation); it is valid
+for any n > 0.
+
+**Default alpha**: there is no default alpha. Operators must opt in to gating
+via `--min-significance` or `--regression-significance`.
+
+## 95% Confidence Interval
+
+The `ci95_lower_pp` / `ci95_upper_pp` fields (and the text `[95% CI: …]` line)
+are computed using the Wilson-score delta method on the **paired** overlap
+subset, not on the full sweep populations. This is the same Wilson CI method
+used by the existing `resolved_delta_ci95` field (which uses the full
+populations).
+
+## Underpowered threshold
+
+When the paired test has fewer than **10 discordant pairs** (or `paired_n = 0`)
+the `underpowered` flag is set to `true` with a `underpowered_reason`.
+
+This threshold reflects the minimum number of discordant pairs needed for the
+exact McNemar test to have any practical power to distinguish signal from noise
+at conventional alpha levels. Below this threshold the p-value is still
+computed (and shown), but operators should interpret it with extreme caution.
+
+Text output appends `(underpowered)` to the significance line. JSON consumers
+should check `underpowered` before acting on `p_value`.
+
+## Instances excluded from the test
+
+Instances present in only one sweep are **excluded** from the paired test.
+They are counted in `only_in_baseline` and `only_in_candidate` in the JSON
+block. The paired counts (`paired_n`, `pass_to_fail`, `fail_to_pass`) cover
+only the overlap.
+
+## CLI flags
+
+### `--min-significance <alpha>`
+
+Exit non-zero when the resolved-rate delta is **positive** but `p_value >
+alpha`. This gate blocks suspected-noise wins from passing CI.
+
+- The gate only fires when `resolved_delta_rate > 0`.
+- If the test is underpowered and `--allow-underpowered` is not set, the gate
+  exits non-zero regardless of p-value.
+- Example: `--min-significance 0.05`
+
+### `--regression-significance <alpha>`
+
+Exit non-zero when the resolved-rate delta is **negative** and `p_value <=
+alpha` (significant regression). Insignificant regressions are not blocked by
+this flag, preserving the existing `--max-regressions` behavior independently.
+
+- The gate only fires when `resolved_delta_rate < 0`.
+- If the test is underpowered and `--allow-underpowered` is not set, the gate
+  exits non-zero regardless of p-value.
+- Example: `--regression-significance 0.05`
+
+### `--allow-underpowered`
+
+When set, significance-based gating proceeds using only the p-value (ignoring
+the `underpowered` flag). Without this flag, any underpowered result causes
+gating to exit non-zero when a significance gate is active.
+
+Use this flag when you understand the low-power context and still want to gate
+on the computed p-value (e.g., 7 discordant pairs, p=0.016 < 0.05).
+
+## Operator decision recipes
+
+| Scenario | Recommendation |
+|---|---|
+| `underpowered=true` | Run more instances before gating on significance. |
+| `p > 0.05`, positive delta | Likely noise; do not ship. Use `--min-significance 0.05`. |
+| `p < 0.05`, positive delta | Evidence of real improvement. Safe to promote. |
+| `p < 0.05`, negative delta | Significant regression; block with `--regression-significance 0.05`. |
+| `p > 0.05`, negative delta | Insignificant regression; use `--max-regressions` for a raw count gate instead. |
+
+## JSON schema
+
+```json
+{
+  "resolved_rate_significance": {
+    "test_name": "mcnemar_exact",
+    "p_value": 0.00195,
+    "ci95_lower_pp": 12.34,
+    "ci95_upper_pp": 45.67,
+    "paired_n": 100,
+    "pass_to_fail": 2,
+    "fail_to_pass": 12,
+    "underpowered": false,
+    "underpowered_reason": null,
+    "only_in_baseline": 0,
+    "only_in_candidate": 0
+  }
+}
+```
+
+Fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `test_name` | string | Always `"mcnemar_exact"`. |
+| `p_value` | number or null | Two-sided exact McNemar p-value. `null` when `paired_n == 0`. |
+| `ci95_lower_pp` | number | Lower bound of 95% Wilson-score CI on rate delta (percentage points). |
+| `ci95_upper_pp` | number | Upper bound of 95% Wilson-score CI on rate delta (percentage points). |
+| `paired_n` | integer | Instances present in both sweeps (overlap). |
+| `pass_to_fail` | integer | Discordant pairs: baseline pass, candidate fail. |
+| `fail_to_pass` | integer | Discordant pairs: baseline fail, candidate pass. |
+| `underpowered` | boolean | True when `discordant < 10` or `paired_n == 0`. |
+| `underpowered_reason` | string or null | Human-readable reason; null when powered. |
+| `only_in_baseline` | integer | Instances present only in the baseline sweep. |
+| `only_in_candidate` | integer | Instances present only in the candidate sweep. |

--- a/docs/spec-significance.md
+++ b/docs/spec-significance.md
@@ -41,10 +41,21 @@ via `--min-significance` or `--regression-significance`.
 ## 95% Confidence Interval
 
 The `ci95_lower_pp` / `ci95_upper_pp` fields (and the text `[95% CI: …]` line)
-are computed using the Wilson-score delta method on the **paired** overlap
-subset, not on the full sweep populations. This is the same Wilson CI method
-used by the existing `resolved_delta_ci95` field (which uses the full
-populations).
+are computed using the Wilson-score delta method (Newcombe's method) on the
+**paired** overlap subset, not on the full sweep populations. This is a
+conservative choice: because Newcombe treats the two proportions as independent
+it overestimates variance for paired data, so intervals are wider than necessary
+(safe, not dangerous). A more efficient alternative such as Tango's score
+interval is a candidate for a future improvement; the McNemar p-value, which
+correctly accounts for pairing, is the primary decision metric.
+
+**Paired delta**: the `paired_delta_rate` field and the `Δ` shown in text output
+use the rate difference within the overlap subset only — `(fail_to_pass −
+pass_to_fail) / paired_n`. The gating logic also uses this paired delta
+direction, ensuring the sign of the delta used for gating is consistent with the
+p-value (both derived from the same paired data). When sweeps have
+non-overlapping instances, this may differ from the population-level
+`resolved_delta_rate`.
 
 ## Underpowered threshold
 
@@ -120,6 +131,7 @@ on the computed p-value (e.g., 7 discordant pairs, p=0.016 < 0.05).
     "paired_n": 100,
     "pass_to_fail": 2,
     "fail_to_pass": 12,
+    "paired_delta_rate": 0.10,
     "underpowered": false,
     "underpowered_reason": null,
     "only_in_baseline": 0,
@@ -139,6 +151,7 @@ Fields:
 | `paired_n` | integer | Instances present in both sweeps (overlap). |
 | `pass_to_fail` | integer | Discordant pairs: baseline pass, candidate fail. |
 | `fail_to_pass` | integer | Discordant pairs: baseline fail, candidate pass. |
+| `paired_delta_rate` | number | Rate delta within the overlap: `(fail_to_pass − pass_to_fail) / paired_n`. Use this for interpreting the CI and p-value; it may differ from the population `resolved_delta_rate` when sweeps have non-overlapping instances. |
 | `underpowered` | boolean | True when `discordant < 10` or `paired_n == 0`. |
 | `underpowered_reason` | string or null | Human-readable reason; null when powered. |
 | `only_in_baseline` | integer | Instances present only in the baseline sweep. |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -683,6 +683,25 @@ pub struct CompareCmd {
     /// inspect-diff output.
     #[arg(long, default_value_t = false)]
     pub show_noise: bool,
+
+    /// Exit non-zero when the resolved-rate delta is positive but p > alpha
+    /// (suspected-noise wins fail CI gates). Unset disables this gate.
+    /// Example: --min-significance 0.05
+    #[arg(long, value_name = "ALPHA")]
+    pub min_significance: Option<f64>,
+
+    /// Exit non-zero when the resolved-rate delta is negative and p <= alpha
+    /// (significant regressions are blocked). Unset disables this gate;
+    /// insignificant regressions are not blocked by this flag.
+    /// Example: --regression-significance 0.05
+    #[arg(long, value_name = "ALPHA")]
+    pub regression_significance: Option<f64>,
+
+    /// When set, allow significance-based gating to proceed even when the
+    /// paired test is underpowered. Without this flag, any underpowered result
+    /// causes gating flags to exit non-zero.
+    #[arg(long, default_value_t = false)]
+    pub allow_underpowered: bool,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1066,6 +1066,21 @@ fn apply_significance_gates(
 ) {
     let sig = &report.resolved_rate_significance;
 
+    // Validate alpha values before any gating: must be a finite probability in (0, 1).
+    for (flag, alpha) in [
+        ("--min-significance", min_significance),
+        ("--regression-significance", regression_significance),
+    ] {
+        if let Some(a) = alpha {
+            if !a.is_finite() || a <= 0.0 || a >= 1.0 {
+                exit_with_outcome(
+                    ExitCode::RegressionGateFailure,
+                    &format!("compare: {flag} alpha must be a probability in (0, 1), got {a}"),
+                );
+            }
+        }
+    }
+
     // Check underpowered block first — applies whenever a significance gate is active.
     let any_gate_active = min_significance.is_some() || regression_significance.is_some();
     if any_gate_active && sig.underpowered && !allow_underpowered {
@@ -1080,21 +1095,26 @@ fn apply_significance_gates(
         );
     }
 
+    // Use the paired-subset delta direction (fail_to_pass vs pass_to_fail) for gating.
+    // This ensures the gate direction matches the data the p-value was computed from,
+    // which is important when sweeps have non-overlapping instances.
+    let paired_positive = sig.fail_to_pass > sig.pass_to_fail;
+    let paired_negative = sig.pass_to_fail > sig.fail_to_pass;
+
     if let Some(alpha) = min_significance {
-        // Gate fires when the delta is positive AND p > alpha (noise win).
-        let positive_delta = report.resolved_delta_rate > 0.0;
-        if positive_delta {
+        // Gate fires when the paired delta is positive AND p > alpha (noise win).
+        if paired_positive {
             let p = sig.p_value.unwrap_or(1.0);
             if p > alpha {
                 tracing::error!(
                     p_value = p,
                     alpha = alpha,
-                    "compare: positive resolved-rate delta is not significant at --min-significance threshold"
+                    "compare: positive paired delta is not significant at --min-significance threshold"
                 );
                 exit_with_outcome(
                     ExitCode::RegressionGateFailure,
                     &format!(
-                        "compare: positive delta is not significant (p={p:.4} > alpha={alpha})"
+                        "compare: positive paired delta is not significant (p={p:.4} > alpha={alpha})"
                     ),
                 );
             }
@@ -1102,15 +1122,14 @@ fn apply_significance_gates(
     }
 
     if let Some(alpha) = regression_significance {
-        // Gate fires when the delta is negative AND p <= alpha (significant regression).
-        let negative_delta = report.resolved_delta_rate < 0.0;
-        if negative_delta {
+        // Gate fires when the paired delta is negative AND p <= alpha (significant regression).
+        if paired_negative {
             let p = sig.p_value.unwrap_or(1.0);
             if p <= alpha {
                 tracing::error!(
                     p_value = p,
                     alpha = alpha,
-                    "compare: negative resolved-rate delta is significant at --regression-significance threshold"
+                    "compare: negative paired delta is significant at --regression-significance threshold"
                 );
                 exit_with_outcome(
                     ExitCode::RegressionGateFailure,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1049,7 +1049,12 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
             );
         }
     }
-    apply_significance_gates(&report, c.min_significance, c.regression_significance, c.allow_underpowered);
+    apply_significance_gates(
+        &report,
+        c.min_significance,
+        c.regression_significance,
+        c.allow_underpowered,
+    );
     Ok(())
 }
 
@@ -1109,9 +1114,7 @@ fn apply_significance_gates(
                 );
                 exit_with_outcome(
                     ExitCode::RegressionGateFailure,
-                    &format!(
-                        "compare: significant regression (p={p:.4} <= alpha={alpha})"
-                    ),
+                    &format!("compare: significant regression (p={p:.4} <= alpha={alpha})"),
                 );
             }
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -999,6 +999,9 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
         min_delta_pp: c.breakdown_min_delta_pp / 100.0,
         cost_attribution: matches!(c.cost_attribution, args::OnOffArg::On),
         cost_attribution_min_delta_usd: c.cost_attribution_min_delta_usd,
+        min_significance: c.min_significance,
+        regression_significance: c.regression_significance,
+        allow_underpowered: c.allow_underpowered,
     })?;
     match format {
         crate::run::compare::CompareFormat::Text => print!("{}", report.human_table()),
@@ -1046,7 +1049,73 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
             );
         }
     }
+    apply_significance_gates(&report, c.min_significance, c.regression_significance, c.allow_underpowered);
     Ok(())
+}
+
+fn apply_significance_gates(
+    report: &crate::run::compare::CompareReport,
+    min_significance: Option<f64>,
+    regression_significance: Option<f64>,
+    allow_underpowered: bool,
+) {
+    let sig = &report.resolved_rate_significance;
+
+    // Check underpowered block first — applies whenever a significance gate is active.
+    let any_gate_active = min_significance.is_some() || regression_significance.is_some();
+    if any_gate_active && sig.underpowered && !allow_underpowered {
+        tracing::error!(
+            paired_n = sig.paired_n,
+            underpowered_reason = sig.underpowered_reason.as_deref().unwrap_or(""),
+            "compare: significance test is underpowered; pass --allow-underpowered to override"
+        );
+        exit_with_outcome(
+            ExitCode::RegressionGateFailure,
+            "compare: significance test is underpowered (add --allow-underpowered to override)",
+        );
+    }
+
+    if let Some(alpha) = min_significance {
+        // Gate fires when the delta is positive AND p > alpha (noise win).
+        let positive_delta = report.resolved_delta_rate > 0.0;
+        if positive_delta {
+            let p = sig.p_value.unwrap_or(1.0);
+            if p > alpha {
+                tracing::error!(
+                    p_value = p,
+                    alpha = alpha,
+                    "compare: positive resolved-rate delta is not significant at --min-significance threshold"
+                );
+                exit_with_outcome(
+                    ExitCode::RegressionGateFailure,
+                    &format!(
+                        "compare: positive delta is not significant (p={p:.4} > alpha={alpha})"
+                    ),
+                );
+            }
+        }
+    }
+
+    if let Some(alpha) = regression_significance {
+        // Gate fires when the delta is negative AND p <= alpha (significant regression).
+        let negative_delta = report.resolved_delta_rate < 0.0;
+        if negative_delta {
+            let p = sig.p_value.unwrap_or(1.0);
+            if p <= alpha {
+                tracing::error!(
+                    p_value = p,
+                    alpha = alpha,
+                    "compare: negative resolved-rate delta is significant at --regression-significance threshold"
+                );
+                exit_with_outcome(
+                    ExitCode::RegressionGateFailure,
+                    &format!(
+                        "compare: significant regression (p={p:.4} <= alpha={alpha})"
+                    ),
+                );
+            }
+        }
+    }
 }
 
 fn parse_compare_format(raw: &str) -> Result<crate::run::compare::CompareFormat, Error> {

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -2658,15 +2658,6 @@ fn compare_evaluator_provenance(
 
 // ── Paired significance (McNemar exact test) ──────────────────────────────
 
-/// Compute log of binomial coefficient C(n, k) in log-space to avoid overflow.
-#[allow(clippy::cast_precision_loss)]
-fn log_binomial_coeff(n: usize, k: usize) -> f64 {
-    let k = k.min(n - k); // use symmetry: C(n,k) = C(n,n-k)
-    (0..k)
-        .map(|i| ((n - i) as f64).ln() - ((i + 1) as f64).ln())
-        .sum()
-}
-
 /// Two-sided exact McNemar p-value.
 ///
 /// `pass_to_fail` = n01 (baseline pass, candidate fail)
@@ -2675,6 +2666,9 @@ fn log_binomial_coeff(n: usize, k: usize) -> f64 {
 /// Under H0 each discordant pair is equally likely to go either way, so
 /// the smaller count follows Binomial(n_discordant, 0.5). The two-sided
 /// p-value is 2 * Σ_{k=0}^{min(n01,n10)} C(n,k) * 0.5^n, capped at 1.
+///
+/// log C(n,k) is accumulated incrementally via the recurrence
+/// log C(n,k) = log C(n,k-1) + log(n-k+1) - log(k), giving O(m) time.
 #[allow(clippy::cast_precision_loss)]
 fn mcnemar_exact_p_value(pass_to_fail: usize, fail_to_pass: usize) -> f64 {
     let n = pass_to_fail + fail_to_pass;
@@ -2683,9 +2677,15 @@ fn mcnemar_exact_p_value(pass_to_fail: usize, fail_to_pass: usize) -> f64 {
     }
     let m = pass_to_fail.min(fail_to_pass);
     let log_half_n = -(n as f64) * std::f64::consts::LN_2;
-    let tail: f64 = (0..=m)
-        .map(|k| (log_binomial_coeff(n, k) + log_half_n).exp())
-        .sum();
+    let mut log_binom = 0.0_f64; // log C(n, 0) = 0
+    let mut tail = 0.0_f64;
+    for k in 0..=m {
+        tail += (log_binom + log_half_n).exp();
+        if k < m {
+            // recurrence: log C(n,k+1) = log C(n,k) + log(n-k) - log(k+1)
+            log_binom += ((n - k) as f64).ln() - ((k + 1) as f64).ln();
+        }
+    }
     (2.0 * tail).min(1.0)
 }
 

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -461,7 +461,11 @@ fn write_significance_line(
     sig: &ResolvedRateSignificance,
     resolved_delta_rate: f64,
 ) {
-    let underpowered_tag = if sig.underpowered { " (underpowered)" } else { "" };
+    let underpowered_tag = if sig.underpowered {
+        " (underpowered)"
+    } else {
+        ""
+    };
     let sig_str = match sig.p_value {
         Some(p) => format!(
             "resolved-rate \u{394} {:+.2}pp [95% CI: {:+.2}\u{2013}{:+.2} pp], p={:.4} (paired N={}){underpowered_tag}",
@@ -1659,8 +1663,7 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
         candidate_cost_per_resolved_usd.unwrap_or(f64::NAN),
     );
 
-    let resolved_rate_significance =
-        compute_paired_significance(&transition_summary.transitions);
+    let resolved_rate_significance = compute_paired_significance(&transition_summary.transitions);
 
     CompareReport {
         baseline_dir: baseline_dir.to_path_buf(),
@@ -2682,8 +2685,12 @@ fn compute_paired_significance(
     let pass_fail = *transitions.get(&TransitionKind::PassFail).unwrap_or(&0);
     let fail_pass = *transitions.get(&TransitionKind::FailPass).unwrap_or(&0);
     let fail_fail = *transitions.get(&TransitionKind::FailFail).unwrap_or(&0);
-    let missing_present = *transitions.get(&TransitionKind::MissingPresent).unwrap_or(&0);
-    let present_missing = *transitions.get(&TransitionKind::PresentMissing).unwrap_or(&0);
+    let missing_present = *transitions
+        .get(&TransitionKind::MissingPresent)
+        .unwrap_or(&0);
+    let present_missing = *transitions
+        .get(&TransitionKind::PresentMissing)
+        .unwrap_or(&0);
 
     let paired_n = pass_pass + pass_fail + fail_pass + fail_fail;
     let pass_to_fail = pass_fail;
@@ -2709,10 +2716,7 @@ fn compute_paired_significance(
     };
 
     let (underpowered, underpowered_reason) = if paired_n == 0 {
-        (
-            true,
-            Some("no shared instance_ids (paired_n=0)".to_owned()),
-        )
+        (true, Some("no shared instance_ids (paired_n=0)".to_owned()))
     } else if discordant < UNDERPOWERED_DISCORDANT_THRESHOLD {
         (
             true,

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -286,6 +286,11 @@ pub struct ResolvedRateSignificance {
     pub pass_to_fail: usize,
     /// Discordant pairs where baseline failed and candidate passed.
     pub fail_to_pass: usize,
+    /// Rate delta within the paired overlap subset: candidate_rate − baseline_rate.
+    /// Equals `(fail_to_pass − pass_to_fail) / paired_n`. Zero when `paired_n == 0`.
+    /// Use this — not the population `resolved_delta_rate` — for interpreting the
+    /// CI and p-value, which are also computed on the paired subset.
+    pub paired_delta_rate: f64,
     /// True when the test lacks statistical power (fewer than
     /// `UNDERPOWERED_DISCORDANT_THRESHOLD` discordant pairs, or `paired_n == 0`).
     pub underpowered: bool,
@@ -449,18 +454,10 @@ fn write_compare_overview(s: &mut String, report: &CompareReport) {
         if report.within_noise { "true" } else { "false" }
     );
     let _ = writeln!(s, "Verdict:            {}", report.verdict.label());
-    write_significance_line(
-        s,
-        &report.resolved_rate_significance,
-        report.resolved_delta_rate,
-    );
+    write_significance_line(s, &report.resolved_rate_significance);
 }
 
-fn write_significance_line(
-    s: &mut String,
-    sig: &ResolvedRateSignificance,
-    resolved_delta_rate: f64,
-) {
+fn write_significance_line(s: &mut String, sig: &ResolvedRateSignificance) {
     let underpowered_tag = if sig.underpowered {
         " (underpowered)"
     } else {
@@ -469,7 +466,7 @@ fn write_significance_line(
     let sig_str = match sig.p_value {
         Some(p) => format!(
             "resolved-rate \u{394} {:+.2}pp [95% CI: {:+.2}\u{2013}{:+.2} pp], p={:.4} (paired N={}){underpowered_tag}",
-            resolved_delta_rate * 100.0,
+            sig.paired_delta_rate * 100.0,
             sig.ci95_lower_pp,
             sig.ci95_upper_pp,
             p,
@@ -2707,6 +2704,15 @@ fn compute_paired_significance(
         usize_to_u64(paired_n),
     );
 
+    // Paired delta rate: candidate rate - baseline rate, restricted to the overlap.
+    // = (fail_to_pass - pass_to_fail) / paired_n.  Zero when paired_n==0.
+    #[allow(clippy::cast_precision_loss)]
+    let paired_delta_rate = if paired_n == 0 {
+        0.0
+    } else {
+        (fail_to_pass as f64 - pass_to_fail as f64) / paired_n as f64
+    };
+
     let p_value = if paired_n == 0 {
         None
     } else if discordant == 0 {
@@ -2736,6 +2742,7 @@ fn compute_paired_significance(
         paired_n,
         pass_to_fail,
         fail_to_pass,
+        paired_delta_rate,
         underpowered,
         underpowered_reason,
         only_in_baseline: present_missing,

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -49,6 +49,16 @@ pub struct CompareArgs {
     pub min_delta_pp: f64,
     pub cost_attribution: bool,
     pub cost_attribution_min_delta_usd: f64,
+    /// Exit non-zero when the resolved-rate delta is positive but p > alpha
+    /// (suspected-noise wins). `None` disables this gate.
+    pub min_significance: Option<f64>,
+    /// Exit non-zero when the resolved-rate delta is negative and p <= alpha
+    /// (significant regressions). `None` disables this gate.
+    pub regression_significance: Option<f64>,
+    /// When true, significance-based gating proceeds even when the paired
+    /// sample is underpowered. Without this flag, gating exits non-zero
+    /// whenever the test is underpowered.
+    pub allow_underpowered: bool,
 }
 
 /// Per-task transition between baseline and candidate. `pass` prefers
@@ -207,6 +217,8 @@ pub struct CompareReport {
     /// Empty when `evaluator_provenance_status == Matching`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub evaluator_provenance_warnings: Vec<String>,
+    /// Paired McNemar significance test on the resolved-rate delta.
+    pub resolved_rate_significance: ResolvedRateSignificance,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -247,6 +259,43 @@ pub enum EvaluatorProvenanceStatus {
     Mismatched,
     /// One or both evaluations lack provenance.
     Unavailable,
+}
+
+/// Minimum number of discordant pairs required for the paired significance test
+/// to be considered powered. Below this threshold `underpowered` is `true`.
+pub const UNDERPOWERED_DISCORDANT_THRESHOLD: usize = 10;
+
+/// Paired McNemar significance test result for the resolved-rate delta.
+///
+/// Computed on the overlap subset (instances present in both sweeps). Instances
+/// only in one sweep are counted in `only_in_baseline` / `only_in_candidate`
+/// and excluded from the test.
+#[derive(Debug, Clone, Serialize)]
+pub struct ResolvedRateSignificance {
+    /// Statistical test applied: always `"mcnemar_exact"`.
+    pub test_name: String,
+    /// Two-sided exact McNemar p-value. `null` when `paired_n == 0`.
+    pub p_value: Option<f64>,
+    /// Lower bound of the 95% Wilson-score CI on the rate delta (percentage points).
+    pub ci95_lower_pp: f64,
+    /// Upper bound of the 95% Wilson-score CI on the rate delta (percentage points).
+    pub ci95_upper_pp: f64,
+    /// Number of instances present in both sweeps (the paired overlap).
+    pub paired_n: usize,
+    /// Discordant pairs where baseline passed and candidate failed.
+    pub pass_to_fail: usize,
+    /// Discordant pairs where baseline failed and candidate passed.
+    pub fail_to_pass: usize,
+    /// True when the test lacks statistical power (fewer than
+    /// `UNDERPOWERED_DISCORDANT_THRESHOLD` discordant pairs, or `paired_n == 0`).
+    pub underpowered: bool,
+    /// Human-readable reason why the test is underpowered. `null` when powered.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub underpowered_reason: Option<String>,
+    /// Instance IDs present only in the baseline sweep (excluded from the test).
+    pub only_in_baseline: usize,
+    /// Instance IDs present only in the candidate sweep (excluded from the test).
+    pub only_in_candidate: usize,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -400,6 +449,19 @@ fn write_compare_overview(s: &mut String, report: &CompareReport) {
         if report.within_noise { "true" } else { "false" }
     );
     let _ = writeln!(s, "Verdict:            {}", report.verdict.label());
+    write_significance_line(s, &report.resolved_rate_significance);
+}
+
+fn write_significance_line(s: &mut String, sig: &ResolvedRateSignificance) {
+    let underpowered_tag = if sig.underpowered { " (underpowered)" } else { "" };
+    let sig_str = match sig.p_value {
+        Some(p) => format!(
+            "[95% CI: {:+.2}\u{2013}{:+.2} pp], p={:.4} (paired N={}){underpowered_tag}",
+            sig.ci95_lower_pp, sig.ci95_upper_pp, p, sig.paired_n,
+        ),
+        None => "(underpowered)".to_string(),
+    };
+    let _ = writeln!(s, "Significance:       {sig_str}");
 }
 
 fn write_patch_stats_delta_lines(s: &mut String, report: &CompareReport) {
@@ -1585,6 +1647,9 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
         candidate_cost_per_resolved_usd.unwrap_or(f64::NAN),
     );
 
+    let resolved_rate_significance =
+        compute_paired_significance(&transition_summary.transitions);
+
     CompareReport {
         baseline_dir: baseline_dir.to_path_buf(),
         candidate_dir: candidate_dir.to_path_buf(),
@@ -1651,6 +1716,7 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
         model_mix_warnings: Vec::new(),
         evaluator_provenance_status: EvaluatorProvenanceStatus::Unavailable,
         evaluator_provenance_warnings: Vec::new(),
+        resolved_rate_significance,
     }
 }
 
@@ -2563,6 +2629,104 @@ fn compare_evaluator_provenance(
     }
 }
 
+// ── Paired significance (McNemar exact test) ──────────────────────────────
+
+/// Compute log of binomial coefficient C(n, k) in log-space to avoid overflow.
+#[allow(clippy::cast_precision_loss)]
+fn log_binomial_coeff(n: usize, k: usize) -> f64 {
+    let k = k.min(n - k); // use symmetry: C(n,k) = C(n,n-k)
+    (0..k)
+        .map(|i| ((n - i) as f64).ln() - ((i + 1) as f64).ln())
+        .sum()
+}
+
+/// Two-sided exact McNemar p-value.
+///
+/// `pass_to_fail` = n01 (baseline pass, candidate fail)
+/// `fail_to_pass` = n10 (baseline fail, candidate pass)
+///
+/// Under H0 each discordant pair is equally likely to go either way, so
+/// the smaller count follows Binomial(n_discordant, 0.5). The two-sided
+/// p-value is 2 * Σ_{k=0}^{min(n01,n10)} C(n,k) * 0.5^n, capped at 1.
+#[allow(clippy::cast_precision_loss)]
+fn mcnemar_exact_p_value(pass_to_fail: usize, fail_to_pass: usize) -> f64 {
+    let n = pass_to_fail + fail_to_pass;
+    if n == 0 {
+        return 1.0;
+    }
+    let m = pass_to_fail.min(fail_to_pass);
+    let log_half_n = -(n as f64) * std::f64::consts::LN_2;
+    let tail: f64 = (0..=m)
+        .map(|k| (log_binomial_coeff(n, k) + log_half_n).exp())
+        .sum();
+    (2.0 * tail).min(1.0)
+}
+
+/// Build the `ResolvedRateSignificance` block from the transition counts.
+fn compute_paired_significance(
+    transitions: &BTreeMap<TransitionKind, usize>,
+) -> ResolvedRateSignificance {
+    let pass_pass = *transitions.get(&TransitionKind::PassPass).unwrap_or(&0);
+    let pass_fail = *transitions.get(&TransitionKind::PassFail).unwrap_or(&0);
+    let fail_pass = *transitions.get(&TransitionKind::FailPass).unwrap_or(&0);
+    let fail_fail = *transitions.get(&TransitionKind::FailFail).unwrap_or(&0);
+    let missing_present = *transitions.get(&TransitionKind::MissingPresent).unwrap_or(&0);
+    let present_missing = *transitions.get(&TransitionKind::PresentMissing).unwrap_or(&0);
+
+    let paired_n = pass_pass + pass_fail + fail_pass + fail_fail;
+    let pass_to_fail = pass_fail;
+    let fail_to_pass = fail_pass;
+    let discordant = pass_to_fail + fail_to_pass;
+
+    // Wilson-score CI on the rate delta within the paired subset.
+    let baseline_resolved_paired = pass_pass + pass_fail;
+    let candidate_resolved_paired = pass_pass + fail_pass;
+    let ci = wilson_delta_ci95(
+        usize_to_u64(candidate_resolved_paired),
+        usize_to_u64(paired_n),
+        usize_to_u64(baseline_resolved_paired),
+        usize_to_u64(paired_n),
+    );
+
+    let p_value = if paired_n == 0 {
+        None
+    } else if discordant == 0 {
+        Some(1.0)
+    } else {
+        Some(mcnemar_exact_p_value(pass_to_fail, fail_to_pass))
+    };
+
+    let (underpowered, underpowered_reason) = if paired_n == 0 {
+        (
+            true,
+            Some("no shared instance_ids (paired_n=0)".to_owned()),
+        )
+    } else if discordant < UNDERPOWERED_DISCORDANT_THRESHOLD {
+        (
+            true,
+            Some(format!(
+                "fewer than {UNDERPOWERED_DISCORDANT_THRESHOLD} discordant pairs (got {discordant})"
+            )),
+        )
+    } else {
+        (false, None)
+    };
+
+    ResolvedRateSignificance {
+        test_name: "mcnemar_exact".to_owned(),
+        p_value,
+        ci95_lower_pp: ci.lower * 100.0,
+        ci95_upper_pp: ci.upper * 100.0,
+        paired_n,
+        pass_to_fail,
+        fail_to_pass,
+        underpowered,
+        underpowered_reason,
+        only_in_baseline: present_missing,
+        only_in_candidate: missing_present,
+    }
+}
+
 #[cfg(test)]
 fn cost_attribution_map<S: std::hash::BuildHasher>(
     items: &HashMap<String, InstanceResult, S>,
@@ -3097,6 +3261,9 @@ mod tests {
             min_delta_pp: 0.0,
             cost_attribution: true,
             cost_attribution_min_delta_usd: 1.0,
+            min_significance: None,
+            regression_significance: None,
+            allow_underpowered: false,
         })
         .unwrap();
         assert_eq!(r.regressions.len(), 1);
@@ -3518,6 +3685,9 @@ mod tests {
             min_delta_pp: 0.0,
             cost_attribution: true,
             cost_attribution_min_delta_usd: 1.0,
+            min_significance: None,
+            regression_significance: None,
+            allow_underpowered: false,
         })
         .unwrap();
         assert_eq!(r.baseline_resolved, 1);
@@ -3568,6 +3738,9 @@ mod tests {
             min_delta_pp: 0.0,
             cost_attribution: true,
             cost_attribution_min_delta_usd: 1.0,
+            min_significance: None,
+            regression_significance: None,
+            allow_underpowered: false,
         })
         .unwrap();
         assert_eq!(r.baseline_resolved, 10);

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -449,15 +449,27 @@ fn write_compare_overview(s: &mut String, report: &CompareReport) {
         if report.within_noise { "true" } else { "false" }
     );
     let _ = writeln!(s, "Verdict:            {}", report.verdict.label());
-    write_significance_line(s, &report.resolved_rate_significance);
+    write_significance_line(
+        s,
+        &report.resolved_rate_significance,
+        report.resolved_delta_rate,
+    );
 }
 
-fn write_significance_line(s: &mut String, sig: &ResolvedRateSignificance) {
+fn write_significance_line(
+    s: &mut String,
+    sig: &ResolvedRateSignificance,
+    resolved_delta_rate: f64,
+) {
     let underpowered_tag = if sig.underpowered { " (underpowered)" } else { "" };
     let sig_str = match sig.p_value {
         Some(p) => format!(
-            "[95% CI: {:+.2}\u{2013}{:+.2} pp], p={:.4} (paired N={}){underpowered_tag}",
-            sig.ci95_lower_pp, sig.ci95_upper_pp, p, sig.paired_n,
+            "resolved-rate \u{394} {:+.2}pp [95% CI: {:+.2}\u{2013}{:+.2} pp], p={:.4} (paired N={}){underpowered_tag}",
+            resolved_delta_rate * 100.0,
+            sig.ci95_lower_pp,
+            sig.ci95_upper_pp,
+            p,
+            sig.paired_n,
         ),
         None => "(underpowered)".to_string(),
     };

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -1660,7 +1660,22 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
         candidate_cost_per_resolved_usd.unwrap_or(f64::NAN),
     );
 
-    let resolved_rate_significance = compute_paired_significance(&transition_summary.transitions);
+    let mut resolved_rate_significance =
+        compute_paired_significance(&transition_summary.transitions);
+    // For rerun sweeps the transition matrix uses resolved_count > 0 (pass@k),
+    // which does not reflect the multi-run resolved rate used by the population
+    // metrics.  Mark the significance block underpowered so gating flags require
+    // --allow-underpowered and operators are not silently misled.
+    let either_is_rerun =
+        baseline.values().any(|r| r.runs > 1) || candidate.values().any(|r| r.runs > 1);
+    if either_is_rerun {
+        resolved_rate_significance.underpowered = true;
+        resolved_rate_significance.underpowered_reason = Some(
+            "rerun sweep detected: paired test uses pass@k (resolved_count > 0), \
+             not the multi-run resolved rate; significance gating is unreliable"
+                .to_owned(),
+        );
+    }
 
     CompareReport {
         baseline_dir: baseline_dir.to_path_buf(),

--- a/src/run/report.rs
+++ b/src/run/report.rs
@@ -111,6 +111,9 @@ fn baseline_compare_report(args: &ReportArgs) -> Result<Option<CompareReport>, E
         min_delta_pp: 0.05,
         cost_attribution: false,
         cost_attribution_min_delta_usd: 1.0,
+        min_significance: None,
+        regression_significance: None,
+        allow_underpowered: false,
     })?;
     Ok(Some(report))
 }

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -2921,6 +2921,10 @@ fn compare_text_output_has_significance_line() {
         "text output must include a Significance: line; got:\n{stdout}"
     );
     assert!(
+        stdout.contains("resolved-rate"),
+        "significance line must include 'resolved-rate'; got:\n{stdout}"
+    );
+    assert!(
         stdout.contains("paired N="),
         "text output must include paired N=; got:\n{stdout}"
     );

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -2617,7 +2617,7 @@ fn compare_json_has_resolved_rate_significance_block() {
         "stderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("valid json");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
     let sig = &v["resolved_rate_significance"];
     assert!(
         sig.is_object(),

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -2802,10 +2802,7 @@ fn compare_significance_zero_overlap_is_underpowered() {
     );
     write_results(
         candidate_dir.path(),
-        vec![
-            submitted("candidate-only-1"),
-            submitted("candidate-only-2"),
-        ],
+        vec![submitted("candidate-only-1"), submitted("candidate-only-2")],
     );
 
     let out = Command::new(binary_path())

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -848,6 +848,9 @@ fn compare_treats_wallclock_timeout_as_ordinary_failure_transition() {
             min_delta_pp: 0.0,
             cost_attribution: true,
             cost_attribution_min_delta_usd: 1.0,
+            min_significance: None,
+            regression_significance: None,
+            allow_underpowered: false,
         })
         .unwrap();
     assert_eq!(
@@ -871,6 +874,9 @@ fn compare_treats_wallclock_timeout_as_ordinary_failure_transition() {
             min_delta_pp: 0.0,
             cost_attribution: true,
             cost_attribution_min_delta_usd: 1.0,
+            min_significance: None,
+            regression_significance: None,
+            allow_underpowered: false,
         })
         .unwrap();
     assert_eq!(
@@ -1503,6 +1509,9 @@ fn compare_uses_manifest_model_for_fallback_cost_repricing() {
             min_delta_pp: 0.0,
             cost_attribution: false,
             cost_attribution_min_delta_usd: 1.0,
+            min_significance: None,
+            regression_significance: None,
+            allow_underpowered: false,
         })
         .unwrap();
 
@@ -2568,5 +2577,625 @@ fn evaluate_breakdown_csv_includes_cost_per_resolved_usd_column() {
     assert!(
         stdout.contains("NaN"),
         "expected NaN for zero-resolved bucket; got:\n{stdout}"
+    );
+}
+
+// -- Issue #176: resolved_rate_significance block --
+
+#[test]
+fn compare_json_has_resolved_rate_significance_block() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    write_results(
+        baseline_dir.path(),
+        vec![
+            submitted("id-1"),
+            submitted("id-2"),
+            errored("id-3", FailureCategory::StepLimit),
+        ],
+    );
+    write_results(
+        candidate_dir.path(),
+        vec![submitted("id-1"), submitted("id-2"), submitted("id-3")],
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("valid json");
+    let sig = &v["resolved_rate_significance"];
+    assert!(
+        sig.is_object(),
+        "expected resolved_rate_significance object; got: {sig}"
+    );
+    assert_eq!(
+        sig["test_name"].as_str().unwrap(),
+        "mcnemar_exact",
+        "expected test_name=mcnemar_exact"
+    );
+    assert!(
+        sig["paired_n"].as_u64().is_some(),
+        "expected paired_n field"
+    );
+    assert!(
+        sig["pass_to_fail"].as_u64().is_some(),
+        "expected pass_to_fail field"
+    );
+    assert!(
+        sig["fail_to_pass"].as_u64().is_some(),
+        "expected fail_to_pass field"
+    );
+    assert!(
+        sig["underpowered"].as_bool().is_some(),
+        "expected underpowered bool field"
+    );
+}
+
+#[test]
+fn compare_significance_identical_sweeps_is_underpowered() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    let instances: Vec<InstanceResult> = (0..10).map(|i| submitted(&format!("id-{i}"))).collect();
+    write_results(baseline_dir.path(), instances.clone());
+    write_results(candidate_dir.path(), instances);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let sig = &v["resolved_rate_significance"];
+    assert_eq!(sig["paired_n"].as_u64().unwrap(), 10);
+    assert_eq!(sig["pass_to_fail"].as_u64().unwrap(), 0);
+    assert_eq!(sig["fail_to_pass"].as_u64().unwrap(), 0);
+    assert!(
+        sig["underpowered"].as_bool().unwrap(),
+        "identical sweeps have no discordant pairs and must be underpowered"
+    );
+    let lower = sig["ci95_lower_pp"].as_f64().unwrap();
+    let upper = sig["ci95_upper_pp"].as_f64().unwrap();
+    assert!(
+        lower <= 0.0 && upper >= 0.0,
+        "CI should straddle zero for identical sweeps; got [{lower}, {upper}]"
+    );
+}
+
+#[test]
+fn compare_significance_clearly_significant_delta() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+
+    let mut b = vec![];
+    let mut c = vec![];
+    for i in 0..5 {
+        b.push(submitted(&format!("pp-{i}")));
+        c.push(submitted(&format!("pp-{i}")));
+    }
+    for i in 0..5 {
+        b.push(errored(&format!("ff-{i}"), FailureCategory::StepLimit));
+        c.push(errored(&format!("ff-{i}"), FailureCategory::StepLimit));
+    }
+    // 10 fail->pass
+    for i in 0..10 {
+        b.push(errored(&format!("fp-{i}"), FailureCategory::StepLimit));
+        c.push(submitted(&format!("fp-{i}")));
+    }
+    write_results(baseline_dir.path(), b);
+    write_results(candidate_dir.path(), c);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let sig = &v["resolved_rate_significance"];
+
+    assert_eq!(sig["paired_n"].as_u64().unwrap(), 20);
+    assert_eq!(sig["pass_to_fail"].as_u64().unwrap(), 0);
+    assert_eq!(sig["fail_to_pass"].as_u64().unwrap(), 10);
+    assert!(
+        !sig["underpowered"].as_bool().unwrap(),
+        "10 discordant pairs should not be underpowered"
+    );
+    let p = sig["p_value"].as_f64().unwrap();
+    assert!(
+        p < 0.01,
+        "10 one-sided discordant pairs should yield p < 0.01; got p={p}"
+    );
+}
+
+#[test]
+fn compare_significance_clearly_noisy_delta() {
+    // 10 fail->pass AND 10 pass->fail: symmetric -> p=1.0
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+
+    let mut b = vec![];
+    let mut c = vec![];
+    for i in 0..10 {
+        b.push(errored(&format!("fp-{i}"), FailureCategory::StepLimit));
+        c.push(submitted(&format!("fp-{i}")));
+    }
+    for i in 0..10 {
+        b.push(submitted(&format!("pf-{i}")));
+        c.push(errored(&format!("pf-{i}"), FailureCategory::StepLimit));
+    }
+    for i in 0..10 {
+        b.push(submitted(&format!("pp-{i}")));
+        c.push(submitted(&format!("pp-{i}")));
+    }
+    write_results(baseline_dir.path(), b);
+    write_results(candidate_dir.path(), c);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let sig = &v["resolved_rate_significance"];
+
+    assert_eq!(sig["pass_to_fail"].as_u64().unwrap(), 10);
+    assert_eq!(sig["fail_to_pass"].as_u64().unwrap(), 10);
+    assert!(
+        !sig["underpowered"].as_bool().unwrap(),
+        "20 discordant pairs should not be underpowered"
+    );
+    let p = sig["p_value"].as_f64().unwrap();
+    assert!(
+        p > 0.5,
+        "symmetric discordant pairs yield p > 0.5; got p={p}"
+    );
+}
+
+#[test]
+fn compare_significance_zero_overlap_is_underpowered() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    write_results(
+        baseline_dir.path(),
+        vec![submitted("baseline-only-1"), submitted("baseline-only-2")],
+    );
+    write_results(
+        candidate_dir.path(),
+        vec![
+            submitted("candidate-only-1"),
+            submitted("candidate-only-2"),
+        ],
+    );
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let sig = &v["resolved_rate_significance"];
+
+    assert_eq!(sig["paired_n"].as_u64().unwrap(), 0);
+    assert!(
+        sig["underpowered"].as_bool().unwrap(),
+        "paired_n=0 must be underpowered"
+    );
+    assert!(
+        sig["only_in_baseline"].as_u64().unwrap() >= 2,
+        "only_in_baseline should count baseline-only instances"
+    );
+    assert!(
+        sig["only_in_candidate"].as_u64().unwrap() >= 2,
+        "only_in_candidate should count candidate-only instances"
+    );
+    assert!(
+        sig["p_value"].is_null(),
+        "p_value must be null when paired_n=0"
+    );
+}
+
+#[test]
+fn compare_significance_few_discordant_pairs_is_underpowered() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+
+    let mut b = vec![];
+    let mut c = vec![];
+    for i in 0..10 {
+        b.push(errored(&format!("ff-{i}"), FailureCategory::StepLimit));
+        c.push(errored(&format!("ff-{i}"), FailureCategory::StepLimit));
+    }
+    for i in 0..3 {
+        b.push(errored(&format!("fp-{i}"), FailureCategory::StepLimit));
+        c.push(submitted(&format!("fp-{i}")));
+    }
+    write_results(baseline_dir.path(), b);
+    write_results(candidate_dir.path(), c);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let sig = &v["resolved_rate_significance"];
+
+    assert_eq!(sig["fail_to_pass"].as_u64().unwrap(), 3);
+    assert!(
+        sig["underpowered"].as_bool().unwrap(),
+        "3 discordant pairs < threshold -> must be underpowered"
+    );
+    assert!(
+        sig["underpowered_reason"].as_str().is_some(),
+        "underpowered_reason must be present"
+    );
+}
+
+#[test]
+fn compare_text_output_has_significance_line() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    let mut b = vec![];
+    let mut c = vec![];
+    for i in 0..10 {
+        b.push(errored(&format!("fp-{i}"), FailureCategory::StepLimit));
+        c.push(submitted(&format!("fp-{i}")));
+    }
+    write_results(baseline_dir.path(), b);
+    write_results(candidate_dir.path(), c);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Significance:"),
+        "text output must include a Significance: line; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("paired N="),
+        "text output must include paired N=; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("p="),
+        "text output must include p= value; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn compare_text_output_prints_underpowered_tag() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    let instances: Vec<InstanceResult> = (0..5).map(|i| submitted(&format!("id-{i}"))).collect();
+    write_results(baseline_dir.path(), instances.clone());
+    write_results(candidate_dir.path(), instances);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("(underpowered)"),
+        "text output must print (underpowered) tag; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn compare_min_significance_exits_nonzero_on_noisy_win() {
+    // 11 fail->pass and 10 pass->fail: slight positive delta but p >> 0.05.
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    let mut b = vec![];
+    let mut c = vec![];
+    for i in 0..11 {
+        b.push(errored(&format!("fp-{i}"), FailureCategory::StepLimit));
+        c.push(submitted(&format!("fp-{i}")));
+    }
+    for i in 0..10 {
+        b.push(submitted(&format!("pf-{i}")));
+        c.push(errored(&format!("pf-{i}"), FailureCategory::StepLimit));
+    }
+    write_results(baseline_dir.path(), b);
+    write_results(candidate_dir.path(), c);
+
+    // Without flag: exit 0
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "no gate flag -> always exit 0");
+
+    // With --min-significance 0.05: positive delta but p >> 0.05 -> exit non-zero
+    let out2 = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--min-significance",
+            "0.05",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out2.status.success(),
+        "positive-but-noisy delta must fail --min-significance gate"
+    );
+}
+
+#[test]
+fn compare_min_significance_passes_when_delta_is_significant() {
+    // 10 fail->pass, 0 pass->fail: p ~= 0.002 < 0.05 -> gate passes
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    let mut b = vec![];
+    let mut c = vec![];
+    for i in 0..10 {
+        b.push(errored(&format!("fp-{i}"), FailureCategory::StepLimit));
+        c.push(submitted(&format!("fp-{i}")));
+    }
+    write_results(baseline_dir.path(), b);
+    write_results(candidate_dir.path(), c);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--min-significance",
+            "0.05",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "significant positive delta should pass --min-significance gate; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn compare_regression_significance_exits_nonzero_on_significant_regression() {
+    // 10 pass->fail, 0 fail->pass: p ~= 0.002 < 0.05 -> regression gate fires
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    let mut b = vec![];
+    let mut c = vec![];
+    for i in 0..10 {
+        b.push(submitted(&format!("pf-{i}")));
+        c.push(errored(&format!("pf-{i}"), FailureCategory::StepLimit));
+    }
+    write_results(baseline_dir.path(), b);
+    write_results(candidate_dir.path(), c);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--regression-significance",
+            "0.05",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "significant regression should exit non-zero"
+    );
+}
+
+#[test]
+fn compare_regression_significance_passes_on_insignificant_regression() {
+    // 11 pass->fail, 10 fail->pass: slight negative delta but p >> 0.05
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    let mut b = vec![];
+    let mut c = vec![];
+    for i in 0..11 {
+        b.push(submitted(&format!("pf-{i}")));
+        c.push(errored(&format!("pf-{i}"), FailureCategory::StepLimit));
+    }
+    for i in 0..10 {
+        b.push(errored(&format!("fp-{i}"), FailureCategory::StepLimit));
+        c.push(submitted(&format!("fp-{i}")));
+    }
+    write_results(baseline_dir.path(), b);
+    write_results(candidate_dir.path(), c);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--regression-significance",
+            "0.05",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "insignificant regression must not trigger --regression-significance gate"
+    );
+}
+
+#[test]
+fn compare_min_significance_gate_blocked_when_underpowered() {
+    // 3 fail->pass: underpowered -> blocked without --allow-underpowered
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    let mut b = vec![];
+    let mut c = vec![];
+    for i in 0..3 {
+        b.push(errored(&format!("fp-{i}"), FailureCategory::StepLimit));
+        c.push(submitted(&format!("fp-{i}")));
+    }
+    write_results(baseline_dir.path(), b);
+    write_results(candidate_dir.path(), c);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--min-significance",
+            "0.05",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "underpowered without --allow-underpowered must exit non-zero"
+    );
+}
+
+#[test]
+fn compare_allow_underpowered_overrides_underpowered_block_for_significant_delta() {
+    // 7 fail->pass: p = 2/128 ~= 0.0156 < 0.05, but underpowered (7 < 10)
+    // With --allow-underpowered: p < alpha, delta positive -> passes gate
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+    let mut b = vec![];
+    let mut c = vec![];
+    for i in 0..7 {
+        b.push(errored(&format!("fp-{i}"), FailureCategory::StepLimit));
+        c.push(submitted(&format!("fp-{i}")));
+    }
+    write_results(baseline_dir.path(), b);
+    write_results(candidate_dir.path(), c);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--min-significance",
+            "0.05",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "underpowered without --allow-underpowered must exit non-zero"
+    );
+
+    let out2 = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--min-significance",
+            "0.05",
+            "--allow-underpowered",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out2.status.success(),
+        "with --allow-underpowered and p < alpha, positive delta passes; stderr: {}",
+        String::from_utf8_lossy(&out2.stderr)
     );
 }

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -3200,3 +3200,86 @@ fn compare_allow_underpowered_overrides_underpowered_block_for_significant_delta
         String::from_utf8_lossy(&out2.stderr)
     );
 }
+
+#[test]
+fn compare_significance_rerun_sweep_is_underpowered() {
+    // Rerun sweeps: each instance has runs=10.
+    // Baseline: 1/10 reruns resolved (pass@k=true, resolved_count=1).
+    // Candidate: 10/10 reruns resolved (pass@k=true, resolved_count=10).
+    // Both sweeps have resolved_count > 0, so all instances are PassPass.
+    // paired_delta_rate = 0, but population resolved rate went from 10% to 100%.
+    // The significance block must be marked underpowered to prevent misleading gating.
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+
+    let baseline_instances: Vec<InstanceResult> = (0..10)
+        .map(|i| rerun_result(&format!("id-{i}"), 10, 1))
+        .collect();
+    let candidate_instances: Vec<InstanceResult> = (0..10)
+        .map(|i| rerun_result(&format!("id-{i}"), 10, 10))
+        .collect();
+    write_results(baseline_dir.path(), baseline_instances);
+    write_results(candidate_dir.path(), candidate_instances);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let sig = &v["resolved_rate_significance"];
+
+    assert!(
+        sig["underpowered"].as_bool().unwrap(),
+        "rerun sweep must be marked underpowered; got: {sig}"
+    );
+    let reason = sig["underpowered_reason"].as_str().unwrap_or("");
+    assert!(
+        reason.contains("rerun"),
+        "underpowered_reason must mention rerun; got: {reason}"
+    );
+}
+
+#[test]
+fn compare_min_significance_gate_blocked_for_rerun_sweep() {
+    // --min-significance must exit non-zero for rerun sweeps without --allow-underpowered.
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+
+    let baseline_instances: Vec<InstanceResult> = (0..10)
+        .map(|i| rerun_result(&format!("id-{i}"), 10, 1))
+        .collect();
+    let candidate_instances: Vec<InstanceResult> = (0..10)
+        .map(|i| rerun_result(&format!("id-{i}"), 10, 10))
+        .collect();
+    write_results(baseline_dir.path(), baseline_instances);
+    write_results(candidate_dir.path(), candidate_instances);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--min-significance",
+            "0.05",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "rerun sweep without --allow-underpowered must exit non-zero; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/tests/evaluator_provenance.rs
+++ b/tests/evaluator_provenance.rs
@@ -155,6 +155,9 @@ fn compare_args(baseline: &Path, candidate: &Path) -> CompareArgs {
         min_delta_pp: 0.0,
         cost_attribution: false,
         cost_attribution_min_delta_usd: 0.0,
+        min_significance: None,
+        regression_significance: None,
+        allow_underpowered: false,
     }
 }
 


### PR DESCRIPTION
## Summary

This PR implements paired statistical significance testing for the resolved-rate delta in `bench compare`. The test uses the exact McNemar method on instances present in both sweeps, with new CLI flags to gate on significance and control for underpowered tests.

## Key Changes

- **New `ResolvedRateSignificance` struct**: Captures the paired McNemar test results including p-value, 95% Wilson-score CI, discordant pair counts, and underpowered status
- **Exact McNemar test implementation**: Computes two-sided p-values in log-space to avoid overflow, with a 10 discordant-pair threshold for determining if a test is underpowered
- **CLI flags for significance gating**:
  - `--min-significance <alpha>`: Blocks positive deltas that fail to reach significance (p > alpha)
  - `--regression-significance <alpha>`: Blocks significant regressions (negative delta with p ≤ alpha)
  - `--allow-underpowered`: Overrides the underpowered block to allow gating on p-value alone
- **JSON output**: New `resolved_rate_significance` block in compare reports with test metadata, p-value, CI bounds, and instance counts
- **Text output**: Single `Significance:` line showing delta, CI, p-value, paired N, and underpowered status
- **Comprehensive test coverage**: 11 new tests covering significance computation, gating behavior, underpowered detection, and edge cases
- **Documentation**: New `docs/spec-significance.md` with test methodology, decision recipes, and JSON schema

## Implementation Details

- Paired test operates only on the overlap subset (instances in both sweeps); instances unique to one sweep are counted separately but excluded from the test
- Wilson-score CI is computed on the paired subset, consistent with existing delta CI methodology
- Underpowered flag is set when paired_n=0 or discordant pairs < 10, with human-readable reasons
- Significance gates check underpowered status first and block unless `--allow-underpowered` is set
- All existing test fixtures updated to include the three new `CompareArgs` fields

https://claude.ai/code/session_01LdM8BJ9MeTrGSUF15zB5sM