### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/src/agent/parse.rs
+++ b/src/agent/parse.rs
@@ -224,10 +224,9 @@ fn raw_tool_arguments_to_input(tool_name: &str, arguments: &Value) -> Option<Str
     match arguments {
         Value::String(s) => {
             if let Ok(parsed) = serde_json::from_str::<Value>(s) {
-                raw_tool_arguments_to_input(tool_name, &parsed)
-            } else {
-                Some(s.clone())
+                return raw_tool_arguments_to_input(tool_name, &parsed);
             }
+            Some(s.clone())
         }
         Value::Object(map) if tool_name == BASH_TOOL_NAME => map
             .get("command")
@@ -459,6 +458,30 @@ mod tests {
         assert_eq!(
             extract_action_from_model_response(content, &raw, &["bash".into()]),
             Action::Submit("final".into())
+        );
+    }
+
+    #[test]
+    fn raw_tool_arguments_fall_back_to_json_string() {
+        let raw = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "tool_calls": [{
+                        "function": {
+                            "name": "custom_tool",
+                            "arguments": {"key": "value"}
+                        }
+                    }]
+                }
+            }]
+        });
+
+        assert_eq!(
+            extract_action_from_model_response("Let me run that.", &raw, &["custom_tool".into()]),
+            Action::Tool(ToolCall {
+                name: "custom_tool".into(),
+                input: "{\"key\":\"value\"}".into()
+            })
         );
     }
 }


### PR DESCRIPTION
🎯 Target: `src/agent/parse.rs` - `raw_tool_arguments_to_input`\n💣 Risk: Untested branch dropping back to `serde_json::to_string` could fail silently if JSON schema changes.\n🧪 Strategy: Added a new test `raw_tool_arguments_fall_back_to_json_string` which creates a non-bash tool call, and simulates missing "input" arguments, ensuring it stringifies correctly.\n🔬 Verification: `cargo test --lib agent::parse`

---
*PR created automatically by Jules for task [14221266062576317051](https://jules.google.com/task/14221266062576317051) started by @madmax983*