### PR TITLE
Add `mini --interactive` confirmation + ratatui dashboard (issue #312)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,9 +293,23 @@ version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -292,7 +321,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -304,7 +333,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -334,6 +363,23 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "futures-core",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -342,7 +388,7 @@ dependencies = [
  "crossterm_winapi",
  "document-features",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "winapi",
 ]
 
@@ -363,6 +409,41 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -463,6 +544,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -695,6 +782,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -946,6 +1035,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,9 +1081,18 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console 0.16.3",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1002,6 +1106,19 @@ dependencies = [
  "serde",
  "similar",
  "tempfile",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1025,6 +1142,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1098,6 +1224,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1121,7 +1253,7 @@ dependencies = [
  "hex",
  "hmac",
  "jsonwebtoken",
- "lru",
+ "lru 0.16.4",
  "parking_lot",
  "paste",
  "pin-project-lite",
@@ -1171,6 +1303,15 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
@@ -1202,6 +1343,7 @@ dependencies = [
  "chrono",
  "clap",
  "comfy-table",
+ "crossterm 0.28.1",
  "dialoguer",
  "flate2",
  "futures",
@@ -1211,6 +1353,7 @@ dependencies = [
  "minijinja",
  "pretty_assertions",
  "proptest",
+ "ratatui",
  "regex",
  "reqwest",
  "serde",
@@ -1281,6 +1424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1596,6 +1740,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru 0.12.5",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,6 +1892,19 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1734,7 +1912,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1921,6 +2099,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,10 +2182,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -2045,7 +2272,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2400,10 +2627,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -2932,7 +3176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ minijinja = { version = "2", features = ["loader"] }
 clap = { version = "4", features = ["derive", "env"] }
 dialoguer = "0.11"
 indicatif = "0.18.4"
+# `mini --interactive` confirmation prompt: single-key reads on a TTY plus
+# a ratatui dashboard when `--ui ratatui` is selected (issue #312).
+crossterm = { version = "0.28", features = ["event-stream"] }
+ratatui = "0.29"
 
 # HTTP fallback (used inside `LitellmBackend` for headers, and as a thin
 # escape hatch if any backend needs raw HTTP).

--- a/README.md
+++ b/README.md
@@ -137,16 +137,19 @@ seance gets a receipt.
 Keep the paid path separate from the no-key smoke path. Set the credential for
 the model family you choose, keep the task local and tiny, and set both a step
 limit and a per-task budget. Local execution runs model-generated shell commands
-from this checkout, so treat it as trusted-code execution. Use Docker isolation
-when available for untrusted repositories or tasks; see
-[`docs/spec-interactive-mode.md`](docs/spec-interactive-mode.md) for the local
-execution safety rationale.
+from this checkout, so treat it as trusted-code execution. **For any `--env
+local` run, pass `--interactive` (issue #312):** the agent pauses before every
+bash action and asks the operator to approve, reject, or abort — closing the
+"one hallucinated `rm -rf` away from a wiped checkout" gap that Docker isolation
+otherwise covers. See [`docs/spec-interactive-mode.md`](docs/spec-interactive-mode.md)
+for the full contract; use `--interactive --ui ratatui` for a full-screen
+dashboard, or `--yolo` to run unattended with a per-step status line.
 
 PowerShell:
 
 ```powershell
 $env:ANTHROPIC_API_KEY = "<your Anthropic key>"
-cargo run --quiet -- --log info mini --task "Create runs/live-task/hello.txt containing hello from maxwells-daemon." --model claude-opus-4-7 --env local --output runs/live-quickstart --trajectory-name live-hello --step-limit 8 --task-timeout-secs 300 --per-task-budget-usd 0.25
+cargo run --quiet -- --log info mini --interactive --task "Create runs/live-task/hello.txt containing hello from maxwells-daemon." --model claude-opus-4-7 --env local --output runs/live-quickstart --trajectory-name live-hello --step-limit 8 --task-timeout-secs 300 --per-task-budget-usd 0.25
 cargo run --quiet -- --log error bench inspect --sweep runs/live-quickstart --instance live-hello
 ```
 
@@ -154,9 +157,16 @@ macOS/Linux:
 
 ```bash
 export ANTHROPIC_API_KEY="<your Anthropic key>"
-cargo run --quiet -- --log info mini --task "Create runs/live-task/hello.txt containing hello from maxwells-daemon." --model claude-opus-4-7 --env local --output runs/live-quickstart --trajectory-name live-hello --step-limit 8 --task-timeout-secs 300 --per-task-budget-usd 0.25
+cargo run --quiet -- --log info mini --interactive --task "Create runs/live-task/hello.txt containing hello from maxwells-daemon." --model claude-opus-4-7 --env local --output runs/live-quickstart --trajectory-name live-hello --step-limit 8 --task-timeout-secs 300 --per-task-budget-usd 0.25
 cargo run --quiet -- --log error bench inspect --sweep runs/live-quickstart --instance live-hello
 ```
+
+At each bash action the prompt prints the proposed command, the current step,
+cumulative cost, and the cache marker, then reads one keystroke: `y` approves,
+`n` rejects (the model receives a synthetic `Exit code: 1` observation and may
+revise), `a` (or Esc/Ctrl-C) aborts the run cleanly. Rejections and aborts are
+recorded on the trajectory as structured events so `bench inspect` can show
+exactly which commands the operator vetoed.
 
 For a real SWE-bench sweep, run `bench doctor` first, then `bench forecast`
 with a cost cap, then `bench swebench` only after the forecast clears your

--- a/docs/spec-interactive-mode.md
+++ b/docs/spec-interactive-mode.md
@@ -22,4 +22,10 @@ Success = 0 accidental destructive commands executed during a local run when Int
 
 ## 🕳️ Gap Analysis
 - **SWE-agent**: Offers robust interactive modes allowing users to intercede.
-- **maxwells-daemon today**: The codebase has an `InteractiveAgent` struct that prints a status line and catches `Ctrl-C`, but fails to actually pause and ask for confirmation before executing actions. The CLI also lacks the necessary flags to launch a single-task run in interactive mode.
+- **maxwells-daemon today**: shipped in `mini --interactive` (issue #312). `--interactive` enables a stderr y/n/a prompt before every bash/tool action; `--interactive --ui ratatui` swaps it for a full-screen dashboard with a modal prompt and live trajectory feed; `--yolo` alone prints a per-step status line without prompting. Non-TTY stdin without `--yolo` fails fast with "interactive mode requires a TTY; pass --yolo for unattended runs." Hook ordering: PreToolUse hooks fire before the prompt so the operator sees the same command the hook layer evaluated; a denied hook short-circuits the prompt. Rejections write `interactive_decision: "reject"` (+ proposed command, tool name, timestamp) onto the trajectory observation; aborts stamp `interactive_abort` onto trajectory info before `finalize_cancelled` runs.
+
+## Implementation notes
+- Confirmation lives on `DefaultAgent.confirm_callback: Option<Arc<dyn ConfirmCallback>>`. `ConfirmCallback::confirm(ctx) -> ConfirmDecision { Approve, Reject, Abort }` is the only entry point; tests use `ScriptedConfirmer`, the CLI uses `StderrCliConfirmer` (crossterm raw mode with line-buffered fallback), the dashboard uses `RatatuiDashboard` (also a `StreamSink`).
+- `ConfirmContext` carries `tool_name`, redacted `command`, `step`, `step_limit`, `cost_usd`, and the cache marker (`cache:explicit` / `cache:auto-or-none`).
+- Reject returns a synthetic `Exit code: 1\nCommand rejected by operator (interactive mode). …` user observation so the model can revise within the same step budget.
+- Mutually exclusive with `--render-only`; enforced at the clap layer.

--- a/src/agent/confirm.rs
+++ b/src/agent/confirm.rs
@@ -1,0 +1,141 @@
+//! Operator confirmation callback for issue #312 interactive mode.
+//!
+//! `DefaultAgent` consults the optional `confirm_callback` after a model-
+//! proposed bash/tool action has cleared the policy gate and PreToolUse
+//! hooks but before the environment is invoked. Operators can approve,
+//! reject (returns a synthetic observation to the model so it can revise),
+//! or abort the run (the loop terminates with
+//! `ExitReason::UserInterrupt`).
+//!
+//! Production implementations live in `confirm_cli` and `confirm_tui`;
+//! tests use the `ScriptedConfirmer` shipped here.
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+/// Information shown to the operator at the confirmation prompt.
+#[derive(Debug, Clone)]
+pub struct ConfirmContext {
+    /// `"bash"` for shell actions, or the MCP/command-tool name.
+    pub tool_name: String,
+    /// The exact command/input string, already redacted for trajectory
+    /// display.
+    pub command: String,
+    /// 0-based current step at the moment the prompt is shown.
+    pub step: u32,
+    /// `config.agent.step_limit` for this run.
+    pub step_limit: u32,
+    /// Cumulative spend in USD across the run so far.
+    pub cost_usd: f64,
+    /// Cache marker mirroring `InteractiveAgent::status_line`:
+    /// `"cache:explicit"` or `"cache:auto-or-none"`.
+    pub cache_marker: &'static str,
+}
+
+/// The operator's decision returned by `ConfirmCallback::confirm`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfirmDecision {
+    /// Execute the proposed action normally.
+    Approve,
+    /// Skip execution; surface a synthetic observation to the model.
+    Reject,
+    /// Terminate the run cleanly with `ExitReason::UserInterrupt`.
+    Abort,
+}
+
+impl ConfirmDecision {
+    /// Stable lowercase label for trajectory `interactive_decision` entries.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Approve => "approve",
+            Self::Reject => "reject",
+            Self::Abort => "abort",
+        }
+    }
+}
+
+/// Pause the agent loop and collect an operator decision.
+///
+/// Implementors own whatever I/O they need (stdin raw mode, ratatui
+/// frame draw, channel send, etc.). The agent loop only sees the typed
+/// return value.
+#[async_trait]
+pub trait ConfirmCallback: Send + Sync {
+    /// Ask the operator how to proceed with `ctx`.
+    async fn confirm(&self, ctx: &ConfirmContext) -> ConfirmDecision;
+}
+
+/// Test/scripted confirmer that returns decisions from a fixed queue.
+///
+/// When the queue is exhausted the confirmer returns `Approve` so a test
+/// that exercises a `Submit`-only flow can pass an empty queue. Use
+/// `call_count()` to verify exact call counts.
+pub struct ScriptedConfirmer {
+    decisions: Mutex<std::collections::VecDeque<ConfirmDecision>>,
+    calls: Mutex<u32>,
+}
+
+impl ScriptedConfirmer {
+    #[must_use]
+    pub fn new(decisions: impl IntoIterator<Item = ConfirmDecision>) -> Self {
+        Self {
+            decisions: Mutex::new(decisions.into_iter().collect()),
+            calls: Mutex::new(0),
+        }
+    }
+
+    #[must_use]
+    pub fn call_count(&self) -> u32 {
+        *self
+            .calls
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+#[async_trait]
+impl ConfirmCallback for ScriptedConfirmer {
+    async fn confirm(&self, _ctx: &ConfirmContext) -> ConfirmDecision {
+        *self
+            .calls
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) += 1;
+        self.decisions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .pop_front()
+            .unwrap_or(ConfirmDecision::Approve)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+
+    #[tokio::test]
+    async fn scripted_returns_decisions_in_order_then_default_approve() {
+        let c = ScriptedConfirmer::new([ConfirmDecision::Reject, ConfirmDecision::Abort]);
+        let ctx = ConfirmContext {
+            tool_name: "bash".into(),
+            command: "x".into(),
+            step: 0,
+            step_limit: 1,
+            cost_usd: 0.0,
+            cache_marker: "cache:auto-or-none",
+        };
+        assert_eq!(c.confirm(&ctx).await, ConfirmDecision::Reject);
+        assert_eq!(c.confirm(&ctx).await, ConfirmDecision::Abort);
+        assert_eq!(c.confirm(&ctx).await, ConfirmDecision::Approve);
+        assert_eq!(c.call_count(), 3);
+    }
+
+    #[test]
+    fn decision_labels_are_stable() {
+        assert_eq!(ConfirmDecision::Approve.label(), "approve");
+        assert_eq!(ConfirmDecision::Reject.label(), "reject");
+        assert_eq!(ConfirmDecision::Abort.label(), "abort");
+    }
+}

--- a/src/agent/confirm_cli.rs
+++ b/src/agent/confirm_cli.rs
@@ -1,0 +1,158 @@
+//! Stderr single-line confirmation prompt for `mini --interactive`.
+//!
+//! Prints proposed command, step, cost, and cache marker to stderr, then
+//! reads one keystroke from the TTY (`y` approve, `n` reject, `a`/Esc/Ctrl-C
+//! abort). When stdin is a TTY we enter raw mode for single-keystroke
+//! input. When stdin is not a TTY the constructor returns `None`; the
+//! agent runner translates that into the documented
+//! "interactive mode requires a TTY; pass --yolo for unattended runs"
+//! error.
+
+use std::io::{IsTerminal as _, Write as _};
+
+use async_trait::async_trait;
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+
+use super::confirm::{ConfirmCallback, ConfirmContext, ConfirmDecision};
+
+pub struct StderrCliConfirmer;
+
+impl StderrCliConfirmer {
+    /// Build a stderr confirmer iff stdin is a TTY. `None` otherwise.
+    #[must_use]
+    pub fn new_if_tty() -> Option<Self> {
+        std::io::stdin().is_terminal().then_some(Self)
+    }
+
+    /// Forced constructor for callers that have already gated on a TTY
+    /// elsewhere (or tests that drive a fake stdin).
+    #[must_use]
+    pub fn forced() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ConfirmCallback for StderrCliConfirmer {
+    async fn confirm(&self, ctx: &ConfirmContext) -> ConfirmDecision {
+        let ctx = ctx.clone();
+        tokio::task::spawn_blocking(move || prompt_blocking(&ctx))
+            .await
+            .unwrap_or(ConfirmDecision::Abort)
+    }
+}
+
+fn prompt_blocking(ctx: &ConfirmContext) -> ConfirmDecision {
+    let mut err = std::io::stderr();
+    let banner = format!(
+        "\n[interactive] step {}/{}  cost ${:.4}  {}\n\
+         [interactive] tool: {}\n\
+         [interactive] command:\n{}\n\
+         [interactive] (y)approve / (n)reject / (a)abort? ",
+        ctx.step,
+        ctx.step_limit,
+        ctx.cost_usd,
+        ctx.cache_marker,
+        ctx.tool_name,
+        indent_command(&ctx.command),
+    );
+    let _ = err.write_all(banner.as_bytes());
+    let _ = err.flush();
+
+    match read_single_keystroke() {
+        Some(decision) => {
+            let _ = err.write_all(b"\n");
+            decision
+        }
+        None => read_line_buffered(),
+    }
+}
+
+fn indent_command(cmd: &str) -> String {
+    cmd.lines()
+        .map(|line| format!("    {line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn read_single_keystroke() -> Option<ConfirmDecision> {
+    if !std::io::stdin().is_terminal() {
+        return None;
+    }
+    if crossterm::terminal::enable_raw_mode().is_err() {
+        return None;
+    }
+    let decision = loop {
+        match crossterm::event::read() {
+            Ok(Event::Key(KeyEvent {
+                code,
+                modifiers,
+                kind: KeyEventKind::Press,
+                ..
+            })) => {
+                if modifiers.contains(KeyModifiers::CONTROL)
+                    && matches!(code, KeyCode::Char('c' | 'C'))
+                {
+                    break ConfirmDecision::Abort;
+                }
+                match code {
+                    KeyCode::Char('y' | 'Y') => break ConfirmDecision::Approve,
+                    KeyCode::Char('n' | 'N') => break ConfirmDecision::Reject,
+                    KeyCode::Char('a' | 'A') | KeyCode::Esc => break ConfirmDecision::Abort,
+                    _ => {}
+                }
+            }
+            Ok(_) => {}
+            Err(_) => break ConfirmDecision::Abort,
+        }
+    };
+    let _ = crossterm::terminal::disable_raw_mode();
+    Some(decision)
+}
+
+fn read_line_buffered() -> ConfirmDecision {
+    let mut buf = String::new();
+    let Ok(_) = std::io::stdin().read_line(&mut buf) else {
+        return ConfirmDecision::Abort;
+    };
+    parse_line_decision(&buf)
+}
+
+/// Map a line of operator input into a `ConfirmDecision`. EOF and empty
+/// input map to `Abort` so a closed/piped stdin never silently approves.
+pub fn parse_line_decision(input: &str) -> ConfirmDecision {
+    let trimmed = input.trim().to_ascii_lowercase();
+    match trimmed.as_str() {
+        "y" | "yes" => ConfirmDecision::Approve,
+        "n" | "no" => ConfirmDecision::Reject,
+        _ => ConfirmDecision::Abort,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn indent_command_indents_every_line() {
+        assert_eq!(indent_command("a\nb\nc"), "    a\n    b\n    c");
+    }
+
+    #[test]
+    fn parse_line_decision_matches_documented_keys() {
+        assert_eq!(parse_line_decision("y\n"), ConfirmDecision::Approve);
+        assert_eq!(parse_line_decision(" Y "), ConfirmDecision::Approve);
+        assert_eq!(parse_line_decision("yes"), ConfirmDecision::Approve);
+        assert_eq!(parse_line_decision("n"), ConfirmDecision::Reject);
+        assert_eq!(parse_line_decision("NO"), ConfirmDecision::Reject);
+        assert_eq!(parse_line_decision("a"), ConfirmDecision::Abort);
+        assert_eq!(parse_line_decision("abort"), ConfirmDecision::Abort);
+        assert_eq!(parse_line_decision(""), ConfirmDecision::Abort);
+        assert_eq!(parse_line_decision("z"), ConfirmDecision::Abort);
+    }
+
+    #[test]
+    fn forced_constructor_builds_in_non_tty() {
+        let _c = StderrCliConfirmer::forced();
+    }
+}

--- a/src/agent/confirm_cli.rs
+++ b/src/agent/confirm_cli.rs
@@ -44,7 +44,22 @@ impl ConfirmCallback for StderrCliConfirmer {
 
 fn prompt_blocking(ctx: &ConfirmContext) -> ConfirmDecision {
     let mut err = std::io::stderr();
-    let banner = format!(
+    let _ = err.write_all(render_banner(ctx).as_bytes());
+    let _ = err.flush();
+
+    match read_single_keystroke() {
+        Some(decision) => {
+            let _ = err.write_all(b"\n");
+            decision
+        }
+        None => read_line_buffered(),
+    }
+}
+
+/// Pure renderer for the stderr prompt banner, factored out so tests can
+/// assert on the bytes without going through stderr.
+fn render_banner(ctx: &ConfirmContext) -> String {
+    format!(
         "\n[interactive] step {}/{}  cost ${:.4}  {}\n\
          [interactive] tool: {}\n\
          [interactive] command:\n{}\n\
@@ -55,17 +70,7 @@ fn prompt_blocking(ctx: &ConfirmContext) -> ConfirmDecision {
         ctx.cache_marker,
         ctx.tool_name,
         indent_command(&ctx.command),
-    );
-    let _ = err.write_all(banner.as_bytes());
-    let _ = err.flush();
-
-    match read_single_keystroke() {
-        Some(decision) => {
-            let _ = err.write_all(b"\n");
-            decision
-        }
-        None => read_line_buffered(),
-    }
+    )
 }
 
 fn indent_command(cmd: &str) -> String {
@@ -84,22 +89,9 @@ fn read_single_keystroke() -> Option<ConfirmDecision> {
     }
     let decision = loop {
         match crossterm::event::read() {
-            Ok(Event::Key(KeyEvent {
-                code,
-                modifiers,
-                kind: KeyEventKind::Press,
-                ..
-            })) => {
-                if modifiers.contains(KeyModifiers::CONTROL)
-                    && matches!(code, KeyCode::Char('c' | 'C'))
-                {
-                    break ConfirmDecision::Abort;
-                }
-                match code {
-                    KeyCode::Char('y' | 'Y') => break ConfirmDecision::Approve,
-                    KeyCode::Char('n' | 'N') => break ConfirmDecision::Reject,
-                    KeyCode::Char('a' | 'A') | KeyCode::Esc => break ConfirmDecision::Abort,
-                    _ => {}
+            Ok(Event::Key(key)) => {
+                if let Some(d) = key_event_to_decision(key) {
+                    break d;
                 }
             }
             Ok(_) => {}
@@ -108,6 +100,26 @@ fn read_single_keystroke() -> Option<ConfirmDecision> {
     };
     let _ = crossterm::terminal::disable_raw_mode();
     Some(decision)
+}
+
+/// Map a crossterm key event to a `ConfirmDecision`. Returns `None` for
+/// non-press events or keys outside the documented y/n/a set so the
+/// caller can keep polling. Pulled out so tests can exercise the
+/// keystroke mapping without raw mode.
+fn key_event_to_decision(key: KeyEvent) -> Option<ConfirmDecision> {
+    if !matches!(key.kind, KeyEventKind::Press) {
+        return None;
+    }
+    if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c' | 'C'))
+    {
+        return Some(ConfirmDecision::Abort);
+    }
+    match key.code {
+        KeyCode::Char('y' | 'Y') => Some(ConfirmDecision::Approve),
+        KeyCode::Char('n' | 'N') => Some(ConfirmDecision::Reject),
+        KeyCode::Char('a' | 'A') | KeyCode::Esc => Some(ConfirmDecision::Abort),
+        _ => None,
+    }
 }
 
 fn read_line_buffered() -> ConfirmDecision {
@@ -154,5 +166,129 @@ mod tests {
     #[test]
     fn forced_constructor_builds_in_non_tty() {
         let _c = StderrCliConfirmer::forced();
+    }
+
+    fn ctx_for(cmd: &str) -> ConfirmContext {
+        ConfirmContext {
+            tool_name: "bash".into(),
+            command: cmd.into(),
+            step: 2,
+            step_limit: 7,
+            cost_usd: 0.0123,
+            cache_marker: "cache:explicit",
+        }
+    }
+
+    #[test]
+    fn render_banner_includes_step_cost_command_and_keys() {
+        let banner = render_banner(&ctx_for("echo hi"));
+        assert!(banner.contains("step 2/7"));
+        assert!(banner.contains("cost $0.0123"));
+        assert!(banner.contains("cache:explicit"));
+        assert!(banner.contains("tool: bash"));
+        assert!(banner.contains("    echo hi"));
+        assert!(banner.contains("(y)approve / (n)reject / (a)abort?"));
+    }
+
+    #[test]
+    fn render_banner_indents_multiline_commands() {
+        let banner = render_banner(&ctx_for("ls -la\necho done"));
+        assert!(banner.contains("    ls -la\n    echo done"));
+    }
+
+    #[test]
+    fn key_event_to_decision_press_keys_map_correctly() {
+        for (code, modifiers, expected) in [
+            (
+                KeyCode::Char('y'),
+                KeyModifiers::NONE,
+                Some(ConfirmDecision::Approve),
+            ),
+            (
+                KeyCode::Char('Y'),
+                KeyModifiers::NONE,
+                Some(ConfirmDecision::Approve),
+            ),
+            (
+                KeyCode::Char('n'),
+                KeyModifiers::NONE,
+                Some(ConfirmDecision::Reject),
+            ),
+            (
+                KeyCode::Char('N'),
+                KeyModifiers::NONE,
+                Some(ConfirmDecision::Reject),
+            ),
+            (
+                KeyCode::Char('a'),
+                KeyModifiers::NONE,
+                Some(ConfirmDecision::Abort),
+            ),
+            (
+                KeyCode::Esc,
+                KeyModifiers::NONE,
+                Some(ConfirmDecision::Abort),
+            ),
+            (
+                KeyCode::Char('c'),
+                KeyModifiers::CONTROL,
+                Some(ConfirmDecision::Abort),
+            ),
+            (
+                KeyCode::Char('C'),
+                KeyModifiers::CONTROL,
+                Some(ConfirmDecision::Abort),
+            ),
+            // Junk keys keep the prompt alive.
+            (KeyCode::Char('z'), KeyModifiers::NONE, None),
+            (KeyCode::Enter, KeyModifiers::NONE, None),
+            // Plain 'c' (no Ctrl) is junk too — only Ctrl-C is abort.
+            (KeyCode::Char('c'), KeyModifiers::NONE, None),
+        ] {
+            let key = KeyEvent::new(code, modifiers);
+            assert_eq!(key_event_to_decision(key), expected, "code={code:?}");
+        }
+    }
+
+    #[test]
+    fn key_event_to_decision_ignores_release_events() {
+        let mut key = KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE);
+        key.kind = KeyEventKind::Release;
+        assert_eq!(key_event_to_decision(key), None);
+    }
+
+    #[test]
+    fn read_single_keystroke_returns_none_when_stdin_is_not_a_tty() {
+        // `cargo test` redirects stdin away from the TTY, so this is the
+        // production non-interactive path and should bail out cleanly
+        // rather than blocking on raw-mode reads.
+        assert!(read_single_keystroke().is_none());
+    }
+
+    #[test]
+    fn new_if_tty_returns_none_under_cargo_test() {
+        // Under `cargo test` stdin is not a TTY; `new_if_tty` must refuse
+        // to construct the confirmer.
+        assert!(StderrCliConfirmer::new_if_tty().is_none());
+    }
+
+    #[tokio::test]
+    async fn confirm_under_non_tty_stdin_aborts_on_eof() {
+        // `prompt_blocking` writes the banner to stderr, finds no TTY,
+        // falls through to `read_line_buffered`. With cargo-test's
+        // closed/redirected stdin, the read returns EOF, which
+        // `parse_line_decision` maps to Abort. End-to-end: confirm()
+        // returns Abort without hanging.
+        let c = StderrCliConfirmer::forced();
+        let ctx = ConfirmContext {
+            tool_name: "bash".into(),
+            command: "echo x".into(),
+            step: 0,
+            step_limit: 1,
+            cost_usd: 0.0,
+            cache_marker: "cache:auto-or-none",
+        };
+        let d = c.confirm(&ctx).await;
+        assert_eq!(d, ConfirmDecision::Abort);
     }
 }

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -1,0 +1,565 @@
+//! Full-screen ratatui dashboard for `mini --interactive --ui ratatui`.
+//!
+//! `RatatuiDashboard` is both a `StreamSink` (so trajectory events flow
+//! into a live log panel) and a `ConfirmCallback` (so the confirmation
+//! prompt is rendered as a centred modal). The renderer task owns the
+//! terminal; the agent thread drives state through a mutex and a
+//! `Notify` channel.
+
+use std::collections::VecDeque;
+use std::io::{Stdout, Write as _};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use futures::stream::StreamExt as _;
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+use tokio::sync::{Notify, oneshot};
+
+use super::confirm::{ConfirmCallback, ConfirmContext, ConfirmDecision};
+use crate::stream::{StreamEvent, StreamSink};
+
+const MAX_LOG_LINES: usize = 400;
+
+#[derive(Default)]
+struct DashboardState {
+    task: Option<String>,
+    model: Option<String>,
+    started_at: Option<String>,
+    cost_usd: f64,
+    step: u32,
+    step_limit: u32,
+    log: VecDeque<LogLine>,
+    pending: Option<PendingPrompt>,
+    finished: Option<String>,
+}
+
+#[derive(Clone)]
+struct LogLine {
+    kind: LineKind,
+    text: String,
+}
+
+#[derive(Clone, Copy)]
+enum LineKind {
+    Info,
+    AssistantMsg,
+    BashRun,
+    BashOk,
+    BashErr,
+    Observation,
+    Warn,
+}
+
+struct PendingPrompt {
+    ctx: ConfirmContext,
+    responder: oneshot::Sender<ConfirmDecision>,
+}
+
+pub struct RatatuiDashboardHandle {
+    inner: Arc<RatatuiDashboard>,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    renderer_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl RatatuiDashboardHandle {
+    pub fn stream_sink(&self) -> Arc<dyn StreamSink> {
+        self.inner.clone() as Arc<dyn StreamSink>
+    }
+
+    pub fn confirm_callback(&self) -> Arc<dyn ConfirmCallback> {
+        self.inner.clone() as Arc<dyn ConfirmCallback>
+    }
+
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(task) = self.renderer_task.take() {
+            let _ = task.await;
+        }
+    }
+}
+
+impl Drop for RatatuiDashboardHandle {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        let _ = restore_terminal();
+    }
+}
+
+pub struct RatatuiDashboard {
+    state: Mutex<DashboardState>,
+    notify: Notify,
+}
+
+impl RatatuiDashboard {
+    /// Enter alt-screen + raw mode and spawn the renderer task.
+    ///
+    /// # Errors
+    /// Returns `Err` if the terminal cannot be put into raw mode or
+    /// alt-screen mode.
+    pub fn start() -> std::io::Result<RatatuiDashboardHandle> {
+        enable_raw_mode()?;
+        let mut stdout = std::io::stdout();
+        execute!(stdout, EnterAlternateScreen)?;
+        let backend = CrosstermBackend::new(stdout);
+        let terminal = Terminal::new(backend)?;
+        let dash = Arc::new(Self {
+            state: Mutex::new(DashboardState::default()),
+            notify: Notify::new(),
+        });
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let renderer_task = tokio::spawn(renderer_loop(dash.clone(), terminal, shutdown_rx));
+        Ok(RatatuiDashboardHandle {
+            inner: dash,
+            shutdown_tx: Some(shutdown_tx),
+            renderer_task: Some(renderer_task),
+        })
+    }
+
+    fn append(&self, kind: LineKind, text: impl Into<String>) {
+        let mut s = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if s.log.len() >= MAX_LOG_LINES {
+            s.log.pop_front();
+        }
+        s.log.push_back(LogLine {
+            kind,
+            text: text.into(),
+        });
+        drop(s);
+        self.notify.notify_waiters();
+    }
+}
+
+fn restore_terminal() -> std::io::Result<()> {
+    let mut stdout: Stdout = std::io::stdout();
+    let _ = execute!(stdout, LeaveAlternateScreen);
+    let _ = stdout.flush();
+    disable_raw_mode()
+}
+
+impl StreamSink for RatatuiDashboard {
+    fn emit(&self, event: StreamEvent) {
+        match event {
+            StreamEvent::RunStarted {
+                task,
+                model,
+                started_at,
+            } => {
+                {
+                    let mut s = self
+                        .state
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    s.task = Some(task.clone());
+                    s.model = Some(model.clone());
+                    s.started_at = Some(started_at);
+                }
+                self.append(LineKind::Info, format!("run started: {model} :: {task}"));
+            }
+            StreamEvent::AssistantMessage {
+                step,
+                content,
+                cost_usd,
+                ..
+            } => {
+                {
+                    let mut s = self
+                        .state
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    if let Some(cost) = cost_usd {
+                        s.cost_usd = cost;
+                    }
+                    s.step = step;
+                }
+                let preview = first_lines(&content, 6);
+                self.append(
+                    LineKind::AssistantMsg,
+                    format!("step {step} assistant: {preview}"),
+                );
+            }
+            StreamEvent::BashStart { step, command, .. } => {
+                self.append(LineKind::BashRun, format!("step {step} bash: {command}"));
+            }
+            StreamEvent::BashResult {
+                step,
+                exit_code,
+                stdout,
+                stderr,
+                timed_out,
+                ..
+            } => {
+                let kind = if exit_code == 0 && !timed_out {
+                    LineKind::BashOk
+                } else {
+                    LineKind::BashErr
+                };
+                let summary = format!(
+                    "step {step} bash exit {exit_code}{}{}",
+                    if timed_out { " timed_out" } else { "" },
+                    summarize_stream(&stdout, &stderr),
+                );
+                self.append(kind, summary);
+            }
+            StreamEvent::Observation { step, content, .. } => {
+                let preview = first_lines(&content, 4);
+                self.append(
+                    LineKind::Observation,
+                    format!("step {step} observation: {preview}"),
+                );
+            }
+            StreamEvent::FormatError { step, content, .. } => {
+                let preview = first_lines(&content, 4);
+                self.append(LineKind::Warn, format!("step {step} format error: {preview}"));
+            }
+            StreamEvent::RunEnded {
+                exit_reason,
+                steps,
+                total_cost_usd,
+                ..
+            } => {
+                {
+                    let mut s = self
+                        .state
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    s.cost_usd = total_cost_usd;
+                    s.step = steps;
+                    s.finished = Some(exit_reason.clone());
+                }
+                self.append(
+                    LineKind::Info,
+                    format!("run ended: {exit_reason} (steps={steps} cost=${total_cost_usd:.4})"),
+                );
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl ConfirmCallback for RatatuiDashboard {
+    async fn confirm(&self, ctx: &ConfirmContext) -> ConfirmDecision {
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut s = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            s.step = ctx.step;
+            s.step_limit = ctx.step_limit;
+            s.cost_usd = ctx.cost_usd;
+            s.pending = Some(PendingPrompt {
+                ctx: ctx.clone(),
+                responder: tx,
+            });
+        }
+        self.notify.notify_waiters();
+        rx.await.unwrap_or(ConfirmDecision::Abort)
+    }
+}
+
+async fn renderer_loop(
+    dash: Arc<RatatuiDashboard>,
+    mut terminal: Terminal<CrosstermBackend<Stdout>>,
+    mut shutdown: oneshot::Receiver<()>,
+) {
+    let mut events = EventStream::new();
+    let mut tick = tokio::time::interval(Duration::from_millis(150));
+    loop {
+        if let Err(err) = draw_frame(&dash, &mut terminal) {
+            tracing::warn!(?err, "ratatui draw failed");
+        }
+        tokio::select! {
+            _ = &mut shutdown => break,
+            () = dash.notify.notified() => {}
+            _ = tick.tick() => {}
+            ev = events.next() => {
+                match ev {
+                    Some(Ok(Event::Key(key))) => handle_key(&dash, key),
+                    Some(Err(err)) => {
+                        tracing::warn!(?err, "ratatui event stream error");
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    let _ = terminal.show_cursor();
+    drop(terminal);
+    let _ = restore_terminal();
+}
+
+fn handle_key(dash: &Arc<RatatuiDashboard>, key: KeyEvent) {
+    if !matches!(key.kind, KeyEventKind::Press) {
+        return;
+    }
+    let pending = {
+        let mut s = dash
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        s.pending.take()
+    };
+    let Some(pending) = pending else {
+        return;
+    };
+    let ctrl_c = key.modifiers.contains(KeyModifiers::CONTROL)
+        && matches!(key.code, KeyCode::Char('c' | 'C'));
+    let decision = if ctrl_c {
+        Some(ConfirmDecision::Abort)
+    } else {
+        match key.code {
+            KeyCode::Char('y' | 'Y') => Some(ConfirmDecision::Approve),
+            KeyCode::Char('n' | 'N') => Some(ConfirmDecision::Reject),
+            KeyCode::Char('a' | 'A') | KeyCode::Esc => Some(ConfirmDecision::Abort),
+            _ => None,
+        }
+    };
+    if let Some(d) = decision {
+        let _ = pending.responder.send(d);
+    } else {
+        let mut s = dash
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        s.pending = Some(pending);
+    }
+}
+
+fn draw_frame(
+    dash: &Arc<RatatuiDashboard>,
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+) -> std::io::Result<()> {
+    let snapshot = {
+        let s = dash
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        DashboardSnapshot {
+            task: s.task.clone(),
+            model: s.model.clone(),
+            step: s.step,
+            step_limit: s.step_limit,
+            cost_usd: s.cost_usd,
+            finished: s.finished.clone(),
+            log: s.log.iter().cloned().collect(),
+            pending: s.pending.as_ref().map(|p| p.ctx.clone()),
+        }
+    };
+    terminal.draw(|frame| draw(frame, &snapshot))?;
+    Ok(())
+}
+
+struct DashboardSnapshot {
+    task: Option<String>,
+    model: Option<String>,
+    step: u32,
+    step_limit: u32,
+    cost_usd: f64,
+    finished: Option<String>,
+    log: Vec<LogLine>,
+    pending: Option<ConfirmContext>,
+}
+
+fn draw(frame: &mut ratatui::Frame, snap: &DashboardSnapshot) {
+    let area = frame.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(0),
+            Constraint::Length(3),
+        ])
+        .split(area);
+
+    frame.render_widget(header_paragraph(snap), chunks[0]);
+    frame.render_widget(log_paragraph(snap), chunks[1]);
+    frame.render_widget(footer_paragraph(snap), chunks[2]);
+
+    if let Some(ctx) = &snap.pending {
+        draw_modal(frame, ctx, area);
+    }
+}
+
+fn header_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
+    let title = snap
+        .task
+        .as_deref()
+        .unwrap_or("(no task)")
+        .lines()
+        .next()
+        .unwrap_or("");
+    let model = snap.model.as_deref().unwrap_or("(no model)");
+    let line = Line::from(vec![
+        Span::styled(
+            format!("step {}/{}  ", snap.step, snap.step_limit),
+            Style::default().fg(Color::Cyan),
+        ),
+        Span::styled(
+            format!("cost ${:.4}  ", snap.cost_usd),
+            Style::default().fg(Color::Yellow),
+        ),
+        Span::styled(format!("model: {model}  "), Style::default().fg(Color::Green)),
+        Span::styled(
+            format!("task: {title}"),
+            Style::default().add_modifier(Modifier::DIM),
+        ),
+    ]);
+    Paragraph::new(line).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" maxwell's daemon — interactive "),
+    )
+}
+
+fn log_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
+    let max_lines = snap.log.len().min(MAX_LOG_LINES);
+    let take_from = snap.log.len().saturating_sub(max_lines);
+    let lines: Vec<Line> = snap.log[take_from..]
+        .iter()
+        .map(|l| {
+            let style = match l.kind {
+                LineKind::Info => Style::default().fg(Color::Gray),
+                LineKind::AssistantMsg => Style::default().fg(Color::Cyan),
+                LineKind::BashRun => Style::default().fg(Color::White),
+                LineKind::BashOk => Style::default().fg(Color::Green),
+                LineKind::BashErr => Style::default().fg(Color::Red),
+                LineKind::Observation => Style::default().fg(Color::LightBlue),
+                LineKind::Warn => Style::default().fg(Color::LightYellow),
+            };
+            Line::from(Span::styled(l.text.clone(), style))
+        })
+        .collect();
+    Paragraph::new(lines)
+        .block(Block::default().borders(Borders::ALL).title(" trajectory "))
+        .wrap(Wrap { trim: false })
+}
+
+fn footer_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
+    let hint = if snap.finished.is_some() {
+        "run complete — press 'q' or Ctrl-C to close"
+    } else if snap.pending.is_some() {
+        "(y) approve   (n) reject   (a) abort"
+    } else {
+        "waiting for next agent step…"
+    };
+    Paragraph::new(Line::from(Span::styled(
+        hint,
+        Style::default().add_modifier(Modifier::BOLD),
+    )))
+    .block(Block::default().borders(Borders::ALL))
+}
+
+fn draw_modal(frame: &mut ratatui::Frame, ctx: &ConfirmContext, area: Rect) {
+    let modal = centered_rect(70, 50, area);
+    frame.render_widget(Clear, modal);
+    let mut lines = vec![
+        Line::from(Span::styled(
+            format!(
+                "step {}/{}  cost ${:.4}  {}",
+                ctx.step, ctx.step_limit, ctx.cost_usd, ctx.cache_marker
+            ),
+            Style::default().fg(Color::Yellow),
+        )),
+        Line::from(Span::styled(
+            format!("tool: {}", ctx.tool_name),
+            Style::default().fg(Color::Cyan),
+        )),
+        Line::from(""),
+        Line::from(Span::styled("command:", Style::default().fg(Color::White))),
+    ];
+    for cmd_line in ctx.command.lines().take(12) {
+        lines.push(Line::from(format!("  {cmd_line}")));
+    }
+    if ctx.command.lines().count() > 12 {
+        lines.push(Line::from(Span::styled(
+            "  …",
+            Style::default().add_modifier(Modifier::DIM),
+        )));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "(y) approve   (n) reject   (a) abort",
+        Style::default().add_modifier(Modifier::BOLD),
+    )));
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" confirm action ");
+    let p = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+    frame.render_widget(p, modal);
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}
+
+fn first_lines(s: &str, n: usize) -> String {
+    let lines: Vec<&str> = s.lines().take(n).collect();
+    let mut out = lines.join(" | ");
+    if s.lines().count() > n {
+        out.push_str(" …");
+    }
+    if out.len() > 240 {
+        out.truncate(240);
+        out.push_str(" …");
+    }
+    out
+}
+
+fn summarize_stream(stdout: &str, stderr: &str) -> String {
+    let bytes = stdout.len() + stderr.len();
+    if bytes > 0 {
+        format!(" ({bytes}B output)")
+    } else {
+        String::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_lines_caps_count_and_length() {
+        let s = "a\nb\nc\nd\ne\nf\ng";
+        assert_eq!(first_lines(s, 3), "a | b | c …");
+    }
+
+    #[test]
+    fn summarize_stream_returns_byte_count() {
+        assert_eq!(summarize_stream("abc", ""), " (3B output)");
+        assert_eq!(summarize_stream("", ""), "");
+    }
+}

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -579,6 +579,7 @@ fn summarize_stream(stdout: &str, stderr: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
 
     #[test]
@@ -613,5 +614,497 @@ mod tests {
     #[test]
     fn summarize_stream_counts_both_streams() {
         assert_eq!(summarize_stream("ab", "cd"), " (4B output)");
+    }
+
+    // ── Dashboard-without-a-terminal tests ──────────────────────────────
+    //
+    // Most renderer behaviour is locked behind `start()`, which enters
+    // alt-screen + raw mode. These tests construct a `RatatuiDashboard`
+    // directly and exercise the `StreamSink` / `ConfirmCallback` paths
+    // plus the pure draw helpers via ratatui's `TestBackend`, so the
+    // interesting logic ships covered even though a real renderer-loop
+    // tick needs a TTY.
+
+    use ratatui::Terminal as RatatuiTerminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use tokio::sync::oneshot;
+
+    fn make_dashboard() -> Arc<RatatuiDashboard> {
+        Arc::new(RatatuiDashboard {
+            state: Mutex::new(DashboardState::default()),
+            notify: Notify::new(),
+        })
+    }
+
+    fn snap(dash: &Arc<RatatuiDashboard>) -> DashboardSnapshot {
+        let s = dash
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        DashboardSnapshot {
+            task: s.task.clone(),
+            model: s.model.clone(),
+            step: s.step,
+            step_limit: s.step_limit,
+            cost_usd: s.cost_usd,
+            finished: s.finished.clone(),
+            log: s.log.iter().cloned().collect(),
+            pending: s.pending.as_ref().map(|p| p.ctx.clone()),
+        }
+    }
+
+    fn render_to_buffer(snap: &DashboardSnapshot, w: u16, h: u16) -> Buffer {
+        let backend = TestBackend::new(w, h);
+        let mut terminal = RatatuiTerminal::new(backend).unwrap();
+        terminal.draw(|frame| draw(frame, snap)).unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn buffer_text(buf: &Buffer) -> String {
+        let mut out = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                out.push_str(buf[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    #[test]
+    fn emit_run_started_populates_header_state() {
+        let d = make_dashboard();
+        d.emit(StreamEvent::RunStarted {
+            task: "fix the bug".into(),
+            model: "claude-opus-4-7".into(),
+            started_at: "2026-05-18T12:00:00Z".into(),
+        });
+        let s = snap(&d);
+        assert_eq!(s.task.as_deref(), Some("fix the bug"));
+        assert_eq!(s.model.as_deref(), Some("claude-opus-4-7"));
+        assert_eq!(s.log.len(), 1);
+        assert!(s.log[0].text.contains("run started"));
+    }
+
+    #[test]
+    fn emit_assistant_message_updates_step_and_cost() {
+        let d = make_dashboard();
+        d.emit(StreamEvent::AssistantMessage {
+            step: 4,
+            content: "think think".into(),
+            cost_usd: Some(0.1234),
+            timestamp: "t".into(),
+        });
+        let s = snap(&d);
+        assert_eq!(s.step, 4);
+        assert!((s.cost_usd - 0.1234).abs() < f64::EPSILON);
+        assert!(s.log[0].text.contains("step 4 assistant"));
+    }
+
+    #[test]
+    fn emit_assistant_message_without_cost_keeps_prior_cost() {
+        let d = make_dashboard();
+        // First set a cost.
+        d.emit(StreamEvent::AssistantMessage {
+            step: 1,
+            content: "x".into(),
+            cost_usd: Some(0.5),
+            timestamp: "t".into(),
+        });
+        // Second message without cost shouldn't reset to 0.
+        d.emit(StreamEvent::AssistantMessage {
+            step: 2,
+            content: "y".into(),
+            cost_usd: None,
+            timestamp: "t".into(),
+        });
+        let s = snap(&d);
+        assert_eq!(s.step, 2);
+        assert!((s.cost_usd - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn emit_bash_lifecycle_logs_run_and_result() {
+        let d = make_dashboard();
+        d.emit(StreamEvent::BashStart {
+            step: 2,
+            command: "echo hi".into(),
+            timestamp: "t".into(),
+        });
+        d.emit(StreamEvent::BashResult {
+            step: 2,
+            exit_code: 0,
+            stdout: "hi\n".into(),
+            stderr: String::new(),
+            timed_out: false,
+            timestamp: "t".into(),
+        });
+        d.emit(StreamEvent::BashResult {
+            step: 3,
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "oops".into(),
+            timed_out: false,
+            timestamp: "t".into(),
+        });
+        d.emit(StreamEvent::BashResult {
+            step: 4,
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+            timed_out: true,
+            timestamp: "t".into(),
+        });
+        let s = snap(&d);
+        assert_eq!(s.log.len(), 4);
+        assert!(matches!(s.log[0].kind, LineKind::BashRun));
+        assert!(matches!(s.log[1].kind, LineKind::BashOk));
+        assert!(matches!(s.log[2].kind, LineKind::BashErr));
+        assert!(s.log[3].text.contains("timed_out"));
+    }
+
+    #[test]
+    fn emit_observation_and_format_error_log_with_preview() {
+        let d = make_dashboard();
+        d.emit(StreamEvent::Observation {
+            step: 1,
+            content: "line1\nline2".into(),
+            timestamp: "t".into(),
+        });
+        d.emit(StreamEvent::FormatError {
+            step: 1,
+            content: "bad".into(),
+            timestamp: "t".into(),
+        });
+        let s = snap(&d);
+        assert_eq!(s.log.len(), 2);
+        assert!(matches!(s.log[0].kind, LineKind::Observation));
+        assert!(matches!(s.log[1].kind, LineKind::Warn));
+    }
+
+    #[test]
+    fn emit_run_ended_stamps_finished_and_totals() {
+        let d = make_dashboard();
+        d.emit(StreamEvent::RunEnded {
+            exit_reason: "submitted".into(),
+            failure_category: None,
+            final_output: None,
+            steps: 7,
+            total_cost_usd: 1.2345,
+            ended_at: "t".into(),
+        });
+        let s = snap(&d);
+        assert_eq!(s.step, 7);
+        assert!((s.cost_usd - 1.2345).abs() < f64::EPSILON);
+        assert_eq!(s.finished.as_deref(), Some("submitted"));
+    }
+
+    #[test]
+    fn append_caps_log_at_max_lines() {
+        let d = make_dashboard();
+        for _ in 0..(MAX_LOG_LINES + 10) {
+            d.append(LineKind::Info, "x");
+        }
+        let s = snap(&d);
+        assert_eq!(s.log.len(), MAX_LOG_LINES);
+    }
+
+    #[tokio::test]
+    async fn confirm_publishes_pending_and_completes_on_decision() {
+        let d = make_dashboard();
+        let d2 = d.clone();
+        let ctx = ConfirmContext {
+            tool_name: "bash".into(),
+            command: "echo".into(),
+            step: 1,
+            step_limit: 5,
+            cost_usd: 0.0,
+            cache_marker: "cache:auto-or-none",
+        };
+        let task = tokio::spawn(async move { d2.confirm(&ctx).await });
+        // Spin briefly until the pending slot is populated.
+        for _ in 0..50 {
+            let s = snap(&d);
+            if s.pending.is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        // Simulate the renderer thread receiving a `y` keystroke.
+        let key = KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE);
+        handle_key(&d, key);
+        let decision = task.await.unwrap();
+        assert_eq!(decision, ConfirmDecision::Approve);
+    }
+
+    #[tokio::test]
+    async fn confirm_falls_back_to_abort_when_responder_dropped() {
+        let d = make_dashboard();
+        let d2 = d.clone();
+        let ctx = ConfirmContext {
+            tool_name: "bash".into(),
+            command: "echo".into(),
+            step: 0,
+            step_limit: 1,
+            cost_usd: 0.0,
+            cache_marker: "cache:auto-or-none",
+        };
+        let task = tokio::spawn(async move { d2.confirm(&ctx).await });
+        for _ in 0..50 {
+            if snap(&d).pending.is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        // Pull the pending prompt out and drop the responder — confirm()
+        // should observe the dropped sender and abort.
+        let pending = {
+            let mut s = d
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            s.pending.take()
+        };
+        drop(pending);
+        let decision = task.await.unwrap();
+        assert_eq!(decision, ConfirmDecision::Abort);
+    }
+
+    fn make_pending(d: &Arc<RatatuiDashboard>) -> oneshot::Receiver<ConfirmDecision> {
+        let (tx, rx) = oneshot::channel();
+        let mut s = d
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        s.pending = Some(PendingPrompt {
+            ctx: ConfirmContext {
+                tool_name: "bash".into(),
+                command: "x".into(),
+                step: 0,
+                step_limit: 1,
+                cost_usd: 0.0,
+                cache_marker: "cache:auto-or-none",
+            },
+            responder: tx,
+        });
+        rx
+    }
+
+    #[test]
+    fn handle_key_maps_keystrokes_to_decisions() {
+        let d = make_dashboard();
+        for (key, expected) in [
+            (
+                KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE),
+                ConfirmDecision::Approve,
+            ),
+            (
+                KeyEvent::new(KeyCode::Char('Y'), KeyModifiers::NONE),
+                ConfirmDecision::Approve,
+            ),
+            (
+                KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE),
+                ConfirmDecision::Reject,
+            ),
+            (
+                KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
+                ConfirmDecision::Abort,
+            ),
+            (
+                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+                ConfirmDecision::Abort,
+            ),
+            (
+                KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+                ConfirmDecision::Abort,
+            ),
+        ] {
+            let mut rx = make_pending(&d);
+            handle_key(&d, key);
+            assert_eq!(rx.try_recv().unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn handle_key_unknown_keystroke_keeps_prompt_open() {
+        let d = make_dashboard();
+        let _rx = make_pending(&d);
+        // 'z' is not a documented key; the prompt should stay pending.
+        let key = KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE);
+        handle_key(&d, key);
+        assert!(snap(&d).pending.is_some());
+    }
+
+    #[test]
+    fn handle_key_ignores_release_events() {
+        let d = make_dashboard();
+        let _rx = make_pending(&d);
+        let mut key = KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE);
+        key.kind = KeyEventKind::Release;
+        handle_key(&d, key);
+        // The release event shouldn't consume the prompt.
+        assert!(snap(&d).pending.is_some());
+    }
+
+    #[test]
+    fn handle_key_with_no_pending_is_noop() {
+        let d = make_dashboard();
+        let key = KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE);
+        // Just verify it doesn't panic when state has no pending prompt.
+        handle_key(&d, key);
+        assert!(snap(&d).pending.is_none());
+    }
+
+    #[test]
+    fn draw_renders_header_log_and_footer_against_test_backend() {
+        let d = make_dashboard();
+        d.emit(StreamEvent::RunStarted {
+            task: "round trip".into(),
+            model: "deterministic".into(),
+            started_at: "t".into(),
+        });
+        d.emit(StreamEvent::BashStart {
+            step: 1,
+            command: "echo hi".into(),
+            timestamp: "t".into(),
+        });
+        let s = snap(&d);
+        let buf = render_to_buffer(&s, 80, 12);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("round trip"),
+            "task title should appear in header; got:\n{text}"
+        );
+        assert!(
+            text.contains("deterministic"),
+            "model name should appear; got:\n{text}"
+        );
+        assert!(
+            text.contains("echo hi"),
+            "bash line should appear in log; got:\n{text}"
+        );
+        assert!(
+            text.contains("waiting for next agent step"),
+            "footer hint should appear; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn draw_modal_renders_when_pending_prompt_present() {
+        let d = make_dashboard();
+        // Inject a pending prompt directly.
+        {
+            let (tx, _rx) = oneshot::channel();
+            let mut s = d
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            s.pending = Some(PendingPrompt {
+                ctx: ConfirmContext {
+                    tool_name: "bash".into(),
+                    command: "rm -rf /tmp/dangerous".into(),
+                    step: 2,
+                    step_limit: 5,
+                    cost_usd: 0.0099,
+                    cache_marker: "cache:explicit",
+                },
+                responder: tx,
+            });
+        }
+        let s = snap(&d);
+        let buf = render_to_buffer(&s, 100, 20);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("rm -rf /tmp/dangerous"),
+            "modal should show command; got:\n{text}"
+        );
+        assert!(
+            text.contains("(y) approve"),
+            "modal should show key hint; got:\n{text}"
+        );
+        assert!(
+            text.contains("step 2/5"),
+            "modal should show step counter; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn draw_modal_marks_long_commands_with_ellipsis() {
+        let d = make_dashboard();
+        let big = (0..20)
+            .map(|i| format!("line_{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        {
+            let (tx, _rx) = oneshot::channel();
+            let mut s = d
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            s.pending = Some(PendingPrompt {
+                ctx: ConfirmContext {
+                    tool_name: "bash".into(),
+                    command: big,
+                    step: 0,
+                    step_limit: 1,
+                    cost_usd: 0.0,
+                    cache_marker: "cache:explicit",
+                },
+                responder: tx,
+            });
+        }
+        let s = snap(&d);
+        // Render tall so the 12-line cap + ellipsis line both fit
+        // inside the modal area (the modal is 50% of the screen height).
+        let buf = render_to_buffer(&s, 100, 50);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("…"),
+            "long commands should be truncated with an ellipsis; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn footer_changes_when_run_finished() {
+        let d = make_dashboard();
+        d.emit(StreamEvent::RunEnded {
+            exit_reason: "submitted".into(),
+            failure_category: None,
+            final_output: None,
+            steps: 3,
+            total_cost_usd: 0.1,
+            ended_at: "t".into(),
+        });
+        let s = snap(&d);
+        let buf = render_to_buffer(&s, 80, 8);
+        let text = buffer_text(&buf);
+        assert!(text.contains("run complete"));
+    }
+
+    #[test]
+    fn centered_rect_is_subset_of_area() {
+        let area = Rect::new(0, 0, 100, 50);
+        let inner = centered_rect(50, 50, area);
+        assert!(inner.x >= area.x);
+        assert!(inner.y >= area.y);
+        assert!(inner.x + inner.width <= area.x + area.width);
+        assert!(inner.y + inner.height <= area.y + area.height);
+    }
+
+    #[test]
+    fn handle_dashboard_handle_constructors_clone_arcs() {
+        // Construct the handle without going through `start()` so we don't
+        // mutate the terminal. Renderer task is fake — `oneshot::channel`
+        // gives us a sender we drop immediately.
+        let (shutdown_tx, _shutdown_rx) = oneshot::channel::<()>();
+        let handle = RatatuiDashboardHandle {
+            inner: make_dashboard(),
+            shutdown_tx: Some(shutdown_tx),
+            renderer_task: None,
+        };
+        let _sink = handle.stream_sink();
+        let _cb = handle.confirm_callback();
     }
 }

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -110,13 +110,24 @@ impl RatatuiDashboard {
     ///
     /// # Errors
     /// Returns `Err` if the terminal cannot be put into raw mode or
-    /// alt-screen mode.
+    /// alt-screen mode. On failure the terminal is restored to cooked
+    /// mode and the alt-screen is left, so the caller never observes a
+    /// half-initialised terminal.
     pub fn start() -> std::io::Result<RatatuiDashboardHandle> {
         enable_raw_mode()?;
         let mut stdout = std::io::stdout();
-        execute!(stdout, EnterAlternateScreen)?;
+        if let Err(e) = execute!(stdout, EnterAlternateScreen) {
+            let _ = disable_raw_mode();
+            return Err(e);
+        }
         let backend = CrosstermBackend::new(stdout);
-        let terminal = Terminal::new(backend)?;
+        let terminal = match Terminal::new(backend) {
+            Ok(t) => t,
+            Err(e) => {
+                let _ = restore_terminal();
+                return Err(e);
+            }
+        };
         let dash = Arc::new(Self {
             state: Mutex::new(DashboardState::default()),
             notify: Notify::new(),
@@ -227,7 +238,10 @@ impl StreamSink for RatatuiDashboard {
             }
             StreamEvent::FormatError { step, content, .. } => {
                 let preview = first_lines(&content, 4);
-                self.append(LineKind::Warn, format!("step {step} format error: {preview}"));
+                self.append(
+                    LineKind::Warn,
+                    format!("step {step} format error: {preview}"),
+                );
             }
             StreamEvent::RunEnded {
                 exit_reason,
@@ -416,7 +430,10 @@ fn header_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
             format!("cost ${:.4}  ", snap.cost_usd),
             Style::default().fg(Color::Yellow),
         ),
-        Span::styled(format!("model: {model}  "), Style::default().fg(Color::Green)),
+        Span::styled(
+            format!("model: {model}  "),
+            Style::default().fg(Color::Green),
+        ),
         Span::styled(
             format!("task: {title}"),
             Style::default().add_modifier(Modifier::DIM),
@@ -488,7 +505,9 @@ fn draw_modal(frame: &mut ratatui::Frame, ctx: &ConfirmContext, area: Rect) {
     for cmd_line in ctx.command.lines().take(12) {
         lines.push(Line::from(format!("  {cmd_line}")));
     }
-    if ctx.command.lines().count() > 12 {
+    // Short-circuit at the first line past the cap instead of counting
+    // every line in a long command string.
+    if ctx.command.lines().nth(12).is_some() {
         lines.push(Line::from(Span::styled(
             "  …",
             Style::default().add_modifier(Modifier::DIM),
@@ -502,7 +521,9 @@ fn draw_modal(frame: &mut ratatui::Frame, ctx: &ConfirmContext, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
         .title(" confirm action ");
-    let p = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+    let p = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
     frame.render_widget(p, modal);
 }
 
@@ -528,11 +549,20 @@ fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
 fn first_lines(s: &str, n: usize) -> String {
     let lines: Vec<&str> = s.lines().take(n).collect();
     let mut out = lines.join(" | ");
-    if s.lines().count() > n {
+    // Short-circuit at the first line past the cap rather than counting
+    // every line in the source string.
+    if s.lines().nth(n).is_some() {
         out.push_str(" …");
     }
     if out.len() > 240 {
-        out.truncate(240);
+        // `String::truncate` panics if the index falls inside a
+        // multi-byte UTF-8 codepoint. Walk back to the nearest char
+        // boundary so arbitrary tool output never crashes the renderer.
+        let mut cut = 240;
+        while !out.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        out.truncate(cut);
         out.push_str(" …");
     }
     out
@@ -561,5 +591,27 @@ mod tests {
     fn summarize_stream_returns_byte_count() {
         assert_eq!(summarize_stream("abc", ""), " (3B output)");
         assert_eq!(summarize_stream("", ""), "");
+    }
+
+    #[test]
+    fn first_lines_truncates_at_char_boundary_for_multibyte_input() {
+        // 240 bytes of a 3-byte UTF-8 character ("é" is 2 bytes; "🦀" is 4).
+        // Repeat 🦀 (4 bytes) enough times to overflow 240 — a naive
+        // truncate(240) would land mid-codepoint and panic.
+        let s = "🦀".repeat(200);
+        let out = first_lines(&s, 1);
+        // Must not panic; result is bounded and ends with our ellipsis marker.
+        assert!(out.len() <= 244);
+        assert!(out.ends_with("…"));
+    }
+
+    #[test]
+    fn first_lines_no_ellipsis_when_under_cap() {
+        assert_eq!(first_lines("hello", 4), "hello");
+    }
+
+    #[test]
+    fn summarize_stream_counts_both_streams() {
+        assert_eq!(summarize_stream("ab", "cd"), " (4B output)");
     }
 }

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -1123,10 +1123,7 @@ impl Agent for DefaultAgent {
         // PreToolUse hook layer already blocked the tool — the operator
         // never sees a prompt for a command that won't run anyway.
         if !tool_use_blocked {
-            if let Some(decision) = self
-                .confirm_operator_action(&tool_name, &tool_input)
-                .await
-            {
+            if let Some(decision) = self.confirm_operator_action(&tool_name, &tool_input).await {
                 match decision {
                     super::ConfirmDecision::Approve => {}
                     super::ConfirmDecision::Reject => {
@@ -1694,9 +1691,10 @@ impl DefaultAgent {
             "interactive_tool_name".into(),
             serde_json::Value::String(tool_name.to_owned()),
         );
-        obs_extra
-            .other
-            .insert("interactive_timestamp".into(), serde_json::Value::String(ts));
+        obs_extra.other.insert(
+            "interactive_timestamp".into(),
+            serde_json::Value::String(ts),
+        );
         record_redacted_message(&mut self.trajectory, &obs_msg, obs_extra, &self.redactor);
         self.stream.emit(StreamEvent::Observation {
             step: self.steps,

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -395,6 +395,10 @@ pub struct DefaultAgent {
     all_step_responders: Vec<String>,
     /// In-loop stagnation detector; `None` when detection is disabled.
     stagnation_detector: Option<StagnationDetector>,
+    /// Issue #312 — operator confirmation hook. When `Some`, every
+    /// tool/bash action is gated on the operator's y/n/a decision
+    /// between PreToolUse hooks and `env.run`.
+    pub confirm_callback: Option<std::sync::Arc<dyn super::confirm::ConfirmCallback>>,
 }
 
 pub struct DefaultAgentBuilder {
@@ -546,6 +550,7 @@ impl DefaultAgentBuilder {
             last_responding_model: None,
             all_step_responders: Vec::new(),
             stagnation_detector,
+            confirm_callback: None,
         })
     }
 }
@@ -1114,6 +1119,31 @@ impl Agent for DefaultAgent {
             return Ok(StepOutcome::Terminate(ExitReason::UserInterrupt));
         }
 
+        // 5d. Operator confirmation gate (issue #312). Skipped when the
+        // PreToolUse hook layer already blocked the tool — the operator
+        // never sees a prompt for a command that won't run anyway.
+        if !tool_use_blocked {
+            if let Some(decision) = self
+                .confirm_operator_action(&tool_name, &tool_input)
+                .await
+            {
+                match decision {
+                    super::ConfirmDecision::Approve => {}
+                    super::ConfirmDecision::Reject => {
+                        self.record_interactive_rejection(&tool_name, &tool_input);
+                        self.last_measurement_end = Instant::now();
+                        self.steps += 1;
+                        return Ok(StepOutcome::Continue);
+                    }
+                    super::ConfirmDecision::Abort => {
+                        self.record_interactive_abort(&tool_name, &tool_input);
+                        self.finalize_cancelled();
+                        return Ok(StepOutcome::Terminate(ExitReason::UserInterrupt));
+                    }
+                }
+            }
+        }
+
         // Don't compute harness yet — we want post-tool hooks and
         // observation rendering inside *this* turn's harness, not leaked to
         // the next turn (and lost entirely if the run terminates here).
@@ -1603,6 +1633,96 @@ impl DefaultAgent {
         self.trajectory.info.ended_at = Some(chrono::Utc::now().to_rfc3339());
         self.finalize_run_metadata(outcome::ERROR);
         self.emit_run_ended(exit_reason::CANCELLED, None, None);
+    }
+
+    /// Ask the optional `confirm_callback` whether to proceed with the
+    /// proposed tool action. Returns `None` when no callback is
+    /// configured (the unattended path).
+    async fn confirm_operator_action(
+        &self,
+        tool_name: &str,
+        tool_input: &str,
+    ) -> Option<super::ConfirmDecision> {
+        let cb = self.confirm_callback.as_ref()?;
+        let ctx = super::ConfirmContext {
+            tool_name: tool_name.to_owned(),
+            command: self
+                .redactor
+                .redact_text(tool_input, surface::TRAJECTORY)
+                .text,
+            step: self.steps,
+            step_limit: self.config.root.agent.step_limit,
+            cost_usd: self.total_cost_usd,
+            cache_marker: if self.model.supports_explicit_cache() {
+                "cache:explicit"
+            } else {
+                "cache:auto-or-none"
+            },
+        };
+        Some(cb.confirm(&ctx).await)
+    }
+
+    /// Record an operator rejection: surface a synthetic observation to
+    /// the model so it can revise, and tag the trajectory record with
+    /// the structured `interactive_decision: "reject"` event.
+    fn record_interactive_rejection(&mut self, tool_name: &str, tool_input: &str) {
+        let ts = chrono::Utc::now().to_rfc3339();
+        let rejection = "Exit code: 1\nOutput:\nCommand rejected by operator (interactive mode). \
+                         The command was not executed. Please attempt a safer alternative."
+            .to_owned();
+        let obs_msg = Message::user(rejection.clone());
+        self.history.push(obs_msg.clone());
+
+        let redacted_command = self
+            .redactor
+            .redact_text(tool_input, surface::TRAJECTORY)
+            .text;
+        let mut obs_extra = MessageExtra {
+            harness_overhead_ms: Some(elapsed_ms_since(self.last_measurement_end)),
+            ..MessageExtra::default()
+        };
+        obs_extra.timestamp = Some(ts.clone());
+        obs_extra.other.insert(
+            "interactive_decision".into(),
+            serde_json::Value::String(super::ConfirmDecision::Reject.label().to_owned()),
+        );
+        obs_extra.other.insert(
+            "interactive_proposed_command".into(),
+            serde_json::Value::String(redacted_command),
+        );
+        obs_extra.other.insert(
+            "interactive_tool_name".into(),
+            serde_json::Value::String(tool_name.to_owned()),
+        );
+        obs_extra
+            .other
+            .insert("interactive_timestamp".into(), serde_json::Value::String(ts));
+        record_redacted_message(&mut self.trajectory, &obs_msg, obs_extra, &self.redactor);
+        self.stream.emit(StreamEvent::Observation {
+            step: self.steps,
+            content: rejection,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        });
+    }
+
+    /// Tag the trajectory with the operator's abort decision before the
+    /// shared `finalize_cancelled` path stamps `UserInterrupt`.
+    fn record_interactive_abort(&mut self, tool_name: &str, tool_input: &str) {
+        let ts = chrono::Utc::now().to_rfc3339();
+        let redacted_command = self
+            .redactor
+            .redact_text(tool_input, surface::TRAJECTORY)
+            .text;
+        self.trajectory.info.other.insert(
+            "interactive_abort".into(),
+            serde_json::json!({
+                "decision": super::ConfirmDecision::Abort.label(),
+                "proposed_command": redacted_command,
+                "tool_name": tool_name,
+                "timestamp": ts,
+                "step": self.steps,
+            }),
+        );
     }
 
     #[allow(clippy::cast_precision_loss)]

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -9,9 +9,16 @@ use async_trait::async_trait;
 
 use crate::error::Error;
 
+pub mod confirm;
+pub mod confirm_cli;
+pub mod confirm_tui;
 pub mod default;
 pub mod interactive;
 pub mod parse;
+
+pub use confirm::{ConfirmCallback, ConfirmContext, ConfirmDecision, ScriptedConfirmer};
+pub use confirm_cli::StderrCliConfirmer;
+pub use confirm_tui::{RatatuiDashboard, RatatuiDashboardHandle};
 
 pub use default::DefaultAgent;
 pub use interactive::InteractiveAgent;

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -21,6 +21,16 @@ pub enum OnOffArg {
     Off,
 }
 
+/// Confirmation-prompt UI selector for `mini --interactive` (issue #312).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum UiKind {
+    /// Single-line stderr prompt — the default. Works over any TTY.
+    Stderr,
+    /// Full-screen ratatui dashboard with a modal prompt and live
+    /// trajectory feed.
+    Ratatui,
+}
+
 #[derive(Debug, Clone, Args)]
 pub struct MiniGithubPrArgs {
     /// Open a GitHub pull request from the final patch after a submitted run.
@@ -100,6 +110,7 @@ pub struct SwebenchGithubPrArgs {
 }
 
 #[derive(Debug, Args)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct MiniCmd {
     /// The task prompt.
     #[arg(long)]
@@ -232,6 +243,23 @@ pub struct MiniCmd {
     /// `json` (stable, schema-versioned, suitable for CI diffing).
     #[arg(long, default_value = "text")]
     pub format: String,
+
+    /// Issue #312 — pause before every bash/tool action and ask the
+    /// operator to approve, reject, or abort. Mutually exclusive with
+    /// `--render-only`. Requires a TTY unless `--yolo` is also set.
+    #[arg(long, default_value_t = false, conflicts_with = "render_only")]
+    pub interactive: bool,
+
+    /// Run unattended but still print the interactive status line on
+    /// each step boundary. Implied by `--interactive --yolo`; usable on
+    /// its own when no prompts are wanted but the status line helps.
+    #[arg(long, default_value_t = false)]
+    pub yolo: bool,
+
+    /// UI for the confirmation prompt: `stderr` (default, single-line)
+    /// or `ratatui` (full-screen dashboard).
+    #[arg(long, value_enum, default_value_t = UiKind::Stderr)]
+    pub ui: UiKind,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2878,7 +2878,7 @@ mod tests {
     #![allow(clippy::unwrap_used)]
     use super::{
         Cli, args, cancellation_exit_code, maybe_publish_mini_github_pr, mini_github_pr_options,
-        parse_verify_checks, required_github_arg, swebench_args_from_cmd,
+        parse_verify_checks, required_github_arg, resolve_interactive_mode, swebench_args_from_cmd,
         swebench_github_pr_config, trajectory_submitted, validate_observation_head_ratio,
         validate_swebench_github_pr_args,
     };
@@ -3216,6 +3216,44 @@ mod tests {
          @@ -1 +1 @@\n\
          -base\n\
          +patched\n"
+    }
+
+    #[test]
+    fn resolve_interactive_mode_off_when_neither_flag_set() {
+        let m = resolve_interactive_mode(false, false, args::UiKind::Stderr);
+        assert_eq!(m, crate::run::mini::InteractiveMode::Off);
+    }
+
+    #[test]
+    fn resolve_interactive_mode_yolo_alone_is_status_only() {
+        let m = resolve_interactive_mode(false, true, args::UiKind::Stderr);
+        assert_eq!(m, crate::run::mini::InteractiveMode::YoloStatusOnly);
+    }
+
+    #[test]
+    fn resolve_interactive_mode_interactive_picks_ui() {
+        assert_eq!(
+            resolve_interactive_mode(true, false, args::UiKind::Stderr),
+            crate::run::mini::InteractiveMode::StderrPrompt
+        );
+        assert_eq!(
+            resolve_interactive_mode(true, false, args::UiKind::Ratatui),
+            crate::run::mini::InteractiveMode::Ratatui
+        );
+    }
+
+    #[test]
+    fn resolve_interactive_mode_yolo_overrides_interactive() {
+        // `--interactive --yolo` short-circuits to status-line mode for
+        // operators who want live progress but no prompts.
+        assert_eq!(
+            resolve_interactive_mode(true, true, args::UiKind::Stderr),
+            crate::run::mini::InteractiveMode::YoloStatusOnly
+        );
+        assert_eq!(
+            resolve_interactive_mode(true, true, args::UiKind::Ratatui),
+            crate::run::mini::InteractiveMode::YoloStatusOnly
+        );
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -250,6 +250,7 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
     };
 
     let verification_checks = parse_verify_checks(&m.verify)?;
+    let interactive_mode = resolve_interactive_mode(m.interactive, m.yolo, m.ui);
     let args = crate::run::mini::MiniArgs {
         task: m.task,
         extra_context: m.extra_context,
@@ -264,6 +265,7 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         patch_capture,
         verification_checks,
         verification_timeout_secs: m.verify_timeout_secs,
+        interactive_mode,
     };
     let run_result = crate::run::mini::run(args).await;
     // Only publish when the run succeeded or failed at verification — those are
@@ -967,6 +969,25 @@ fn swebench_args_from_cmd(
         systemic_failure_min_samples: s.systemic_failure_min_samples,
         systemic_failure_share_pct: s.systemic_failure_share_pct,
     })
+}
+
+/// Map `(interactive, yolo, ui)` CLI flags onto a `run::mini::InteractiveMode`.
+fn resolve_interactive_mode(
+    interactive: bool,
+    yolo: bool,
+    ui: args::UiKind,
+) -> crate::run::mini::InteractiveMode {
+    use crate::run::mini::InteractiveMode;
+    match (interactive, yolo) {
+        (false, false) => InteractiveMode::Off,
+        // `--interactive --yolo` short-circuits to status-line mode — the
+        // operator wants live progress on stderr without prompts.
+        (_, true) => InteractiveMode::YoloStatusOnly,
+        (true, false) => match ui {
+            args::UiKind::Stderr => InteractiveMode::StderrPrompt,
+            args::UiKind::Ratatui => InteractiveMode::Ratatui,
+        },
+    }
 }
 
 fn parse_verify_checks(
@@ -3098,6 +3119,9 @@ mod tests {
             },
             render_only: false,
             format: "text".into(),
+            interactive: false,
+            yolo: false,
+            ui: args::UiKind::Stderr,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,9 @@ pub use skills::{
     ActiveSkill, ActiveSkillManifest, ActiveSkillSet, ResolvedSkillContext, SkillActivationReason,
     SkillManifest, SkillRegistry, SkillResolveRequest, resolve_for_task,
 };
-pub use stream::{BroadcastSink, NullSink, SseServer, StreamEvent, StreamSink};
+pub use stream::{
+    BroadcastSink, MultiSink, NullSink, SseServer, StatusLineStderrSink, StreamEvent, StreamSink,
+};
 pub use tool::{
     BASH_TOOL_NAME, CommandTool, McpStdioServer, ToolCall, ToolDefinition, ToolInvocation,
     ToolManifestEntry, ToolOutput, ToolPromptInfo, ToolProvider, ToolRegistry, ToolSource,

--- a/src/run/hello_world.rs
+++ b/src/run/hello_world.rs
@@ -3,7 +3,7 @@
 
 use std::path::{Path, PathBuf};
 
-use super::mini::{MiniArgs, run};
+use super::mini::{InteractiveMode, MiniArgs, run};
 use crate::config::Config;
 use crate::error::Error;
 
@@ -31,6 +31,7 @@ pub async fn main(output_dir: PathBuf, config_path: Option<&Path>) -> Result<(),
         patch_capture: None,
         verification_checks: vec![],
         verification_timeout_secs: 60,
+        interactive_mode: InteractiveMode::Off,
     };
     run(args).await?;
     println!("hello-world smoke complete");

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -7,16 +7,19 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crate::agent::{Agent, DefaultAgent, default::DefaultAgentBuilder};
+use crate::agent::{
+    Agent, ConfirmCallback, DefaultAgent, RatatuiDashboardHandle, StderrCliConfirmer,
+    default::DefaultAgentBuilder,
+};
 use crate::config::{Config, EnvKind};
 #[cfg(feature = "docker")]
 use crate::env::DockerEnvironment;
 use crate::env::{Environment, LocalEnvironment, RunRequest};
-use crate::error::Error;
+use crate::error::{ConfigError, Error};
 use crate::model::litellm::LitellmBackend;
 use crate::model::{DeterministicModel, FallbackModel, Model, ModelUsage};
 use crate::redaction::surface;
-use crate::stream::{BroadcastSink, SseServer, StreamSink};
+use crate::stream::{BroadcastSink, MultiSink, SseServer, StatusLineStderrSink, StreamSink};
 use crate::trajectory::FailureCategory;
 
 pub use crate::env::CancellationToken as MiniCancellation;
@@ -113,6 +116,25 @@ pub struct MiniArgs {
     pub verification_checks: Vec<crate::trajectory::VerificationCheck>,
     /// Per-check timeout in seconds. Defaults to 60.
     pub verification_timeout_secs: u64,
+    /// Issue #312 — operator interaction mode for this run.
+    pub interactive_mode: InteractiveMode,
+}
+
+/// Operator-interaction mode for `mini --interactive` (issue #312).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum InteractiveMode {
+    /// Default unattended behaviour — no prompts, no status line.
+    #[default]
+    Off,
+    /// Print a per-step status line to stderr but don't prompt before
+    /// bash actions (`--yolo` without `--interactive`).
+    YoloStatusOnly,
+    /// Pause before every bash/tool action and ask the operator on a
+    /// stderr single-line prompt.
+    StderrPrompt,
+    /// Same as `StderrPrompt` but render the prompt inside a full-screen
+    /// ratatui dashboard that also streams trajectory events.
+    Ratatui,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -141,17 +163,31 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     // Bring up the SSE server first so any client that connects right
     // after CLI startup catches the `run_started` event the builder
     // emits below.
-    let (sink, server): (Option<Arc<dyn StreamSink>>, Option<SseServer>) = match args.stream_addr {
-        Some(addr) => {
-            let bcast = Arc::new(BroadcastSink::default());
-            let server = SseServer::start(addr, bcast.clone()).await.map_err(|e| {
-                Error::Trajectory(format!("failed to bind SSE server on {addr}: {e}"))
-            })?;
-            tracing::info!(addr = %server.local_addr(), "streaming events on http://{}/", server.local_addr());
-            (Some(bcast as Arc<dyn StreamSink>), Some(server))
-        }
-        None => (None, None),
-    };
+    let (sse_sink, server): (Option<Arc<dyn StreamSink>>, Option<SseServer>) =
+        match args.stream_addr {
+            Some(addr) => {
+                let bcast = Arc::new(BroadcastSink::default());
+                let server = SseServer::start(addr, bcast.clone()).await.map_err(|e| {
+                    Error::Trajectory(format!("failed to bind SSE server on {addr}: {e}"))
+                })?;
+                tracing::info!(addr = %server.local_addr(), "streaming events on http://{}/", server.local_addr());
+                (Some(bcast as Arc<dyn StreamSink>), Some(server))
+            }
+            None => (None, None),
+        };
+
+    let (confirm_callback, dashboard) = build_interactive_pieces(args.interactive_mode)?;
+    let sink = compose_stream_sinks(
+        sse_sink,
+        dashboard.as_ref().map(RatatuiDashboardHandle::stream_sink),
+        if args.interactive_mode == InteractiveMode::YoloStatusOnly {
+            Some(Arc::new(StatusLineStderrSink::new(
+                args.config.root.agent.step_limit,
+            )) as Arc<dyn StreamSink>)
+        } else {
+            None
+        },
+    );
 
     let mut agent: DefaultAgent = DefaultAgentBuilder {
         config: args.config.clone(),
@@ -164,6 +200,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     }
     .build_with_tool_providers(tool_providers)?;
     agent.cancellation = args.cancellation.clone();
+    agent.confirm_callback = confirm_callback;
     resolved_skills
         .active_skills
         .record_redacted_provenance(&mut agent.trajectory.info, &agent.redactor)?;
@@ -378,6 +415,9 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     if let Some(server) = server {
         server.shutdown().await;
     }
+    if let Some(dashboard) = dashboard {
+        dashboard.shutdown().await;
+    }
     if let Some(err) = verification_err {
         return Err(err);
     }
@@ -385,6 +425,60 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         return Err(crate::error::Error::AgentStagnation { count, window });
     }
     Ok(())
+}
+
+/// Pair of pieces resolved from an `InteractiveMode`: the optional
+/// confirm callback to set on `DefaultAgent` and the optional ratatui
+/// dashboard handle whose lifetime brackets the run.
+type InteractivePieces = (
+    Option<Arc<dyn ConfirmCallback>>,
+    Option<RatatuiDashboardHandle>,
+);
+
+fn build_interactive_pieces(mode: InteractiveMode) -> Result<InteractivePieces, Error> {
+    match mode {
+        InteractiveMode::Off | InteractiveMode::YoloStatusOnly => Ok((None, None)),
+        InteractiveMode::StderrPrompt => {
+            let confirmer = StderrCliConfirmer::new_if_tty().ok_or_else(|| {
+                Error::Config(ConfigError::Invalid(
+                    "interactive mode requires a TTY; pass --yolo for unattended runs".into(),
+                ))
+            })?;
+            Ok((Some(Arc::new(confirmer) as Arc<dyn ConfirmCallback>), None))
+        }
+        InteractiveMode::Ratatui => {
+            if !std::io::IsTerminal::is_terminal(&std::io::stdin())
+                || !std::io::IsTerminal::is_terminal(&std::io::stdout())
+            {
+                return Err(Error::Config(ConfigError::Invalid(
+                    "ratatui interactive mode requires a TTY on stdin and stdout; \
+                     pass --yolo for unattended runs"
+                        .into(),
+                )));
+            }
+            let handle = crate::agent::RatatuiDashboard::start().map_err(|e| {
+                Error::Trajectory(format!("failed to start ratatui dashboard: {e}"))
+            })?;
+            let cb = handle.confirm_callback();
+            Ok((Some(cb), Some(handle)))
+        }
+    }
+}
+
+fn compose_stream_sinks(
+    sse: Option<Arc<dyn StreamSink>>,
+    dashboard: Option<Arc<dyn StreamSink>>,
+    status_line: Option<Arc<dyn StreamSink>>,
+) -> Option<Arc<dyn StreamSink>> {
+    let sinks: Vec<Arc<dyn StreamSink>> = [sse, dashboard, status_line]
+        .into_iter()
+        .flatten()
+        .collect();
+    match sinks.len() {
+        0 => None,
+        1 => sinks.into_iter().next(),
+        _ => Some(Arc::new(MultiSink::new(sinks)) as Arc<dyn StreamSink>),
+    }
 }
 
 fn finalize_cancelled_if_requested(
@@ -1405,6 +1499,7 @@ index 8a1218a..24c5735 100644\n\
             }),
             verification_checks: vec![],
             verification_timeout_secs: 60,
+            interactive_mode: InteractiveMode::Off,
         };
 
         run(args).await.unwrap();
@@ -1489,6 +1584,7 @@ index 8a1218a..24c5735 100644\n\
             }),
             verification_checks: vec![],
             verification_timeout_secs: 60,
+            interactive_mode: InteractiveMode::Off,
         };
 
         run(args).await.unwrap();

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -163,27 +163,29 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     // Bring up the SSE server first so any client that connects right
     // after CLI startup catches the `run_started` event the builder
     // emits below.
-    let (sse_sink, server): (Option<Arc<dyn StreamSink>>, Option<SseServer>) =
-        match args.stream_addr {
-            Some(addr) => {
-                let bcast = Arc::new(BroadcastSink::default());
-                let server = SseServer::start(addr, bcast.clone()).await.map_err(|e| {
-                    Error::Trajectory(format!("failed to bind SSE server on {addr}: {e}"))
-                })?;
-                tracing::info!(addr = %server.local_addr(), "streaming events on http://{}/", server.local_addr());
-                (Some(bcast as Arc<dyn StreamSink>), Some(server))
-            }
-            None => (None, None),
-        };
+    let (sse_sink, server): (Option<Arc<dyn StreamSink>>, Option<SseServer>) = match args
+        .stream_addr
+    {
+        Some(addr) => {
+            let bcast = Arc::new(BroadcastSink::default());
+            let server = SseServer::start(addr, bcast.clone()).await.map_err(|e| {
+                Error::Trajectory(format!("failed to bind SSE server on {addr}: {e}"))
+            })?;
+            tracing::info!(addr = %server.local_addr(), "streaming events on http://{}/", server.local_addr());
+            (Some(bcast as Arc<dyn StreamSink>), Some(server))
+        }
+        None => (None, None),
+    };
 
     let (confirm_callback, dashboard) = build_interactive_pieces(args.interactive_mode)?;
     let sink = compose_stream_sinks(
         sse_sink,
         dashboard.as_ref().map(RatatuiDashboardHandle::stream_sink),
         if args.interactive_mode == InteractiveMode::YoloStatusOnly {
-            Some(Arc::new(StatusLineStderrSink::new(
-                args.config.root.agent.step_limit,
-            )) as Arc<dyn StreamSink>)
+            Some(
+                Arc::new(StatusLineStderrSink::new(args.config.root.agent.step_limit))
+                    as Arc<dyn StreamSink>,
+            )
         } else {
             None
         },
@@ -977,6 +979,55 @@ mod tests {
     use std::path::Path;
     use std::process::Command;
     use std::sync::Mutex;
+
+    use crate::stream::{NullSink, StreamEvent, StreamSink};
+
+    #[test]
+    fn compose_stream_sinks_returns_none_when_all_absent() {
+        assert!(compose_stream_sinks(None, None, None).is_none());
+    }
+
+    #[test]
+    fn compose_stream_sinks_unwraps_single_sink_without_multi_wrap() {
+        let sse: Arc<dyn StreamSink> = Arc::new(NullSink);
+        let composed = compose_stream_sinks(Some(sse.clone()), None, None).unwrap();
+        // Single-sink path returns the same Arc, not a MultiSink wrapper.
+        assert!(Arc::ptr_eq(&composed, &sse));
+    }
+
+    #[test]
+    fn compose_stream_sinks_multi_wraps_when_multiple() {
+        let a: Arc<dyn StreamSink> = Arc::new(NullSink);
+        let b: Arc<dyn StreamSink> = Arc::new(NullSink);
+        let composed = compose_stream_sinks(Some(a), Some(b), None).unwrap();
+        // Just emit through it to verify it works; if it were a NullSink
+        // directly the call would still succeed, but MultiSink::emit
+        // exercises the fan-out path.
+        composed.emit(StreamEvent::RunStarted {
+            task: "t".into(),
+            model: "m".into(),
+            started_at: "s".into(),
+        });
+    }
+
+    #[test]
+    fn build_interactive_pieces_off_yields_no_callback() {
+        let (cb, dash) = build_interactive_pieces(InteractiveMode::Off).unwrap();
+        assert!(cb.is_none());
+        assert!(dash.is_none());
+    }
+
+    #[test]
+    fn build_interactive_pieces_yolo_status_only_yields_no_callback() {
+        let (cb, dash) = build_interactive_pieces(InteractiveMode::YoloStatusOnly).unwrap();
+        assert!(cb.is_none());
+        assert!(dash.is_none());
+    }
+
+    #[test]
+    fn interactive_mode_default_is_off() {
+        assert_eq!(InteractiveMode::default(), InteractiveMode::Off);
+    }
     use tokio::sync::watch;
 
     #[test]

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -4015,6 +4015,7 @@ async fn run_one(inst: SweBenchInstance, run_index: u32, params: RunOneParams) -
             }),
             verification_checks: vec![],
             verification_timeout_secs: 60,
+            interactive_mode: crate::run::mini::InteractiveMode::Off,
         };
         let run_err = crate::run::mini::run(args).await.err();
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -115,6 +115,62 @@ impl StreamSink for NullSink {
     fn emit(&self, _event: StreamEvent) {}
 }
 
+/// Fan out one event to many sinks. Used so the agent can drive an SSE
+/// broadcast, the ratatui dashboard, and an stderr status line from the
+/// same emission path without each subsystem owning a side channel.
+pub struct MultiSink {
+    sinks: Vec<std::sync::Arc<dyn StreamSink>>,
+}
+
+impl MultiSink {
+    #[must_use]
+    pub fn new(sinks: Vec<std::sync::Arc<dyn StreamSink>>) -> Self {
+        Self { sinks }
+    }
+}
+
+impl StreamSink for MultiSink {
+    fn emit(&self, event: StreamEvent) {
+        for sink in &self.sinks {
+            sink.emit(event.clone());
+        }
+    }
+}
+
+/// Issue #312 `--yolo`-without-`--interactive` status-line printer.
+/// Prints one terse `[status] step N/M cost $X.XXXX` line to stderr on
+/// each `AssistantMessage` (a clean per-step boundary that fires once
+/// after every model turn, before tool execution).
+pub struct StatusLineStderrSink {
+    step_limit: u32,
+}
+
+impl StatusLineStderrSink {
+    #[must_use]
+    pub fn new(step_limit: u32) -> Self {
+        Self { step_limit }
+    }
+}
+
+impl StreamSink for StatusLineStderrSink {
+    fn emit(&self, event: StreamEvent) {
+        if let StreamEvent::AssistantMessage {
+            step, cost_usd, ..
+        } = event
+        {
+            let cost = cost_usd.unwrap_or(0.0);
+            let _ = std::io::Write::write_all(
+                &mut std::io::stderr(),
+                format!(
+                    "[status] step {}/{}  cost ${:.4}\n",
+                    step, self.step_limit, cost
+                )
+                .as_bytes(),
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -154,10 +154,7 @@ impl StatusLineStderrSink {
 
 impl StreamSink for StatusLineStderrSink {
     fn emit(&self, event: StreamEvent) {
-        if let StreamEvent::AssistantMessage {
-            step, cost_usd, ..
-        } = event
-        {
+        if let StreamEvent::AssistantMessage { step, cost_usd, .. } = event {
             let cost = cost_usd.unwrap_or(0.0);
             let _ = std::io::Write::write_all(
                 &mut std::io::stderr(),
@@ -206,6 +203,119 @@ mod tests {
             task: "t".into(),
             model: "m".into(),
             started_at: "s".into(),
+        });
+    }
+
+    /// Test sink that captures emitted events into a shared vec so tests
+    /// can verify fan-out and ordering.
+    #[derive(Default)]
+    struct CapturingSink {
+        events: std::sync::Mutex<Vec<&'static str>>,
+    }
+
+    impl CapturingSink {
+        fn names(&self) -> Vec<&'static str> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    impl StreamSink for CapturingSink {
+        fn emit(&self, event: StreamEvent) {
+            self.events.lock().unwrap().push(event.event_name());
+        }
+    }
+
+    #[test]
+    fn multi_sink_fans_out_to_every_sink_in_order() {
+        let a = std::sync::Arc::new(CapturingSink::default());
+        let b = std::sync::Arc::new(CapturingSink::default());
+        let multi = MultiSink::new(vec![
+            a.clone() as std::sync::Arc<dyn StreamSink>,
+            b.clone() as std::sync::Arc<dyn StreamSink>,
+        ]);
+        multi.emit(StreamEvent::RunStarted {
+            task: "t".into(),
+            model: "m".into(),
+            started_at: "s".into(),
+        });
+        multi.emit(StreamEvent::BashStart {
+            step: 1,
+            command: "echo".into(),
+            timestamp: "t".into(),
+        });
+        assert_eq!(a.names(), vec!["run_started", "bash_start"]);
+        assert_eq!(b.names(), vec!["run_started", "bash_start"]);
+    }
+
+    #[test]
+    fn multi_sink_empty_is_noop() {
+        let multi = MultiSink::new(vec![]);
+        // Just verify it doesn't panic.
+        multi.emit(StreamEvent::Observation {
+            step: 0,
+            content: "x".into(),
+            timestamp: "t".into(),
+        });
+    }
+
+    #[test]
+    fn status_line_sink_silent_on_non_assistant_events() {
+        // We can't easily capture the stderr write — but we can at
+        // least confirm the sink doesn't panic for the non-matching arms.
+        let sink = StatusLineStderrSink::new(50);
+        sink.emit(StreamEvent::RunStarted {
+            task: "t".into(),
+            model: "m".into(),
+            started_at: "s".into(),
+        });
+        sink.emit(StreamEvent::BashStart {
+            step: 1,
+            command: "echo".into(),
+            timestamp: "t".into(),
+        });
+        sink.emit(StreamEvent::BashResult {
+            step: 1,
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+            timed_out: false,
+            timestamp: "t".into(),
+        });
+        sink.emit(StreamEvent::Observation {
+            step: 1,
+            content: "x".into(),
+            timestamp: "t".into(),
+        });
+        sink.emit(StreamEvent::FormatError {
+            step: 1,
+            content: "x".into(),
+            timestamp: "t".into(),
+        });
+        sink.emit(StreamEvent::RunEnded {
+            exit_reason: "submitted".into(),
+            failure_category: None,
+            final_output: None,
+            steps: 1,
+            total_cost_usd: 0.0,
+            ended_at: "t".into(),
+        });
+    }
+
+    #[test]
+    fn status_line_sink_emits_on_assistant_message() {
+        // Smoke: also doesn't panic for the matching arm.
+        let sink = StatusLineStderrSink::new(7);
+        sink.emit(StreamEvent::AssistantMessage {
+            step: 3,
+            content: "x".into(),
+            cost_usd: Some(0.1234),
+            timestamp: "t".into(),
+        });
+        sink.emit(StreamEvent::AssistantMessage {
+            step: 4,
+            content: "y".into(),
+            cost_usd: None,
+            timestamp: "t".into(),
         });
     }
 }

--- a/tests/cli_interactive_e2e.rs
+++ b/tests/cli_interactive_e2e.rs
@@ -1,0 +1,80 @@
+//! End-to-end CLI behaviour for `mini --interactive` (issue #312).
+//!
+//! Spawns the compiled `max` binary as a subprocess to exercise the
+//! non-TTY rejection path. The happy in-process path is covered by
+//! `tests/interactive_confirm.rs`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::process::{Command, Stdio};
+
+mod support;
+use support::binary_path;
+
+#[test]
+fn non_tty_without_yolo_rejects_with_usage_error() {
+    let bin = binary_path();
+    let out = Command::new(&bin)
+        .args([
+            "mini",
+            "--task",
+            "noop",
+            "--model",
+            "deterministic",
+            "--env",
+            "local",
+            "--step-limit",
+            "1",
+            "--interactive",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn `max mini`");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit; stdout={stdout}\nstderr={stderr}"
+    );
+    assert!(
+        stderr.contains("requires a TTY"),
+        "stderr missing TTY guidance: {stderr}"
+    );
+    assert!(
+        stderr.contains("--yolo"),
+        "stderr missing --yolo hint: {stderr}"
+    );
+}
+
+#[test]
+fn yolo_alone_does_not_require_tty() {
+    let bin = binary_path();
+    let dir = tempfile::tempdir().unwrap();
+    let out = Command::new(&bin)
+        .args([
+            "mini",
+            "--task",
+            "noop",
+            "--model",
+            "deterministic",
+            "--env",
+            "local",
+            "--step-limit",
+            "1",
+            "--yolo",
+            "--output",
+            dir.path().to_str().unwrap(),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn `max mini --yolo`");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("requires a TTY"),
+        "yolo run should not surface the TTY error; stderr={stderr}"
+    );
+}

--- a/tests/cli_interactive_flags.rs
+++ b/tests/cli_interactive_flags.rs
@@ -1,0 +1,103 @@
+//! Issue #312 — `--interactive`, `--yolo`, `--ui` flag parsing on `mini`.
+
+#![allow(clippy::unwrap_used)]
+
+use clap::Parser;
+use maxwells_daemon::cli::{Cli, Command, args::UiKind};
+
+fn parse(argv: &[&str]) -> Cli {
+    Cli::try_parse_from(argv).unwrap()
+}
+
+#[test]
+fn interactive_flag_defaults_false() {
+    let cli = parse(&["max", "mini", "--task", "t"]);
+    let Command::Mini(m) = cli.command else {
+        panic!("expected mini");
+    };
+    assert!(!m.interactive);
+    assert!(!m.yolo);
+    assert!(matches!(m.ui, UiKind::Stderr));
+}
+
+#[test]
+fn interactive_flag_parses() {
+    let cli = parse(&["max", "mini", "--task", "t", "--interactive"]);
+    let Command::Mini(m) = cli.command else {
+        panic!("expected mini");
+    };
+    assert!(m.interactive);
+}
+
+#[test]
+fn yolo_flag_parses() {
+    let cli = parse(&["max", "mini", "--task", "t", "--yolo"]);
+    let Command::Mini(m) = cli.command else {
+        panic!("expected mini");
+    };
+    assert!(m.yolo);
+}
+
+#[test]
+fn interactive_and_yolo_can_both_be_set() {
+    let cli = parse(&["max", "mini", "--task", "t", "--interactive", "--yolo"]);
+    let Command::Mini(m) = cli.command else {
+        panic!("expected mini");
+    };
+    assert!(m.interactive);
+    assert!(m.yolo);
+}
+
+#[test]
+fn ui_ratatui_parses() {
+    let cli = parse(&[
+        "max",
+        "mini",
+        "--task",
+        "t",
+        "--interactive",
+        "--ui",
+        "ratatui",
+    ]);
+    let Command::Mini(m) = cli.command else {
+        panic!("expected mini");
+    };
+    assert!(matches!(m.ui, UiKind::Ratatui));
+}
+
+#[test]
+fn ui_stderr_parses() {
+    let cli = parse(&[
+        "max",
+        "mini",
+        "--task",
+        "t",
+        "--interactive",
+        "--ui",
+        "stderr",
+    ]);
+    let Command::Mini(m) = cli.command else {
+        panic!("expected mini");
+    };
+    assert!(matches!(m.ui, UiKind::Stderr));
+}
+
+#[test]
+fn unknown_ui_value_is_rejected() {
+    let res = Cli::try_parse_from([
+        "max",
+        "mini",
+        "--task",
+        "t",
+        "--interactive",
+        "--ui",
+        "bogus",
+    ]);
+    assert!(res.is_err());
+}
+
+#[test]
+fn interactive_and_render_only_are_mutually_exclusive() {
+    let res = Cli::try_parse_from(["max", "mini", "--task", "t", "--interactive", "--render-only"]);
+    assert!(res.is_err());
+}

--- a/tests/cli_interactive_flags.rs
+++ b/tests/cli_interactive_flags.rs
@@ -98,6 +98,13 @@ fn unknown_ui_value_is_rejected() {
 
 #[test]
 fn interactive_and_render_only_are_mutually_exclusive() {
-    let res = Cli::try_parse_from(["max", "mini", "--task", "t", "--interactive", "--render-only"]);
+    let res = Cli::try_parse_from([
+        "max",
+        "mini",
+        "--task",
+        "t",
+        "--interactive",
+        "--render-only",
+    ]);
     assert!(res.is_err());
 }

--- a/tests/interactive_confirm.rs
+++ b/tests/interactive_confirm.rs
@@ -1,0 +1,290 @@
+//! Integration tests for issue #312 interactive-mode confirmation.
+//!
+//! These tests drive the agent end-to-end with a scripted
+//! `ConfirmCallback` and assert:
+//!   1. Approve runs the proposed bash command.
+//!   2. Reject skips execution, surfaces a synthetic observation, and
+//!      tags the trajectory with `interactive_decision: "reject"`.
+//!   3. Abort terminates with `ExitReason::UserInterrupt`, leaves the
+//!      trajectory flushable, and stamps `interactive_abort` on info.
+//!   4. The confirmer is not consulted on `Submit`.
+//!   5. `ConfirmContext` carries command, tool name, step, step limit,
+//!      and cumulative cost.
+//!   6. The full scripted approve→reject→approve→abort sequence works.
+
+#![allow(clippy::unwrap_used)]
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use maxwells_daemon::agent::confirm::{
+    ConfirmCallback, ConfirmContext, ConfirmDecision, ScriptedConfirmer,
+};
+use maxwells_daemon::agent::default::DefaultAgentBuilder;
+use maxwells_daemon::{
+    Agent, Config, DeterministicModel, Environment, ExitReason, LocalEnvironment,
+};
+
+#[tokio::test]
+async fn approve_lets_command_execute() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+    let model = Arc::new(DeterministicModel::new(vec![
+        "```bash\necho approved-line\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let confirmer = Arc::new(ScriptedConfirmer::new(vec![ConfirmDecision::Approve]));
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "approve-test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+    agent.confirm_callback = Some(confirmer.clone() as Arc<dyn ConfirmCallback>);
+
+    let result = agent.run().await.unwrap();
+    assert!(matches!(result, ExitReason::Submitted { .. }));
+    assert_eq!(confirmer.call_count(), 1);
+    let approved = agent
+        .trajectory
+        .messages
+        .iter()
+        .any(|m| m.content.contains("approved-line"));
+    assert!(approved, "expected `approved-line` in trajectory");
+}
+
+#[tokio::test]
+async fn reject_records_synthetic_observation_and_event() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+    let model = Arc::new(DeterministicModel::new(vec![
+        "```bash\nrm -rf /tmp/should-never-run\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nrecovered\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let confirmer = Arc::new(ScriptedConfirmer::new(vec![ConfirmDecision::Reject]));
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "reject-test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+    agent.confirm_callback = Some(confirmer.clone() as Arc<dyn ConfirmCallback>);
+
+    let result = agent.run().await.unwrap();
+    assert!(matches!(result, ExitReason::Submitted { .. }));
+    assert_eq!(confirmer.call_count(), 1);
+
+    // Rejected commands have no run_result observation.
+    let executed = agent
+        .trajectory
+        .messages
+        .iter()
+        .any(|m| m.extra.other.contains_key("run_result"));
+    assert!(!executed);
+
+    let has_rejection = agent.trajectory.messages.iter().any(|m| {
+        m.extra
+            .other
+            .get("interactive_decision")
+            .and_then(|v| v.as_str())
+            == Some("reject")
+    });
+    assert!(has_rejection);
+}
+
+#[tokio::test]
+async fn abort_terminates_with_user_interrupt() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+    let model = Arc::new(DeterministicModel::new(vec![
+        "```bash\necho should-not-execute\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let confirmer = Arc::new(ScriptedConfirmer::new(vec![ConfirmDecision::Abort]));
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "abort-test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+    agent.confirm_callback = Some(confirmer.clone() as Arc<dyn ConfirmCallback>);
+
+    let result = agent.run().await.unwrap();
+    assert!(matches!(result, ExitReason::UserInterrupt));
+
+    let executed = agent
+        .trajectory
+        .messages
+        .iter()
+        .any(|m| m.extra.other.contains_key("run_result"));
+    assert!(!executed);
+
+    let abort_meta = agent.trajectory.info.other.get("interactive_abort");
+    assert!(abort_meta.is_some());
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    agent.trajectory.save_pretty(tmp.path()).unwrap();
+}
+
+#[tokio::test]
+async fn scripted_approve_reject_approve_abort_sequence() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 10;
+    let model = Arc::new(DeterministicModel::new(vec![
+        "```bash\necho first-approved\n```".into(),
+        "```bash\nrm -rf /tmp/rejected-cmd\n```".into(),
+        "```bash\necho third-approved\n```".into(),
+        "```bash\necho fourth-aborted\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let confirmer = Arc::new(ScriptedConfirmer::new(vec![
+        ConfirmDecision::Approve,
+        ConfirmDecision::Reject,
+        ConfirmDecision::Approve,
+        ConfirmDecision::Abort,
+    ]));
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "scripted".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+    agent.confirm_callback = Some(confirmer.clone() as Arc<dyn ConfirmCallback>);
+
+    let result = agent.run().await.unwrap();
+    assert!(matches!(result, ExitReason::UserInterrupt));
+    assert_eq!(confirmer.call_count(), 4);
+
+    let executed: Vec<String> = agent
+        .trajectory
+        .messages
+        .iter()
+        .filter_map(|m| {
+            if m.role != "user" {
+                return None;
+            }
+            m.extra
+                .other
+                .get("run_result")
+                .and_then(|v| v.get("stdout"))
+                .and_then(|s| s.as_str())
+                .map(str::to_owned)
+        })
+        .collect();
+    assert!(executed.iter().any(|s| s.contains("first-approved")));
+    assert!(executed.iter().any(|s| s.contains("third-approved")));
+    assert!(!executed.iter().any(|s| s.contains("fourth-aborted")));
+    assert!(!executed.iter().any(|s| s.contains("/tmp/rejected-cmd")));
+
+    let rejects = agent
+        .trajectory
+        .messages
+        .iter()
+        .filter(|m| {
+            m.extra
+                .other
+                .get("interactive_decision")
+                .and_then(|v| v.as_str())
+                == Some("reject")
+        })
+        .count();
+    assert_eq!(rejects, 1);
+}
+
+#[tokio::test]
+async fn confirmer_not_called_on_submit() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 3;
+    let model = Arc::new(DeterministicModel::new(vec![
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\ndone\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let confirmer = Arc::new(ScriptedConfirmer::new(vec![]));
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "submit-only".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+    agent.confirm_callback = Some(confirmer.clone() as Arc<dyn ConfirmCallback>);
+
+    let result = agent.run().await.unwrap();
+    assert!(matches!(result, ExitReason::Submitted { .. }));
+    assert_eq!(confirmer.call_count(), 0);
+}
+
+#[derive(Default)]
+struct ContextRecorder {
+    seen: Mutex<Vec<ConfirmContext>>,
+}
+
+#[async_trait]
+impl ConfirmCallback for ContextRecorder {
+    async fn confirm(&self, ctx: &ConfirmContext) -> ConfirmDecision {
+        self.seen.lock().unwrap().push(ctx.clone());
+        ConfirmDecision::Approve
+    }
+}
+
+#[tokio::test]
+async fn confirm_context_carries_command_and_step_metadata() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 7;
+    let model = Arc::new(DeterministicModel::new(vec![
+        "```bash\necho context-probe\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let recorder = Arc::new(ContextRecorder::default());
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "ctx-probe".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+    }
+    .build()
+    .unwrap();
+    agent.confirm_callback = Some(recorder.clone() as Arc<dyn ConfirmCallback>);
+
+    let _ = agent.run().await.unwrap();
+    let ctx = {
+        let seen = recorder.seen.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        seen[0].clone()
+    };
+    assert_eq!(ctx.command.trim(), "echo context-probe");
+    assert_eq!(ctx.tool_name, "bash");
+    assert_eq!(ctx.step_limit, 7);
+    assert_eq!(ctx.step, 0);
+    assert!(ctx.cost_usd >= 0.0);
+}

--- a/tests/skills.rs
+++ b/tests/skills.rs
@@ -448,6 +448,7 @@ paths = ["{skill_path}"]
         patch_capture: None,
         verification_checks: vec![],
         verification_timeout_secs: 60,
+        interactive_mode: maxwells_daemon::run::mini::InteractiveMode::Off,
     })
     .await
     .unwrap();
@@ -516,6 +517,7 @@ secret_literals = ["TOP_SECRET_VALUE", "TOP_SECRET_ROOT"]
         patch_capture: None,
         verification_checks: vec![],
         verification_timeout_secs: 60,
+        interactive_mode: maxwells_daemon::run::mini::InteractiveMode::Off,
     })
     .await
     .unwrap();

--- a/tests/verification.rs
+++ b/tests/verification.rs
@@ -7,7 +7,7 @@
 
 use maxwells_daemon::{
     config::Config,
-    run::mini::{MiniArgs, run},
+    run::mini::{InteractiveMode, MiniArgs, run},
     trajectory::{VerificationCheck, verification_status},
 };
 
@@ -35,6 +35,7 @@ fn mini_args(work: &tempfile::TempDir, name: &str, checks: Vec<VerificationCheck
         patch_capture: None,
         verification_checks: checks,
         verification_timeout_secs: 10,
+        interactive_mode: InteractiveMode::Off,
     }
 }
 


### PR DESCRIPTION
Closes #312.

TDD red → green → refactor for the `mini --interactive` operator-confirmation
slice, with both a stderr prompt and a full-screen ratatui dashboard as
alternate UIs.

## Summary

- `mini --interactive` pauses before every bash/tool action and prompts
  the operator (`y` approve, `n` reject, `a`/Esc/Ctrl-C abort) with the
  proposed command, step `N/M`, cumulative cost, and cache marker.
- `mini --interactive --ui ratatui` swaps the stderr prompt for a
  full-screen ratatui dashboard that also streams trajectory events
  (assistant messages, bash start/result, observations, format errors,
  run ended) into a coloured log panel.
- `mini --yolo` runs unattended but prints a `[status] step N/M cost $...`
  line on each step boundary.
- Non-TTY stdin without `--yolo` exits with `usage_error` and the
  documented message: `interactive mode requires a TTY; pass --yolo for
  unattended runs.`

## How it works

- New `src/agent/confirm.rs` defines `ConfirmContext`,
  `ConfirmDecision { Approve, Reject, Abort }`, the `ConfirmCallback`
  trait, and `ScriptedConfirmer` for tests.
- `DefaultAgent.confirm_callback` is consulted after PreToolUse hooks
  but before `env.run`. PreToolUse denial bypasses the prompt so
  operators never see commands that won't run anyway.
- Reject surfaces a synthetic `Exit code: 1\nCommand rejected by
  operator (interactive mode). …` observation to the model and tags
  the trajectory record with `interactive_decision: "reject"` plus the
  proposed command, tool name, and timestamp.
- Abort stamps `interactive_abort` onto `trajectory.info.other` then
  calls `finalize_cancelled`; the runner saves the trajectory before
  returning `ExitReason::UserInterrupt`.
- Two production confirmers: `StderrCliConfirmer` (crossterm raw mode
  with line-buffered fallback) and `RatatuiDashboard` (which is both a
  `StreamSink` and a `ConfirmCallback`). New `MultiSink` +
  `StatusLineStderrSink` keep SSE broadcast, dashboard, and status
  line composable.

## Acceptance criteria

All 12 ACs from #312 are covered:

- [x] `--interactive` flag, mutually exclusive with `--render-only`
- [x] `--yolo` flag with status line, no prompts; usable on its own
- [x] Stderr prompt shows command, step, cost (4 dp), cache marker
- [x] Single keystroke (raw mode) with line-buffered fallback
- [x] Non-TTY without `--yolo` exits with documented error
- [x] Reject recorded as structured event in trajectory
- [x] Abort flushes trajectory before exit
- [x] Ctrl-C at prompt = `a` (abort)
- [x] `--yolo` alone prints status line per step boundary
- [x] PreToolUse hooks fire before prompt; hook denial bypasses it
- [x] README Live-Model Quickstart updated; spec rewritten
- [x] Integration test drives scripted approve/reject/approve/abort

## Test plan

- [x] `cargo test --lib --tests` — 1635 tests pass, 0 fail
- [x] `cargo clippy --lib --tests --all-features` — clean (pedantic + nursery)
- [x] `tests/interactive_confirm.rs` (6 in-process integration tests)
- [x] `tests/cli_interactive_flags.rs` (8 flag-parsing tests)
- [x] `tests/cli_interactive_e2e.rs` (2 subprocess tests for non-TTY)
- [ ] Manual smoke: `cargo run -- mini --interactive --task "..." --yolo`
- [ ] Manual smoke: `cargo run -- mini --interactive --ui ratatui --task "..."`