### PR TITLE
Add `bench behavior` command to classify agent actions by outcome

### DIFF
--- a/docs/spec-behavior.md
+++ b/docs/spec-behavior.md
@@ -1,0 +1,187 @@
+# spec-behavior: `bench behavior`
+
+## Overview
+
+`bench behavior` is a read-only post-sweep diagnostic that classifies every
+assistant turn into a semantic action class (read, write, test, build, search,
+nav, git, other, noop) and surfaces per-class counts, shares, and cost
+attribution broken down by outcome bucket. It writes `behavior.json` beside the
+sweep artifacts and prints a ranked text table.
+
+No agent loop, no model call, no sweep re-run.
+
+---
+
+## Action Taxonomy
+
+| Class   | Command heads                                                                                   |
+|---------|-------------------------------------------------------------------------------------------------|
+| `test`  | `pytest`, `cargo test`, `npm test`, `yarn test`, `go test`, `gradle test`, `mvn test`, `tox`, `nose`, `jest`, `mocha`, `vitest`, `phpunit`, `rspec` |
+| `write` | `sed`, `awk`, `tee`, `patch`, `dd`; `echo` when the full action string contains `>` (output redirect) |
+| `build` | `cargo build`, `cargo check`, `cargo clippy`, `cargo fmt`, `make`, `ninja`, `cmake`, `npm build`, `yarn build`, `go build`, `gradle build`, `mvn package`, `tsc` |
+| `search`| `grep`, `rg`, `find`, `fd`, `ack`, `ag`, `locate`                                             |
+| `read`  | `cat`, `head`, `tail`, `less`, `more`, `bat`, `file`, `wc`, `od`, `xxd`, `column`, `ls`       |
+| `nav`   | `cd`, `pwd`, `which`, `whereis`, `pushd`, `popd`, `dirs`                                       |
+| `git`   | any command whose head is `git`                                                                  |
+| `noop`  | assistant turn with no parseable bash action (reasoning-only, no actions, all `__SUBMIT__`)    |
+| `other` | command heads not in any class above                                                            |
+
+`taxonomy_version` is bumped whenever the mapping table changes so historical
+`behavior.json` artifacts remain interpretable.
+
+### Head extraction rules
+
+The same prefix-stripping rules used by `bench command-stats` apply here:
+
+- Leading `sudo` is stripped.
+- Leading `time` is stripped.
+- Leading `env VAR=val …` is stripped.
+- Leading bare `VAR=val` environment assignments are stripped.
+
+For dispatch commands (`cargo`, `npm`, `yarn`, `go`, `gradle`, `mvn`), the
+first argument (subcommand) determines the class.
+
+### Per-turn classification
+
+Each assistant turn is classified into exactly one **primary action class**:
+
+1. All bash actions in the turn are split on pipeline operators (`|`, not `||`).
+2. Each pipeline segment is classified individually.
+3. The turn's class is the **highest-priority class** found across all segments.
+
+Priority order (highest → lowest):
+
+```
+test > write > build > search > read > nav > git > other > noop
+```
+
+A turn with no actions, or whose only action is `__SUBMIT__`, is classified as
+`noop`.
+
+---
+
+## `behavior.json` Schema
+
+```json
+{
+  "sweep": "<path>",
+  "generated_at": "<ISO-8601>",
+  "taxonomy_version": 1,
+  "totals": {
+    "<class>": {
+      "turn_count": <integer>,
+      "share": <0.0–1.0>
+    }
+  },
+  "by_outcome": {
+    "resolved|unresolved|errored|all": {
+      "<class>": {
+        "turn_count": <integer>,
+        "share": <0.0–1.0>,
+        "mean_turns_per_instance": <float>,
+        "attributed_cost_usd": <float>
+      }
+    }
+  },
+  "comparisons": {
+    "resolved_vs_unresolved": [
+      {
+        "action_class": "<class>",
+        "resolved_share": <float>,
+        "unresolved_share": <float>,
+        "share_delta": <float>   // resolved_share − unresolved_share, sorted descending
+      }
+    ]
+  },
+  "per_instance": [             // present only when --per-instance is set
+    {
+      "instance_id": "<id>",
+      "class_counts": { "<class>": <integer> }
+    }
+  ],
+  "unclassified_heads": {
+    "<head>": <invocation_count>
+  }
+}
+```
+
+- `totals` covers the whole sweep (all outcome buckets combined).
+- `by_outcome.all` is the union of all four buckets.
+- `comparisons.resolved_vs_unresolved[*].share_delta` is `resolved_share −
+  unresolved_share`; positive = class is more prevalent in resolved instances.
+- `unclassified_heads` lists command heads that fell into `other`, so operators
+  can extend the taxonomy.
+
+---
+
+## CLI Reference
+
+```
+bench behavior --sweep <DIR> [OPTIONS]
+```
+
+| Flag             | Description                                                                           | Default |
+|------------------|---------------------------------------------------------------------------------------|---------|
+| `--sweep <DIR>`  | Completed sweep directory (must contain `results.json`).                              | —       |
+| `--format`       | `text` (ranked table) or `json` (full artifact to stdout).                            | `text`  |
+| `--bucket`       | Restrict text output to one bucket: `resolved`, `unresolved`, `errored`, `all`.       | all     |
+| `--min-share`    | Hide classes whose `all`-bucket share is below this threshold (0.0–1.0) in text mode. | `0.0`   |
+| `--filter`       | Instance filter in `key=value` form (same syntax as `bench inspect --filter`).        | —       |
+| `--per-instance` | Include per-instance class counts in the JSON output and written artifact.            | off     |
+
+### Exit codes
+
+Follows the project's stable contract (#98):
+
+- `0` — success regardless of outcome mix.
+- Non-zero — missing/unreadable sweep artifacts or invalid flags.
+
+---
+
+## `bench compare` integration
+
+When both sweep directories contain a `behavior.json`, `bench compare --format
+text` appends a one-paragraph **Action-Shape Diff** section that reports the
+per-class share deltas (candidate − baseline) with a headline naming the largest
+shift. The section is omitted silently when either artifact is absent.
+
+---
+
+## Worked example
+
+Sweep A (edit-heavy prompt):
+
+```
+--- Outcome: resolved ---
+action_class   turn_count   share    mean_turns/instance   attributed_cost_usd
+write          9            0.6000   3.00                  0.090000
+test           3            0.2000   1.00                  0.030000
+read           3            0.2000   1.00                  0.010000
+```
+
+Sweep B (read-heavy prompt):
+
+```
+--- Outcome: unresolved ---
+action_class   turn_count   share    mean_turns/instance   attributed_cost_usd
+read           15           0.8333   5.00                  0.050000
+search         3            0.1667   1.00                  0.010000
+```
+
+`bench compare` action-shape diff:
+
+```
+--- Action-Shape Diff ---
+Agent shifted to more write-heavy: +60pp write, +20pp test, -63pp read
+```
+
+---
+
+## Non-goals
+
+- MCP tool-call classification (bash only; MCP tool calls are a separate channel).
+- Time- or token-weighted shares beyond `attributed_cost_usd`.
+- Significance testing on action-class deltas (see #176).
+- Per-step sequence patterns or n-gram action transition matrices.
+- Adaptive or learned taxonomies.
+- Real-time action-shape during a running sweep (post-hoc only).

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -341,6 +341,8 @@ pub enum BenchCmd {
     Report(ReportCmd),
     /// Re-run only the failed instances of a completed sweep and merge results.
     Retry(RetryCmd),
+    /// Surface agent action-class mix (read/write/test/…) by outcome bucket.
+    Behavior(BehaviorCmd),
 }
 
 /// `bench retry` — re-run selected failed instances and merge into sweep dir.
@@ -1303,4 +1305,35 @@ pub struct EvaluatorSelftestCmd {
     /// Parallel worker count for the `sb-cli` evaluation backend.
     #[arg(long, default_value_t = 4)]
     pub parallel: usize,
+}
+
+/// `bench behavior` — surface agent action-class mix by outcome bucket.
+#[derive(Debug, Args)]
+pub struct BehaviorCmd {
+    /// Completed sweep directory produced by `bench swebench`.
+    #[arg(long)]
+    pub sweep: PathBuf,
+
+    /// Restrict output to one outcome bucket: `resolved`, `unresolved`,
+    /// `errored`, or `all`.
+    #[arg(long)]
+    pub bucket: Option<String>,
+
+    /// Hide action classes whose `all`-bucket share is below this threshold
+    /// in text output (0.0–1.0).
+    #[arg(long)]
+    pub min_share: Option<f64>,
+
+    /// Filter instances using the same syntax as `bench inspect --filter`.
+    /// Example: `failure_category=model_parse`.
+    #[arg(long)]
+    pub filter: Option<String>,
+
+    /// Emit per-instance class counts in the JSON output and artifact.
+    #[arg(long, default_value_t = false)]
+    pub per_instance: bool,
+
+    /// Output format: `text` (default) or `json`.
+    #[arg(long, default_value = "text")]
+    pub format: String,
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1009,10 +1009,9 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
     match format {
         crate::run::compare::CompareFormat::Text => {
             print!("{}", report.human_table());
-            if let Some(diff) = crate::run::behavior::behavior_compare_section(
-                &c.baseline,
-                &c.candidate,
-            ) {
+            if let Some(diff) =
+                crate::run::behavior::behavior_compare_section(&c.baseline, &c.candidate)
+            {
                 print!("{diff}");
             }
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -120,6 +120,9 @@ pub async fn run() -> Result<(), Error> {
         Command::Bench {
             cmd: args::BenchCmd::Retry(r),
         } => Box::pin(bench_retry(r)).await,
+        Command::Bench {
+            cmd: args::BenchCmd::Behavior(b),
+        } => bench_behavior(b),
         #[cfg(feature = "docker")]
         Command::Cleanup => cleanup_cmd().await,
         #[cfg(not(feature = "docker"))]
@@ -1004,7 +1007,15 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
         allow_underpowered: c.allow_underpowered,
     })?;
     match format {
-        crate::run::compare::CompareFormat::Text => print!("{}", report.human_table()),
+        crate::run::compare::CompareFormat::Text => {
+            print!("{}", report.human_table());
+            if let Some(diff) = crate::run::behavior::behavior_compare_section(
+                &c.baseline,
+                &c.candidate,
+            ) {
+                print!("{diff}");
+            }
+        }
         crate::run::compare::CompareFormat::Json => {
             println!("{}", report.to_json_pretty()?);
         }
@@ -1740,6 +1751,38 @@ fn bench_command_stats(c: args::CommandStatsCmd) -> Result<(), Error> {
         CommandStatsFormat::Json => {
             println!("{}", serde_json::to_string_pretty(&report)?);
         }
+    }
+    Ok(())
+}
+
+fn bench_behavior(b: args::BehaviorCmd) -> Result<(), Error> {
+    let is_json = match b.format.as_str() {
+        "text" => false,
+        "json" => true,
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "behavior: unknown --format `{other}` (expected `text` or `json`)"
+            ))));
+        }
+    };
+    let report = crate::run::behavior::run(&crate::run::behavior::BehaviorArgs {
+        sweep_dir: b.sweep,
+        bucket: b.bucket.clone(),
+        min_share: b.min_share,
+        filter: b.filter,
+        per_instance: b.per_instance,
+    })?;
+    if is_json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!(
+            "{}",
+            crate::run::behavior::render_text(
+                &report,
+                b.bucket.as_deref(),
+                b.min_share.unwrap_or(0.0),
+            )
+        );
     }
     Ok(())
 }

--- a/src/run/behavior.rs
+++ b/src/run/behavior.rs
@@ -69,10 +69,9 @@ impl ActionClass {
 
 // ── public classification API (used by unit tests) ────────────────────────────
 
-/// Classify a single bash action string (may be a pipeline) into an action class.
+/// Classify a single bash action string (may span multiple commands / pipelines).
 pub fn classify_action(action: &str) -> ActionClass {
-    let segments = split_pipeline(action);
-    segments
+    split_and_pipeline(action)
         .iter()
         .map(|seg| classify_segment(seg).0)
         .reduce(|a, b| if a.priority() >= b.priority() { a } else { b })
@@ -82,12 +81,12 @@ pub fn classify_action(action: &str) -> ActionClass {
 /// Classify a turn's list of action strings into the primary action class.
 ///
 /// - Empty slice → `Noop`
-/// - All `__SUBMIT__` → `Noop`
+/// - All `__SUBMIT__` or tool calls → `Noop`
 /// - Otherwise → highest-priority class across all actions
 pub fn classify_turn(actions: &[&str]) -> ActionClass {
     actions
         .iter()
-        .filter(|&&a| a != "__SUBMIT__")
+        .filter(|&&a| a != "__SUBMIT__" && !is_tool_call(a))
         .map(|&a| classify_action(a))
         .fold(ActionClass::Noop, |best, class| {
             if class.priority() > best.priority() {
@@ -658,10 +657,10 @@ fn classify_turn_tracking(
     let mut best = ActionClass::Noop;
 
     for action in actions {
-        if action == "__SUBMIT__" {
+        if action == "__SUBMIT__" || is_tool_call(action) {
             continue;
         }
-        for seg in split_pipeline(action) {
+        for seg in split_and_pipeline(action) {
             let (class, maybe_head) = classify_segment(seg);
             if let Some(head) = maybe_head {
                 *unclassified_heads.entry(head).or_default() += 1;
@@ -678,23 +677,52 @@ fn classify_turn_tracking(
 // ── classification internals ──────────────────────────────────────────────────
 
 /// Split on `|` but not `||` (logical-OR stops pipeline classification).
+/// Respects single- and double-quoted strings so `echo 'a|b' > file` is not split.
 fn split_pipeline(command: &str) -> Vec<&str> {
     let mut segments = Vec::new();
     let bytes = command.as_bytes();
     let mut start = 0;
     let mut i = 0;
+    let mut in_single = false;
+    let mut in_double = false;
     while i < bytes.len() {
-        if bytes[i] == b'|' && i + 1 < bytes.len() && bytes[i + 1] == b'|' {
-            break;
-        }
-        if bytes[i] == b'|' {
-            segments.push(&command[start..i]);
-            start = i + 1;
+        match bytes[i] {
+            b'\'' if !in_double => in_single = !in_single,
+            b'"' if !in_single => in_double = !in_double,
+            b'|' if !in_single && !in_double => {
+                if i + 1 < bytes.len() && bytes[i + 1] == b'|' {
+                    break;
+                }
+                segments.push(&command[start..i]);
+                start = i + 1;
+            }
+            _ => {}
         }
         i += 1;
     }
     segments.push(&command[start..]);
     segments
+}
+
+/// Split a multi-command action string (newlines, `&&`, `;`) then split each
+/// fragment on pipeline `|`. Returns all segments for classification.
+fn split_and_pipeline(action: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    for line in action.lines() {
+        for and_part in line.split("&&") {
+            for semi_part in and_part.split(';') {
+                out.extend(split_pipeline(semi_part));
+            }
+        }
+    }
+    out
+}
+
+/// Return true when an action string is a non-bash tool call (e.g. `diagnose:{…}`).
+fn is_tool_call(action: &str) -> bool {
+    // Mini-swe-agent encodes tool calls as `name:{json}`; shell commands never
+    // contain `:{` as a literal token boundary.
+    action.trim().contains(":{")
 }
 
 /// Return the first arg in `args` that is a member of `known`, skipping over flags.
@@ -736,10 +764,12 @@ fn classify_segment(segment: &str) -> (ActionClass, Option<String>) {
         "cargo" => {
             match find_subcommand(
                 rest,
-                &["test", "nextest", "build", "check", "clippy", "fmt"],
+                &[
+                    "test", "t", "nextest", "build", "b", "check", "c", "clippy", "fmt",
+                ],
             ) {
-                "test" | "nextest" => ActionClass::Test,
-                "build" | "check" | "clippy" | "fmt" => ActionClass::Build,
+                "test" | "t" | "nextest" => ActionClass::Test,
+                "build" | "b" | "check" | "c" | "clippy" | "fmt" => ActionClass::Build,
                 _ => ActionClass::Other,
             }
         }

--- a/src/run/behavior.rs
+++ b/src/run/behavior.rs
@@ -1,0 +1,904 @@
+//! `bench behavior`: surface agent action-class mix by outcome bucket.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::artifact::{ArtifactKind, classify_json_value};
+use crate::error::Error;
+use crate::run::compare::{load_evaluation_results_checked, load_sweep};
+use crate::run::swebench::InstanceResult;
+use crate::trajectory::{FailureCategory, Trajectory};
+
+// ── taxonomy ──────────────────────────────────────────────────────────────────
+
+pub const TAXONOMY_VERSION: u32 = 1;
+
+const ALL_CLASSES: &[&str] = &[
+    "test", "write", "build", "search", "read", "nav", "git", "other", "noop",
+];
+
+const VALID_BUCKETS: &[&str] = &["resolved", "unresolved", "errored", "all"];
+
+/// Semantic action class for a single agent turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActionClass {
+    Test,
+    Write,
+    Build,
+    Search,
+    Read,
+    Nav,
+    Git,
+    Other,
+    Noop,
+}
+
+impl ActionClass {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Test => "test",
+            Self::Write => "write",
+            Self::Build => "build",
+            Self::Search => "search",
+            Self::Read => "read",
+            Self::Nav => "nav",
+            Self::Git => "git",
+            Self::Other => "other",
+            Self::Noop => "noop",
+        }
+    }
+
+    /// Higher value = higher priority when multiple classes appear in one turn.
+    fn priority(&self) -> u8 {
+        match self {
+            Self::Test => 8,
+            Self::Write => 7,
+            Self::Build => 6,
+            Self::Search => 5,
+            Self::Read => 4,
+            Self::Nav => 3,
+            Self::Git => 2,
+            Self::Other => 1,
+            Self::Noop => 0,
+        }
+    }
+}
+
+// ── public classification API (used by unit tests) ────────────────────────────
+
+/// Classify a single bash action string (may be a pipeline) into an action class.
+pub fn classify_action(action: &str) -> ActionClass {
+    let segments = split_pipeline(action);
+    segments
+        .iter()
+        .map(|seg| classify_segment(seg).0)
+        .reduce(|a, b| if a.priority() >= b.priority() { a } else { b })
+        .unwrap_or(ActionClass::Noop)
+}
+
+/// Classify a turn's list of action strings into the primary action class.
+///
+/// - Empty slice → `Noop`
+/// - All `__SUBMIT__` → `Noop`
+/// - Otherwise → highest-priority class across all actions
+pub fn classify_turn(actions: &[&str]) -> ActionClass {
+    actions
+        .iter()
+        .filter(|&&a| a != "__SUBMIT__")
+        .map(|&a| classify_action(a))
+        .fold(ActionClass::Noop, |best, class| {
+            if class.priority() > best.priority() { class } else { best }
+        })
+}
+
+// ── public argument / report types ───────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct BehaviorArgs {
+    pub sweep_dir: PathBuf,
+    pub bucket: Option<String>,
+    pub min_share: Option<f64>,
+    pub filter: Option<String>,
+    pub per_instance: bool,
+}
+
+/// Per-class metrics for one outcome bucket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassMetrics {
+    pub turn_count: usize,
+    pub share: f64,
+    pub mean_turns_per_instance: f64,
+    pub attributed_cost_usd: f64,
+}
+
+/// Simplified metrics for the `totals` section (no per-instance breakdown).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TotalsMetrics {
+    pub turn_count: usize,
+    pub share: f64,
+}
+
+/// Per-class share delta between the resolved and unresolved buckets.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShapeDelta {
+    pub action_class: String,
+    pub resolved_share: f64,
+    pub unresolved_share: f64,
+    pub share_delta: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BehaviorComparisons {
+    pub resolved_vs_unresolved: Vec<ShapeDelta>,
+}
+
+/// Per-instance class counts (emitted only with `--per-instance`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstanceBehavior {
+    pub instance_id: String,
+    pub class_counts: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BehaviorReport {
+    pub sweep: String,
+    pub generated_at: String,
+    pub taxonomy_version: u32,
+    /// Whole-sweep per-class turn counts and shares.
+    pub totals: BTreeMap<String, TotalsMetrics>,
+    /// Per-class metrics broken down by outcome bucket.
+    pub by_outcome: BTreeMap<String, BTreeMap<String, ClassMetrics>>,
+    /// Shape comparisons (resolved vs unresolved).
+    pub comparisons: BehaviorComparisons,
+    /// Per-instance class counts, present only when `--per-instance` is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub per_instance: Option<Vec<InstanceBehavior>>,
+    /// Command heads that fell into the `other` class, with invocation counts.
+    pub unclassified_heads: BTreeMap<String, usize>,
+}
+
+// ── entry point ───────────────────────────────────────────────────────────────
+
+pub fn run(args: &BehaviorArgs) -> Result<BehaviorReport, Error> {
+    let mut report = build_report(args)?;
+    report.generated_at = utc_now_iso8601();
+    let output_path = args.sweep_dir.join("behavior.json");
+    let file = std::fs::File::create(output_path)?;
+    serde_json::to_writer_pretty(file, &report)?;
+    Ok(report)
+}
+
+// ── text rendering ────────────────────────────────────────────────────────────
+
+pub fn render_text(report: &BehaviorReport, bucket_filter: Option<&str>, min_share: f64) -> String {
+    use comfy_table::Table;
+    use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+    use comfy_table::presets::UTF8_FULL;
+
+    let mut out = String::new();
+    out.push_str("\n=== bench behavior ===\n");
+    let _ = writeln!(out, "Sweep: {}", report.sweep);
+    let total_turns: usize = report.totals.values().map(|m| m.turn_count).sum();
+    let _ = writeln!(out, "Taxonomy version: {}  total turns: {}", report.taxonomy_version, total_turns);
+    out.push('\n');
+
+    let buckets_to_show: Vec<&str> = match bucket_filter {
+        Some("all") | None => VALID_BUCKETS.to_vec(),
+        Some(b) => vec![b],
+    };
+
+    for bucket_name in buckets_to_show {
+        let Some(class_map) = report.by_outcome.get(bucket_name) else {
+            continue;
+        };
+
+        // Apply min_share filter using the all-bucket share for each class
+        let all_bucket = report.by_outcome.get("all");
+        let visible: Vec<(&str, &ClassMetrics)> = ALL_CLASSES
+            .iter()
+            .filter_map(|&cls| {
+                let metrics = class_map.get(cls)?;
+                let all_share = all_bucket
+                    .and_then(|b| b.get(cls))
+                    .map_or(metrics.share, |m| m.share);
+                if all_share >= min_share {
+                    Some((cls, metrics))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if visible.is_empty() {
+            let _ = writeln!(out, "--- Outcome: {bucket_name} --- (no classes above min-share threshold)");
+            continue;
+        }
+
+        let _ = writeln!(out, "--- Outcome: {bucket_name} ---");
+        let mut table = Table::new();
+        table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec![
+                "action_class",
+                "turn_count",
+                "share",
+                "mean_turns/instance",
+                "attributed_cost_usd",
+            ]);
+
+        for (cls, m) in visible {
+            table.add_row(vec![
+                cls.to_owned(),
+                m.turn_count.to_string(),
+                format!("{:.4}", m.share),
+                format!("{:.2}", m.mean_turns_per_instance),
+                format!("{:.6}", m.attributed_cost_usd),
+            ]);
+        }
+
+        out.push_str(&table.to_string());
+        out.push('\n');
+    }
+
+    // Action-shape diff section
+    let deltas = &report.comparisons.resolved_vs_unresolved;
+    if !deltas.is_empty() {
+        // Produce a headline for the biggest delta
+        if let Some(top) = deltas.first() {
+            let direction = if top.share_delta > 0.0 { "more" } else { "less" };
+            let _ = writeln!(
+                out,
+                "Action-shape headline: agent is {direction} {}-heavy in resolved vs unresolved ({:+.0}pp)",
+                top.action_class,
+                top.share_delta * 100.0
+            );
+        }
+        out.push_str("--- Action-Shape: resolved vs unresolved ---\n");
+        let mut table = Table::new();
+        table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec![
+                "action_class",
+                "resolved_share",
+                "unresolved_share",
+                "share_delta",
+            ]);
+        for d in deltas {
+            table.add_row(vec![
+                d.action_class.clone(),
+                format!("{:.4}", d.resolved_share),
+                format!("{:.4}", d.unresolved_share),
+                format!("{:+.4}", d.share_delta),
+            ]);
+        }
+        out.push_str(&table.to_string());
+        out.push('\n');
+    }
+
+    if !report.unclassified_heads.is_empty() {
+        let _ = writeln!(out, "Unclassified heads (other):");
+        for (head, count) in &report.unclassified_heads {
+            let _ = writeln!(out, "  {head}: {count}");
+        }
+    }
+
+    out
+}
+
+/// Try to load behavior.json from two sweep directories and produce a shape diff paragraph.
+/// Returns `None` when either file is absent or unreadable.
+pub fn behavior_compare_section(baseline: &Path, candidate: &Path) -> Option<String> {
+    let b_path = baseline.join("behavior.json");
+    let c_path = candidate.join("behavior.json");
+
+    if !b_path.exists() || !c_path.exists() {
+        return None;
+    }
+
+    let b_text = std::fs::read_to_string(&b_path).ok()?;
+    let c_text = std::fs::read_to_string(&c_path).ok()?;
+    let b: BehaviorReport = serde_json::from_str(&b_text).ok()?;
+    let c: BehaviorReport = serde_json::from_str(&c_text).ok()?;
+
+    let b_all = b.by_outcome.get("all")?;
+    let c_all = c.by_outcome.get("all")?;
+
+    let all_classes: BTreeSet<&str> = b_all
+        .keys()
+        .chain(c_all.keys())
+        .map(String::as_str)
+        .collect();
+
+    let mut deltas: Vec<(String, f64)> = all_classes
+        .iter()
+        .map(|&cls| {
+            let b_share = b_all.get(cls).map_or(0.0, |m| m.share);
+            let c_share = c_all.get(cls).map_or(0.0, |m| m.share);
+            (cls.to_owned(), c_share - b_share)
+        })
+        .collect();
+
+    deltas.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+    let biggest = deltas.first()?;
+    if biggest.1.abs() < 0.01 {
+        return Some("\n--- Action-Shape Diff ---\nNo significant action-shape shift detected.\n".to_owned());
+    }
+
+    let direction = if biggest.1 > 0.0 { "more" } else { "less" };
+    let mut out = String::from("\n--- Action-Shape Diff ---\n");
+    let _ = writeln!(
+        out,
+        "Agent shifted to {} {}-heavy: {:+.0}pp {}",
+        direction,
+        biggest.0,
+        biggest.1 * 100.0,
+        deltas
+            .iter()
+            .take(3)
+            .map(|(cls, d)| format!("{:+.0}pp {cls}", d * 100.0))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    Some(out)
+}
+
+// ── internal build logic ──────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct TurnRecord {
+    instance_id: String,
+    bucket: String,
+    action_class: String,
+    cost_usd: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum OutcomeBucket {
+    Resolved,
+    Unresolved,
+    Errored,
+}
+
+impl OutcomeBucket {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Resolved => "resolved",
+            Self::Unresolved => "unresolved",
+            Self::Errored => "errored",
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn build_report(args: &BehaviorArgs) -> Result<BehaviorReport, Error> {
+    if let Some(b) = &args.bucket {
+        if !VALID_BUCKETS.contains(&b.as_str()) {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "behavior: unknown --bucket `{b}`; valid values: resolved, unresolved, errored, all"
+            ))));
+        }
+    }
+
+    let sweep = load_sweep(&args.sweep_dir)?;
+    let evaluation = load_evaluation_results_checked(&args.sweep_dir)?;
+
+    let resolved_set: HashSet<String> = evaluation
+        .as_ref()
+        .map(|ev| {
+            ev.results
+                .instances
+                .iter()
+                .filter(|i| i.resolved)
+                .map(|i| i.instance_id.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut sorted_ids: Vec<String> = sweep.instances.keys().cloned().collect();
+    sorted_ids.sort();
+
+    let mut instance_buckets: Vec<(String, OutcomeBucket)> = Vec::new();
+    for id in &sorted_ids {
+        let instance = &sweep.instances[id];
+        let is_resolved = resolved_set.contains(id);
+        if let Some(filter) = &args.filter {
+            if !matches_filter(instance, Some(is_resolved), filter)? {
+                continue;
+            }
+        }
+        let bucket = classify_outcome(id, instance, &resolved_set);
+        instance_buckets.push((id.clone(), bucket));
+    }
+
+    let mut turns: Vec<TurnRecord> = Vec::new();
+    let mut unclassified_heads: BTreeMap<String, usize> = BTreeMap::new();
+    let mut per_instance_rows: Vec<InstanceBehavior> = Vec::new();
+
+    for (instance_id, bucket) in &instance_buckets {
+        let mut instance_class_counts: BTreeMap<String, usize> = BTreeMap::new();
+
+        for trajectory_path in resolve_trajectory_paths(&args.sweep_dir, instance_id) {
+            let Ok(trajectory) = load_trajectory(&trajectory_path) else {
+                continue;
+            };
+
+            let traj_turns = extract_turns_from_trajectory(
+                &trajectory,
+                instance_id,
+                bucket,
+                &mut unclassified_heads,
+            );
+
+            for t in &traj_turns {
+                *instance_class_counts
+                    .entry(t.action_class.clone())
+                    .or_default() += 1;
+            }
+            turns.extend(traj_turns);
+        }
+
+        if args.per_instance {
+            per_instance_rows.push(InstanceBehavior {
+                instance_id: instance_id.clone(),
+                class_counts: instance_class_counts,
+            });
+        }
+    }
+
+    // Build by_outcome
+    let bucket_names = ["resolved", "unresolved", "errored", "all"];
+    let mut by_outcome: BTreeMap<String, BTreeMap<String, ClassMetrics>> = BTreeMap::new();
+
+    for &bucket_name in &bucket_names {
+        let bucket_turns: Vec<&TurnRecord> = turns
+            .iter()
+            .filter(|t| bucket_name == "all" || t.bucket == bucket_name)
+            .collect();
+
+        let total_turns = bucket_turns.len();
+        let mut class_map: BTreeMap<String, ClassMetrics> = BTreeMap::new();
+
+        for &class_name in ALL_CLASSES {
+            let class_turns: Vec<&&TurnRecord> = bucket_turns
+                .iter()
+                .filter(|t| t.action_class == class_name)
+                .collect();
+
+            if class_turns.is_empty() {
+                continue;
+            }
+
+            let turn_count = class_turns.len();
+            let unique_instances: HashSet<&str> =
+                class_turns.iter().map(|t| t.instance_id.as_str()).collect();
+            let instance_count = unique_instances.len();
+
+            #[allow(clippy::cast_precision_loss)]
+            let share = if total_turns > 0 {
+                turn_count as f64 / total_turns as f64
+            } else {
+                0.0
+            };
+            #[allow(clippy::cast_precision_loss)]
+            let mean_turns_per_instance = if instance_count > 0 {
+                turn_count as f64 / instance_count as f64
+            } else {
+                0.0
+            };
+            let attributed_cost_usd: f64 = class_turns.iter().map(|t| t.cost_usd).sum();
+
+            class_map.insert(
+                class_name.to_owned(),
+                ClassMetrics {
+                    turn_count,
+                    share,
+                    mean_turns_per_instance,
+                    attributed_cost_usd,
+                },
+            );
+        }
+
+        by_outcome.insert(bucket_name.to_owned(), class_map);
+    }
+
+    // Build totals
+    let total_turns = turns.len();
+    let mut totals: BTreeMap<String, TotalsMetrics> = BTreeMap::new();
+    for &class_name in ALL_CLASSES {
+        #[allow(clippy::cast_precision_loss)]
+        let count = turns.iter().filter(|t| t.action_class == class_name).count();
+        if count > 0 {
+            totals.insert(
+                class_name.to_owned(),
+                TotalsMetrics {
+                    turn_count: count,
+                    #[allow(clippy::cast_precision_loss)]
+                    share: if total_turns > 0 {
+                        count as f64 / total_turns as f64
+                    } else {
+                        0.0
+                    },
+                },
+            );
+        }
+    }
+
+    let comparisons = build_comparisons(&by_outcome);
+
+    let per_instance = if args.per_instance {
+        Some(per_instance_rows)
+    } else {
+        None
+    };
+
+    Ok(BehaviorReport {
+        sweep: args.sweep_dir.display().to_string(),
+        generated_at: String::new(),
+        taxonomy_version: TAXONOMY_VERSION,
+        totals,
+        by_outcome,
+        comparisons,
+        per_instance,
+        unclassified_heads,
+    })
+}
+
+fn build_comparisons(
+    by_outcome: &BTreeMap<String, BTreeMap<String, ClassMetrics>>,
+) -> BehaviorComparisons {
+    let (Some(resolved), Some(unresolved)) = (by_outcome.get("resolved"), by_outcome.get("unresolved"))
+    else {
+        return BehaviorComparisons::default();
+    };
+
+    let all_classes: BTreeSet<&str> = resolved
+        .keys()
+        .chain(unresolved.keys())
+        .map(String::as_str)
+        .collect();
+
+    let mut deltas: Vec<ShapeDelta> = all_classes
+        .iter()
+        .map(|&cls| {
+            let r_share = resolved.get(cls).map_or(0.0, |m| m.share);
+            let u_share = unresolved.get(cls).map_or(0.0, |m| m.share);
+            ShapeDelta {
+                action_class: cls.to_owned(),
+                resolved_share: r_share,
+                unresolved_share: u_share,
+                share_delta: r_share - u_share,
+            }
+        })
+        .collect();
+
+    deltas.sort_by(|a, b| {
+        b.share_delta
+            .total_cmp(&a.share_delta)
+            .then_with(|| a.action_class.cmp(&b.action_class))
+    });
+
+    BehaviorComparisons {
+        resolved_vs_unresolved: deltas,
+    }
+}
+
+fn extract_turns_from_trajectory(
+    trajectory: &Trajectory,
+    instance_id: &str,
+    bucket: &OutcomeBucket,
+    unclassified_heads: &mut BTreeMap<String, usize>,
+) -> Vec<TurnRecord> {
+    let mut records = Vec::new();
+    let bucket_str = bucket.as_str().to_owned();
+
+    for msg in &trajectory.messages {
+        if msg.role != "assistant" {
+            continue;
+        }
+
+        let cost = msg.extra.cost.unwrap_or(0.0);
+
+        let action_class = match &msg.extra.actions {
+            Some(actions) if !actions.is_empty() => {
+                classify_turn_tracking(actions, unclassified_heads)
+            }
+            _ => ActionClass::Noop,
+        };
+
+        records.push(TurnRecord {
+            instance_id: instance_id.to_owned(),
+            bucket: bucket_str.clone(),
+            action_class: action_class.as_str().to_owned(),
+            cost_usd: cost,
+        });
+    }
+
+    records
+}
+
+/// Like `classify_turn` but also populates `unclassified_heads` for `other`-class segments.
+fn classify_turn_tracking(
+    actions: &[String],
+    unclassified_heads: &mut BTreeMap<String, usize>,
+) -> ActionClass {
+    let mut best = ActionClass::Noop;
+
+    for action in actions {
+        if action == "__SUBMIT__" {
+            continue;
+        }
+        for seg in split_pipeline(action) {
+            let (class, maybe_head) = classify_segment(seg);
+            if let Some(head) = maybe_head {
+                *unclassified_heads.entry(head).or_default() += 1;
+            }
+            if class.priority() > best.priority() {
+                best = class;
+            }
+        }
+    }
+
+    best
+}
+
+// ── classification internals ──────────────────────────────────────────────────
+
+/// Split on `|` but not `||`.
+fn split_pipeline(command: &str) -> Vec<&str> {
+    let mut segments = Vec::new();
+    let bytes = command.as_bytes();
+    let mut start = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'|' && i + 1 < bytes.len() && bytes[i + 1] == b'|' {
+            break;
+        }
+        if bytes[i] == b'|' {
+            segments.push(&command[start..i]);
+            start = i + 1;
+        }
+        i += 1;
+    }
+    segments.push(&command[start..]);
+    segments
+}
+
+/// Classify one pipeline segment. Returns `(ActionClass, Some(head))` when class is `Other`.
+fn classify_segment(segment: &str) -> (ActionClass, Option<String>) {
+    let segment = segment.trim();
+    if segment.is_empty() {
+        return (ActionClass::Noop, None);
+    }
+
+    let tokens: Vec<&str> = segment.split_whitespace().collect();
+    let start = prefix_start_index(&tokens);
+
+    if start >= tokens.len() {
+        return (ActionClass::Noop, None);
+    }
+
+    let head = tokens[start];
+    let rest = &tokens[start + 1..];
+    let first_arg = rest.first().copied().unwrap_or("");
+
+    let class = match head {
+        // Test (direct invocation)
+        "pytest" | "tox" | "nose" | "jest" | "mocha" | "vitest" | "phpunit" | "rspec" => {
+            ActionClass::Test
+        }
+        // Dispatch commands: test vs build depends on subcommand
+        "cargo" => match first_arg {
+            "test" | "nextest" => ActionClass::Test,
+            "build" | "check" | "clippy" | "fmt" => ActionClass::Build,
+            _ => ActionClass::Other,
+        },
+        "npm" | "yarn" => match first_arg {
+            "test" => ActionClass::Test,
+            "build" => ActionClass::Build,
+            "run" => match rest.get(1).copied().unwrap_or("") {
+                "build" => ActionClass::Build,
+                "test" => ActionClass::Test,
+                _ => ActionClass::Other,
+            },
+            _ => ActionClass::Other,
+        },
+        "go" | "gradle" => match first_arg {
+            "test" => ActionClass::Test,
+            "build" => ActionClass::Build,
+            _ => ActionClass::Other,
+        },
+        "mvn" => match first_arg {
+            "test" => ActionClass::Test,
+            "package" => ActionClass::Build,
+            _ => ActionClass::Other,
+        },
+        // Read
+        "cat" | "head" | "tail" | "less" | "more" | "bat" | "file" | "wc" | "od" | "xxd"
+        | "column" | "ls" => ActionClass::Read,
+        // Search
+        "grep" | "rg" | "find" | "fd" | "ack" | "ag" | "locate" => ActionClass::Search,
+        // Write (direct head match)
+        "sed" | "awk" | "tee" | "patch" | "dd" => ActionClass::Write,
+        // Write only when followed by output redirection
+        "echo" => {
+            if segment.contains('>') {
+                ActionClass::Write
+            } else {
+                ActionClass::Other
+            }
+        }
+        // Nav
+        "cd" | "pwd" | "which" | "whereis" | "pushd" | "popd" | "dirs" => ActionClass::Nav,
+        // Git
+        "git" => ActionClass::Git,
+        // Build (standalone tools)
+        "make" | "ninja" | "cmake" | "tsc" => ActionClass::Build,
+        // Not in any known class
+        _ => ActionClass::Other,
+    };
+
+    let other_head = if class == ActionClass::Other {
+        Some(head.to_owned())
+    } else {
+        None
+    };
+
+    (class, other_head)
+}
+
+/// Return the index of the first non-prefix token (strips sudo, time, env VAR=val, VAR=val).
+fn prefix_start_index(tokens: &[&str]) -> usize {
+    let mut i = 0;
+    while i < tokens.len() {
+        let token = tokens[i];
+
+        if token == "sudo" || token == "time" {
+            i += 1;
+            continue;
+        }
+
+        if token == "env" {
+            i += 1;
+            while i < tokens.len() && tokens[i].contains('=') && !tokens[i].starts_with('-') {
+                i += 1;
+            }
+            continue;
+        }
+
+        if let Some(eq) = token.find('=') {
+            let var = &token[..eq];
+            if !var.is_empty()
+                && !var.starts_with('-')
+                && !var.starts_with('/')
+                && var.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+            {
+                i += 1;
+                continue;
+            }
+        }
+
+        return i;
+    }
+    tokens.len()
+}
+
+// ── shared helpers (mirrors command_stats / triage) ───────────────────────────
+
+fn classify_outcome(
+    instance_id: &str,
+    instance: &InstanceResult,
+    resolved_set: &HashSet<String>,
+) -> OutcomeBucket {
+    if resolved_set.contains(instance_id) {
+        return OutcomeBucket::Resolved;
+    }
+    if instance.outcome.as_deref() == Some(crate::trajectory::outcome::ERROR) {
+        return OutcomeBucket::Errored;
+    }
+    OutcomeBucket::Unresolved
+}
+
+fn matches_filter(
+    instance: &InstanceResult,
+    resolved: Option<bool>,
+    filter: &str,
+) -> Result<bool, Error> {
+    let Some((key, value)) = filter.split_once('=') else {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(
+            "behavior: --filter expects key=value (e.g. failure_category=model_parse)".into(),
+        )));
+    };
+    let (key, value) = (key.trim(), value.trim());
+    match key {
+        "resolved" => {
+            if value != "true" && value != "false" {
+                return Err(Error::Config(crate::error::ConfigError::Invalid(
+                    "behavior: resolved filter must be `true` or `false`".into(),
+                )));
+            }
+            Ok(resolved == Some(value == "true"))
+        }
+        "failure_category" => Ok(instance
+            .failure_category
+            .is_some_and(|fc| failure_category_label(fc) == value)),
+        other => Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "behavior: unsupported filter key `{other}`; supported: `resolved`, `failure_category`"
+        )))),
+    }
+}
+
+fn failure_category_label(c: FailureCategory) -> &'static str {
+    match c {
+        FailureCategory::EnvSetup => "env_setup",
+        FailureCategory::ModelApi => "model_api",
+        FailureCategory::ModelParse => "model_parse",
+        FailureCategory::StepLimit => "step_limit",
+        FailureCategory::CostLimit => "cost_limit",
+        FailureCategory::BudgetExhausted => "budget_exhausted",
+        FailureCategory::WallclockTimeout => "wallclock_timeout",
+        FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::AgentStagnation => "agent_stagnation",
+        FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
+        FailureCategory::PatchEmpty => "patch_empty",
+        FailureCategory::SecretLeakDetected => "secret_leak_detected",
+        FailureCategory::HistoryCompactionFailed => "history_compaction_failed",
+        FailureCategory::Unknown => "unknown",
+    }
+}
+
+fn load_trajectory(path: &Path) -> Result<Trajectory, Error> {
+    let text = std::fs::read_to_string(path)?;
+    let value: serde_json::Value = serde_json::from_str(&text)?;
+    classify_json_value(&value, ArtifactKind::Trajectory, path.display().to_string())
+        .map_err(|err| Error::Trajectory(err.to_string()))?;
+    serde_json::from_value(value).map_err(Into::into)
+}
+
+fn resolve_trajectory_paths(sweep: &Path, instance_id: &str) -> Vec<PathBuf> {
+    let nested = sweep.join(instance_id).join("trajectory.json");
+    if nested.exists() {
+        return vec![nested];
+    }
+
+    let instance_dir = sweep.join(instance_id);
+    if instance_dir.is_dir() {
+        let mut run_paths = Vec::new();
+        let mut n = 1usize;
+        loop {
+            let p = instance_dir.join(format!("run-{n}.traj.json"));
+            if !p.exists() {
+                break;
+            }
+            run_paths.push(p);
+            n += 1;
+        }
+        if !run_paths.is_empty() {
+            return run_paths;
+        }
+    }
+
+    let flat = sweep.join(format!("{instance_id}.traj.json"));
+    if flat.exists() {
+        return vec![flat];
+    }
+
+    let bundled = sweep
+        .join("trajectories")
+        .join(format!("{instance_id}.traj.json"));
+    if bundled.exists() {
+        vec![bundled]
+    } else {
+        vec![]
+    }
+}
+
+fn utc_now_iso8601() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}

--- a/src/run/behavior.rs
+++ b/src/run/behavior.rs
@@ -371,7 +371,6 @@ pub fn behavior_compare_section(baseline: &Path, candidate: &Path) -> Option<Str
 
 #[derive(Debug, Clone)]
 struct TurnRecord {
-    instance_id: String,
     bucket: String,
     action_class: String,
     cost_usd: f64,
@@ -480,6 +479,15 @@ fn build_report(args: &BehaviorArgs) -> Result<BehaviorReport, Error> {
             .filter(|t| bucket_name == "all" || t.bucket == bucket_name)
             .collect();
 
+        // Total instances in this bucket — used as the denominator for
+        // mean_turns_per_instance so the metric is a population mean (all
+        // instances, not just those with at least one turn of the class).
+        #[allow(clippy::cast_precision_loss)]
+        let bucket_instance_count = instance_buckets
+            .iter()
+            .filter(|(_, b)| bucket_name == "all" || b.as_str() == bucket_name)
+            .count();
+
         let total_turns = bucket_turns.len();
         let mut class_map: BTreeMap<String, ClassMetrics> = BTreeMap::new();
 
@@ -494,9 +502,6 @@ fn build_report(args: &BehaviorArgs) -> Result<BehaviorReport, Error> {
             }
 
             let turn_count = class_turns.len();
-            let unique_instances: HashSet<&str> =
-                class_turns.iter().map(|t| t.instance_id.as_str()).collect();
-            let instance_count = unique_instances.len();
 
             #[allow(clippy::cast_precision_loss)]
             let share = if total_turns > 0 {
@@ -505,8 +510,8 @@ fn build_report(args: &BehaviorArgs) -> Result<BehaviorReport, Error> {
                 0.0
             };
             #[allow(clippy::cast_precision_loss)]
-            let mean_turns_per_instance = if instance_count > 0 {
-                turn_count as f64 / instance_count as f64
+            let mean_turns_per_instance = if bucket_instance_count > 0 {
+                turn_count as f64 / bucket_instance_count as f64
             } else {
                 0.0
             };
@@ -613,7 +618,7 @@ fn build_comparisons(
 
 fn extract_turns_from_trajectory(
     trajectory: &Trajectory,
-    instance_id: &str,
+    _instance_id: &str,
     bucket: &OutcomeBucket,
     unclassified_heads: &mut BTreeMap<String, usize>,
 ) -> Vec<TurnRecord> {
@@ -635,7 +640,6 @@ fn extract_turns_from_trajectory(
         };
 
         records.push(TurnRecord {
-            instance_id: instance_id.to_owned(),
             bucket: bucket_str.clone(),
             action_class: action_class.as_str().to_owned(),
             cost_usd: cost,
@@ -680,7 +684,10 @@ fn split_pipeline(command: &str) -> Vec<&str> {
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == b'|' && i + 1 < bytes.len() && bytes[i + 1] == b'|' {
-            break;
+            segments.push(&command[start..i]);
+            start = i + 2;
+            i += 2;
+            continue;
         }
         if bytes[i] == b'|' {
             segments.push(&command[start..i]);
@@ -750,7 +757,7 @@ fn classify_segment(segment: &str) -> (ActionClass, Option<String>) {
         "sed" | "awk" | "tee" | "patch" | "dd" => ActionClass::Write,
         // Write only when followed by output redirection
         "echo" => {
-            if segment.contains('>') {
+            if rest.iter().any(|t| t.starts_with('>')) {
                 ActionClass::Write
             } else {
                 ActionClass::Other
@@ -783,12 +790,19 @@ fn prefix_start_index(tokens: &[&str]) -> usize {
 
         if token == "sudo" || token == "time" {
             i += 1;
+            while i < tokens.len() && tokens[i].starts_with('-') {
+                let flag = tokens[i];
+                i += 1;
+                if ["-u", "-g", "-p", "-C", "-R", "-T"].contains(&flag) && i < tokens.len() {
+                    i += 1;
+                }
+            }
             continue;
         }
 
         if token == "env" {
             i += 1;
-            while i < tokens.len() && tokens[i].contains('=') && !tokens[i].starts_with('-') {
+            while i < tokens.len() && (tokens[i].starts_with('-') || tokens[i].contains('=')) {
                 i += 1;
             }
             continue;

--- a/src/run/behavior.rs
+++ b/src/run/behavior.rs
@@ -708,21 +708,66 @@ fn split_pipeline(command: &str) -> Vec<&str> {
 /// fragment on pipeline `|`. Returns all segments for classification.
 fn split_and_pipeline(action: &str) -> Vec<&str> {
     let mut out = Vec::new();
-    for line in action.lines() {
-        for and_part in line.split("&&") {
-            for semi_part in and_part.split(';') {
-                out.extend(split_pipeline(semi_part));
-            }
-        }
+    for cmd in split_commands(action) {
+        out.extend(split_pipeline(cmd));
     }
     out
 }
 
+/// Split `action` on `&&`, `;`, and newlines while respecting single- and
+/// double-quoted strings, so `echo 'a;b' > file` stays as one command.
+fn split_commands(action: &str) -> Vec<&str> {
+    let mut result = Vec::new();
+    let bytes = action.as_bytes();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut start = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' if !in_double => in_single = !in_single,
+            b'"' if !in_single => in_double = !in_double,
+            b'\n' | b';' if !in_single && !in_double => {
+                let seg = action[start..i].trim();
+                if !seg.is_empty() {
+                    result.push(seg);
+                }
+                start = i + 1;
+            }
+            b'&' if !in_single && !in_double && i + 1 < bytes.len() && bytes[i + 1] == b'&' => {
+                let seg = action[start..i].trim();
+                if !seg.is_empty() {
+                    result.push(seg);
+                }
+                start = i + 2;
+                i += 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    let seg = action[start..].trim();
+    if !seg.is_empty() {
+        result.push(seg);
+    }
+    result
+}
+
 /// Return true when an action string is a non-bash tool call (e.g. `diagnose:{…}`).
 fn is_tool_call(action: &str) -> bool {
-    // Mini-swe-agent encodes tool calls as `name:{json}`; shell commands never
-    // contain `:{` as a literal token boundary.
-    action.trim().contains(":{")
+    // Tool calls in mini-swe-agent look like `name:{json}` where the name is a
+    // bare identifier (word chars only). Require the prefix before `:{` to be
+    // all word chars so that bash actions containing JSON (e.g. `echo '{"k":"v"}'
+    // > file`) are not mistakenly excluded.
+    let action = action.trim();
+    let Some(colon_pos) = action.find(":{") else {
+        return false;
+    };
+    let prefix = &action[..colon_pos];
+    !prefix.is_empty()
+        && prefix
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 /// Return the first arg in `args` that is a member of `known`, skipping over flags.
@@ -841,8 +886,23 @@ fn prefix_start_index(tokens: &[&str]) -> usize {
             while i < tokens.len() && tokens[i].starts_with('-') {
                 let flag = tokens[i];
                 i += 1;
-                // These sudo flags each take one argument
-                if ["-u", "-g", "-p", "-C", "-R", "-T"].contains(&flag) && i < tokens.len() {
+                // Short and long sudo flags that each take one argument
+                let takes_arg = [
+                    "-u",
+                    "-g",
+                    "-p",
+                    "-C",
+                    "-R",
+                    "-T",
+                    "--user",
+                    "--group",
+                    "--prompt",
+                    "--chdir",
+                    "--other-user",
+                    "--host",
+                ]
+                .contains(&flag);
+                if takes_arg && i < tokens.len() && !tokens[i].starts_with('-') {
                     i += 1;
                 }
             }
@@ -865,7 +925,10 @@ fn prefix_start_index(tokens: &[&str]) -> usize {
                 if !t.starts_with('-') && t.contains('=') {
                     // VAR=val assignment
                     i += 1;
-                } else if t == "-u" || t == "--unset" || t == "-C" || t == "--chdir" {
+                } else if matches!(
+                    t,
+                    "-u" | "--unset" | "-C" | "--chdir" | "-S" | "--split-string"
+                ) {
                     // env flags that each take one argument
                     i += 1;
                     if i < tokens.len() {

--- a/src/run/behavior.rs
+++ b/src/run/behavior.rs
@@ -90,7 +90,11 @@ pub fn classify_turn(actions: &[&str]) -> ActionClass {
         .filter(|&&a| a != "__SUBMIT__")
         .map(|&a| classify_action(a))
         .fold(ActionClass::Noop, |best, class| {
-            if class.priority() > best.priority() { class } else { best }
+            if class.priority() > best.priority() {
+                class
+            } else {
+                best
+            }
         })
 }
 
@@ -182,7 +186,11 @@ pub fn render_text(report: &BehaviorReport, bucket_filter: Option<&str>, min_sha
     out.push_str("\n=== bench behavior ===\n");
     let _ = writeln!(out, "Sweep: {}", report.sweep);
     let total_turns: usize = report.totals.values().map(|m| m.turn_count).sum();
-    let _ = writeln!(out, "Taxonomy version: {}  total turns: {}", report.taxonomy_version, total_turns);
+    let _ = writeln!(
+        out,
+        "Taxonomy version: {}  total turns: {}",
+        report.taxonomy_version, total_turns
+    );
     out.push('\n');
 
     let buckets_to_show: Vec<&str> = match bucket_filter {
@@ -213,7 +221,10 @@ pub fn render_text(report: &BehaviorReport, bucket_filter: Option<&str>, min_sha
             .collect();
 
         if visible.is_empty() {
-            let _ = writeln!(out, "--- Outcome: {bucket_name} --- (no classes above min-share threshold)");
+            let _ = writeln!(
+                out,
+                "--- Outcome: {bucket_name} --- (no classes above min-share threshold)"
+            );
             continue;
         }
 
@@ -249,7 +260,11 @@ pub fn render_text(report: &BehaviorReport, bucket_filter: Option<&str>, min_sha
     if !deltas.is_empty() {
         // Produce a headline for the biggest delta
         if let Some(top) = deltas.first() {
-            let direction = if top.share_delta > 0.0 { "more" } else { "less" };
+            let direction = if top.share_delta > 0.0 {
+                "more"
+            } else {
+                "less"
+            };
             let _ = writeln!(
                 out,
                 "Action-shape headline: agent is {direction} {}-heavy in resolved vs unresolved ({:+.0}pp)",
@@ -327,7 +342,9 @@ pub fn behavior_compare_section(baseline: &Path, candidate: &Path) -> Option<Str
 
     let biggest = deltas.first()?;
     if biggest.1.abs() < 0.01 {
-        return Some("\n--- Action-Shape Diff ---\nNo significant action-shape shift detected.\n".to_owned());
+        return Some(
+            "\n--- Action-Shape Diff ---\nNo significant action-shape shift detected.\n".to_owned(),
+        );
     }
 
     let direction = if biggest.1 > 0.0 { "more" } else { "less" };
@@ -513,7 +530,10 @@ fn build_report(args: &BehaviorArgs) -> Result<BehaviorReport, Error> {
     let mut totals: BTreeMap<String, TotalsMetrics> = BTreeMap::new();
     for &class_name in ALL_CLASSES {
         #[allow(clippy::cast_precision_loss)]
-        let count = turns.iter().filter(|t| t.action_class == class_name).count();
+        let count = turns
+            .iter()
+            .filter(|t| t.action_class == class_name)
+            .count();
         if count > 0 {
             totals.insert(
                 class_name.to_owned(),
@@ -553,7 +573,8 @@ fn build_report(args: &BehaviorArgs) -> Result<BehaviorReport, Error> {
 fn build_comparisons(
     by_outcome: &BTreeMap<String, BTreeMap<String, ClassMetrics>>,
 ) -> BehaviorComparisons {
-    let (Some(resolved), Some(unresolved)) = (by_outcome.get("resolved"), by_outcome.get("unresolved"))
+    let (Some(resolved), Some(unresolved)) =
+        (by_outcome.get("resolved"), by_outcome.get("unresolved"))
     else {
         return BehaviorComparisons::default();
     };

--- a/src/run/behavior.rs
+++ b/src/run/behavior.rs
@@ -339,7 +339,7 @@ pub fn behavior_compare_section(baseline: &Path, candidate: &Path) -> Option<Str
         })
         .collect();
 
-    deltas.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    deltas.sort_by(|a, b| b.1.abs().total_cmp(&a.1.abs()).then_with(|| a.0.cmp(&b.0)));
 
     let biggest = deltas.first()?;
     if biggest.1.abs() < 0.01 {
@@ -607,7 +607,8 @@ fn build_comparisons(
 
     deltas.sort_by(|a, b| {
         b.share_delta
-            .total_cmp(&a.share_delta)
+            .abs()
+            .total_cmp(&a.share_delta.abs())
             .then_with(|| a.action_class.cmp(&b.action_class))
     });
 
@@ -676,7 +677,7 @@ fn classify_turn_tracking(
 
 // ── classification internals ──────────────────────────────────────────────────
 
-/// Split on `|` but not `||`.
+/// Split on `|` but not `||` (logical-OR stops pipeline classification).
 fn split_pipeline(command: &str) -> Vec<&str> {
     let mut segments = Vec::new();
     let bytes = command.as_bytes();
@@ -684,10 +685,7 @@ fn split_pipeline(command: &str) -> Vec<&str> {
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == b'|' && i + 1 < bytes.len() && bytes[i + 1] == b'|' {
-            segments.push(&command[start..i]);
-            start = i + 2;
-            i += 2;
-            continue;
+            break;
         }
         if bytes[i] == b'|' {
             segments.push(&command[start..i]);
@@ -755,9 +753,9 @@ fn classify_segment(segment: &str) -> (ActionClass, Option<String>) {
         "grep" | "rg" | "find" | "fd" | "ack" | "ag" | "locate" => ActionClass::Search,
         // Write (direct head match)
         "sed" | "awk" | "tee" | "patch" | "dd" => ActionClass::Write,
-        // Write only when followed by output redirection
+        // Write only when followed by output redirection (handles `echo > f` and `echo foo>f`)
         "echo" => {
-            if rest.iter().any(|t| t.starts_with('>')) {
+            if rest.iter().any(|t| t.contains('>')) {
                 ActionClass::Write
             } else {
                 ActionClass::Other
@@ -788,14 +786,24 @@ fn prefix_start_index(tokens: &[&str]) -> usize {
     while i < tokens.len() {
         let token = tokens[i];
 
-        if token == "sudo" || token == "time" {
+        if token == "sudo" {
             i += 1;
             while i < tokens.len() && tokens[i].starts_with('-') {
                 let flag = tokens[i];
                 i += 1;
+                // These sudo flags each take one argument
                 if ["-u", "-g", "-p", "-C", "-R", "-T"].contains(&flag) && i < tokens.len() {
                     i += 1;
                 }
+            }
+            continue;
+        }
+
+        if token == "time" {
+            i += 1;
+            // time flags (e.g. -p for POSIX format) never take arguments
+            while i < tokens.len() && tokens[i].starts_with('-') {
+                i += 1;
             }
             continue;
         }

--- a/src/run/behavior.rs
+++ b/src/run/behavior.rs
@@ -177,6 +177,7 @@ pub fn run(args: &BehaviorArgs) -> Result<BehaviorReport, Error> {
 
 // ── text rendering ────────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_lines)]
 pub fn render_text(report: &BehaviorReport, bucket_filter: Option<&str>, min_share: f64) -> String {
     use comfy_table::Table;
     use comfy_table::modifiers::UTF8_ROUND_CORNERS;

--- a/src/run/behavior.rs
+++ b/src/run/behavior.rs
@@ -697,6 +697,17 @@ fn split_pipeline(command: &str) -> Vec<&str> {
     segments
 }
 
+/// Return the first arg in `args` that is a member of `known`, skipping over flags.
+///
+/// This lets dispatch commands like `cargo --locked test` or `gradle --no-daemon test`
+/// find their subcommand even when global options appear before it.
+fn find_subcommand<'a>(args: &[&'a str], known: &[&str]) -> &'a str {
+    args.iter()
+        .find(|&&t| known.contains(&t))
+        .copied()
+        .unwrap_or("")
+}
+
 /// Classify one pipeline segment. Returns `(ActionClass, Some(head))` when class is `Other`.
 fn classify_segment(segment: &str) -> (ActionClass, Option<String>) {
     let segment = segment.trim();
@@ -713,35 +724,44 @@ fn classify_segment(segment: &str) -> (ActionClass, Option<String>) {
 
     let head = tokens[start];
     let rest = &tokens[start + 1..];
-    let first_arg = rest.first().copied().unwrap_or("");
 
     let class = match head {
         // Test (direct invocation)
         "pytest" | "tox" | "nose" | "jest" | "mocha" | "vitest" | "phpunit" | "rspec" => {
             ActionClass::Test
         }
-        // Dispatch commands: test vs build depends on subcommand
-        "cargo" => match first_arg {
-            "test" | "nextest" => ActionClass::Test,
-            "build" | "check" | "clippy" | "fmt" => ActionClass::Build,
-            _ => ActionClass::Other,
-        },
-        "npm" | "yarn" => match first_arg {
-            "test" => ActionClass::Test,
-            "build" => ActionClass::Build,
-            "run" => match rest.get(1).copied().unwrap_or("") {
-                "build" => ActionClass::Build,
-                "test" => ActionClass::Test,
+        // Dispatch commands: test vs build depends on subcommand.
+        // Use find_subcommand so global flags (e.g. `cargo --locked test`,
+        // `gradle --no-daemon build`, `mvn -q test`) don't mask the subcommand.
+        "cargo" => {
+            match find_subcommand(
+                rest,
+                &["test", "nextest", "build", "check", "clippy", "fmt"],
+            ) {
+                "test" | "nextest" => ActionClass::Test,
+                "build" | "check" | "clippy" | "fmt" => ActionClass::Build,
                 _ => ActionClass::Other,
-            },
+            }
+        }
+        "npm" | "yarn" => match find_subcommand(rest, &["test", "build", "run"]) {
+            "test" => ActionClass::Test,
+            "build" => ActionClass::Build,
+            "run" => {
+                let run_pos = rest.iter().position(|&t| t == "run").unwrap_or(rest.len());
+                match find_subcommand(&rest[run_pos + 1..], &["build", "test"]) {
+                    "build" => ActionClass::Build,
+                    "test" => ActionClass::Test,
+                    _ => ActionClass::Other,
+                }
+            }
             _ => ActionClass::Other,
         },
-        "go" | "gradle" => match first_arg {
+        "go" | "gradle" => match find_subcommand(rest, &["test", "build"]) {
             "test" => ActionClass::Test,
             "build" => ActionClass::Build,
             _ => ActionClass::Other,
         },
-        "mvn" => match first_arg {
+        "mvn" => match find_subcommand(rest, &["test", "package"]) {
             "test" => ActionClass::Test,
             "package" => ActionClass::Build,
             _ => ActionClass::Other,
@@ -810,8 +830,23 @@ fn prefix_start_index(tokens: &[&str]) -> usize {
 
         if token == "env" {
             i += 1;
-            while i < tokens.len() && (tokens[i].starts_with('-') || tokens[i].contains('=')) {
-                i += 1;
+            while i < tokens.len() {
+                let t = tokens[i];
+                if !t.starts_with('-') && t.contains('=') {
+                    // VAR=val assignment
+                    i += 1;
+                } else if t == "-u" || t == "--unset" || t == "-C" || t == "--chdir" {
+                    // env flags that each take one argument
+                    i += 1;
+                    if i < tokens.len() {
+                        i += 1;
+                    }
+                } else if t.starts_with('-') {
+                    // boolean env flag (e.g. -i / --ignore-environment)
+                    i += 1;
+                } else {
+                    break;
+                }
             }
             continue;
         }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,6 +1,7 @@
 //! Runners: thin glue that wires (config + model + env + agent) together
 //! and writes trajectories to disk.
 
+pub mod behavior;
 pub mod bundle;
 pub mod calibrate;
 pub mod command_stats;

--- a/tests/bench_behavior.rs
+++ b/tests/bench_behavior.rs
@@ -30,8 +30,14 @@ fn classify_search_commands() {
 
 #[test]
 fn classify_write_commands() {
-    assert_eq!(classify_action("sed -i 's/foo/bar/' file.py"), ActionClass::Write);
-    assert_eq!(classify_action("awk '{print $1}' data.txt"), ActionClass::Write);
+    assert_eq!(
+        classify_action("sed -i 's/foo/bar/' file.py"),
+        ActionClass::Write
+    );
+    assert_eq!(
+        classify_action("awk '{print $1}' data.txt"),
+        ActionClass::Write
+    );
     assert_eq!(classify_action("patch -p1 < fix.patch"), ActionClass::Write);
     assert_eq!(classify_action("tee output.txt"), ActionClass::Write);
 }
@@ -71,26 +77,41 @@ fn classify_git_commands() {
 #[test]
 fn classify_unknown_heads_land_in_other() {
     assert_eq!(classify_action("myweirdtool --flag"), ActionClass::Other);
-    assert_eq!(classify_action("anotherspecialtool --arg"), ActionClass::Other);
+    assert_eq!(
+        classify_action("anotherspecialtool --arg"),
+        ActionClass::Other
+    );
 }
 
 #[test]
 fn classify_turn_applies_priority_order_test_beats_write() {
     // A turn with both test and write actions → test wins (higher priority)
     let class = classify_turn(&["sed -i 's/x/y/' f.py", "pytest tests/"]);
-    assert_eq!(class, ActionClass::Test, "test should beat write in priority");
+    assert_eq!(
+        class,
+        ActionClass::Test,
+        "test should beat write in priority"
+    );
 }
 
 #[test]
 fn classify_turn_applies_priority_write_beats_read() {
     let class = classify_turn(&["cat file.py", "sed -i 's/x/y/' f.py"]);
-    assert_eq!(class, ActionClass::Write, "write should beat read in priority");
+    assert_eq!(
+        class,
+        ActionClass::Write,
+        "write should beat read in priority"
+    );
 }
 
 #[test]
 fn classify_turn_applies_priority_search_beats_read() {
     let class = classify_turn(&["cat file.py", "grep -r pattern ."]);
-    assert_eq!(class, ActionClass::Search, "search should beat read in priority");
+    assert_eq!(
+        class,
+        ActionClass::Search,
+        "search should beat read in priority"
+    );
 }
 
 #[test]
@@ -107,12 +128,18 @@ fn classify_turn_submit_only_is_noop() {
 
 #[test]
 fn classify_turn_strips_sudo_prefix() {
-    assert_eq!(classify_action("sudo sed -i 's/x/y/' f.py"), ActionClass::Write);
+    assert_eq!(
+        classify_action("sudo sed -i 's/x/y/' f.py"),
+        ActionClass::Write
+    );
 }
 
 #[test]
 fn classify_turn_strips_env_prefix() {
-    assert_eq!(classify_action("env RUST_LOG=debug cargo test"), ActionClass::Test);
+    assert_eq!(
+        classify_action("env RUST_LOG=debug cargo test"),
+        ActionClass::Test
+    );
 }
 
 // ── CLI integration tests ─────────────────────────────────────────────────────
@@ -195,10 +222,16 @@ fn cli_writes_behavior_json_artifact() {
 
     assert!(report["sweep"].is_string(), "sweep field required");
     assert!(report["generated_at"].is_string(), "generated_at required");
-    assert!(report["taxonomy_version"].is_number(), "taxonomy_version required");
+    assert!(
+        report["taxonomy_version"].is_number(),
+        "taxonomy_version required"
+    );
     assert!(report["totals"].is_object(), "totals required");
     assert!(report["by_outcome"].is_object(), "by_outcome required");
-    assert!(report["unclassified_heads"].is_object(), "unclassified_heads required");
+    assert!(
+        report["unclassified_heads"].is_object(),
+        "unclassified_heads required"
+    );
 }
 
 #[test]
@@ -385,8 +418,14 @@ fn per_instance_flag_emits_per_instance_data() {
     );
 
     let first = &per_instance[0];
-    assert!(first["instance_id"].is_string(), "instance_id required in per-instance row");
-    assert!(first["class_counts"].is_object(), "class_counts required in per-instance row");
+    assert!(
+        first["instance_id"].is_string(),
+        "instance_id required in per-instance row"
+    );
+    assert!(
+        first["class_counts"].is_object(),
+        "class_counts required in per-instance row"
+    );
 }
 
 #[test]
@@ -397,14 +436,7 @@ fn determinism_same_output_on_two_runs() {
     let run = |sweep_path: &str| -> serde_json::Value {
         let output = Command::new(binary_path())
             .args([
-                "--log",
-                "error",
-                "bench",
-                "behavior",
-                "--sweep",
-                sweep_path,
-                "--format",
-                "json",
+                "--log", "error", "bench", "behavior", "--sweep", sweep_path, "--format", "json",
             ])
             .output()
             .unwrap();
@@ -551,9 +583,18 @@ fn by_outcome_schema_includes_all_required_buckets() {
     assert!(output.status.success());
     let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let by_outcome = report["by_outcome"].as_object().unwrap();
-    assert!(by_outcome.contains_key("resolved"), "resolved bucket required");
-    assert!(by_outcome.contains_key("unresolved"), "unresolved bucket required");
-    assert!(by_outcome.contains_key("errored"), "errored bucket required");
+    assert!(
+        by_outcome.contains_key("resolved"),
+        "resolved bucket required"
+    );
+    assert!(
+        by_outcome.contains_key("unresolved"),
+        "unresolved bucket required"
+    );
+    assert!(
+        by_outcome.contains_key("errored"),
+        "errored bucket required"
+    );
     assert!(by_outcome.contains_key("all"), "all bucket required");
 }
 
@@ -580,11 +621,20 @@ fn class_metrics_include_required_fields() {
     let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     // Find a class with turns in the all bucket
     let all_bucket = report["by_outcome"]["all"].as_object().unwrap();
-    let first_class = all_bucket.values().next().expect("at least one class in all bucket");
+    let first_class = all_bucket
+        .values()
+        .next()
+        .expect("at least one class in all bucket");
     assert!(first_class["turn_count"].is_number(), "turn_count required");
     assert!(first_class["share"].is_number(), "share required");
-    assert!(first_class["mean_turns_per_instance"].is_number(), "mean_turns_per_instance required");
-    assert!(first_class["attributed_cost_usd"].is_number(), "attributed_cost_usd required");
+    assert!(
+        first_class["mean_turns_per_instance"].is_number(),
+        "mean_turns_per_instance required"
+    );
+    assert!(
+        first_class["attributed_cost_usd"].is_number(),
+        "attributed_cost_usd required"
+    );
 }
 
 #[test]
@@ -612,7 +662,10 @@ fn totals_include_all_classes_with_share_fields() {
     // Totals should have at least one class
     assert!(!totals.is_empty(), "totals should not be empty");
     let first = totals.values().next().unwrap();
-    assert!(first["turn_count"].is_number(), "turn_count required in totals");
+    assert!(
+        first["turn_count"].is_number(),
+        "turn_count required in totals"
+    );
     assert!(first["share"].is_number(), "share required in totals");
 }
 

--- a/tests/bench_behavior.rs
+++ b/tests/bench_behavior.rs
@@ -1,0 +1,617 @@
+//! `bench behavior`: surface agent read/edit/test mix by outcome.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)]
+
+use std::path::Path;
+use std::process::Command;
+
+mod support;
+use support::binary_path;
+
+// ── unit tests for action class classification ────────────────────────────────
+
+use rust_swe_agent::run::behavior::{ActionClass, classify_action, classify_turn};
+
+#[test]
+fn classify_read_commands() {
+    assert_eq!(classify_action("cat file.py"), ActionClass::Read);
+    assert_eq!(classify_action("head -20 file.py"), ActionClass::Read);
+    assert_eq!(classify_action("tail -f log.txt"), ActionClass::Read);
+    assert_eq!(classify_action("ls -la"), ActionClass::Read);
+    assert_eq!(classify_action("wc -l file.txt"), ActionClass::Read);
+}
+
+#[test]
+fn classify_search_commands() {
+    assert_eq!(classify_action("grep -r 'def test' ."), ActionClass::Search);
+    assert_eq!(classify_action("rg pattern src/"), ActionClass::Search);
+    assert_eq!(classify_action("find . -name '*.py'"), ActionClass::Search);
+}
+
+#[test]
+fn classify_write_commands() {
+    assert_eq!(classify_action("sed -i 's/foo/bar/' file.py"), ActionClass::Write);
+    assert_eq!(classify_action("awk '{print $1}' data.txt"), ActionClass::Write);
+    assert_eq!(classify_action("patch -p1 < fix.patch"), ActionClass::Write);
+    assert_eq!(classify_action("tee output.txt"), ActionClass::Write);
+}
+
+#[test]
+fn classify_test_commands() {
+    assert_eq!(classify_action("pytest tests/"), ActionClass::Test);
+    assert_eq!(classify_action("cargo test"), ActionClass::Test);
+    assert_eq!(classify_action("npm test"), ActionClass::Test);
+    assert_eq!(classify_action("go test ./..."), ActionClass::Test);
+    assert_eq!(classify_action("jest --coverage"), ActionClass::Test);
+}
+
+#[test]
+fn classify_build_commands() {
+    assert_eq!(classify_action("cargo build"), ActionClass::Build);
+    assert_eq!(classify_action("cargo check"), ActionClass::Build);
+    assert_eq!(classify_action("make all"), ActionClass::Build);
+    assert_eq!(classify_action("cmake .."), ActionClass::Build);
+    assert_eq!(classify_action("tsc --outDir dist"), ActionClass::Build);
+}
+
+#[test]
+fn classify_nav_commands() {
+    assert_eq!(classify_action("cd src/"), ActionClass::Nav);
+    assert_eq!(classify_action("pwd"), ActionClass::Nav);
+    assert_eq!(classify_action("which python"), ActionClass::Nav);
+}
+
+#[test]
+fn classify_git_commands() {
+    assert_eq!(classify_action("git status"), ActionClass::Git);
+    assert_eq!(classify_action("git diff HEAD"), ActionClass::Git);
+    assert_eq!(classify_action("git log --oneline"), ActionClass::Git);
+}
+
+#[test]
+fn classify_unknown_heads_land_in_other() {
+    assert_eq!(classify_action("myweirdtool --flag"), ActionClass::Other);
+    assert_eq!(classify_action("anotherspecialtool --arg"), ActionClass::Other);
+}
+
+#[test]
+fn classify_turn_applies_priority_order_test_beats_write() {
+    // A turn with both test and write actions → test wins (higher priority)
+    let class = classify_turn(&["sed -i 's/x/y/' f.py", "pytest tests/"]);
+    assert_eq!(class, ActionClass::Test, "test should beat write in priority");
+}
+
+#[test]
+fn classify_turn_applies_priority_write_beats_read() {
+    let class = classify_turn(&["cat file.py", "sed -i 's/x/y/' f.py"]);
+    assert_eq!(class, ActionClass::Write, "write should beat read in priority");
+}
+
+#[test]
+fn classify_turn_applies_priority_search_beats_read() {
+    let class = classify_turn(&["cat file.py", "grep -r pattern ."]);
+    assert_eq!(class, ActionClass::Search, "search should beat read in priority");
+}
+
+#[test]
+fn classify_turn_empty_actions_is_noop() {
+    let class = classify_turn(&[]);
+    assert_eq!(class, ActionClass::Noop, "empty actions should be noop");
+}
+
+#[test]
+fn classify_turn_submit_only_is_noop() {
+    let class = classify_turn(&["__SUBMIT__"]);
+    assert_eq!(class, ActionClass::Noop, "__SUBMIT__ only should be noop");
+}
+
+#[test]
+fn classify_turn_strips_sudo_prefix() {
+    assert_eq!(classify_action("sudo sed -i 's/x/y/' f.py"), ActionClass::Write);
+}
+
+#[test]
+fn classify_turn_strips_env_prefix() {
+    assert_eq!(classify_action("env RUST_LOG=debug cargo test"), ActionClass::Test);
+}
+
+// ── CLI integration tests ─────────────────────────────────────────────────────
+
+fn copy_main_behavior_fixture(dest: &Path) {
+    let src = Path::new("tests/fixtures/behavior/main_sweep");
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        std::fs::copy(entry.path(), dest.join(entry.file_name())).unwrap();
+    }
+}
+
+fn copy_noop_behavior_fixture(dest: &Path) {
+    let src = Path::new("tests/fixtures/behavior/noop_sweep");
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        std::fs::copy(entry.path(), dest.join(entry.file_name())).unwrap();
+    }
+}
+
+#[test]
+fn cli_produces_text_output() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_main_behavior_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "behavior",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench behavior failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("bench behavior"), "{stdout}");
+    assert!(stdout.contains("resolved"), "{stdout}");
+    assert!(stdout.contains("unresolved"), "{stdout}");
+}
+
+#[test]
+fn cli_writes_behavior_json_artifact() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_main_behavior_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "behavior",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench behavior failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let artifact_path = sweep.path().join("behavior.json");
+    assert!(artifact_path.exists(), "behavior.json should be written");
+
+    let report: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&artifact_path).unwrap()).unwrap();
+
+    assert!(report["sweep"].is_string(), "sweep field required");
+    assert!(report["generated_at"].is_string(), "generated_at required");
+    assert!(report["taxonomy_version"].is_number(), "taxonomy_version required");
+    assert!(report["totals"].is_object(), "totals required");
+    assert!(report["by_outcome"].is_object(), "by_outcome required");
+    assert!(report["unclassified_heads"].is_object(), "unclassified_heads required");
+}
+
+#[test]
+fn cli_json_format_emits_valid_json_to_stdout() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_main_behavior_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "behavior",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench behavior --format json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(report["by_outcome"].is_object());
+    assert!(report["taxonomy_version"].is_number());
+}
+
+#[test]
+fn edit_heavy_resolved_vs_read_heavy_unresolved_shape_diff() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_main_behavior_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "behavior",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    // Resolved bucket should be write-heavy
+    let resolved = &report["by_outcome"]["resolved"];
+    let write_share = resolved["write"]["share"].as_f64().unwrap_or(0.0);
+    assert!(
+        write_share > 0.1,
+        "resolved bucket should have significant write share, got {write_share}"
+    );
+
+    // Unresolved bucket should be read-heavy
+    let unresolved = &report["by_outcome"]["unresolved"];
+    let read_share = unresolved["read"]["share"].as_f64().unwrap_or(0.0);
+    assert!(
+        read_share > 0.5,
+        "unresolved bucket should be read-heavy, got {read_share}"
+    );
+
+    // comparisons should show write with positive delta (more in resolved than unresolved)
+    let comparisons = report["comparisons"]["resolved_vs_unresolved"]
+        .as_array()
+        .unwrap();
+    let write_entry = comparisons
+        .iter()
+        .find(|e| e["action_class"].as_str() == Some("write"))
+        .expect("write class should appear in resolved_vs_unresolved comparison");
+    let delta = write_entry["share_delta"].as_f64().unwrap();
+    assert!(
+        delta > 0.10,
+        "write share delta should be ≥ 10pp, got {delta:.4}"
+    );
+}
+
+#[test]
+fn noop_only_sweep_reports_noop_share_one() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_noop_behavior_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "behavior",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench behavior on noop sweep failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let all_bucket = &report["by_outcome"]["all"];
+    let noop_share = all_bucket["noop"]["share"].as_f64().unwrap_or(0.0);
+    assert!(
+        (noop_share - 1.0).abs() < 1e-9,
+        "noop-only sweep should have noop share = 1.0, got {noop_share}"
+    );
+}
+
+#[test]
+fn unknown_heads_appear_in_unclassified_heads() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_main_behavior_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "behavior",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let unclassified = report["unclassified_heads"].as_object().unwrap();
+    assert!(
+        unclassified.contains_key("myweirdtool") || unclassified.contains_key("anotherspecialtool"),
+        "unclassified_heads should contain unknown command heads, got: {unclassified:?}"
+    );
+}
+
+#[test]
+fn per_instance_flag_emits_per_instance_data() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_main_behavior_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "behavior",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "--per-instance",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench behavior --per-instance failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let per_instance = report["per_instance"]
+        .as_array()
+        .expect("per_instance should be present when --per-instance is set");
+    assert!(
+        !per_instance.is_empty(),
+        "per_instance array should not be empty"
+    );
+
+    let first = &per_instance[0];
+    assert!(first["instance_id"].is_string(), "instance_id required in per-instance row");
+    assert!(first["class_counts"].is_object(), "class_counts required in per-instance row");
+}
+
+#[test]
+fn determinism_same_output_on_two_runs() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_main_behavior_fixture(sweep.path());
+
+    let run = |sweep_path: &str| -> serde_json::Value {
+        let output = Command::new(binary_path())
+            .args([
+                "--log",
+                "error",
+                "bench",
+                "behavior",
+                "--sweep",
+                sweep_path,
+                "--format",
+                "json",
+            ])
+            .output()
+            .unwrap();
+        serde_json::from_slice(&output.stdout).unwrap()
+    };
+
+    let r1 = run(sweep.path().to_str().unwrap());
+    let r2 = run(sweep.path().to_str().unwrap());
+
+    // Compare everything except generated_at
+    let strip_ts = |mut v: serde_json::Value| {
+        if let Some(obj) = v.as_object_mut() {
+            obj.remove("generated_at");
+        }
+        v
+    };
+
+    assert_eq!(
+        strip_ts(r1),
+        strip_ts(r2),
+        "bench behavior should be deterministic (modulo generated_at)"
+    );
+}
+
+#[test]
+fn bucket_filter_all_includes_all_instances() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_main_behavior_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "behavior",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--bucket",
+            "all",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(report["by_outcome"]["all"].is_object());
+}
+
+#[test]
+fn min_share_hides_low_share_classes() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_main_behavior_fixture(sweep.path());
+
+    // With --min-share 0.9, most classes should be hidden in the text output
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "behavior",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--min-share",
+            "0.9",
+        ])
+        .output()
+        .unwrap();
+
+    // Should succeed even if all classes are filtered
+    assert!(
+        output.status.success(),
+        "bench behavior --min-share 0.9 failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn invalid_bucket_exits_with_error() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_main_behavior_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "behavior",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--bucket",
+            "invalid_bucket",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "bench behavior --bucket invalid_bucket should fail"
+    );
+}
+
+#[test]
+fn missing_sweep_exits_with_error() {
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "behavior",
+            "--sweep",
+            "/nonexistent/sweep/path",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "bench behavior with missing sweep should fail"
+    );
+}
+
+#[test]
+fn by_outcome_schema_includes_all_required_buckets() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_main_behavior_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "behavior",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let by_outcome = report["by_outcome"].as_object().unwrap();
+    assert!(by_outcome.contains_key("resolved"), "resolved bucket required");
+    assert!(by_outcome.contains_key("unresolved"), "unresolved bucket required");
+    assert!(by_outcome.contains_key("errored"), "errored bucket required");
+    assert!(by_outcome.contains_key("all"), "all bucket required");
+}
+
+#[test]
+fn class_metrics_include_required_fields() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_main_behavior_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "behavior",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // Find a class with turns in the all bucket
+    let all_bucket = report["by_outcome"]["all"].as_object().unwrap();
+    let first_class = all_bucket.values().next().expect("at least one class in all bucket");
+    assert!(first_class["turn_count"].is_number(), "turn_count required");
+    assert!(first_class["share"].is_number(), "share required");
+    assert!(first_class["mean_turns_per_instance"].is_number(), "mean_turns_per_instance required");
+    assert!(first_class["attributed_cost_usd"].is_number(), "attributed_cost_usd required");
+}
+
+#[test]
+fn totals_include_all_classes_with_share_fields() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_main_behavior_fixture(sweep.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "behavior",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let totals = report["totals"].as_object().unwrap();
+    // Totals should have at least one class
+    assert!(!totals.is_empty(), "totals should not be empty");
+    let first = totals.values().next().unwrap();
+    assert!(first["turn_count"].is_number(), "turn_count required in totals");
+    assert!(first["share"].is_number(), "share required in totals");
+}

--- a/tests/bench_behavior.rs
+++ b/tests/bench_behavior.rs
@@ -615,3 +615,80 @@ fn totals_include_all_classes_with_share_fields() {
     assert!(first["turn_count"].is_number(), "turn_count required in totals");
     assert!(first["share"].is_number(), "share required in totals");
 }
+
+#[test]
+fn rerun_sweep_classifies_turns_from_all_runs() {
+    // Fixture has one instance with run-1.traj.json (3 read turns) and
+    // run-2.traj.json (2 write + 1 test turn). Both runs must contribute
+    // to the totals, proving classification is per-turn, not per-instance.
+    let sweep = tempfile::tempdir().unwrap();
+    let src = Path::new("tests/fixtures/behavior/rerun_sweep");
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dest = sweep.path().join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            std::fs::create_dir_all(&dest).unwrap();
+            for sub in std::fs::read_dir(entry.path()).unwrap() {
+                let sub = sub.unwrap();
+                std::fs::copy(sub.path(), dest.join(sub.file_name())).unwrap();
+            }
+        } else {
+            std::fs::copy(entry.path(), dest).unwrap();
+        }
+    }
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "behavior",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench behavior on rerun sweep failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let all_bucket = &report["by_outcome"]["all"];
+
+    // run-1 contributes 3 read turns; run-2 contributes 2 write + 1 test.
+    // Total = 6, so both runs were processed.
+    let total_turns: u64 = report["totals"]
+        .as_object()
+        .unwrap()
+        .values()
+        .map(|m| m["turn_count"].as_u64().unwrap_or(0))
+        .sum();
+    assert_eq!(
+        total_turns, 6,
+        "expected 6 turns across both runs (3 + 3), got {total_turns}"
+    );
+
+    // read class should appear (from run-1)
+    assert!(
+        all_bucket["read"]["turn_count"].as_u64().unwrap_or(0) >= 3,
+        "expected at least 3 read turns from run-1"
+    );
+
+    // write class should appear (from run-2)
+    assert!(
+        all_bucket["write"]["turn_count"].as_u64().unwrap_or(0) >= 2,
+        "expected at least 2 write turns from run-2"
+    );
+
+    // test class should appear (from run-2)
+    assert!(
+        all_bucket["test"]["turn_count"].as_u64().unwrap_or(0) >= 1,
+        "expected at least 1 test turn from run-2"
+    );
+}

--- a/tests/fixtures/behavior/main_sweep/edit-heavy-resolved.traj.json
+++ b/tests/fixtures/behavior/main_sweep/edit-heavy-resolved.traj.json
@@ -1,0 +1,91 @@
+{
+  "trajectory_format": "mini-swe-agent-1.2",
+  "artifact_kind": "trajectory",
+  "schema_version": {"major": 1, "minor": 4},
+  "info": {
+    "task": "edit-heavy-resolved",
+    "model_name": "fixture-model",
+    "outcome": "submitted",
+    "total_cost_usd": 0.10,
+    "steps": 5,
+    "test_invocations": [],
+    "tests_run_before_submit": true
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Let me read the file first.",
+      "extra": {
+        "actions": ["cat solution.py"],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "def foo(): pass",
+      "extra": {
+        "run_result": {"stdout": "def foo(): pass", "stderr": "", "exit_code": 0, "timed_out": false}
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Fix the bug.",
+      "extra": {
+        "actions": ["sed -i 's/pass/return 42/' solution.py"],
+        "cost": 0.02
+      }
+    },
+    {
+      "role": "user",
+      "content": "",
+      "extra": {
+        "run_result": {"stdout": "", "stderr": "", "exit_code": 0, "timed_out": false}
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Fix another issue.",
+      "extra": {
+        "actions": ["sed -i 's/foo/bar/' solution.py"],
+        "cost": 0.02
+      }
+    },
+    {
+      "role": "user",
+      "content": "",
+      "extra": {
+        "run_result": {"stdout": "", "stderr": "", "exit_code": 0, "timed_out": false}
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Apply patch.",
+      "extra": {
+        "actions": ["awk '{print $1}' data.txt"],
+        "cost": 0.02
+      }
+    },
+    {
+      "role": "user",
+      "content": "col1",
+      "extra": {
+        "run_result": {"stdout": "col1", "stderr": "", "exit_code": 0, "timed_out": false}
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Run tests.",
+      "extra": {
+        "actions": ["pytest tests/"],
+        "cost": 0.03
+      }
+    },
+    {
+      "role": "user",
+      "content": "1 passed",
+      "extra": {
+        "run_result": {"stdout": "1 passed", "stderr": "", "exit_code": 0, "timed_out": false}
+      }
+    }
+  ]
+}

--- a/tests/fixtures/behavior/main_sweep/evaluation.json
+++ b/tests/fixtures/behavior/main_sweep/evaluation.json
@@ -1,0 +1,24 @@
+{
+  "instances": [
+    {
+      "instance_id": "edit-heavy-resolved",
+      "resolved": true,
+      "runs": 1,
+      "resolved_count": 1,
+      "pass_at_1": true,
+      "tests_passed": [],
+      "tests_failed": [],
+      "eval_exit_reason": "resolved"
+    },
+    {
+      "instance_id": "read-heavy-unresolved",
+      "resolved": false,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_passed": [],
+      "tests_failed": [],
+      "eval_exit_reason": "unresolved"
+    }
+  ]
+}

--- a/tests/fixtures/behavior/main_sweep/read-heavy-unresolved.traj.json
+++ b/tests/fixtures/behavior/main_sweep/read-heavy-unresolved.traj.json
@@ -1,0 +1,106 @@
+{
+  "trajectory_format": "mini-swe-agent-1.2",
+  "artifact_kind": "trajectory",
+  "schema_version": {"major": 1, "minor": 4},
+  "info": {
+    "task": "read-heavy-unresolved",
+    "model_name": "fixture-model",
+    "outcome": "step_limit_reached",
+    "total_cost_usd": 0.06,
+    "steps": 6,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Let me look at the code.",
+      "extra": {
+        "actions": ["cat main.py"],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "def main(): pass",
+      "extra": {
+        "run_result": {"stdout": "def main(): pass", "stderr": "", "exit_code": 0, "timed_out": false}
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Read the README.",
+      "extra": {
+        "actions": ["cat README.md"],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "# Project",
+      "extra": {
+        "run_result": {"stdout": "# Project", "stderr": "", "exit_code": 0, "timed_out": false}
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Check the header.",
+      "extra": {
+        "actions": ["head -20 main.py"],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "def main(): pass",
+      "extra": {
+        "run_result": {"stdout": "def main(): pass", "stderr": "", "exit_code": 0, "timed_out": false}
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Search for the bug.",
+      "extra": {
+        "actions": ["grep -r 'error' ."],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "",
+      "extra": {
+        "run_result": {"stdout": "", "stderr": "", "exit_code": 1, "timed_out": false}
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Try another file.",
+      "extra": {
+        "actions": ["cat utils.py"],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "cat: utils.py: No such file",
+      "extra": {
+        "run_result": {"stdout": "", "stderr": "cat: utils.py: No such file", "exit_code": 1, "timed_out": false}
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Read another file.",
+      "extra": {
+        "actions": ["cat config.py"],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "cat: config.py: No such file",
+      "extra": {
+        "run_result": {"stdout": "", "stderr": "cat: config.py: No such file", "exit_code": 1, "timed_out": false}
+      }
+    }
+  ]
+}

--- a/tests/fixtures/behavior/main_sweep/results.json
+++ b/tests/fixtures/behavior/main_sweep/results.json
@@ -1,0 +1,45 @@
+{
+  "artifact_kind": "sweep_results",
+  "schema_version": {"major": 1, "minor": 4},
+  "total": 3,
+  "submitted": 1,
+  "skipped": 0,
+  "errored": 1,
+  "total_cost_usd": 0.18,
+  "instances": [
+    {
+      "instance_id": "edit-heavy-resolved",
+      "exit_reason": "submitted",
+      "outcome": "submitted",
+      "cost_usd": 0.10,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 1,
+      "pass_at_1": true,
+      "tests_run_before_submit": true
+    },
+    {
+      "instance_id": "read-heavy-unresolved",
+      "exit_reason": "step_limit_reached",
+      "outcome": "step_limit_reached",
+      "cost_usd": 0.06,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    },
+    {
+      "instance_id": "unknown-head-errored",
+      "exit_reason": "error",
+      "outcome": "error",
+      "failure_category": "model_parse",
+      "cost_usd": 0.02,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    }
+  ]
+}

--- a/tests/fixtures/behavior/main_sweep/unknown-head-errored.traj.json
+++ b/tests/fixtures/behavior/main_sweep/unknown-head-errored.traj.json
@@ -1,0 +1,47 @@
+{
+  "trajectory_format": "mini-swe-agent-1.2",
+  "artifact_kind": "trajectory",
+  "schema_version": {"major": 1, "minor": 4},
+  "info": {
+    "task": "unknown-head-errored",
+    "model_name": "fixture-model",
+    "outcome": "error",
+    "failure_category": "model_parse",
+    "total_cost_usd": 0.02,
+    "steps": 2,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Run a custom tool.",
+      "extra": {
+        "actions": ["myweirdtool --flag value"],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "command not found",
+      "extra": {
+        "run_result": {"stdout": "", "stderr": "command not found", "exit_code": 127, "timed_out": false}
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Try another unknown tool.",
+      "extra": {
+        "actions": ["anotherspecialtool --arg"],
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "command not found",
+      "extra": {
+        "run_result": {"stdout": "", "stderr": "command not found", "exit_code": 127, "timed_out": false}
+      }
+    }
+  ]
+}

--- a/tests/fixtures/behavior/noop_sweep/noop-only-1.traj.json
+++ b/tests/fixtures/behavior/noop_sweep/noop-only-1.traj.json
@@ -1,0 +1,40 @@
+{
+  "trajectory_format": "mini-swe-agent-1.2",
+  "artifact_kind": "trajectory",
+  "schema_version": {"major": 1, "minor": 4},
+  "info": {
+    "task": "noop-only-1",
+    "model_name": "fixture-model",
+    "outcome": "step_limit_reached",
+    "total_cost_usd": 0.02,
+    "steps": 2,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "I need to think about this problem carefully.",
+      "extra": {
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "Please provide a bash command.",
+      "extra": {}
+    },
+    {
+      "role": "assistant",
+      "content": "Let me reconsider the approach.",
+      "extra": {
+        "cost": 0.01
+      }
+    },
+    {
+      "role": "user",
+      "content": "Please provide a bash command.",
+      "extra": {}
+    }
+  ]
+}

--- a/tests/fixtures/behavior/noop_sweep/results.json
+++ b/tests/fixtures/behavior/noop_sweep/results.json
@@ -1,0 +1,22 @@
+{
+  "artifact_kind": "sweep_results",
+  "schema_version": {"major": 1, "minor": 4},
+  "total": 1,
+  "submitted": 0,
+  "skipped": 0,
+  "errored": 0,
+  "total_cost_usd": 0.02,
+  "instances": [
+    {
+      "instance_id": "noop-only-1",
+      "exit_reason": "step_limit_reached",
+      "outcome": "step_limit_reached",
+      "cost_usd": 0.02,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    }
+  ]
+}

--- a/tests/fixtures/behavior/rerun_sweep/rerun-instance/run-1.traj.json
+++ b/tests/fixtures/behavior/rerun_sweep/rerun-instance/run-1.traj.json
@@ -1,0 +1,46 @@
+{
+  "trajectory_format": "mini-swe-agent-1.2",
+  "artifact_kind": "trajectory",
+  "schema_version": {"major": 1, "minor": 4},
+  "info": {
+    "task": "rerun-instance",
+    "model_name": "fixture-model",
+    "outcome": "step_limit_reached",
+    "total_cost_usd": 0.03,
+    "steps": 3,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Read the main file.",
+      "extra": {"actions": ["cat main.py"], "cost": 0.01}
+    },
+    {
+      "role": "user",
+      "content": "def main(): pass",
+      "extra": {"run_result": {"stdout": "def main(): pass", "stderr": "", "exit_code": 0, "timed_out": false}}
+    },
+    {
+      "role": "assistant",
+      "content": "Read the config.",
+      "extra": {"actions": ["cat config.py"], "cost": 0.01}
+    },
+    {
+      "role": "user",
+      "content": "cat: config.py: No such file",
+      "extra": {"run_result": {"stdout": "", "stderr": "cat: config.py: No such file", "exit_code": 1, "timed_out": false}}
+    },
+    {
+      "role": "assistant",
+      "content": "Read the README.",
+      "extra": {"actions": ["cat README.md"], "cost": 0.01}
+    },
+    {
+      "role": "user",
+      "content": "# Project",
+      "extra": {"run_result": {"stdout": "# Project", "stderr": "", "exit_code": 0, "timed_out": false}}
+    }
+  ]
+}

--- a/tests/fixtures/behavior/rerun_sweep/rerun-instance/run-2.traj.json
+++ b/tests/fixtures/behavior/rerun_sweep/rerun-instance/run-2.traj.json
@@ -1,0 +1,46 @@
+{
+  "trajectory_format": "mini-swe-agent-1.2",
+  "artifact_kind": "trajectory",
+  "schema_version": {"major": 1, "minor": 4},
+  "info": {
+    "task": "rerun-instance",
+    "model_name": "fixture-model",
+    "outcome": "submitted",
+    "total_cost_usd": 0.06,
+    "steps": 3,
+    "test_invocations": [],
+    "tests_run_before_submit": true
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Apply the fix.",
+      "extra": {"actions": ["sed -i 's/pass/return 42/' main.py"], "cost": 0.02}
+    },
+    {
+      "role": "user",
+      "content": "",
+      "extra": {"run_result": {"stdout": "", "stderr": "", "exit_code": 0, "timed_out": false}}
+    },
+    {
+      "role": "assistant",
+      "content": "Apply another fix.",
+      "extra": {"actions": ["sed -i 's/foo/bar/' main.py"], "cost": 0.02}
+    },
+    {
+      "role": "user",
+      "content": "",
+      "extra": {"run_result": {"stdout": "", "stderr": "", "exit_code": 0, "timed_out": false}}
+    },
+    {
+      "role": "assistant",
+      "content": "Run the tests.",
+      "extra": {"actions": ["pytest tests/"], "cost": 0.02}
+    },
+    {
+      "role": "user",
+      "content": "1 passed",
+      "extra": {"run_result": {"stdout": "1 passed", "stderr": "", "exit_code": 0, "timed_out": false}}
+    }
+  ]
+}

--- a/tests/fixtures/behavior/rerun_sweep/results.json
+++ b/tests/fixtures/behavior/rerun_sweep/results.json
@@ -1,0 +1,22 @@
+{
+  "artifact_kind": "sweep_results",
+  "schema_version": {"major": 1, "minor": 4},
+  "total": 1,
+  "submitted": 1,
+  "skipped": 0,
+  "errored": 0,
+  "total_cost_usd": 0.09,
+  "instances": [
+    {
+      "instance_id": "rerun-instance",
+      "exit_reason": "submitted",
+      "outcome": "submitted",
+      "cost_usd": 0.09,
+      "attempts": 2,
+      "runs": 2,
+      "resolved_count": 1,
+      "pass_at_1": false,
+      "tests_run_before_submit": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR introduces a new `bench behavior` subcommand that analyzes completed sweeps to classify every assistant turn into semantic action classes (read, write, test, build, search, nav, git, other, noop) and surfaces per-class metrics broken down by outcome bucket (resolved, unresolved, errored).

## Key Changes

- **New `behavior` module** (`src/run/behavior.rs`): Core implementation with ~900 lines providing:
  - `ActionClass` enum and classification logic for bash commands
  - `classify_action()` and `classify_turn()` functions that map commands to semantic classes using priority-based resolution
  - `BehaviorReport` struct with per-class metrics (turn counts, shares, mean turns per instance, attributed cost)
  - Shape comparison analysis (resolved vs unresolved action distributions)
  - Text and JSON output rendering with configurable filtering

- **CLI integration** (`src/cli/args.rs`, `src/cli/mod.rs`):
  - New `BehaviorCmd` struct with options for `--bucket`, `--min-share`, `--filter`, `--per-instance`
  - Wired into main command dispatcher
  - Integrated behavior shape diff into `bench compare` output

- **Comprehensive test suite** (`tests/bench_behavior.rs`):
  - 20+ unit tests covering action classification (read, write, test, build, search, nav, git, other, noop)
  - Priority ordering validation (test > write > build > search > read > nav > git > other > noop)
  - CLI integration tests validating JSON output, text rendering, per-instance data, determinism
  - Shape diff detection between resolved and unresolved buckets

- **Test fixtures** (`tests/fixtures/behavior/`):
  - `main_sweep/`: Three instances with mixed behaviors (edit-heavy resolved, read-heavy unresolved, unknown-head errored)
  - `noop_sweep/`: Instance with no-op turns for edge case testing
  - `rerun_sweep/`: Instance with multiple runs to test aggregation

- **Specification** (`docs/spec-behavior.md`):
  - Complete taxonomy mapping for all 9 action classes
  - Head extraction rules (sudo/time/env prefix stripping, dispatch command handling)
  - Per-turn classification algorithm with priority resolution
  - Full `behavior.json` schema documentation

## Implementation Details

- **Action classification** uses command head extraction with prefix stripping (sudo, time, env) and dispatch command subcommand detection
- **Pipeline handling** splits on `|` operators and applies highest-priority class across segments
- **Outcome bucketing** classifies instances as resolved/unresolved/errored based on evaluation results
- **Cost attribution** tracks per-turn costs and aggregates by class
- **Shape comparison** computes share deltas between resolved and unresolved buckets, sorted by magnitude
- **Deterministic output** with sorted maps and consistent ordering across runs
- **Filtering support** allows instance filtering by outcome bucket and custom predicates

https://claude.ai/code/session_015Hp2quiXHvGTcfPYiG8vvZ