### PR TITLE
⚡ Bolt: Optimize normalize_search_text

### DIFF
--- a/src/skills.rs
+++ b/src/skills.rs
@@ -500,16 +500,23 @@ fn searchable_tokens(name: &str, description: &str) -> BTreeSet<String> {
         .collect()
 }
 
+/// Normalizes a search string by keeping only alphanumeric characters and
+/// a few select symbols, lowercasing them, and separating them by single spaces.
+/// This implementation avoids intermediate vector allocations (`collect::<Vec<_>>().join()`).
 fn normalize_search_text(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
-    for ch in text.chars() {
-        if ch.is_ascii_alphanumeric() || ch == '$' || ch == '@' || ch == '/' {
-            out.push(ch.to_ascii_lowercase());
-        } else {
+    for token in text.split(|c: char| !(c.is_ascii_alphanumeric() || c == '$' || c == '@' || c == '/')) {
+        if token.is_empty() {
+            continue;
+        }
+        if !out.is_empty() {
             out.push(' ');
         }
+        for ch in token.chars() {
+            out.push(ch.to_ascii_lowercase());
+        }
     }
-    out.split_whitespace().collect::<Vec<_>>().join(" ")
+    out
 }
 
 fn is_stopword(token: &str) -> bool {


### PR DESCRIPTION
💡 What: Replaced intermediate `Vec` allocation in `normalize_search_text` with an allocation-free string building approach using `.split()` and `.chars()`.
🎯 Why: `normalize_search_text` previously allocated a `Vec` just to join tokens by space, causing unnecessary heap allocations on the hot path of resolving skills.
📊 Impact: Reduces heap allocations by eliminating the intermediate `Vec` creation entirely.
🔬 Measurement: Run `cargo clippy`, `cargo test`, and `cargo bench` if available.

---
*PR created automatically by Jules for task [7183908151293461997](https://jules.google.com/task/7183908151293461997) started by @madmax983*