### PR TITLE
Add `bench cache-stats` command for prompt cache effectiveness analysis

### DIFF
--- a/docs/artifact-contract.md
+++ b/docs/artifact-contract.md
@@ -23,7 +23,7 @@ Run artifacts use explicit top-level metadata:
 | `preflight_report` | `bench doctor/swebench --format json` | `artifact_kind`, `schema_version`, `mode`, `checks` | additional check metadata |
 | `swebench_predictions_metadata` | `all_preds.metadata.json`, `all_preds.run-k.metadata.json` | `artifact_kind`, `schema_version`, `predictions_file`, `aggregate`, `row_count`, `swebench_evaluator_compatible` | `run_index`, future provenance fields |
 | `bundle_manifest` | `BUNDLE.json` inside `bench bundle` archives | `artifact_kind`, `schema_version`, `source_sweep_dir`, `source_manifest_hash`, `harness_git_sha`, `bundle_generated_at`, `instance_scope`, `files` | future integrity metadata |
-| `cache_stats_report` | `cache-stats.json` (written by `bench cache-stats`) | `artifact_kind`, `schema_version` `1.0`, `sweep`, `generated_at`, `cache_disabled`, `sweep_totals`, `instances` | `baseline` (delta vs prior sweep) |
+| `cache_stats_report` | `cache-stats.json` (written by `bench cache-stats`) | `artifact_kind`, `schema_version` (harness-wide current), `sweep`, `generated_at`, `cache_disabled`, `sweep_totals`, `instances` | `baseline` (delta vs prior sweep) |
 
 `all_preds*.jsonl` rows intentionally do not carry artifact metadata. They stay compatible with SWE-bench evaluators; version metadata lives in the companion metadata JSON files.
 

--- a/docs/artifact-contract.md
+++ b/docs/artifact-contract.md
@@ -23,6 +23,7 @@ Run artifacts use explicit top-level metadata:
 | `preflight_report` | `bench doctor/swebench --format json` | `artifact_kind`, `schema_version`, `mode`, `checks` | additional check metadata |
 | `swebench_predictions_metadata` | `all_preds.metadata.json`, `all_preds.run-k.metadata.json` | `artifact_kind`, `schema_version`, `predictions_file`, `aggregate`, `row_count`, `swebench_evaluator_compatible` | `run_index`, future provenance fields |
 | `bundle_manifest` | `BUNDLE.json` inside `bench bundle` archives | `artifact_kind`, `schema_version`, `source_sweep_dir`, `source_manifest_hash`, `harness_git_sha`, `bundle_generated_at`, `instance_scope`, `files` | future integrity metadata |
+| `cache_stats_report` | `cache-stats.json` (written by `bench cache-stats`) | `artifact_kind`, `schema_version` `1.0`, `sweep`, `generated_at`, `cache_disabled`, `sweep_totals`, `instances` | `baseline` (delta vs prior sweep) |
 
 `all_preds*.jsonl` rows intentionally do not carry artifact metadata. They stay compatible with SWE-bench evaluators; version metadata lives in the companion metadata JSON files.
 

--- a/docs/spec-cache-stats.md
+++ b/docs/spec-cache-stats.md
@@ -54,15 +54,18 @@ creation (cold run).
 
 ### `estimated_savings_usd_vs_cold`
 
-The USD saved compared to a hypothetical cold run where every cached-read token
-was instead billed as fresh input:
+The net USD saved compared to a hypothetical cold run where every token is
+billed at the standard input rate (1.0×). Cache reads save money (0.10×
+vs 1.0×), but cache creations cost extra (1.25× vs 1.0×), so the result
+can be negative for sweeps with high creation and low reuse:
 
 ```
 estimated_savings_usd_vs_cold =
-    cache_read_tokens × (input_price_per_Mtok / 1 000 000) × (1 − cache_read_multiplier)
+    cache_read_tokens     × (input_price_per_Mtok / 1 000 000) × (1 − cache_read_multiplier)
+  − cache_creation_tokens × (input_price_per_Mtok / 1 000 000) × (cache_creation_multiplier − 1)
 ```
 
-Uses `claude-3-5-sonnet` pricing (`$3/Mtok` input, `0.10×` for cache reads).
+Uses `claude-3-5-sonnet` pricing (`$3/Mtok` input, `0.10×` reads, `1.25×` creations).
 
 ### `realized_cache_spend_usd`
 

--- a/docs/spec-cache-stats.md
+++ b/docs/spec-cache-stats.md
@@ -65,11 +65,16 @@ estimated_savings_usd_vs_cold =
   − cache_creation_tokens × (input_price_per_Mtok / 1 000 000) × (cache_creation_multiplier − 1)
 ```
 
-Uses `claude-3-5-sonnet` pricing (`$3/Mtok` input, `0.10×` reads, `1.25×` creations).
+All USD values use `claude-3-5-sonnet` pricing (`$3/Mtok` input, `0.10×` reads,
+`1.25×` creations) as a **normalized reference**, regardless of the model actually
+used in the sweep. This keeps cost comparisons consistent across sweeps and avoids
+the need to embed per-model pricing tables in the artifact.
 
 ### `realized_cache_spend_usd`
 
-The actual cost of all cache operations (reads + creations):
+The actual cost of cache operations only (reads + creations); **does not include
+fresh input-token cost**. A cache regression that shifts tokens from cache reads to
+fresh input will lower `realized_cache_spend_usd` while raising total prompt spend:
 
 ```
 realized_cache_spend_usd =
@@ -95,8 +100,8 @@ diffing in CI.
     "total_cache_read_tokens": 120000,
     "total_cache_creation_tokens": 80000,
     "cache_hit_rate": 0.4286,
-    "estimated_savings_usd_vs_cold": 0.000324,
-    "realized_cache_spend_usd": 0.000336
+    "estimated_savings_usd_vs_cold": 0.264000,
+    "realized_cache_spend_usd": 0.336000
   },
   "instances": [
     {
@@ -105,14 +110,16 @@ diffing in CI.
       "total_cache_read_tokens": 0,
       "total_cache_creation_tokens": 50000,
       "cache_hit_rate": 0.0,
-      "estimated_savings_usd_vs_cold": 0.0,
-      "realized_cache_spend_usd": 0.0001875
+      "estimated_savings_usd_vs_cold": -0.037500,
+      "realized_cache_spend_usd": 0.187500
     }
   ],
   "baseline": {
     "baseline_sweep": "/path/to/baseline",
     "delta_hit_rate": 0.0714,
-    "delta_realized_spend_usd": -0.000042
+    "delta_realized_cache_spend_usd": -0.042000,
+    "current_instance_count": 3,
+    "baseline_instance_count": 3
   }
 }
 ```

--- a/docs/spec-cache-stats.md
+++ b/docs/spec-cache-stats.md
@@ -1,0 +1,167 @@
+# `bench cache-stats` — Cache Effectiveness Summary
+
+## Overview
+
+`bench cache-stats` reads a completed sweep directory and surfaces prompt-cache
+hit rate, estimated savings, and realized spend at both the sweep level and per
+instance. It reads **only on-disk artifacts and never calls a model provider**
+(zero-cost guarantee).
+
+Prompt caching is the single largest cost lever when using the Anthropic API:
+cache reads cost roughly 10× less than fresh input tokens. Silent cache
+invalidation — caused by history-bounding rewrites, system-message edits,
+sampling-parameter drift, or hook-injected content — can 10× a sweep's cost
+without changing its solve rate. `bench cache-stats` turns the token counters
+already recorded in `results.json` into an operator-readable ratio so that a
+regression is visible before it shows up on a billing statement.
+
+When `cache_creation + cache_read == 0` for the whole sweep (e.g. a non-
+Anthropic provider that does not expose cache tokens), the command prints
+`cache disabled or unsupported by provider` and exits 0 as an informational
+notice, not an error.
+
+## Usage
+
+```
+bench cache-stats --sweep <DIR> [OPTIONS]
+```
+
+### Required
+
+| Argument | Description |
+|---|---|
+| `--sweep <DIR>` | Completed sweep directory produced by `bench swebench` |
+
+### Optional
+
+| Flag | Default | Description |
+|---|---|---|
+| `--format <FMT>` | `text` | Output format: `text` or `json` |
+| `--top <N>` | `10` | Number of per-instance rows to display (worst first) |
+| `--baseline <DIR>` | — | Baseline sweep directory; adds Δ hit_rate and Δ realized_spend_usd columns |
+
+## Key Concepts
+
+### `cache_hit_rate`
+
+```
+cache_hit_rate = cache_read_tokens / (input_tokens + cache_read_tokens + cache_creation_tokens)
+```
+
+A value of 1.0 means every prompt token was served from cache (ideal). A value
+of 0.0 means no cache reads — all tokens were either fresh input or cache
+creation (cold run).
+
+### `estimated_savings_usd_vs_cold`
+
+The USD saved compared to a hypothetical cold run where every cached-read token
+was instead billed as fresh input:
+
+```
+estimated_savings_usd_vs_cold =
+    cache_read_tokens × (input_price_per_Mtok / 1 000 000) × (1 − cache_read_multiplier)
+```
+
+Uses `claude-3-5-sonnet` pricing (`$3/Mtok` input, `0.10×` for cache reads).
+
+### `realized_cache_spend_usd`
+
+The actual cost of all cache operations (reads + creations):
+
+```
+realized_cache_spend_usd =
+    cache_read_tokens     × input_price × cache_read_multiplier     (0.10×)
+  + cache_creation_tokens × input_price × cache_creation_multiplier (1.25×)
+```
+
+## JSON Schema
+
+`--format json` prints to stdout and also writes `cache-stats.json` in the
+sweep directory. The artifact is schema-versioned and suitable for snapshot
+diffing in CI.
+
+```json
+{
+  "artifact_kind": "cache_stats_report",
+  "schema_version": { "major": 1, "minor": 0 },
+  "sweep": "/path/to/sweep",
+  "generated_at": "2026-01-01T00:00:00Z",
+  "cache_disabled": false,
+  "sweep_totals": {
+    "total_input_tokens": 80000,
+    "total_cache_read_tokens": 120000,
+    "total_cache_creation_tokens": 80000,
+    "cache_hit_rate": 0.4286,
+    "estimated_savings_usd_vs_cold": 0.000324,
+    "realized_cache_spend_usd": 0.000336
+  },
+  "instances": [
+    {
+      "instance_id": "cold-1",
+      "total_input_tokens": 50000,
+      "total_cache_read_tokens": 0,
+      "total_cache_creation_tokens": 50000,
+      "cache_hit_rate": 0.0,
+      "estimated_savings_usd_vs_cold": 0.0,
+      "realized_cache_spend_usd": 0.0001875
+    }
+  ],
+  "baseline": {
+    "baseline_sweep": "/path/to/baseline",
+    "delta_hit_rate": 0.0714,
+    "delta_realized_spend_usd": -0.000042
+  }
+}
+```
+
+`baseline` is `null` / omitted when `--baseline` is not supplied.
+
+### Schema version
+
+`cache_stats_report` artifacts use `schema_version: { "major": 1, "minor": 0 }`.
+The version contract follows the rules in `docs/artifact-contract.md`: major
+bumps are breaking, minor bumps are additive.
+
+### Redaction safety
+
+Cache stats contain no message content — only token counts and derived USD
+values. Output is safe to paste into a PR description or a Slack thread.
+
+## Exit Codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success (including cache-disabled informational case) |
+| 2 | Usage or configuration error (bad `--format`, missing `--sweep`) |
+
+## Examples
+
+```bash
+# Text summary — identify which instances had poor cache efficiency
+bench cache-stats --sweep ./results
+
+# JSON artifact for CI snapshot diffing
+bench cache-stats --sweep ./results --format json
+
+# Top 5 worst-cache instances only
+bench cache-stats --sweep ./results --top 5
+
+# Compare two configs — did the prompt change invalidate the cache?
+bench cache-stats --sweep ./results-v2 --baseline ./results-v1
+
+# JSON comparison for programmatic diffing
+bench cache-stats --sweep ./results-v2 --baseline ./results-v1 --format json
+```
+
+## Performance Notes
+
+`bench cache-stats` reads only `results.json` — it does not open individual
+trajectory files. Runtime is proportional to the number of instances in the
+sweep and is typically under 100 ms for sweeps of any practical size.
+
+## Scope
+
+- **In scope**: observability of already-recorded cache token counts.
+- **Out of scope**: modifying how `cache_control` blocks are sent to the
+  provider; real-time display during a live sweep; per-turn cache attribution;
+  non-Anthropic provider cache semantics; recommending target hit rates.

--- a/docs/spec-cache-stats.md
+++ b/docs/spec-cache-stats.md
@@ -83,7 +83,7 @@ diffing in CI.
 ```json
 {
   "artifact_kind": "cache_stats_report",
-  "schema_version": { "major": 1, "minor": 0 },
+  "schema_version": { "major": 1, "minor": 8 },
   "sweep": "/path/to/sweep",
   "generated_at": "2026-01-01T00:00:00Z",
   "cache_disabled": false,
@@ -118,9 +118,12 @@ diffing in CI.
 
 ### Schema version
 
-`cache_stats_report` artifacts use `schema_version: { "major": 1, "minor": 0 }`.
-The version contract follows the rules in `docs/artifact-contract.md`: major
-bumps are breaking, minor bumps are additive.
+`cache_stats_report` artifacts carry the harness-wide `schema_version` (currently
+`{ "major": 1, "minor": 8 }`), the same value written into every other artifact
+produced by this binary. There is no per-artifact override. The version contract
+follows the rules in `docs/artifact-contract.md`: major bumps are breaking, minor
+bumps are additive. Snapshot tests should match against `schema_version.major`
+rather than the full `major.minor` pair to remain stable across minor releases.
 
 ### Redaction safety
 

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -56,6 +56,7 @@ pub enum ArtifactKind {
     BundleManifest,
     SweepHaltReport,
     RenderOnly,
+    CacheStatsReport,
 }
 
 impl ArtifactKind {
@@ -72,6 +73,7 @@ impl ArtifactKind {
             Self::BundleManifest => "bundle_manifest",
             Self::SweepHaltReport => "sweep_halt_report",
             Self::RenderOnly => "render_only",
+            Self::CacheStatsReport => "cache_stats_report",
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -348,6 +348,28 @@ pub enum BenchCmd {
     /// Join historical sweeps on instance_id and report resolution history,
     /// stability class, and flip provenance.
     InstanceHistory(InstanceHistoryCmd),
+    /// Surface prompt-cache hit rate, savings, and spend for a completed sweep.
+    CacheStats(CacheStatsCmd),
+}
+
+/// `bench cache-stats` — surface prompt-cache hit rate per sweep (zero-cost: reads only on-disk artifacts).
+#[derive(Debug, Args)]
+pub struct CacheStatsCmd {
+    /// Completed sweep directory produced by `bench swebench`.
+    #[arg(long)]
+    pub sweep: std::path::PathBuf,
+
+    /// Output format: `text` (default) or `json`.
+    #[arg(long, default_value = "text", value_name = "FMT")]
+    pub format: String,
+
+    /// Number of per-instance rows to display (worst cache efficiency first).
+    #[arg(long, default_value_t = 10, value_name = "N")]
+    pub top: usize,
+
+    /// Baseline sweep directory. When supplied, prints Δ hit_rate and Δ realized_spend_usd.
+    #[arg(long, value_name = "DIR")]
+    pub baseline: Option<std::path::PathBuf>,
 }
 
 /// `bench instance-history` — longitudinal view of instance resolution across sweeps.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -129,6 +129,9 @@ pub async fn run() -> Result<(), Error> {
         Command::Bench {
             cmd: args::BenchCmd::InstanceHistory(h),
         } => bench_instance_history(h),
+        Command::Bench {
+            cmd: args::BenchCmd::CacheStats(c),
+        } => bench_cache_stats(c),
         #[cfg(feature = "docker")]
         Command::Cleanup => cleanup_cmd().await,
         #[cfg(not(feature = "docker"))]
@@ -1881,6 +1884,34 @@ fn bench_instance_history(h: args::InstanceHistoryCmd) -> Result<(), Error> {
         );
     }
 
+    Ok(())
+}
+
+fn bench_cache_stats(c: args::CacheStatsCmd) -> Result<(), Error> {
+    let is_json = match c.format.as_str() {
+        "text" => false,
+        "json" => true,
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "cache-stats: unknown --format `{other}` (expected `text` or `json`)"
+            ))));
+        }
+    };
+    let report = crate::run::cache_stats::run(&crate::run::cache_stats::CacheStatsArgs {
+        sweep_dir: c.sweep,
+        top: c.top,
+        baseline: c.baseline,
+    })?;
+    if is_json {
+        let json =
+            crate::artifact::to_string_pretty(crate::artifact::ArtifactKind::CacheStatsReport, &report)?;
+        println!("{json}");
+    } else {
+        print!(
+            "{}",
+            crate::run::cache_stats::render_text(&report, c.top)
+        );
+    }
     Ok(())
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1903,14 +1903,13 @@ fn bench_cache_stats(c: args::CacheStatsCmd) -> Result<(), Error> {
         baseline: c.baseline,
     })?;
     if is_json {
-        let json =
-            crate::artifact::to_string_pretty(crate::artifact::ArtifactKind::CacheStatsReport, &report)?;
+        let json = crate::artifact::to_string_pretty(
+            crate::artifact::ArtifactKind::CacheStatsReport,
+            &report,
+        )?;
         println!("{json}");
     } else {
-        print!(
-            "{}",
-            crate::run::cache_stats::render_text(&report, c.top)
-        );
+        print!("{}", crate::run::cache_stats::render_text(&report, c.top));
     }
     Ok(())
 }

--- a/src/run/cache_stats.rs
+++ b/src/run/cache_stats.rs
@@ -1,0 +1,295 @@
+//! `bench cache-stats`: surface prompt-cache hit rate per sweep.
+//!
+//! Reads only on-disk artifacts (zero model calls, zero network).
+
+#![allow(clippy::cast_precision_loss)]
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::artifact::ArtifactKind;
+use crate::cost::{
+    ANTHROPIC_CACHE_CREATION_MULTIPLIER, ANTHROPIC_CACHE_READ_MULTIPLIER, SONNET_INPUT_USD_PER_MTOK,
+};
+use crate::error::Error;
+use crate::run::compare::load_sweep;
+
+// ── public calculation helpers (unit-testable) ────────────────────────────────
+
+/// `cache_read / (input + cache_read + cache_creation)`; returns 0.0 for all-zero.
+#[must_use]
+pub fn compute_cache_hit_rate(input: u64, cache_read: u64, cache_creation: u64) -> f64 {
+    let total = input.saturating_add(cache_read).saturating_add(cache_creation);
+    if total == 0 {
+        return 0.0;
+    }
+    cache_read as f64 / total as f64
+}
+
+/// USD saved vs a hypothetical cold run where every cached read was fresh input.
+#[must_use]
+pub fn compute_estimated_savings_usd_vs_cold(cache_read: u64) -> f64 {
+    cache_read as f64 / 1_000_000.0
+        * SONNET_INPUT_USD_PER_MTOK
+        * (1.0 - ANTHROPIC_CACHE_READ_MULTIPLIER)
+}
+
+/// Actual cost of cache operations (reads + creations).
+#[must_use]
+pub fn compute_realized_cache_spend_usd(cache_read: u64, cache_creation: u64) -> f64 {
+    cache_read as f64 / 1_000_000.0 * SONNET_INPUT_USD_PER_MTOK * ANTHROPIC_CACHE_READ_MULTIPLIER
+        + cache_creation as f64 / 1_000_000.0
+            * SONNET_INPUT_USD_PER_MTOK
+            * ANTHROPIC_CACHE_CREATION_MULTIPLIER
+}
+
+// ── public data types ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct CacheStatsArgs {
+    pub sweep_dir: PathBuf,
+    pub top: usize,
+    pub baseline: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstanceCacheRow {
+    pub instance_id: String,
+    pub total_input_tokens: u64,
+    pub total_cache_read_tokens: u64,
+    pub total_cache_creation_tokens: u64,
+    pub cache_hit_rate: f64,
+    pub estimated_savings_usd_vs_cold: f64,
+    pub realized_cache_spend_usd: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SweepCacheTotals {
+    pub total_input_tokens: u64,
+    pub total_cache_read_tokens: u64,
+    pub total_cache_creation_tokens: u64,
+    pub cache_hit_rate: f64,
+    pub estimated_savings_usd_vs_cold: f64,
+    pub realized_cache_spend_usd: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaselineDelta {
+    pub baseline_sweep: String,
+    pub delta_hit_rate: f64,
+    pub delta_realized_spend_usd: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheStatsReport {
+    pub sweep: String,
+    pub generated_at: String,
+    pub cache_disabled: bool,
+    pub sweep_totals: SweepCacheTotals,
+    /// Per-instance rows sorted by `cache_hit_rate` ascending (worst first),
+    /// truncated to the `--top N` requested.
+    pub instances: Vec<InstanceCacheRow>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub baseline: Option<BaselineDelta>,
+}
+
+// ── public entry point ────────────────────────────────────────────────────────
+
+pub fn run(args: &CacheStatsArgs) -> Result<CacheStatsReport, Error> {
+    let report = build_report(args)?;
+    write_artifact(&args.sweep_dir, &report)?;
+    Ok(report)
+}
+
+// ── rendering ─────────────────────────────────────────────────────────────────
+
+pub fn render_text(report: &CacheStatsReport, top: usize) -> String {
+    use comfy_table::Table;
+    use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+    use comfy_table::presets::UTF8_FULL;
+
+    let mut out = String::new();
+    let _ = writeln!(out, "\n=== bench cache-stats ===");
+    let _ = writeln!(out, "Sweep: {}", report.sweep);
+
+    if report.cache_disabled {
+        let _ = writeln!(
+            out,
+            "cache disabled or unsupported by provider (no cache tokens recorded)"
+        );
+        return out;
+    }
+
+    let t = &report.sweep_totals;
+    let _ = writeln!(out);
+    let _ = writeln!(out, "Sweep-level cache summary:");
+    let mut sweep_table = Table::new();
+    sweep_table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec![
+            "total_input_tokens",
+            "cache_read_tokens",
+            "cache_creation_tokens",
+            "cache_hit_rate",
+            "est_savings_usd",
+            "realized_spend_usd",
+        ])
+        .add_row(vec![
+            t.total_input_tokens.to_string(),
+            t.total_cache_read_tokens.to_string(),
+            t.total_cache_creation_tokens.to_string(),
+            format!("{:.4}", t.cache_hit_rate),
+            format!("{:.6}", t.estimated_savings_usd_vs_cold),
+            format!("{:.6}", t.realized_cache_spend_usd),
+        ]);
+    let _ = writeln!(out, "{sweep_table}");
+
+    if let Some(delta) = &report.baseline {
+        let _ = writeln!(
+            out,
+            "Baseline: {}  Δ hit_rate={:+.4}  Δ realized_spend_usd={:+.6}",
+            delta.baseline_sweep, delta.delta_hit_rate, delta.delta_realized_spend_usd
+        );
+        let _ = writeln!(out);
+    }
+
+    let display_top = top.min(report.instances.len());
+    let _ = writeln!(
+        out,
+        "Per-instance breakdown (worst cache efficiency first, top {display_top}):"
+    );
+    let mut inst_table = Table::new();
+    inst_table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec![
+            "instance_id",
+            "input_tokens",
+            "cache_read",
+            "cache_creation",
+            "cache_hit_rate",
+            "est_savings_usd",
+            "realized_spend_usd",
+        ]);
+    for row in report.instances.iter().take(display_top) {
+        inst_table.add_row(vec![
+            row.instance_id.clone(),
+            row.total_input_tokens.to_string(),
+            row.total_cache_read_tokens.to_string(),
+            row.total_cache_creation_tokens.to_string(),
+            format!("{:.4}", row.cache_hit_rate),
+            format!("{:.6}", row.estimated_savings_usd_vs_cold),
+            format!("{:.6}", row.realized_cache_spend_usd),
+        ]);
+    }
+    let _ = writeln!(out, "{inst_table}");
+    out
+}
+
+// ── internals ─────────────────────────────────────────────────────────────────
+
+fn build_report(args: &CacheStatsArgs) -> Result<CacheStatsReport, Error> {
+    let sweep = load_sweep(&args.sweep_dir)?;
+
+    let mut rows: Vec<InstanceCacheRow> = sweep
+        .instances
+        .values()
+        .map(|inst| {
+            let input = inst.prompt_tokens.unwrap_or(0);
+            let reads = inst.cache_read_tokens.unwrap_or(0);
+            let creation = inst.cache_creation_tokens.unwrap_or(0);
+            InstanceCacheRow {
+                instance_id: inst.instance_id.clone(),
+                total_input_tokens: input,
+                total_cache_read_tokens: reads,
+                total_cache_creation_tokens: creation,
+                cache_hit_rate: compute_cache_hit_rate(input, reads, creation),
+                estimated_savings_usd_vs_cold: compute_estimated_savings_usd_vs_cold(reads),
+                realized_cache_spend_usd: compute_realized_cache_spend_usd(reads, creation),
+            }
+        })
+        .collect();
+
+    // sort worst (lowest hit rate) first
+    rows.sort_by(|a, b| {
+        a.cache_hit_rate
+            .partial_cmp(&b.cache_hit_rate)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.instance_id.cmp(&b.instance_id))
+    });
+
+    let total_input: u64 = rows.iter().map(|r| r.total_input_tokens).sum();
+    let total_reads: u64 = rows.iter().map(|r| r.total_cache_read_tokens).sum();
+    let total_creation: u64 = rows.iter().map(|r| r.total_cache_creation_tokens).sum();
+
+    let cache_disabled = total_reads == 0 && total_creation == 0;
+
+    let sweep_totals = SweepCacheTotals {
+        total_input_tokens: total_input,
+        total_cache_read_tokens: total_reads,
+        total_cache_creation_tokens: total_creation,
+        cache_hit_rate: compute_cache_hit_rate(total_input, total_reads, total_creation),
+        estimated_savings_usd_vs_cold: compute_estimated_savings_usd_vs_cold(total_reads),
+        realized_cache_spend_usd: compute_realized_cache_spend_usd(total_reads, total_creation),
+    };
+
+    let baseline = args
+        .baseline
+        .as_deref()
+        .map(|baseline_dir| build_baseline_delta(baseline_dir, &sweep_totals))
+        .transpose()?;
+
+    let top_rows = rows.into_iter().take(args.top).collect();
+
+    Ok(CacheStatsReport {
+        sweep: args.sweep_dir.display().to_string(),
+        generated_at: utc_now_iso8601(),
+        cache_disabled,
+        sweep_totals,
+        instances: top_rows,
+        baseline,
+    })
+}
+
+fn build_baseline_delta(
+    baseline_dir: &Path,
+    current_totals: &SweepCacheTotals,
+) -> Result<BaselineDelta, Error> {
+    let baseline_sweep = load_sweep(baseline_dir)?;
+    let b_input: u64 = baseline_sweep
+        .instances
+        .values()
+        .map(|i| i.prompt_tokens.unwrap_or(0))
+        .sum();
+    let b_reads: u64 = baseline_sweep
+        .instances
+        .values()
+        .map(|i| i.cache_read_tokens.unwrap_or(0))
+        .sum();
+    let b_creation: u64 = baseline_sweep
+        .instances
+        .values()
+        .map(|i| i.cache_creation_tokens.unwrap_or(0))
+        .sum();
+    let b_hit_rate = compute_cache_hit_rate(b_input, b_reads, b_creation);
+    let b_spend = compute_realized_cache_spend_usd(b_reads, b_creation);
+    Ok(BaselineDelta {
+        baseline_sweep: baseline_dir.display().to_string(),
+        delta_hit_rate: current_totals.cache_hit_rate - b_hit_rate,
+        delta_realized_spend_usd: current_totals.realized_cache_spend_usd - b_spend,
+    })
+}
+
+fn write_artifact(sweep_dir: &Path, report: &CacheStatsReport) -> Result<(), Error> {
+    let path = sweep_dir.join("cache-stats.json");
+    let file = std::fs::File::create(&path)?;
+    crate::artifact::to_writer_pretty(file, ArtifactKind::CacheStatsReport, report)?;
+    Ok(())
+}
+
+fn utc_now_iso8601() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}

--- a/src/run/cache_stats.rs
+++ b/src/run/cache_stats.rs
@@ -21,7 +21,9 @@ use crate::run::compare::load_sweep;
 /// `cache_read / (input + cache_read + cache_creation)`; returns 0.0 for all-zero.
 #[must_use]
 pub fn compute_cache_hit_rate(input: u64, cache_read: u64, cache_creation: u64) -> f64 {
-    let total = input.saturating_add(cache_read).saturating_add(cache_creation);
+    let total = input
+        .saturating_add(cache_read)
+        .saturating_add(cache_creation);
     if total == 0 {
         return 0.0;
     }
@@ -39,10 +41,12 @@ pub fn compute_estimated_savings_usd_vs_cold(cache_read: u64) -> f64 {
 /// Actual cost of cache operations (reads + creations).
 #[must_use]
 pub fn compute_realized_cache_spend_usd(cache_read: u64, cache_creation: u64) -> f64 {
-    cache_read as f64 / 1_000_000.0 * SONNET_INPUT_USD_PER_MTOK * ANTHROPIC_CACHE_READ_MULTIPLIER
-        + cache_creation as f64 / 1_000_000.0
+    (cache_read as f64 / 1_000_000.0 * SONNET_INPUT_USD_PER_MTOK).mul_add(
+        ANTHROPIC_CACHE_READ_MULTIPLIER,
+        cache_creation as f64 / 1_000_000.0
             * SONNET_INPUT_USD_PER_MTOK
-            * ANTHROPIC_CACHE_CREATION_MULTIPLIER
+            * ANTHROPIC_CACHE_CREATION_MULTIPLIER,
+    )
 }
 
 // ── public data types ─────────────────────────────────────────────────────────
@@ -242,14 +246,12 @@ fn build_report(args: &CacheStatsArgs) -> Result<CacheStatsReport, Error> {
         .map(|baseline_dir| build_baseline_delta(baseline_dir, &sweep_totals))
         .transpose()?;
 
-    let top_rows = rows.into_iter().take(args.top).collect();
-
     Ok(CacheStatsReport {
         sweep: args.sweep_dir.display().to_string(),
         generated_at: utc_now_iso8601(),
         cache_disabled,
         sweep_totals,
-        instances: top_rows,
+        instances: rows,
         baseline,
     })
 }

--- a/src/run/cache_stats.rs
+++ b/src/run/cache_stats.rs
@@ -123,6 +123,16 @@ pub fn render_text(report: &CacheStatsReport, top: usize) -> String {
             out,
             "cache disabled or unsupported by provider (no cache tokens recorded)"
         );
+        // Still show the baseline delta when supplied — a no-cache sweep compared
+        // against a cached baseline is the exact regression this flag surfaces.
+        if let Some(delta) = &report.baseline {
+            let _ = writeln!(out);
+            let _ = writeln!(
+                out,
+                "Baseline: {}  Δ hit_rate={:+.4}  Δ realized_spend_usd={:+.6}",
+                delta.baseline_sweep, delta.delta_hit_rate, delta.delta_realized_spend_usd
+            );
+        }
         return out;
     }
 

--- a/src/run/cache_stats.rs
+++ b/src/run/cache_stats.rs
@@ -93,7 +93,10 @@ pub struct SweepCacheTotals {
 pub struct BaselineDelta {
     pub baseline_sweep: String,
     pub delta_hit_rate: f64,
-    pub delta_realized_spend_usd: f64,
+    /// Delta of cache-operations-only spend (reads + creations); does NOT include
+    /// fresh input tokens. A cache regression may show a negative delta here while
+    /// total prompt spend rises.
+    pub delta_realized_cache_spend_usd: f64,
     /// Instance counts for both sweeps. When unequal the spend delta is not
     /// normalized; operators should interpret it with this difference in mind.
     pub current_instance_count: usize,
@@ -220,8 +223,11 @@ fn render_baseline_line(out: &mut String, delta: &BaselineDelta) {
     };
     let _ = writeln!(
         out,
-        "Baseline: {}  Δ hit_rate={:+.4}  Δ realized_spend_usd={:+.6}{}",
-        delta.baseline_sweep, delta.delta_hit_rate, delta.delta_realized_spend_usd, count_note
+        "Baseline: {}  Δ hit_rate={:+.4}  Δ realized_cache_spend_usd={:+.6}{}",
+        delta.baseline_sweep,
+        delta.delta_hit_rate,
+        delta.delta_realized_cache_spend_usd,
+        count_note
     );
 }
 
@@ -340,7 +346,7 @@ fn build_baseline_delta(
     Ok(BaselineDelta {
         baseline_sweep: baseline_dir.display().to_string(),
         delta_hit_rate: current_totals.cache_hit_rate - b_hit_rate,
-        delta_realized_spend_usd: current_totals.realized_cache_spend_usd - b_spend,
+        delta_realized_cache_spend_usd: current_totals.realized_cache_spend_usd - b_spend,
         current_instance_count,
         baseline_instance_count,
     })

--- a/src/run/cache_stats.rs
+++ b/src/run/cache_stats.rs
@@ -30,12 +30,22 @@ pub fn compute_cache_hit_rate(input: u64, cache_read: u64, cache_creation: u64) 
     cache_read as f64 / total as f64
 }
 
-/// USD saved vs a hypothetical cold run where every cached read was fresh input.
+/// Net USD saved vs a hypothetical cold run (no cache at all).
+///
+/// A cold run bills every prompt token at 1.0×. With caching:
+/// - reads cost 0.10× (saving 0.90× per token)
+/// - creations cost 1.25× (costing an extra 0.25× per token)
+///
+/// Result can be negative when write overhead exceeds read savings.
 #[must_use]
-pub fn compute_estimated_savings_usd_vs_cold(cache_read: u64) -> f64 {
-    cache_read as f64 / 1_000_000.0
+pub fn compute_estimated_savings_usd_vs_cold(cache_read: u64, cache_creation: u64) -> f64 {
+    let read_savings = cache_read as f64 / 1_000_000.0
         * SONNET_INPUT_USD_PER_MTOK
-        * (1.0 - ANTHROPIC_CACHE_READ_MULTIPLIER)
+        * (1.0 - ANTHROPIC_CACHE_READ_MULTIPLIER);
+    let creation_premium = cache_creation as f64 / 1_000_000.0
+        * SONNET_INPUT_USD_PER_MTOK
+        * (ANTHROPIC_CACHE_CREATION_MULTIPLIER - 1.0);
+    read_savings - creation_premium
 }
 
 /// Actual cost of cache operations (reads + creations).
@@ -84,6 +94,10 @@ pub struct BaselineDelta {
     pub baseline_sweep: String,
     pub delta_hit_rate: f64,
     pub delta_realized_spend_usd: f64,
+    /// Instance counts for both sweeps. When unequal the spend delta is not
+    /// normalized; operators should interpret it with this difference in mind.
+    pub current_instance_count: usize,
+    pub baseline_instance_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -127,11 +141,7 @@ pub fn render_text(report: &CacheStatsReport, top: usize) -> String {
         // against a cached baseline is the exact regression this flag surfaces.
         if let Some(delta) = &report.baseline {
             let _ = writeln!(out);
-            let _ = writeln!(
-                out,
-                "Baseline: {}  Δ hit_rate={:+.4}  Δ realized_spend_usd={:+.6}",
-                delta.baseline_sweep, delta.delta_hit_rate, delta.delta_realized_spend_usd
-            );
+            render_baseline_line(&mut out, delta);
         }
         return out;
     }
@@ -162,11 +172,7 @@ pub fn render_text(report: &CacheStatsReport, top: usize) -> String {
     let _ = writeln!(out, "{sweep_table}");
 
     if let Some(delta) = &report.baseline {
-        let _ = writeln!(
-            out,
-            "Baseline: {}  Δ hit_rate={:+.4}  Δ realized_spend_usd={:+.6}",
-            delta.baseline_sweep, delta.delta_hit_rate, delta.delta_realized_spend_usd
-        );
+        render_baseline_line(&mut out, delta);
         let _ = writeln!(out);
     }
 
@@ -203,6 +209,22 @@ pub fn render_text(report: &CacheStatsReport, top: usize) -> String {
     out
 }
 
+fn render_baseline_line(out: &mut String, delta: &BaselineDelta) {
+    let count_note = if delta.current_instance_count == delta.baseline_instance_count {
+        String::new()
+    } else {
+        format!(
+            " [instance counts differ: current={} baseline={}; spend delta not normalized]",
+            delta.current_instance_count, delta.baseline_instance_count
+        )
+    };
+    let _ = writeln!(
+        out,
+        "Baseline: {}  Δ hit_rate={:+.4}  Δ realized_spend_usd={:+.6}{}",
+        delta.baseline_sweep, delta.delta_hit_rate, delta.delta_realized_spend_usd, count_note
+    );
+}
+
 // ── internals ─────────────────────────────────────────────────────────────────
 
 fn build_report(args: &CacheStatsArgs) -> Result<CacheStatsReport, Error> {
@@ -221,11 +243,22 @@ fn build_report(args: &CacheStatsArgs) -> Result<CacheStatsReport, Error> {
                 total_cache_read_tokens: reads,
                 total_cache_creation_tokens: creation,
                 cache_hit_rate: compute_cache_hit_rate(input, reads, creation),
-                estimated_savings_usd_vs_cold: compute_estimated_savings_usd_vs_cold(reads),
+                estimated_savings_usd_vs_cold: compute_estimated_savings_usd_vs_cold(
+                    reads, creation,
+                ),
                 realized_cache_spend_usd: compute_realized_cache_spend_usd(reads, creation),
             }
         })
         .collect();
+
+    // Exclude instances that made no model calls (budget_halt, skipped, etc.).
+    // Their 0/0 hit rate is absence of data, not a cache miss, and would
+    // otherwise dominate the "worst offenders" table.
+    rows.retain(|r| {
+        r.total_input_tokens > 0
+            || r.total_cache_read_tokens > 0
+            || r.total_cache_creation_tokens > 0
+    });
 
     // sort worst (lowest hit rate) first
     rows.sort_by(|a, b| {
@@ -235,6 +268,7 @@ fn build_report(args: &CacheStatsArgs) -> Result<CacheStatsReport, Error> {
             .then_with(|| a.instance_id.cmp(&b.instance_id))
     });
 
+    let current_instance_count = rows.len();
     let total_input: u64 = rows.iter().map(|r| r.total_input_tokens).sum();
     let total_reads: u64 = rows.iter().map(|r| r.total_cache_read_tokens).sum();
     let total_creation: u64 = rows.iter().map(|r| r.total_cache_creation_tokens).sum();
@@ -246,14 +280,19 @@ fn build_report(args: &CacheStatsArgs) -> Result<CacheStatsReport, Error> {
         total_cache_read_tokens: total_reads,
         total_cache_creation_tokens: total_creation,
         cache_hit_rate: compute_cache_hit_rate(total_input, total_reads, total_creation),
-        estimated_savings_usd_vs_cold: compute_estimated_savings_usd_vs_cold(total_reads),
+        estimated_savings_usd_vs_cold: compute_estimated_savings_usd_vs_cold(
+            total_reads,
+            total_creation,
+        ),
         realized_cache_spend_usd: compute_realized_cache_spend_usd(total_reads, total_creation),
     };
 
     let baseline = args
         .baseline
         .as_deref()
-        .map(|baseline_dir| build_baseline_delta(baseline_dir, &sweep_totals))
+        .map(|baseline_dir| {
+            build_baseline_delta(baseline_dir, &sweep_totals, current_instance_count)
+        })
         .transpose()?;
 
     Ok(CacheStatsReport {
@@ -269,21 +308,31 @@ fn build_report(args: &CacheStatsArgs) -> Result<CacheStatsReport, Error> {
 fn build_baseline_delta(
     baseline_dir: &Path,
     current_totals: &SweepCacheTotals,
+    current_instance_count: usize,
 ) -> Result<BaselineDelta, Error> {
     let baseline_sweep = load_sweep(baseline_dir)?;
-    let b_input: u64 = baseline_sweep
+    // Mirror the zero-token exclusion applied to the current sweep so that
+    // skipped/budget-halted instances don't skew the baseline aggregates either.
+    let active_baseline: Vec<_> = baseline_sweep
         .instances
         .values()
+        .filter(|i| {
+            i.prompt_tokens.unwrap_or(0) > 0
+                || i.cache_read_tokens.unwrap_or(0) > 0
+                || i.cache_creation_tokens.unwrap_or(0) > 0
+        })
+        .collect();
+    let baseline_instance_count = active_baseline.len();
+    let b_input: u64 = active_baseline
+        .iter()
         .map(|i| i.prompt_tokens.unwrap_or(0))
         .sum();
-    let b_reads: u64 = baseline_sweep
-        .instances
-        .values()
+    let b_reads: u64 = active_baseline
+        .iter()
         .map(|i| i.cache_read_tokens.unwrap_or(0))
         .sum();
-    let b_creation: u64 = baseline_sweep
-        .instances
-        .values()
+    let b_creation: u64 = active_baseline
+        .iter()
         .map(|i| i.cache_creation_tokens.unwrap_or(0))
         .sum();
     let b_hit_rate = compute_cache_hit_rate(b_input, b_reads, b_creation);
@@ -292,6 +341,8 @@ fn build_baseline_delta(
         baseline_sweep: baseline_dir.display().to_string(),
         delta_hit_rate: current_totals.cache_hit_rate - b_hit_rate,
         delta_realized_spend_usd: current_totals.realized_cache_spend_usd - b_spend,
+        current_instance_count,
+        baseline_instance_count,
     })
 }
 

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod behavior;
 pub mod bundle;
+pub mod cache_stats;
 pub mod calibrate;
 pub mod command_stats;
 pub mod compare;

--- a/src/run/report.rs
+++ b/src/run/report.rs
@@ -412,17 +412,10 @@ fn md_cache_effectiveness(buf: &mut String, instances: &[&InstanceResult]) {
         return;
     }
 
-    let total_input: u64 = instances
-        .iter()
-        .map(|i| i.prompt_tokens.unwrap_or(0))
-        .sum();
-    let hit_rate = crate::run::cache_stats::compute_cache_hit_rate(
-        total_input,
-        total_reads,
-        total_creation,
-    );
-    let savings =
-        crate::run::cache_stats::compute_estimated_savings_usd_vs_cold(total_reads);
+    let total_input: u64 = instances.iter().map(|i| i.prompt_tokens.unwrap_or(0)).sum();
+    let hit_rate =
+        crate::run::cache_stats::compute_cache_hit_rate(total_input, total_reads, total_creation);
+    let savings = crate::run::cache_stats::compute_estimated_savings_usd_vs_cold(total_reads);
     let spend =
         crate::run::cache_stats::compute_realized_cache_spend_usd(total_reads, total_creation);
 

--- a/src/run/report.rs
+++ b/src/run/report.rs
@@ -415,7 +415,8 @@ fn md_cache_effectiveness(buf: &mut String, instances: &[&InstanceResult]) {
     let total_input: u64 = instances.iter().map(|i| i.prompt_tokens.unwrap_or(0)).sum();
     let hit_rate =
         crate::run::cache_stats::compute_cache_hit_rate(total_input, total_reads, total_creation);
-    let savings = crate::run::cache_stats::compute_estimated_savings_usd_vs_cold(total_reads);
+    let savings =
+        crate::run::cache_stats::compute_estimated_savings_usd_vs_cold(total_reads, total_creation);
     let spend =
         crate::run::cache_stats::compute_realized_cache_spend_usd(total_reads, total_creation);
 

--- a/src/run/report.rs
+++ b/src/run/report.rs
@@ -142,6 +142,7 @@ fn render_markdown(
         &args.sweep_dir,
     );
     md_eval_section(&mut buf, eval);
+    md_cache_effectiveness(&mut buf, instances);
     if let Some(report) = baseline_report {
         md_baseline_delta(&mut buf, report);
     }
@@ -389,6 +390,47 @@ fn md_top_failures(
         )
         .ok();
     }
+    writeln!(buf).ok();
+}
+
+fn md_cache_effectiveness(buf: &mut String, instances: &[&InstanceResult]) {
+    writeln!(buf, "## Cache Effectiveness").ok();
+    writeln!(buf).ok();
+
+    let total_reads: u64 = instances
+        .iter()
+        .map(|i| i.cache_read_tokens.unwrap_or(0))
+        .sum();
+    let total_creation: u64 = instances
+        .iter()
+        .map(|i| i.cache_creation_tokens.unwrap_or(0))
+        .sum();
+
+    if total_reads == 0 && total_creation == 0 {
+        writeln!(buf, "_no cache data_").ok();
+        writeln!(buf).ok();
+        return;
+    }
+
+    let total_input: u64 = instances
+        .iter()
+        .map(|i| i.prompt_tokens.unwrap_or(0))
+        .sum();
+    let hit_rate = crate::run::cache_stats::compute_cache_hit_rate(
+        total_input,
+        total_reads,
+        total_creation,
+    );
+    let savings =
+        crate::run::cache_stats::compute_estimated_savings_usd_vs_cold(total_reads);
+    let spend =
+        crate::run::cache_stats::compute_realized_cache_spend_usd(total_reads, total_creation);
+
+    writeln!(buf, "| Metric | Value |").ok();
+    writeln!(buf, "|---|---|").ok();
+    writeln!(buf, "| Cache hit rate | {:.2}% |", hit_rate * 100.0).ok();
+    writeln!(buf, "| Realized cache spend USD | ${spend:.6} |").ok();
+    writeln!(buf, "| Estimated savings vs cold USD | ${savings:.6} |").ok();
     writeln!(buf).ok();
 }
 

--- a/tests/bench_cache_stats.rs
+++ b/tests/bench_cache_stats.rs
@@ -49,7 +49,10 @@ fn estimated_savings_zero_reads_is_zero() {
 fn estimated_savings_one_million_reads() {
     // 1 M reads × $3/M × (1 − 0.10) = $2.70
     let savings = compute_estimated_savings_usd_vs_cold(1_000_000);
-    assert!((savings - 2.70).abs() < 1e-9, "expected 2.70, got {savings}");
+    assert!(
+        (savings - 2.70).abs() < 1e-9,
+        "expected 2.70, got {savings}"
+    );
 }
 
 #[test]
@@ -81,18 +84,15 @@ fn realized_spend_mixed() {
 // ── CLI integration tests ─────────────────────────────────────────────────────
 
 fn cache_stats_sweep_fixture() -> std::path::PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/fixtures/cache_stats/sweep")
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/cache_stats/sweep")
 }
 
 fn no_cache_fixture() -> std::path::PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/fixtures/cache_stats/no_cache")
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/cache_stats/no_cache")
 }
 
 fn baseline_fixture() -> std::path::PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/fixtures/cache_stats/baseline")
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/cache_stats/baseline")
 }
 
 fn run_cache_stats(sweep: &Path, extra_args: &[&str]) -> std::process::Output {
@@ -206,8 +206,7 @@ fn cli_json_has_required_sweep_total_fields() {
         "estimated_savings_usd_vs_cold required"
     );
     assert!(
-        totals["realized_cache_spend_usd"].is_f64()
-            || totals["realized_cache_spend_usd"].is_u64(),
+        totals["realized_cache_spend_usd"].is_f64() || totals["realized_cache_spend_usd"].is_u64(),
         "realized_cache_spend_usd required"
     );
 }
@@ -299,15 +298,46 @@ fn cli_json_instance_row_has_required_fields() {
 }
 
 #[test]
-fn cli_top_flag_limits_instance_rows() {
+fn cli_top_flag_limits_text_display() {
+    // --top only clips the rendered text table; JSON artifact keeps all instances.
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&cache_stats_sweep_fixture(), sweep.path());
+
+    // Text output with --top 1: only the single worst instance row should appear.
+    let output = run_cache_stats(sweep.path(), &["--top", "1"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("top 1"),
+        "text output should reflect --top 1 limit:\n{stdout}"
+    );
+
+    // JSON artifact on disk should contain all 3 instances regardless of --top.
+    let artifact: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(sweep.path().join("cache-stats.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        artifact["instances"].as_array().unwrap().len(),
+        3,
+        "JSON artifact must contain all instances regardless of --top"
+    );
+}
+
+#[test]
+fn cli_json_format_includes_all_instances_regardless_of_top() {
     let sweep = tempfile::tempdir().unwrap();
     copy_dir(&cache_stats_sweep_fixture(), sweep.path());
 
     let output = run_cache_stats(sweep.path(), &["--format", "json", "--top", "1"]);
     assert!(output.status.success());
     let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    let instances = report["instances"].as_array().unwrap();
-    assert_eq!(instances.len(), 1, "expected exactly 1 instance with --top 1");
+    // JSON output (stdout) always includes full instance list; --top is a text-rendering flag.
+    assert_eq!(
+        report["instances"].as_array().unwrap().len(),
+        3,
+        "JSON stdout should include all instances even with --top 1"
+    );
 }
 
 #[test]

--- a/tests/bench_cache_stats.rs
+++ b/tests/bench_cache_stats.rs
@@ -379,6 +379,31 @@ fn cli_cache_disabled_exits_zero_and_prints_message() {
 }
 
 #[test]
+fn cli_cache_disabled_still_shows_baseline_delta() {
+    // A no-cache sweep compared against a cached baseline should still surface
+    // the delta — that regression is exactly what --baseline is meant to expose.
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&no_cache_fixture(), sweep.path());
+    let baseline_dir = tempfile::tempdir().unwrap();
+    copy_dir(&baseline_fixture(), baseline_dir.path());
+
+    let output = run_cache_stats(
+        sweep.path(),
+        &["--baseline", baseline_dir.path().to_str().unwrap()],
+    );
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("cache disabled") || stdout.contains("unsupported"),
+        "should still report disabled:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("delta") || stdout.contains("Δ") || stdout.contains("baseline"),
+        "baseline delta must appear even when current sweep has no cache data:\n{stdout}"
+    );
+}
+
+#[test]
 fn cli_json_cache_disabled_sets_flag() {
     let sweep = tempfile::tempdir().unwrap();
     copy_dir(&no_cache_fixture(), sweep.path());

--- a/tests/bench_cache_stats.rs
+++ b/tests/bench_cache_stats.rs
@@ -1,0 +1,435 @@
+//! `bench cache-stats`: surface prompt-cache hit rate per sweep.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)]
+
+use std::path::Path;
+use std::process::Command;
+
+mod support;
+use support::binary_path;
+
+// ── unit tests for pure calculation functions ─────────────────────────────────
+
+use rust_swe_agent::run::cache_stats::{
+    compute_cache_hit_rate, compute_estimated_savings_usd_vs_cold, compute_realized_cache_spend_usd,
+};
+
+#[test]
+fn cache_hit_rate_zero_tokens_returns_zero() {
+    assert_eq!(compute_cache_hit_rate(0, 0, 0), 0.0);
+}
+
+#[test]
+fn cache_hit_rate_all_reads() {
+    // 100 % of prompt tokens are cache reads
+    let rate = compute_cache_hit_rate(0, 100_000, 0);
+    assert!((rate - 1.0).abs() < 1e-9, "expected 1.0, got {rate}");
+}
+
+#[test]
+fn cache_hit_rate_no_reads() {
+    // no cache reads at all
+    let rate = compute_cache_hit_rate(50_000, 0, 50_000);
+    assert_eq!(rate, 0.0);
+}
+
+#[test]
+fn cache_hit_rate_mixed() {
+    // 80 000 reads / (10 000 input + 80 000 reads + 10 000 creation) = 80/100
+    let rate = compute_cache_hit_rate(10_000, 80_000, 10_000);
+    assert!((rate - 0.8).abs() < 1e-9, "expected 0.8, got {rate}");
+}
+
+#[test]
+fn estimated_savings_zero_reads_is_zero() {
+    assert_eq!(compute_estimated_savings_usd_vs_cold(0), 0.0);
+}
+
+#[test]
+fn estimated_savings_one_million_reads() {
+    // 1 M reads × $3/M × (1 − 0.10) = $2.70
+    let savings = compute_estimated_savings_usd_vs_cold(1_000_000);
+    assert!((savings - 2.70).abs() < 1e-9, "expected 2.70, got {savings}");
+}
+
+#[test]
+fn realized_spend_zero_tokens_is_zero() {
+    assert_eq!(compute_realized_cache_spend_usd(0, 0), 0.0);
+}
+
+#[test]
+fn realized_spend_reads_only() {
+    // 1 M reads × $3/M × 0.10 = $0.30
+    let spend = compute_realized_cache_spend_usd(1_000_000, 0);
+    assert!((spend - 0.30).abs() < 1e-9, "expected 0.30, got {spend}");
+}
+
+#[test]
+fn realized_spend_creation_only() {
+    // 1 M creation × $3/M × 1.25 = $3.75
+    let spend = compute_realized_cache_spend_usd(0, 1_000_000);
+    assert!((spend - 3.75).abs() < 1e-9, "expected 3.75, got {spend}");
+}
+
+#[test]
+fn realized_spend_mixed() {
+    // reads: 1M × $3/M × 0.10 = $0.30 + creation: 1M × $3/M × 1.25 = $3.75 = $4.05
+    let spend = compute_realized_cache_spend_usd(1_000_000, 1_000_000);
+    assert!((spend - 4.05).abs() < 1e-9, "expected 4.05, got {spend}");
+}
+
+// ── CLI integration tests ─────────────────────────────────────────────────────
+
+fn cache_stats_sweep_fixture() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/cache_stats/sweep")
+}
+
+fn no_cache_fixture() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/cache_stats/no_cache")
+}
+
+fn baseline_fixture() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/cache_stats/baseline")
+}
+
+fn run_cache_stats(sweep: &Path, extra_args: &[&str]) -> std::process::Output {
+    let mut cmd = Command::new(binary_path());
+    cmd.args(["--log", "error", "bench", "cache-stats", "--sweep"])
+        .arg(sweep);
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    cmd.output().unwrap()
+}
+
+fn run_cache_stats_json(sweep: &Path) -> serde_json::Value {
+    let output = run_cache_stats(sweep, &["--format", "json"]);
+    assert!(
+        output.status.success(),
+        "bench cache-stats --format json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn cli_exits_zero_with_cache_data() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&cache_stats_sweep_fixture(), sweep.path());
+
+    let output = run_cache_stats(sweep.path(), &[]);
+    assert!(
+        output.status.success(),
+        "bench cache-stats failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn cli_text_output_shows_bench_header() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&cache_stats_sweep_fixture(), sweep.path());
+
+    let output = run_cache_stats(sweep.path(), &[]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("bench cache-stats"),
+        "expected 'bench cache-stats' header in:\n{stdout}"
+    );
+}
+
+#[test]
+fn cli_text_output_shows_cache_hit_rate() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&cache_stats_sweep_fixture(), sweep.path());
+
+    let output = run_cache_stats(sweep.path(), &[]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("cache_hit_rate") || stdout.contains("hit_rate"),
+        "expected hit rate label in:\n{stdout}"
+    );
+}
+
+#[test]
+fn cli_json_emits_versioned_artifact_kind() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&cache_stats_sweep_fixture(), sweep.path());
+
+    let report = run_cache_stats_json(sweep.path());
+    assert_eq!(
+        report["artifact_kind"],
+        serde_json::json!("cache_stats_report"),
+        "wrong artifact_kind"
+    );
+    assert!(
+        report["schema_version"].is_object(),
+        "schema_version must be present"
+    );
+    assert_eq!(report["schema_version"]["major"], 1);
+}
+
+#[test]
+fn cli_json_has_required_sweep_total_fields() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&cache_stats_sweep_fixture(), sweep.path());
+
+    let report = run_cache_stats_json(sweep.path());
+    let totals = &report["sweep_totals"];
+    assert!(totals.is_object(), "sweep_totals required");
+    assert!(
+        totals["total_input_tokens"].is_u64(),
+        "total_input_tokens required"
+    );
+    assert!(
+        totals["total_cache_read_tokens"].is_u64(),
+        "total_cache_read_tokens required"
+    );
+    assert!(
+        totals["total_cache_creation_tokens"].is_u64(),
+        "total_cache_creation_tokens required"
+    );
+    assert!(
+        totals["cache_hit_rate"].is_f64() || totals["cache_hit_rate"].is_u64(),
+        "cache_hit_rate required"
+    );
+    assert!(
+        totals["estimated_savings_usd_vs_cold"].is_f64()
+            || totals["estimated_savings_usd_vs_cold"].is_u64(),
+        "estimated_savings_usd_vs_cold required"
+    );
+    assert!(
+        totals["realized_cache_spend_usd"].is_f64()
+            || totals["realized_cache_spend_usd"].is_u64(),
+        "realized_cache_spend_usd required"
+    );
+}
+
+#[test]
+fn cli_json_sweep_totals_correct_values() {
+    // sweep fixture: input=80000, reads=120000, creation=80000
+    // hit_rate = 120000 / 280000 ≈ 0.4286
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&cache_stats_sweep_fixture(), sweep.path());
+
+    let report = run_cache_stats_json(sweep.path());
+    let totals = &report["sweep_totals"];
+    assert_eq!(totals["total_input_tokens"].as_u64().unwrap(), 80_000);
+    assert_eq!(totals["total_cache_read_tokens"].as_u64().unwrap(), 120_000);
+    assert_eq!(
+        totals["total_cache_creation_tokens"].as_u64().unwrap(),
+        80_000
+    );
+    let hit_rate = totals["cache_hit_rate"].as_f64().unwrap();
+    let expected_rate = 120_000.0_f64 / 280_000.0;
+    assert!(
+        (hit_rate - expected_rate).abs() < 1e-6,
+        "expected ~{expected_rate:.4}, got {hit_rate:.4}"
+    );
+}
+
+#[test]
+fn cli_json_instances_sorted_worst_first() {
+    // cold-1 has 0% hit rate, partial-1 has 50%, warm-1 has 80%
+    // sorted ascending → cold-1 first
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&cache_stats_sweep_fixture(), sweep.path());
+
+    let report = run_cache_stats_json(sweep.path());
+    let instances = report["instances"].as_array().unwrap();
+    assert!(!instances.is_empty(), "instances must not be empty");
+    // Verify ascending order by cache_hit_rate
+    for i in 1..instances.len() {
+        let prev = instances[i - 1]["cache_hit_rate"].as_f64().unwrap();
+        let curr = instances[i]["cache_hit_rate"].as_f64().unwrap();
+        assert!(
+            prev <= curr,
+            "instances should be sorted ascending by cache_hit_rate: {prev} before {curr}"
+        );
+    }
+    // First entry should be cold-1 (0% hit rate)
+    assert_eq!(
+        instances[0]["instance_id"],
+        serde_json::json!("cold-1"),
+        "worst-cache instance should be first"
+    );
+}
+
+#[test]
+fn cli_json_instance_row_has_required_fields() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&cache_stats_sweep_fixture(), sweep.path());
+
+    let report = run_cache_stats_json(sweep.path());
+    let instances = report["instances"].as_array().unwrap();
+    let row = &instances[0];
+    assert!(row["instance_id"].is_string(), "instance_id required");
+    assert!(
+        row["total_input_tokens"].is_u64(),
+        "total_input_tokens required"
+    );
+    assert!(
+        row["total_cache_read_tokens"].is_u64(),
+        "total_cache_read_tokens required"
+    );
+    assert!(
+        row["total_cache_creation_tokens"].is_u64(),
+        "total_cache_creation_tokens required"
+    );
+    assert!(
+        row["cache_hit_rate"].is_f64() || row["cache_hit_rate"].is_u64(),
+        "cache_hit_rate required"
+    );
+    assert!(
+        row["estimated_savings_usd_vs_cold"].is_f64()
+            || row["estimated_savings_usd_vs_cold"].is_u64(),
+        "estimated_savings_usd_vs_cold required"
+    );
+    assert!(
+        row["realized_cache_spend_usd"].is_f64() || row["realized_cache_spend_usd"].is_u64(),
+        "realized_cache_spend_usd required"
+    );
+}
+
+#[test]
+fn cli_top_flag_limits_instance_rows() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&cache_stats_sweep_fixture(), sweep.path());
+
+    let output = run_cache_stats(sweep.path(), &["--format", "json", "--top", "1"]);
+    assert!(output.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let instances = report["instances"].as_array().unwrap();
+    assert_eq!(instances.len(), 1, "expected exactly 1 instance with --top 1");
+}
+
+#[test]
+fn cli_writes_cache_stats_json_to_disk() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&cache_stats_sweep_fixture(), sweep.path());
+
+    let output = run_cache_stats(sweep.path(), &[]);
+    assert!(output.status.success());
+
+    let artifact_path = sweep.path().join("cache-stats.json");
+    assert!(
+        artifact_path.exists(),
+        "cache-stats.json should be written to sweep dir"
+    );
+
+    let content = std::fs::read_to_string(&artifact_path).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(v["artifact_kind"], serde_json::json!("cache_stats_report"));
+}
+
+#[test]
+fn cli_cache_disabled_exits_zero_and_prints_message() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&no_cache_fixture(), sweep.path());
+
+    let output = run_cache_stats(sweep.path(), &[]);
+    assert!(
+        output.status.success(),
+        "bench cache-stats on no-cache sweep should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("cache disabled") || stdout.contains("unsupported"),
+        "expected informational message for no-cache sweep, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn cli_json_cache_disabled_sets_flag() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&no_cache_fixture(), sweep.path());
+
+    let output = run_cache_stats(sweep.path(), &["--format", "json"]);
+    assert!(output.status.success());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        report["cache_disabled"],
+        serde_json::json!(true),
+        "cache_disabled should be true when no cache tokens"
+    );
+}
+
+#[test]
+fn cli_baseline_json_includes_delta_fields() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&cache_stats_sweep_fixture(), sweep.path());
+    let baseline_dir = tempfile::tempdir().unwrap();
+    copy_dir(&baseline_fixture(), baseline_dir.path());
+
+    let output = run_cache_stats(
+        sweep.path(),
+        &[
+            "--format",
+            "json",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "bench cache-stats --baseline failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let baseline = &report["baseline"];
+    assert!(baseline.is_object(), "baseline delta object required");
+    assert!(
+        baseline["delta_hit_rate"].is_f64() || baseline["delta_hit_rate"].is_u64(),
+        "delta_hit_rate required"
+    );
+    assert!(
+        baseline["delta_realized_spend_usd"].is_f64()
+            || baseline["delta_realized_spend_usd"].is_u64(),
+        "delta_realized_spend_usd required"
+    );
+}
+
+#[test]
+fn cli_baseline_text_shows_delta_column() {
+    let sweep = tempfile::tempdir().unwrap();
+    copy_dir(&cache_stats_sweep_fixture(), sweep.path());
+    let baseline_dir = tempfile::tempdir().unwrap();
+    copy_dir(&baseline_fixture(), baseline_dir.path());
+
+    let output = run_cache_stats(
+        sweep.path(),
+        &["--baseline", baseline_dir.path().to_str().unwrap()],
+    );
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("delta") || stdout.contains("Δ") || stdout.contains("baseline"),
+        "expected delta info in text output with --baseline, got:\n{stdout}"
+    );
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn copy_dir(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        let target = dst.join(entry.file_name());
+        if path.is_dir() {
+            copy_dir(&path, &target);
+        } else {
+            std::fs::copy(&path, &target).unwrap();
+        }
+    }
+}

--- a/tests/bench_cache_stats.rs
+++ b/tests/bench_cache_stats.rs
@@ -41,17 +41,40 @@ fn cache_hit_rate_mixed() {
 }
 
 #[test]
-fn estimated_savings_zero_reads_is_zero() {
-    assert_eq!(compute_estimated_savings_usd_vs_cold(0), 0.0);
+fn estimated_savings_zero_tokens_is_zero() {
+    assert_eq!(compute_estimated_savings_usd_vs_cold(0, 0), 0.0);
 }
 
 #[test]
-fn estimated_savings_one_million_reads() {
-    // 1 M reads × $3/M × (1 − 0.10) = $2.70
-    let savings = compute_estimated_savings_usd_vs_cold(1_000_000);
+fn estimated_savings_reads_only() {
+    // 1 M reads × $3/M × (1 − 0.10) = $2.70; no creation premium
+    let savings = compute_estimated_savings_usd_vs_cold(1_000_000, 0);
     assert!(
         (savings - 2.70).abs() < 1e-9,
         "expected 2.70, got {savings}"
+    );
+}
+
+#[test]
+fn estimated_savings_creation_only_is_negative() {
+    // Cache writes cost 1.25× vs 1.0× cold — net is a loss.
+    // 1 M creation × $3/M × 0.25 premium = −$0.75
+    let savings = compute_estimated_savings_usd_vs_cold(0, 1_000_000);
+    assert!(
+        (savings - (-0.75)).abs() < 1e-9,
+        "expected −0.75, got {savings}"
+    );
+}
+
+#[test]
+fn estimated_savings_mixed_reads_and_creation() {
+    // reads: 1M × 0.90 × $3/M = $2.70 saved
+    // creation: 1M × 0.25 × $3/M = $0.75 premium
+    // net = $2.70 − $0.75 = $1.95
+    let savings = compute_estimated_savings_usd_vs_cold(1_000_000, 1_000_000);
+    assert!(
+        (savings - 1.95).abs() < 1e-9,
+        "expected 1.95, got {savings}"
     );
 }
 
@@ -451,6 +474,14 @@ fn cli_baseline_json_includes_delta_fields() {
         baseline["delta_realized_spend_usd"].is_f64()
             || baseline["delta_realized_spend_usd"].is_u64(),
         "delta_realized_spend_usd required"
+    );
+    assert!(
+        baseline["current_instance_count"].is_u64(),
+        "current_instance_count required for comparability transparency"
+    );
+    assert!(
+        baseline["baseline_instance_count"].is_u64(),
+        "baseline_instance_count required for comparability transparency"
     );
 }
 

--- a/tests/bench_cache_stats.rs
+++ b/tests/bench_cache_stats.rs
@@ -471,9 +471,9 @@ fn cli_baseline_json_includes_delta_fields() {
         "delta_hit_rate required"
     );
     assert!(
-        baseline["delta_realized_spend_usd"].is_f64()
-            || baseline["delta_realized_spend_usd"].is_u64(),
-        "delta_realized_spend_usd required"
+        baseline["delta_realized_cache_spend_usd"].is_f64()
+            || baseline["delta_realized_cache_spend_usd"].is_u64(),
+        "delta_realized_cache_spend_usd required"
     );
     assert!(
         baseline["current_instance_count"].is_u64(),

--- a/tests/bench_report.rs
+++ b/tests/bench_report.rs
@@ -1286,7 +1286,9 @@ fn bench_report_cache_effectiveness_section_present_with_cache_data() {
         "report should contain 'Cache Effectiveness' section\ncontent:\n{content}"
     );
     assert!(
-        content.contains("cache_hit_rate") || content.contains("hit rate") || content.contains("Cache hit"),
+        content.contains("cache_hit_rate")
+            || content.contains("hit rate")
+            || content.contains("Cache hit"),
         "cache effectiveness section should show hit rate\ncontent:\n{content}"
     );
     assert!(

--- a/tests/bench_report.rs
+++ b/tests/bench_report.rs
@@ -1228,3 +1228,132 @@ fn bench_report_resolved_instance_not_in_failed_table() {
     // at least verify the report was generated successfully.
     assert!(!content.is_empty(), "report should not be empty");
 }
+
+// ── Cache Effectiveness section (issue #265) ──────────────────────────────────
+
+fn submitted_with_cache(id: &str, input: u64, reads: u64, creation: u64) -> InstanceResult {
+    InstanceResult {
+        instance_id: id.into(),
+        exit_reason: "submitted".into(),
+        outcome: Some(outcome::SUBMITTED.into()),
+        failure_category: None,
+        steps: Some(4),
+        cost_usd: Some(0.05),
+        prompt_tokens: Some(input),
+        cache_read_tokens: Some(reads),
+        cache_creation_tokens: Some(creation),
+        completion_tokens: Some(100),
+        duration_secs: Some(8.0),
+        error: None,
+        github_pr_error: None,
+        patch_present: true,
+        non_empty_patch: true,
+        attempts: 1,
+        retry_reasons: Vec::new(),
+        runs: 1,
+        resolved_count: 1,
+        pass_at_1: true,
+        tests_run_before_submit: false,
+        last_tests_passed: None,
+        fallback_count: None,
+        final_model: None,
+        retry_id: None,
+        previous_failure_category: None,
+    }
+}
+
+#[test]
+fn bench_report_cache_effectiveness_section_present_with_cache_data() {
+    let work = tempfile::tempdir().unwrap();
+    write_sweep(
+        work.path(),
+        vec![
+            submitted_with_cache("django__django-001", 10_000, 80_000, 10_000),
+            submitted_with_cache("django__django-002", 5_000, 40_000, 5_000),
+        ],
+    );
+    let out_file = work.path().join("report.md");
+    let out = bench_report(&[
+        "--sweep",
+        &work.path().display().to_string(),
+        "--output",
+        &out_file.display().to_string(),
+    ]);
+    assert!(out.status.success());
+    let content = std::fs::read_to_string(&out_file).unwrap();
+    assert!(
+        content.contains("Cache Effectiveness"),
+        "report should contain 'Cache Effectiveness' section\ncontent:\n{content}"
+    );
+    assert!(
+        content.contains("cache_hit_rate") || content.contains("hit rate") || content.contains("Cache hit"),
+        "cache effectiveness section should show hit rate\ncontent:\n{content}"
+    );
+    assert!(
+        content.contains("savings") || content.contains("Savings"),
+        "cache effectiveness section should show savings\ncontent:\n{content}"
+    );
+    assert!(
+        content.contains("spend") || content.contains("Spend"),
+        "cache effectiveness section should show realized spend\ncontent:\n{content}"
+    );
+}
+
+#[test]
+fn bench_report_cache_effectiveness_renders_no_cache_data_gracefully() {
+    let work = tempfile::tempdir().unwrap();
+    // submitted() helper creates instances with cache_read=0 and cache_creation=0
+    write_sweep(
+        work.path(),
+        vec![
+            submitted("django__django-001"),
+            submitted("django__django-002"),
+        ],
+    );
+    let out_file = work.path().join("report.md");
+    let out = bench_report(&[
+        "--sweep",
+        &work.path().display().to_string(),
+        "--output",
+        &out_file.display().to_string(),
+    ]);
+    assert!(out.status.success());
+    let content = std::fs::read_to_string(&out_file).unwrap();
+    assert!(
+        content.contains("Cache Effectiveness"),
+        "Cache Effectiveness section should be present even with no cache data\ncontent:\n{content}"
+    );
+    assert!(
+        content.contains("no cache data"),
+        "should render '_no cache data_' gracefully\ncontent:\n{content}"
+    );
+}
+
+#[test]
+fn bench_report_cache_effectiveness_hit_rate_value_is_correct() {
+    // 80 000 reads / (10 000 input + 80 000 reads + 10 000 creation) = 80%
+    let work = tempfile::tempdir().unwrap();
+    write_sweep(
+        work.path(),
+        vec![submitted_with_cache(
+            "django__django-001",
+            10_000,
+            80_000,
+            10_000,
+        )],
+    );
+    let out_file = work.path().join("report.md");
+    let out = bench_report(&[
+        "--sweep",
+        &work.path().display().to_string(),
+        "--output",
+        &out_file.display().to_string(),
+    ]);
+    assert!(out.status.success());
+    let content = std::fs::read_to_string(&out_file).unwrap();
+    // 80.00 % hit rate should appear
+    assert!(
+        content.contains("80.00"),
+        "expected 80.00% hit rate in report\ncontent:\n{content}"
+    );
+}

--- a/tests/fixtures/cache_stats/baseline/results.json
+++ b/tests/fixtures/cache_stats/baseline/results.json
@@ -1,0 +1,53 @@
+{
+  "artifact_kind": "sweep_results",
+  "schema_version": {
+    "major": 1,
+    "minor": 8
+  },
+  "total": 3,
+  "submitted": 1,
+  "skipped": 0,
+  "errored": 0,
+  "total_cost_usd": 0.12,
+  "instances": [
+    {
+      "instance_id": "warm-1",
+      "exit_reason": "submitted",
+      "outcome": "submitted",
+      "total_input_tokens": 10000,
+      "total_cache_read_tokens": 50000,
+      "total_cache_creation_tokens": 40000,
+      "cost_usd": 0.07,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 1,
+      "pass_at_1": true
+    },
+    {
+      "instance_id": "cold-1",
+      "exit_reason": "submitted",
+      "outcome": "submitted",
+      "total_input_tokens": 50000,
+      "total_cache_read_tokens": 0,
+      "total_cache_creation_tokens": 50000,
+      "cost_usd": 0.03,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false
+    },
+    {
+      "instance_id": "partial-1",
+      "exit_reason": "step_limit_reached",
+      "outcome": "step_limit_reached",
+      "total_input_tokens": 20000,
+      "total_cache_read_tokens": 20000,
+      "total_cache_creation_tokens": 40000,
+      "cost_usd": 0.02,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false
+    }
+  ]
+}

--- a/tests/fixtures/cache_stats/no_cache/results.json
+++ b/tests/fixtures/cache_stats/no_cache/results.json
@@ -1,0 +1,36 @@
+{
+  "artifact_kind": "sweep_results",
+  "schema_version": {
+    "major": 1,
+    "minor": 8
+  },
+  "total": 2,
+  "submitted": 1,
+  "skipped": 0,
+  "errored": 0,
+  "total_cost_usd": 0.04,
+  "instances": [
+    {
+      "instance_id": "no-cache-1",
+      "exit_reason": "submitted",
+      "outcome": "submitted",
+      "total_input_tokens": 20000,
+      "cost_usd": 0.02,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 1,
+      "pass_at_1": true
+    },
+    {
+      "instance_id": "no-cache-2",
+      "exit_reason": "step_limit_reached",
+      "outcome": "step_limit_reached",
+      "total_input_tokens": 20000,
+      "cost_usd": 0.02,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false
+    }
+  ]
+}

--- a/tests/fixtures/cache_stats/sweep/results.json
+++ b/tests/fixtures/cache_stats/sweep/results.json
@@ -1,0 +1,53 @@
+{
+  "artifact_kind": "sweep_results",
+  "schema_version": {
+    "major": 1,
+    "minor": 8
+  },
+  "total": 3,
+  "submitted": 1,
+  "skipped": 0,
+  "errored": 0,
+  "total_cost_usd": 0.09,
+  "instances": [
+    {
+      "instance_id": "warm-1",
+      "exit_reason": "submitted",
+      "outcome": "submitted",
+      "total_input_tokens": 10000,
+      "total_cache_read_tokens": 80000,
+      "total_cache_creation_tokens": 10000,
+      "cost_usd": 0.05,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 1,
+      "pass_at_1": true
+    },
+    {
+      "instance_id": "cold-1",
+      "exit_reason": "submitted",
+      "outcome": "submitted",
+      "total_input_tokens": 50000,
+      "total_cache_read_tokens": 0,
+      "total_cache_creation_tokens": 50000,
+      "cost_usd": 0.03,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false
+    },
+    {
+      "instance_id": "partial-1",
+      "exit_reason": "step_limit_reached",
+      "outcome": "step_limit_reached",
+      "total_input_tokens": 20000,
+      "total_cache_read_tokens": 40000,
+      "total_cache_creation_tokens": 20000,
+      "cost_usd": 0.02,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false
+    }
+  ]
+}

--- a/tests/snapshots/bench_report__bench_report_basic.snap
+++ b/tests/snapshots/bench_report__bench_report_basic.snap
@@ -50,3 +50,7 @@ expression: content
 ## Evaluation
 
 _no evaluation data — run `bench evaluate` to populate_
+
+## Cache Effectiveness
+
+_no cache data_


### PR DESCRIPTION
## Summary

Adds a new `bench cache-stats` subcommand that analyzes prompt cache effectiveness from completed sweep results. This command reads only on-disk artifacts (zero-cost, no model calls) and surfaces cache hit rates, estimated savings, and realized spend at both sweep and per-instance levels.

## Key Changes

- **New `bench cache-stats` command** (`src/cli/args.rs`, `src/cli/mod.rs`):
  - Accepts `--sweep` (required), `--format` (text/json, default: text), `--top` (default: 10), and `--baseline` (optional) flags
  - Reads completed sweep directories and generates cache effectiveness reports
  - Writes `cache-stats.json` artifact to the sweep directory

- **Cache stats calculation module** (`src/run/cache_stats.rs`):
  - Pure calculation functions: `compute_cache_hit_rate()`, `compute_estimated_savings_usd_vs_cold()`, `compute_realized_cache_spend_usd()`
  - Uses Anthropic pricing constants (Claude 3.5 Sonnet: $3/Mtok input, 0.10× for cache reads, 1.25× for cache creation)
  - Builds detailed reports with per-instance rows sorted by cache efficiency (worst first)
  - Supports baseline comparison with delta calculations
  - Handles cache-disabled case gracefully (exits 0 with informational message)

- **Report rendering**:
  - Text output: formatted tables showing sweep totals and per-instance breakdown
  - JSON output: schema-versioned artifact (`cache_stats_report`, v1.0) suitable for CI snapshot diffing
  - Includes baseline delta fields when `--baseline` is provided

- **Integration with `bench report`** (`src/run/report.rs`):
  - Adds "Cache Effectiveness" section to markdown reports
  - Shows cache hit rate, estimated savings, and realized spend
  - Gracefully handles sweeps with no cache data

- **Comprehensive test coverage** (`tests/bench_cache_stats.rs`):
  - Unit tests for all calculation functions
  - CLI integration tests with fixtures for cache-enabled, cache-disabled, and baseline scenarios
  - Validates JSON schema, field presence, sorting order, and artifact writing
  - Tests `--top` flag limiting and baseline delta computation

- **Test fixtures** (`tests/fixtures/cache_stats/`):
  - `sweep/`: cache-enabled sweep with mixed hit rates (0%, 50%, 80%)
  - `no_cache/`: sweep without cache tokens
  - `baseline/`: baseline sweep for delta comparison

- **Documentation** (`docs/spec-cache-stats.md`):
  - Complete usage guide with examples
  - Key concepts explained (hit rate, savings, realized spend)
  - JSON schema reference
  - Performance notes and scope definition

- **Artifact registry** (`src/artifact.rs`):
  - Registers `CacheStatsReport` as a new artifact kind

## Notable Implementation Details

- Cache hit rate formula: `cache_read / (input + cache_read + cache_creation)`, returns 0.0 for all-zero tokens
- Estimated savings assumes a hypothetical cold run where cached reads were fresh input
- Realized spend accounts for different multipliers: 0.10× for reads, 1.25× for creation
- Instances sorted ascending by hit rate (worst first) for easy identification of cache regressions
- Zero-cost guarantee: reads only `results.json`, never calls model provider
- Handles non-Anthropic providers gracefully by detecting zero cache tokens

https://claude.ai/code/session_01VahRMywZoB89uo8AYFVbcy