### PR TITLE
⚡ Bolt: [performance improvement] Remove intermediate Vec allocations in quantiles calculation

### DIFF
--- a/src/run/calibrate.rs
+++ b/src/run/calibrate.rs
@@ -434,51 +434,46 @@ fn build_per_instance(forecast: &ForecastReport, actual: &SweepResults) -> PerIn
         input_tokens: DistributionCalibration::new(
             forecast.per_instance.input_tokens,
             quantiles(
-                &actual
+                actual
                     .instances
                     .iter()
-                    .map(|row| row.prompt_tokens.map_or(0.0, as_f64_u64))
-                    .collect::<Vec<_>>(),
+                    .map(|row| row.prompt_tokens.map_or(0.0, as_f64_u64)),
             ),
         ),
         output_tokens: DistributionCalibration::new(
             forecast.per_instance.output_tokens,
             quantiles(
-                &actual
+                actual
                     .instances
                     .iter()
-                    .map(|row| row.completion_tokens.map_or(0.0, as_f64_u64))
-                    .collect::<Vec<_>>(),
+                    .map(|row| row.completion_tokens.map_or(0.0, as_f64_u64)),
             ),
         ),
         usd_cost: DistributionCalibration::new(
             forecast.per_instance.usd_cost,
             quantiles(
-                &actual
+                actual
                     .instances
                     .iter()
-                    .map(|row| row.effective_cost_usd(model_name).unwrap_or_default())
-                    .collect::<Vec<_>>(),
+                    .map(|row| row.effective_cost_usd(model_name).unwrap_or_default()),
             ),
         ),
         step_count: DistributionCalibration::new(
             forecast.per_instance.step_count,
             quantiles(
-                &actual
+                actual
                     .instances
                     .iter()
-                    .map(|row| row.steps.map_or(0.0, f64::from))
-                    .collect::<Vec<_>>(),
+                    .map(|row| row.steps.map_or(0.0, f64::from)),
             ),
         ),
         wall_clock_seconds: DistributionCalibration::new(
             forecast.per_instance.wall_clock_seconds,
             quantiles(
-                &actual
+                actual
                     .instances
                     .iter()
-                    .map(|row| row.duration_secs.unwrap_or_default())
-                    .collect::<Vec<_>>(),
+                    .map(|row| row.duration_secs.unwrap_or_default()),
             ),
         ),
     }
@@ -749,15 +744,15 @@ fn manifest_wall_clock_seconds(manifest: Option<&ProvenanceManifest>) -> Option<
     }
 }
 
-fn quantiles(values: &[f64]) -> QuantileSummary {
-    if values.is_empty() {
+fn quantiles(values: impl Iterator<Item = f64>) -> QuantileSummary {
+    let mut sorted: Vec<f64> = values.collect();
+    if sorted.is_empty() {
         return QuantileSummary {
             p10: 0.0,
             median: 0.0,
             p90: 0.0,
         };
     }
-    let mut sorted = values.to_vec();
     sorted.sort_by(f64::total_cmp);
     QuantileSummary {
         p10: quantile_sorted(&sorted, 0.10),


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Remove intermediate Vec allocations in quantiles calculation

💡 What: Changed the `quantiles` function in `src/run/calibrate.rs` to accept `impl Iterator<Item = f64>` instead of `&[f64]`. This eliminates the need for callers to collect iterators into intermediate `Vec<_>`s just to pass them as slices.
🎯 Why: The original implementation caused multiple redundant allocations and copies per call to `build_per_instance`. The caller collected the mapped values into a `Vec` and took a slice, and then `quantiles` immediately called `.to_vec()` to clone it.
📊 Impact: Saves exactly 5 intermediate `Vec` allocations and their subsequent cloning operations per call to `build_per_instance`.
🔬 Measurement: Run `cargo bench` or `cargo test bench_calibrate`. Verified code continues to pass testing.

---
*PR created automatically by Jules for task [1475225160710975414](https://jules.google.com/task/1475225160710975414) started by @madmax983*