### PR TITLE
⚡ Bolt: Pre-allocate performance evaluation vectors

### DIFF
--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -1513,9 +1513,11 @@ fn build_latency_summary_from_slots(
     sweep_dir: &Path,
     slots: &[crate::run::compare::LoadedRunSlot],
 ) -> Option<LatencySummary> {
-    let mut model_totals: Vec<u64> = Vec::new();
-    let mut tool_totals: Vec<u64> = Vec::new();
-    let mut harness_totals: Vec<u64> = Vec::new();
+    // ⚡ Bolt: Pre-allocate vectors using the number of slots since we push at most one
+    // item per slot. This avoids heap reallocation overhead during large sweep evaluations.
+    let mut model_totals: Vec<u64> = Vec::with_capacity(slots.len());
+    let mut tool_totals: Vec<u64> = Vec::with_capacity(slots.len());
+    let mut harness_totals: Vec<u64> = Vec::with_capacity(slots.len());
     for slot in slots {
         let path = swebench::trajectory_path_for_run(sweep_dir, &slot.instance_id, slot.run_index);
         let path = if path.exists() {


### PR DESCRIPTION
💡 What: Switched to pre-allocating `model_totals`, `tool_totals`, and `harness_totals` vectors with `Vec::with_capacity(slots.len())` in `build_latency_summary_from_slots`.
🎯 Why: Vectors were being allocated empty (`Vec::new()`) and populated using `.push()` inside a loop that iterated over all trajectory slots. During large benchmarking evaluations, this caused multiple O(N) heap reallocation and copying cycles as the vectors grew. Since we know the maximum possible size (at most one item per slot), we can reserve the exact needed capacity upfront.
📊 Impact: Reduces heap memory reallocation overhead and avoids element copying during array growth in the telemetry evaluation pipeline.
🔬 Measurement: Run `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test` to ensure tests still pass.

---
*PR created automatically by Jules for task [248000556271806707](https://jules.google.com/task/248000556271806707) started by @madmax983*