### PR TITLE
feat(#324): wire WebhookSink into mini --webhook-url for per-step push streaming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ pretty_assertions = "1"
 tokio = { version = "1", features = ["full", "test-util"] }
 
 [features]
-default = []
+default = ["webhook"]
 docker = []
 chaos = []
 live-anthropic = []

--- a/README.md
+++ b/README.md
@@ -179,6 +179,30 @@ revise), `a` (or Esc/Ctrl-C) aborts the run cleanly. Rejections and aborts are
 recorded on the trajectory as structured events so `bench inspect` can show
 exactly which commands the operator vetoed.
 
+### Live Event Streaming
+
+Two transports let you observe per-step events without waiting for the trajectory file:
+
+- **SSE (`--stream <host:port>`)** — the agent binds an HTTP server; clients dial in.
+  Good for an interactive local session where you can `curl` or open a browser.
+- **Webhook (`--webhook-url <url>`)** — the agent POSTs each event to your listener.
+  Good for headless CI, Docker, or any environment that cannot expose an inbound port.
+
+Both can be active at once:
+
+```bash
+max mini --task "…" \
+  --stream 127.0.0.1:7878 \
+  --webhook-url https://hooks.example.com/agent-events \
+  --webhook-header "Authorization: Bearer $TOKEN"
+```
+
+Each webhook POST body is a versioned JSON envelope
+(`{ "schema_version": {"major":1,"minor":0}, "run_id": "…", "event": {…}, "emitted_at": "…" }`).
+Secrets are redacted before POST. HTTP failures are logged and counted; they never
+block or abort the run. See [`docs/spec-streaming.md`](docs/spec-streaming.md) for the
+full transport comparison and envelope schema.
+
 For a real SWE-bench sweep, run `bench doctor` first, then `bench forecast`
 with a cost cap, then `bench swebench` only after the forecast clears your
 budget, and finally `bench calibrate` against the completed `results.json`.

--- a/docs/spec-streaming.md
+++ b/docs/spec-streaming.md
@@ -1,4 +1,4 @@
-# 🔭 Vantage: Spec for Streaming Trajectories via SSE/WebSockets
+# 🔭 Vantage: Spec for Streaming Trajectories
 
 ## 👤 User Story
 "As a Developer running the agent locally, I want to stream agent steps and outputs in real-time, so that I can monitor progress without waiting for the full trajectory file to be written at the end of the run."
@@ -11,3 +11,97 @@
 ## 🚫 Out of Scope
 - Full UI web application (Phase 2).
 - History playback of old runs over streaming endpoints (Phase 2).
+
+---
+
+## Transports
+
+Maxwell's Daemon supports two complementary transports for per-step event streaming.
+They are independently composable: either, both, or neither can be enabled on the same run.
+
+### SSE (Server-Sent Events) — `--stream <host:port>`
+
+The agent binds an HTTP server and pushes events over persistent SSE connections.
+
+- **Direction**: clients dial **in** to the agent.
+- **Use case**: interactive local runs where an operator opens a browser or `curl`.
+- **Frame format**: standard SSE `event:` / `data:` pairs; `data:` is a JSON object with a `type` discriminator.
+- **Disconnect safety**: a dropped client connection silently closes the per-connection task; the agent loop continues unaffected.
+
+### Webhook (HTTP POST) — `--webhook-url <url>`
+
+The agent POSTs each event to your HTTP listener as it occurs.
+
+- **Direction**: the agent calls **out** to your server.
+- **Use case**: headless CI runners, Docker containers, remote schedulers that cannot expose an inbound port.
+- **Requires**: Cargo feature `webhook` (default-enabled since issue #324).
+
+#### Webhook Envelope
+
+Every POST body is a JSON object with this stable envelope:
+
+```json
+{
+  "schema_version": { "major": 1, "minor": 0 },
+  "run_id":         "<trajectory-name>",
+  "event":          { "type": "bash_start", "step": 1, "command": "…", "timestamp": "…" },
+  "emitted_at":     "2026-05-19T12:00:00Z"
+}
+```
+
+For the final `RunEnded` event, an additional envelope-level field is appended:
+
+```json
+{
+  …,
+  "webhook_events_dropped": 0
+}
+```
+
+`webhook_events_dropped` counts events silently lost due to buffer-full or HTTP failure.
+If the count is ≥ 1 the binary prints a single `warn` line to stderr at run end.
+
+#### Delivery Posture
+
+| Property | Value |
+|---|---|
+| Buffer | Bounded MPSC (1 024 events by default) |
+| Full-buffer behaviour | Drop-on-full, non-blocking; counted in `webhook_events_dropped` |
+| HTTP timeout | 5 seconds per request |
+| Retries | None (best-effort) |
+| HTTP failures | Logged at `warn`; counted in `webhook_events_dropped`; run continues |
+| Agent blocking | **Never** — delivery failures are fully absorbed by the sink |
+
+#### Custom Headers — `--webhook-header "Name: Value"`
+
+Repeatable. Injects arbitrary HTTP headers on every POST.
+Header bytes are **not** echoed in logs and **not** passed through the secret redactor
+(operator-supplied credentials are not observed content).
+
+```bash
+max mini --task "…" \
+  --webhook-url "$SLACK_INCOMING_HOOK" \
+  --webhook-header "Authorization: Bearer $TOKEN"
+```
+
+#### Secret Redaction
+
+The redactor is applied to every string field of every event payload **before** POST,
+identical to the trajectory write path (`stream` surface).
+Configured `secret_literals`, `custom_patterns`, and structured-secret rules all apply.
+
+#### Composing SSE + Webhook
+
+```bash
+max mini --task "…" \
+  --stream 127.0.0.1:7878 \
+  --webhook-url http://my-listener/events
+```
+
+Both transports observe the same `StreamEvent` sequence; the envelope wrapping differs.
+
+#### Feature Flag
+
+The `webhook` feature is **default-enabled** (`Cargo.toml: default = ["webhook"]`).
+If you build with `--no-default-features` and pass `--webhook-url`, the binary prints
+an actionable error and exits.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -181,6 +181,19 @@ pub struct MiniCmd {
     #[arg(long)]
     pub stream: Option<String>,
 
+    /// POST each `StreamEvent` to this HTTP URL as a JSON envelope.
+    /// Optional; absent = no background webhook task spawned. Composable
+    /// with `--stream` — both transports see the same event sequence.
+    /// Requires the `webhook` Cargo feature (default-enabled).
+    #[arg(long)]
+    pub webhook_url: Option<String>,
+
+    /// Inject an HTTP request header into every webhook POST.
+    /// Format: `"Name: Value"`. Repeatable. Header bytes are not logged.
+    /// Example: `--webhook-header "Authorization: Bearer $TOKEN"`
+    #[arg(long = "webhook-header", value_name = "NAME: VALUE")]
+    pub webhook_headers: Vec<String>,
+
     /// Skip `git apply --check` and empty-diff validation after patch capture.
     /// Escape hatch for non-git environments; not for normal use.
     #[arg(long, default_value_t = false)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -275,6 +275,8 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         resume_from: None,
         interactive_mode,
         trace_id: None,
+        webhook_url: m.webhook_url,
+        webhook_headers: m.webhook_headers,
     };
     let run_result = crate::run::mini::run(args).await;
     // Only publish when the run succeeded or failed at verification — those are
@@ -3260,6 +3262,8 @@ mod tests {
             interactive: false,
             yolo: false,
             ui: args::UiKind::Stderr,
+            webhook_url: None,
+            webhook_headers: vec![],
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -301,6 +301,8 @@ fn mini_render_only_cmd(m: args::MiniCmd, cfg: crate::config::Config) -> Result<
             has_verify_checks: !m.verify.is_empty(),
             open_pr: m.github_pr.open_pr,
             pr_dry_run: m.github_pr.github_pr_dry_run,
+            webhook_url: m.webhook_url.is_some(),
+            webhook_headers: !m.webhook_headers.is_empty(),
         },
     )?;
 
@@ -337,6 +339,8 @@ fn bench_swebench_render_only(s: &args::SwebenchCmd) -> Result<(), Error> {
             has_verify_checks: false,
             open_pr: s.github_pr.open_prs,
             pr_dry_run: s.github_pr.github_pr_dry_run,
+            webhook_url: false,
+            webhook_headers: false,
         },
     )?;
     let format = s.format.clone();

--- a/src/run/hello_world.rs
+++ b/src/run/hello_world.rs
@@ -34,6 +34,8 @@ pub async fn main(output_dir: PathBuf, config_path: Option<&Path>) -> Result<(),
         resume_from: None,
         interactive_mode: InteractiveMode::Off,
         trace_id: None,
+        webhook_url: None,
+        webhook_headers: vec![],
     };
     run(args).await?;
     println!("hello-world smoke complete");

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -204,13 +204,15 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         let headers: Vec<(String, String)> = args
             .webhook_headers
             .iter()
-            .filter_map(|h| {
-                let mut parts = h.splitn(2, ':');
-                let name = parts.next()?.trim().to_owned();
-                let value = parts.next()?.trim().to_owned();
-                Some((name, value))
+            .map(|h| {
+                let (name, value) = h.split_once(':').ok_or_else(|| {
+                    Error::Config(ConfigError::Invalid(format!(
+                        "webhook header `{h}` is missing `:` separator (use `Name: Value`)"
+                    )))
+                })?;
+                Ok((name.trim().to_owned(), value.trim().to_owned()))
             })
-            .collect();
+            .collect::<Result<Vec<_>, Error>>()?;
         let sink = WebhookSink::new(url.clone(), &headers)
             .map_err(|e| Error::Config(ConfigError::Invalid(format!("webhook sink: {e}"))))?;
         let sink_arc = Arc::new(sink);
@@ -226,19 +228,9 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         };
         let handle = WebhookSinkHandle::new(sink_arc, run_id);
         // Log only scheme + host — path/query/userinfo may contain credentials.
-        let safe_url = url
-            .find("://")
-            .map(|i| {
-                let after = &url[i + 3..];
-                // Strip userinfo (user:pass@).
-                let host_start = after.rfind('@').map_or(0, |j| j + 1);
-                // Stop at first /, ?, or # (path / query / fragment).
-                let host_end = after[host_start..]
-                    .find(['/', '?', '#'])
-                    .map_or(after.len() - host_start, |j| j)
-                    + host_start;
-                format!("{}://{}", &url[..i], &after[host_start..host_end])
-            })
+        let safe_url = reqwest::Url::parse(url)
+            .ok()
+            .and_then(|u| u.host_str().map(|h| format!("{}://{}", u.scheme(), h)))
             .unwrap_or_else(|| "<url>".to_owned());
         tracing::info!(url = %safe_url, "webhook push enabled");
         (Some(Arc::new(handle) as Arc<dyn StreamSink>), Some(counter))
@@ -368,6 +360,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
                         Some(crate::trajectory::verification_status::UNVERIFIED.into());
                     agent.trajectory.save_pretty(&traj_path)?;
                     tracing::info!(?traj_path, patch_written, "trajectory written");
+                    warn_dropped_webhook_events(webhook_dropped_counter.as_deref());
                     if let Some(server) = server {
                         server.shutdown().await;
                     }
@@ -403,6 +396,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
                         Some(crate::trajectory::verification_status::UNVERIFIED.into());
                     agent.trajectory.save_pretty(&traj_path)?;
                     tracing::info!(?traj_path, patch_written, "trajectory written");
+                    warn_dropped_webhook_events(webhook_dropped_counter.as_deref());
                     if let Some(server) = server {
                         server.shutdown().await;
                     }
@@ -528,6 +522,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     let exit = match run_result {
         Ok(exit) => exit,
         Err(e) => {
+            warn_dropped_webhook_events(webhook_dropped_counter.as_deref());
             if let Some(server) = server {
                 server.shutdown().await;
             }
@@ -545,15 +540,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     tracing::info!(?traj_path, patch_written, "trajectory written");
 
     // Emit stderr warning if any webhook events were dropped (issue #324 AC 5).
-    if let Some(ref counter) = webhook_dropped_counter {
-        let n = counter.load(std::sync::atomic::Ordering::Relaxed);
-        if n >= 1 {
-            let _ = std::io::Write::write_all(
-                &mut std::io::stderr(),
-                format!("warn: {n} webhook event(s) were dropped during this run\n").as_bytes(),
-            );
-        }
-    }
+    warn_dropped_webhook_events(webhook_dropped_counter.as_deref());
 
     if let Some(server) = server {
         server.shutdown().await;
@@ -604,6 +591,18 @@ fn build_interactive_pieces(mode: InteractiveMode) -> Result<InteractivePieces, 
             })?;
             let cb = handle.confirm_callback();
             Ok((Some(cb), Some(handle)))
+        }
+    }
+}
+
+fn warn_dropped_webhook_events(counter: Option<&std::sync::atomic::AtomicU64>) {
+    if let Some(counter) = counter {
+        let n = counter.load(std::sync::atomic::Ordering::Relaxed);
+        if n >= 1 {
+            let _ = std::io::Write::write_all(
+                &mut std::io::stderr(),
+                format!("warn: {n} webhook event(s) were dropped during this run\n").as_bytes(),
+            );
         }
     }
 }

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -201,9 +201,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         Option<Arc<dyn StreamSink>>,
         Option<Arc<std::sync::atomic::AtomicU64>>,
     ) = if let Some(ref url) = args.webhook_url {
-        let run_id = args
-            .trajectory_name
-            .clone();
+        let run_id = args.trajectory_name.clone();
         let headers: Vec<(String, String)> = args
             .webhook_headers
             .iter()

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -20,6 +20,8 @@ use crate::model::litellm::LitellmBackend;
 use crate::model::{DeterministicModel, FallbackModel, Model, ModelUsage};
 use crate::redaction::surface;
 use crate::stream::{BroadcastSink, MultiSink, SseServer, StatusLineStderrSink, StreamSink};
+#[cfg(feature = "webhook")]
+use crate::stream::{WebhookSink, WebhookSinkHandle};
 use crate::trajectory::FailureCategory;
 
 pub use crate::env::CancellationToken as MiniCancellation;
@@ -127,6 +129,13 @@ pub struct MiniArgs {
     /// save so the trajectory and its span share the same correlation key.
     /// `None` when OTLP is not configured.
     pub trace_id: Option<String>,
+    /// Optional webhook URL for per-step push streaming (issue #324).
+    /// When `Some`, each `StreamEvent` is POSTed as a JSON envelope to this
+    /// URL by a background task.  Absent = no background task spawned.
+    pub webhook_url: Option<String>,
+    /// Extra HTTP headers to inject on every webhook POST, e.g.
+    /// `"Authorization: Bearer <token>"`.  Not echoed in logs.
+    pub webhook_headers: Vec<String>,
 }
 
 /// Operator-interaction mode for `mini --interactive` (issue #312).
@@ -186,6 +195,55 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         None => (None, None),
     };
 
+    // Build the optional webhook sink (issue #324).
+    #[cfg(feature = "webhook")]
+    let (webhook_sink_opt, webhook_dropped_counter): (
+        Option<Arc<dyn StreamSink>>,
+        Option<Arc<std::sync::atomic::AtomicU64>>,
+    ) = if let Some(ref url) = args.webhook_url {
+        let run_id = args
+            .trajectory_name
+            .clone();
+        let headers: Vec<(String, String)> = args
+            .webhook_headers
+            .iter()
+            .filter_map(|h| {
+                let mut parts = h.splitn(2, ':');
+                let name = parts.next()?.trim().to_owned();
+                let value = parts.next()?.trim().to_owned();
+                Some((name, value))
+            })
+            .collect();
+        match WebhookSink::new(url.clone(), headers) {
+            Ok(sink) => {
+                let sink_arc = Arc::new(sink);
+                let counter = sink_arc.dropped_counter();
+                let handle = WebhookSinkHandle::new(sink_arc, run_id);
+                tracing::info!(%url, "webhook push enabled");
+                (Some(Arc::new(handle) as Arc<dyn StreamSink>), Some(counter))
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to create webhook sink; continuing without it");
+                (None, None)
+            }
+        }
+    } else {
+        (None, None)
+    };
+    #[cfg(not(feature = "webhook"))]
+    let (webhook_sink_opt, webhook_dropped_counter): (
+        Option<Arc<dyn StreamSink>>,
+        Option<Arc<std::sync::atomic::AtomicU64>>,
+    ) = {
+        if args.webhook_url.is_some() {
+            tracing::error!(
+                "--webhook-url requires the `webhook` Cargo feature; \
+                 rebuild with --features webhook"
+            );
+        }
+        (None, None)
+    };
+
     let resume_state = args.resume_from.map(|traj| {
         let history = traj.messages_as_model_history();
         let steps = traj.info.steps.unwrap_or(0);
@@ -212,6 +270,16 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         })
     });
     let (confirm_callback, dashboard) = build_interactive_pieces(args.interactive_mode)?;
+
+    // Redact the webhook sink so secrets are stripped before each POST.
+    let webhook_sink_redacted: Option<Arc<dyn StreamSink>> = webhook_sink_opt.map(|ws| {
+        // We need the redactor before the agent is built, so create a temporary
+        // one from the config. The agent will build its own for trajectory/model
+        // surfaces; this one covers the stream surface only.
+        let redactor = crate::redaction::Redactor::from_config_lossy(&args.config.root.redaction);
+        Arc::new(crate::redaction::RedactingSink::new(ws, redactor)) as Arc<dyn StreamSink>
+    });
+
     let sink = compose_stream_sinks(
         sse_sink,
         dashboard.as_ref().map(RatatuiDashboardHandle::stream_sink),
@@ -223,6 +291,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         } else {
             None
         },
+        webhook_sink_redacted,
     );
 
     let mut agent: DefaultAgent = DefaultAgentBuilder {
@@ -459,6 +528,17 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
 
     tracing::info!(?traj_path, patch_written, "trajectory written");
 
+    // Emit stderr warning if any webhook events were dropped (issue #324 AC 5).
+    if let Some(ref counter) = webhook_dropped_counter {
+        let n = counter.load(std::sync::atomic::Ordering::Relaxed);
+        if n >= 1 {
+            let _ = std::io::Write::write_all(
+                &mut std::io::stderr(),
+                format!("warn: {n} webhook event(s) were dropped during this run\n").as_bytes(),
+            );
+        }
+    }
+
     if let Some(server) = server {
         server.shutdown().await;
     }
@@ -516,8 +596,9 @@ fn compose_stream_sinks(
     sse: Option<Arc<dyn StreamSink>>,
     dashboard: Option<Arc<dyn StreamSink>>,
     status_line: Option<Arc<dyn StreamSink>>,
+    webhook: Option<Arc<dyn StreamSink>>,
 ) -> Option<Arc<dyn StreamSink>> {
-    let sinks: Vec<Arc<dyn StreamSink>> = [sse, dashboard, status_line]
+    let sinks: Vec<Arc<dyn StreamSink>> = [sse, dashboard, status_line, webhook]
         .into_iter()
         .flatten()
         .collect();
@@ -1029,13 +1110,13 @@ mod tests {
 
     #[test]
     fn compose_stream_sinks_returns_none_when_all_absent() {
-        assert!(compose_stream_sinks(None, None, None).is_none());
+        assert!(compose_stream_sinks(None, None, None, None).is_none());
     }
 
     #[test]
     fn compose_stream_sinks_unwraps_single_sink_without_multi_wrap() {
         let sse: Arc<dyn StreamSink> = Arc::new(NullSink);
-        let composed = compose_stream_sinks(Some(sse.clone()), None, None).unwrap();
+        let composed = compose_stream_sinks(Some(sse.clone()), None, None, None).unwrap();
         // Single-sink path returns the same Arc, not a MultiSink wrapper.
         assert!(Arc::ptr_eq(&composed, &sse));
     }
@@ -1044,7 +1125,7 @@ mod tests {
     fn compose_stream_sinks_multi_wraps_when_multiple() {
         let a: Arc<dyn StreamSink> = Arc::new(NullSink);
         let b: Arc<dyn StreamSink> = Arc::new(NullSink);
-        let composed = compose_stream_sinks(Some(a), Some(b), None).unwrap();
+        let composed = compose_stream_sinks(Some(a), Some(b), None, None).unwrap();
         // Just emit through it to verify it works; if it were a NullSink
         // directly the call would still succeed, but MultiSink::emit
         // exercises the fan-out path.
@@ -1598,6 +1679,8 @@ index 8a1218a..24c5735 100644\n\
             resume_from: None,
             interactive_mode: InteractiveMode::Off,
             trace_id: None,
+            webhook_url: None,
+            webhook_headers: vec![],
         };
 
         run(args).await.unwrap();
@@ -1685,6 +1768,8 @@ index 8a1218a..24c5735 100644\n\
             resume_from: None,
             interactive_mode: InteractiveMode::Off,
             trace_id: None,
+            webhook_url: None,
+            webhook_headers: vec![],
         };
 
         run(args).await.unwrap();

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -212,19 +212,22 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
                 Some((name, value))
             })
             .collect();
-        match WebhookSink::new(url.clone(), headers) {
-            Ok(sink) => {
-                let sink_arc = Arc::new(sink);
-                let counter = sink_arc.dropped_counter();
-                let handle = WebhookSinkHandle::new(sink_arc, run_id);
-                tracing::info!(%url, "webhook push enabled");
-                (Some(Arc::new(handle) as Arc<dyn StreamSink>), Some(counter))
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "failed to create webhook sink; continuing without it");
-                (None, None)
-            }
-        }
+        let sink = WebhookSink::new(url.clone(), &headers)
+            .map_err(|e| Error::Config(ConfigError::Invalid(format!("webhook sink: {e}"))))?;
+        let sink_arc = Arc::new(sink);
+        let counter = sink_arc.dropped_counter();
+        let handle = WebhookSinkHandle::new(sink_arc, run_id);
+        // Log only the URL origin — the path/query may contain credentials.
+        let safe_url = url
+            .find("://")
+            .map(|i| {
+                let after = &url[i + 3..];
+                let host_end = after.find('/').unwrap_or(after.len());
+                format!("{}://{}", &url[..i], &after[..host_end])
+            })
+            .unwrap_or_else(|| "<url>".to_owned());
+        tracing::info!(url = %safe_url, "webhook push enabled");
+        (Some(Arc::new(handle) as Arc<dyn StreamSink>), Some(counter))
     } else {
         (None, None)
     };
@@ -234,10 +237,11 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         Option<Arc<std::sync::atomic::AtomicU64>>,
     ) = {
         if args.webhook_url.is_some() {
-            tracing::error!(
+            return Err(Error::Config(ConfigError::Invalid(
                 "--webhook-url requires the `webhook` Cargo feature; \
                  rebuild with --features webhook"
-            );
+                    .into(),
+            )));
         }
         (None, None)
     };

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -204,10 +204,13 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         let headers: Vec<(String, String)> = args
             .webhook_headers
             .iter()
-            .map(|h| {
+            .enumerate()
+            .map(|(i, h)| {
                 let (name, value) = h.split_once(':').ok_or_else(|| {
                     Error::Config(ConfigError::Invalid(format!(
-                        "webhook header `{h}` is missing `:` separator (use `Name: Value`)"
+                        "--webhook-header at position {} is missing `:` separator \
+                         (use `Name: Value`)",
+                        i + 1
                     )))
                 })?;
                 Ok((name.trim().to_owned(), value.trim().to_owned()))
@@ -235,6 +238,13 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         tracing::info!(url = %safe_url, "webhook push enabled");
         (Some(Arc::new(handle) as Arc<dyn StreamSink>), Some(counter))
     } else {
+        if !args.webhook_headers.is_empty() {
+            return Err(Error::Config(ConfigError::Invalid(
+                "--webhook-header requires --webhook-url; \
+                 headers have no effect without a webhook URL"
+                    .into(),
+            )));
+        }
         (None, None)
     };
     #[cfg(not(feature = "webhook"))]
@@ -246,6 +256,13 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
             return Err(Error::Config(ConfigError::Invalid(
                 "--webhook-url requires the `webhook` Cargo feature; \
                  rebuild with --features webhook"
+                    .into(),
+            )));
+        }
+        if !args.webhook_headers.is_empty() {
+            return Err(Error::Config(ConfigError::Invalid(
+                "--webhook-header requires --webhook-url; \
+                 headers have no effect without a webhook URL"
                     .into(),
             )));
         }

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -201,7 +201,6 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         Option<Arc<dyn StreamSink>>,
         Option<Arc<std::sync::atomic::AtomicU64>>,
     ) = if let Some(ref url) = args.webhook_url {
-        let run_id = args.trajectory_name.clone();
         let headers: Vec<(String, String)> = args
             .webhook_headers
             .iter()
@@ -216,14 +215,29 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
             .map_err(|e| Error::Config(ConfigError::Invalid(format!("webhook sink: {e}"))))?;
         let sink_arc = Arc::new(sink);
         let counter = sink_arc.dropped_counter();
+        // Redact the trajectory name so configured secret literals can't leak
+        // through the envelope's run_id field, which bypasses RedactingSink.
+        let run_id = {
+            let redactor =
+                crate::redaction::Redactor::from_config_lossy(&args.config.root.redaction);
+            redactor
+                .redact_text(&args.trajectory_name, surface::TRAJECTORY)
+                .text
+        };
         let handle = WebhookSinkHandle::new(sink_arc, run_id);
-        // Log only the URL origin — the path/query may contain credentials.
+        // Log only scheme + host — path/query/userinfo may contain credentials.
         let safe_url = url
             .find("://")
             .map(|i| {
                 let after = &url[i + 3..];
-                let host_end = after.find('/').unwrap_or(after.len());
-                format!("{}://{}", &url[..i], &after[..host_end])
+                // Strip userinfo (user:pass@).
+                let host_start = after.rfind('@').map_or(0, |j| j + 1);
+                // Stop at first /, ?, or # (path / query / fragment).
+                let host_end = after[host_start..]
+                    .find(['/', '?', '#'])
+                    .map_or(after.len() - host_start, |j| j)
+                    + host_start;
+                format!("{}://{}", &url[..i], &after[host_start..host_end])
             })
             .unwrap_or_else(|| "<url>".to_owned());
         tracing::info!(url = %safe_url, "webhook push enabled");

--- a/src/run/render_only.rs
+++ b/src/run/render_only.rs
@@ -212,6 +212,7 @@ pub fn render(args: RenderOnlyArgs) -> Result<RenderOnlyReport, Error> {
 ///
 /// Each entry is `(flag_name, is_set)`. The function returns the first
 /// conflict found, which is enough for a clear error message.
+#[allow(clippy::struct_excessive_bools)]
 pub struct IncompatibleFlags<'a> {
     pub per_task_budget_usd: Option<f64>,
     pub task_timeout_secs: Option<u64>,
@@ -223,6 +224,10 @@ pub struct IncompatibleFlags<'a> {
     pub open_pr: bool,
     /// `--github-pr-dry-run` is a PR-publishing mode that requires a completed trajectory.
     pub pr_dry_run: bool,
+    /// `--webhook-url` pushes streaming events during a run; meaningless without one.
+    pub webhook_url: bool,
+    /// `--webhook-header` configures headers for webhook push; meaningless without a run.
+    pub webhook_headers: bool,
 }
 
 /// Validate that `--render-only` is not combined with execution-time flags
@@ -235,6 +240,8 @@ pub fn reject_incompatible_flags(flags: &IncompatibleFlags<'_>) -> Result<(), Er
         ("--verify", flags.has_verify_checks),
         ("--open-pr / --open-prs", flags.open_pr),
         ("--github-pr-dry-run", flags.pr_dry_run),
+        ("--webhook-url", flags.webhook_url),
+        ("--webhook-header", flags.webhook_headers),
     ];
     for (name, set) in conflicts {
         if *set {
@@ -408,6 +415,8 @@ mod tests {
             has_verify_checks: false,
             open_pr: false,
             pr_dry_run: false,
+            webhook_url: false,
+            webhook_headers: false,
         }
     }
 
@@ -460,6 +469,24 @@ mod tests {
     fn reject_incompatible_flags_pr_dry_run_err() {
         let flags = IncompatibleFlags {
             pr_dry_run: true,
+            ..clean_flags()
+        };
+        assert!(reject_incompatible_flags(&flags).is_err());
+    }
+
+    #[test]
+    fn reject_incompatible_flags_webhook_url_err() {
+        let flags = IncompatibleFlags {
+            webhook_url: true,
+            ..clean_flags()
+        };
+        assert!(reject_incompatible_flags(&flags).is_err());
+    }
+
+    #[test]
+    fn reject_incompatible_flags_webhook_headers_err() {
+        let flags = IncompatibleFlags {
+            webhook_headers: true,
             ..clean_flags()
         };
         assert!(reject_incompatible_flags(&flags).is_err());

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -4301,6 +4301,8 @@ async fn run_one(inst: SweBenchInstance, run_index: u32, params: RunOneParams) -
             resume_from: attempt_resume,
             interactive_mode: crate::run::mini::InteractiveMode::Off,
             trace_id: params.trace_id.clone(),
+            webhook_url: None,
+            webhook_headers: vec![],
         };
         let run_err = crate::run::mini::run(args).await.err();
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -21,7 +21,7 @@ pub mod webhook;
 pub use broadcast::BroadcastSink;
 pub use sse::SseServer;
 #[cfg(feature = "webhook")]
-pub use webhook::{WebhookSink, WebhookSinkError};
+pub use webhook::{SchemaVersion, WebhookEnvelope, WebhookSink, WebhookSinkError, WebhookSinkHandle};
 
 /// One step-level event in the agent trajectory.
 ///

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -21,7 +21,9 @@ pub mod webhook;
 pub use broadcast::BroadcastSink;
 pub use sse::SseServer;
 #[cfg(feature = "webhook")]
-pub use webhook::{SchemaVersion, WebhookEnvelope, WebhookSink, WebhookSinkError, WebhookSinkHandle};
+pub use webhook::{
+    SchemaVersion, WebhookEnvelope, WebhookSink, WebhookSinkError, WebhookSinkHandle,
+};
 
 /// One step-level event in the agent trajectory.
 ///

--- a/src/stream/webhook.rs
+++ b/src/stream/webhook.rs
@@ -1,46 +1,98 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
+
+use chrono::Utc;
+use serde::Serialize;
 use tokio::runtime::{Handle, TryCurrentError};
 use tokio::sync::mpsc;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use super::{StreamEvent, StreamSink};
 
 const DEFAULT_WEBHOOK_BUFFER_CAPACITY: usize = 1024;
+const WEBHOOK_HTTP_TIMEOUT_SECS: u64 = 5;
+
+/// Stable schema version sent in every webhook envelope.
+#[derive(Debug, Clone, Serialize)]
+pub struct SchemaVersion {
+    pub major: u32,
+    pub minor: u32,
+}
+
+impl Default for SchemaVersion {
+    fn default() -> Self {
+        Self { major: 1, minor: 0 }
+    }
+}
+
+/// The envelope wrapper POSTed to the webhook URL for every event.
+///
+/// Schema: `{ "schema_version": {"major":1,"minor":0}, "run_id": "...",
+///            "event": { "type": "...", ...fields }, "emitted_at": "..." }`
+/// For `RunEnded` events an additional `webhook_events_dropped` field is
+/// appended at the envelope level so operators can detect missed events.
+#[derive(Debug, Serialize)]
+pub struct WebhookEnvelope {
+    pub schema_version: SchemaVersion,
+    pub run_id: String,
+    pub event: StreamEvent,
+    pub emitted_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub webhook_events_dropped: Option<u64>,
+}
+
+/// The message sent through the bounded channel to the background sender task.
+struct EnvelopeMsg {
+    envelope: WebhookEnvelope,
+}
 
 /// A `StreamSink` that forwards events to an HTTP webhook endpoint via POST.
 ///
-/// It does not block the agent loop. Instead, `emit` tries to enqueue the event
-/// into a bounded channel, and a background task dequeues and POSTs each event
-/// to the specified URL using `reqwest`. Events are dropped when the bounded
-/// buffer is full.
+/// Non-blocking: `emit` enqueues into a bounded channel; a background task
+/// dequeues and POSTs each event wrapped in the schema envelope.  Events are
+/// silently dropped when the buffer is full.  HTTP failures (timeout, 4xx,
+/// 5xx, network errors) are logged at `warn` and counted toward the
+/// `dropped` counter, which appears in the `RunEnded` envelope.
+///
+/// The agent loop is **never** blocked on webhook delivery.
 #[derive(Debug)]
 pub struct WebhookSink {
-    tx: mpsc::Sender<StreamEvent>,
+    tx: mpsc::Sender<EnvelopeMsg>,
+    /// Shared drop counter — incremented both in `emit` (buffer-full) and
+    /// in the background task (HTTP failures).
+    dropped: Arc<AtomicU64>,
 }
 
 /// Failure to create a [`WebhookSink`].
 #[derive(Debug, thiserror::Error)]
 pub enum WebhookSinkError {
-    /// No Tokio runtime is active on the current thread.
     #[error("webhook sink requires an active Tokio runtime")]
     NoRuntime(#[source] TryCurrentError),
-    /// Webhook buffering must be bounded to at least one event.
     #[error("webhook buffer capacity must be greater than zero")]
     InvalidBufferCapacity,
-    /// The HTTP client could not be built.
     #[error("failed to build webhook HTTP client")]
     Client(#[source] reqwest::Error),
 }
 
 impl WebhookSink {
-    /// Creates a new `WebhookSink` with the default bounded buffer capacity.
-    pub fn new(url: String) -> Result<Self, WebhookSinkError> {
-        Self::with_buffer_capacity(url, DEFAULT_WEBHOOK_BUFFER_CAPACITY)
+    /// Creates a `WebhookSink` with the default buffer capacity.
+    ///
+    /// `run_id` is embedded in every envelope so log-aggregators can
+    /// correlate events from the same run.
+    /// `headers` are injected on every POST (e.g. `Authorization: Bearer …`).
+    /// Headers are not logged.
+    pub fn new(
+        url: String,
+        headers: Vec<(String, String)>,
+    ) -> Result<Self, WebhookSinkError> {
+        Self::with_buffer_capacity(url, headers, DEFAULT_WEBHOOK_BUFFER_CAPACITY)
     }
 
-    /// Creates a new `WebhookSink` with a caller-provided bounded buffer capacity.
+    /// Creates a `WebhookSink` with a caller-specified buffer capacity.
     pub fn with_buffer_capacity(
         url: String,
+        headers: Vec<(String, String)>,
         buffer_capacity: usize,
     ) -> Result<Self, WebhookSinkError> {
         if buffer_capacity == 0 {
@@ -48,36 +100,119 @@ impl WebhookSink {
         }
 
         let handle = Handle::try_current().map_err(WebhookSinkError::NoRuntime)?;
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .build()
-            .map_err(WebhookSinkError::Client)?;
-        let (tx, mut rx) = mpsc::channel::<StreamEvent>(buffer_capacity);
+
+        let mut builder = reqwest::Client::builder()
+            .timeout(Duration::from_secs(WEBHOOK_HTTP_TIMEOUT_SECS));
+        // Pre-build the default header map so we don't parse on every request.
+        let mut default_headers = reqwest::header::HeaderMap::new();
+        for (name, value) in &headers {
+            if let (Ok(n), Ok(v)) = (
+                reqwest::header::HeaderName::from_bytes(name.as_bytes()),
+                reqwest::header::HeaderValue::from_str(value),
+            ) {
+                default_headers.insert(n, v);
+            }
+        }
+        builder = builder.default_headers(default_headers);
+        let client = builder.build().map_err(WebhookSinkError::Client)?;
+
+        let dropped = Arc::new(AtomicU64::new(0));
+        let dropped_bg = dropped.clone();
+
+        let (tx, mut rx) = mpsc::channel::<EnvelopeMsg>(buffer_capacity);
 
         handle.spawn(async move {
-            while let Some(event) = rx.recv().await {
-                match client.post(&url).json(&event).send().await {
-                    Ok(resp) => {
-                        if !resp.status().is_success() {
-                            debug!("Webhook returned non-success status: {}", resp.status());
-                        }
+            while let Some(EnvelopeMsg { envelope }) = rx.recv().await {
+                let event_type = envelope.event.event_name();
+                match client.post(&url).json(&envelope).send().await {
+                    Ok(resp) if !resp.status().is_success() => {
+                        warn!(
+                            event_type,
+                            status = resp.status().as_u16(),
+                            "webhook POST returned non-success; counting as dropped"
+                        );
+                        dropped_bg.fetch_add(1, Ordering::Relaxed);
                     }
                     Err(e) => {
-                        debug!("Failed to send webhook event: {}", e);
+                        let error_class = if e.is_timeout() {
+                            "timeout"
+                        } else if e.is_connect() {
+                            "connection_refused"
+                        } else {
+                            "network_error"
+                        };
+                        warn!(
+                            event_type,
+                            error_class,
+                            error = %e,
+                            "webhook POST failed; counting as dropped"
+                        );
+                        dropped_bg.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Ok(_) => {
+                        debug!(event_type, "webhook POST succeeded");
                     }
                 }
             }
         });
 
-        Ok(Self { tx })
+        Ok(Self { tx, dropped })
+    }
+
+    /// Returns the current count of events that were dropped (buffer-full or
+    /// HTTP failure).  Used by `mini::run` to emit the `RunEnded` envelope
+    /// field and the stderr warning.
+    pub fn dropped_count(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Returns a clone of the shared drop counter so the caller can read it
+    /// after this sink has been passed into a `dyn StreamSink` trait object.
+    pub fn dropped_counter(&self) -> Arc<AtomicU64> {
+        self.dropped.clone()
+    }
+
+    /// Internal: build the envelope for a given event, reading the current
+    /// drop count for `RunEnded`.
+    fn make_envelope(&self, event: StreamEvent, run_id: &str) -> WebhookEnvelope {
+        let is_run_ended = matches!(event, StreamEvent::RunEnded { .. });
+        let webhook_events_dropped = if is_run_ended {
+            Some(self.dropped.load(Ordering::Relaxed))
+        } else {
+            None
+        };
+        WebhookEnvelope {
+            schema_version: SchemaVersion::default(),
+            run_id: run_id.to_owned(),
+            event,
+            emitted_at: Utc::now().to_rfc3339(),
+            webhook_events_dropped,
+        }
     }
 }
 
-impl StreamSink for WebhookSink {
+/// Internal wrapper so `WebhookSinkWithRunId` is what actually implements
+/// `StreamSink` — the `run_id` must travel with the sink.
+///
+/// Constructed by [`WebhookSinkHandle::into_sink`].
+pub struct WebhookSinkHandle {
+    inner: Arc<WebhookSink>,
+    run_id: String,
+}
+
+impl WebhookSinkHandle {
+    pub fn new(inner: Arc<WebhookSink>, run_id: String) -> Self {
+        Self { inner, run_id }
+    }
+}
+
+impl StreamSink for WebhookSinkHandle {
     fn emit(&self, event: StreamEvent) {
-        match self.tx.try_send(event) {
+        let envelope = self.inner.make_envelope(event, &self.run_id);
+        match self.inner.tx.try_send(EnvelopeMsg { envelope }) {
             Err(mpsc::error::TrySendError::Full(_)) => {
-                debug!("Dropping webhook event because the buffer is full");
+                debug!("dropping webhook event: buffer full");
+                self.inner.dropped.fetch_add(1, Ordering::Relaxed);
             }
             Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
         }
@@ -92,64 +227,66 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
-    const WEBHOOK_TEST_IO_TIMEOUT: Duration = Duration::from_secs(1);
+    const TEST_IO_TIMEOUT: Duration = Duration::from_secs(1);
+
+    fn run_id() -> String {
+        "test-run-id".to_owned()
+    }
 
     #[tokio::test]
-    async fn test_webhook_sink_emits_http_post() {
-        // Spin up a local TCP listener to act as our mock HTTP server.
+    async fn test_webhook_sink_emits_http_post_with_envelope() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let url = format!("http://{addr}");
 
-        // Create the sink and emit an event.
-        let sink = WebhookSink::new(url).unwrap();
+        let sink_inner = Arc::new(WebhookSink::new(url, vec![]).unwrap());
+        let sink = WebhookSinkHandle::new(sink_inner, run_id());
 
         let event = StreamEvent::RunStarted {
             task: "test task".into(),
             model: "test model".into(),
             started_at: "now".into(),
         };
+        sink.emit(event);
 
-        sink.emit(event.clone());
+        let mut socket = accept_connection(&listener).await;
+        let mut buf = vec![0; 4096];
+        let n = read_bytes(&mut socket, &mut buf).await;
+        let req = String::from_utf8_lossy(&buf[..n]);
 
-        // Wait for the incoming connection from reqwest and read the payload.
-        let mut socket = accept_webhook_connection(&listener).await;
+        assert!(req.starts_with("POST / HTTP/1.1"));
 
-        let mut buf = vec![0; 1024];
-        let n = read_webhook_bytes(&mut socket, &mut buf).await;
-        let request_str = String::from_utf8_lossy(&buf[..n]);
+        let body_start = req.find("\r\n\r\n").unwrap() + 4;
+        let body = &req[body_start..];
+        let v: serde_json::Value = serde_json::from_str(body).unwrap();
 
-        // Verify it's a POST request
-        assert!(request_str.starts_with("POST / HTTP/1.1"));
-
-        // Find the JSON body
-        let body_start = request_str.find("\r\n\r\n").unwrap() + 4;
-        let body = &request_str[body_start..];
-
-        // Parse it back and assert it matches (rudimentary check).
-        // Since StreamEvent serialization is tested elsewhere, we just check for basic substrings.
-        assert!(body.contains("\"type\":\"run_started\""));
-        assert!(body.contains("\"task\":\"test task\""));
-        assert!(body.contains("\"model\":\"test model\""));
+        // Must have schema envelope.
+        assert_eq!(v["schema_version"]["major"], 1);
+        assert!(v.get("run_id").is_some());
+        assert!(v.get("emitted_at").is_some());
+        assert_eq!(v["event"]["type"], "run_started");
+        assert_eq!(v["event"]["task"], "test task");
     }
 
     #[test]
     fn new_reports_missing_tokio_runtime() {
-        let err = WebhookSink::new("http://127.0.0.1:1".to_owned()).unwrap_err();
-
+        let err = WebhookSink::new("http://127.0.0.1:1".to_owned(), vec![]).unwrap_err();
         assert!(matches!(err, WebhookSinkError::NoRuntime(_)));
     }
 
     #[test]
     fn with_buffer_capacity_rejects_zero_capacity() {
-        let err =
-            WebhookSink::with_buffer_capacity("http://127.0.0.1:1".to_owned(), 0).unwrap_err();
-
+        let err = WebhookSink::with_buffer_capacity(
+            "http://127.0.0.1:1".to_owned(),
+            vec![],
+            0,
+        )
+        .unwrap_err();
         assert!(matches!(err, WebhookSinkError::InvalidBufferCapacity));
     }
 
     #[test]
-    fn emit_drops_events_when_webhook_buffer_is_full() {
+    fn emit_drops_events_when_buffer_is_full() {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -161,27 +298,80 @@ mod tests {
 
         {
             let _guard = rt.enter();
-            let sink = WebhookSink::with_buffer_capacity(url, 1).unwrap();
+            let sink_inner = Arc::new(
+                WebhookSink::with_buffer_capacity(url, vec![], 1).unwrap(),
+            );
+            let sink = WebhookSinkHandle::new(sink_inner.clone(), run_id());
 
             sink.emit(run_started("first"));
             sink.emit(run_started("second"));
 
-            assert_eq!(sink.tx.capacity(), 0);
-            assert_eq!(sink.tx.max_capacity(), 1);
+            // Buffer size is 1, so second should be dropped.
+            assert_eq!(sink_inner.dropped_count(), 1);
             drop(sink);
         }
 
         rt.block_on(async move {
             let listener = TcpListener::from_std(std_listener).unwrap();
-            let socket = accept_webhook_connection(&listener).await;
-
-            let request = read_http_request(socket).await;
+            let socket = accept_connection(&listener).await;
+            let request = read_full_http_request(socket).await;
             assert!(request.contains("\"task\":\"first\""));
             assert!(!request.contains("\"task\":\"second\""));
 
-            let second = tokio::time::timeout(Duration::from_millis(150), listener.accept()).await;
-            assert!(second.is_err());
+            let second =
+                tokio::time::timeout(Duration::from_millis(150), listener.accept()).await;
+            assert!(second.is_err(), "second event must not be delivered");
         });
+    }
+
+    #[tokio::test]
+    async fn run_ended_envelope_includes_drop_count() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{addr}");
+
+        let sink_inner = Arc::new(WebhookSink::new(url, vec![]).unwrap());
+        let sink = WebhookSinkHandle::new(sink_inner, run_id());
+
+        sink.emit(StreamEvent::RunEnded {
+            exit_reason: "submitted".into(),
+            failure_category: None,
+            final_output: None,
+            steps: 1,
+            total_cost_usd: 0.0,
+            ended_at: "now".into(),
+        });
+
+        let socket = accept_connection(&listener).await;
+        let request = read_full_http_request(socket).await;
+        let body_start = request.find("\r\n\r\n").unwrap() + 4;
+        let v: serde_json::Value = serde_json::from_str(&request[body_start..]).unwrap();
+
+        assert!(
+            v.get("webhook_events_dropped").is_some(),
+            "run_ended envelope must have webhook_events_dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn custom_headers_appear_in_request() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{addr}");
+
+        let headers = vec![("X-Test-Header".to_owned(), "hello-world".to_owned())];
+        let sink_inner = Arc::new(WebhookSink::new(url, headers).unwrap());
+        let sink = WebhookSinkHandle::new(sink_inner, run_id());
+
+        sink.emit(run_started("hdr-test"));
+
+        let socket = accept_connection(&listener).await;
+        let request = read_full_http_request(socket).await;
+        let lower = request.to_ascii_lowercase();
+        assert!(
+            lower.contains("x-test-header: hello-world"),
+            "custom header not found in: {request}"
+        );
     }
 
     fn run_started(task: &str) -> StreamEvent {
@@ -192,62 +382,57 @@ mod tests {
         }
     }
 
-    async fn accept_webhook_connection(listener: &TcpListener) -> tokio::net::TcpStream {
-        match tokio::time::timeout(WEBHOOK_TEST_IO_TIMEOUT, listener.accept()).await {
+    async fn accept_connection(listener: &TcpListener) -> tokio::net::TcpStream {
+        match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((socket, _))) => socket,
-            Ok(Err(e)) => panic!("failed to accept webhook POST connection: {e}"),
-            Err(e) => panic!("timed out waiting for webhook POST connection: {e}"),
+            Ok(Err(e)) => panic!("failed to accept: {e}"),
+            Err(e) => panic!("timed out: {e}"),
         }
     }
 
-    async fn read_webhook_bytes<R>(reader: &mut R, buf: &mut [u8]) -> usize
+    async fn read_bytes<R>(reader: &mut R, buf: &mut [u8]) -> usize
     where
         R: tokio::io::AsyncRead + Unpin,
     {
-        match tokio::time::timeout(WEBHOOK_TEST_IO_TIMEOUT, reader.read(buf)).await {
+        match tokio::time::timeout(TEST_IO_TIMEOUT, reader.read(buf)).await {
             Ok(Ok(n)) => n,
-            Ok(Err(e)) => panic!("failed to read webhook POST request: {e}"),
-            Err(e) => panic!("timed out reading webhook POST request: {e}"),
+            Ok(Err(e)) => panic!("read error: {e}"),
+            Err(e) => panic!("read timeout: {e}"),
         }
     }
 
-    async fn read_http_request(mut socket: tokio::net::TcpStream) -> String {
+    async fn read_full_http_request(mut socket: tokio::net::TcpStream) -> String {
         let mut buf = Vec::new();
-        let mut chunk = [0_u8; 1024];
-
+        let mut chunk = [0u8; 4096];
         loop {
-            let n = read_webhook_bytes(&mut socket, &mut chunk).await;
+            let n = read_bytes(&mut socket, &mut chunk).await;
             if n == 0 {
                 break;
             }
             buf.extend_from_slice(&chunk[..n]);
-            if request_is_complete(&buf) {
+            if is_complete(&buf) {
                 break;
             }
         }
-
-        socket
-            .write_all(b"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n")
-            .await
-            .unwrap();
-
+        let _ = socket
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+            .await;
         String::from_utf8_lossy(&buf).into_owned()
     }
 
-    fn request_is_complete(buf: &[u8]) -> bool {
-        let request = String::from_utf8_lossy(buf);
-        let Some(header_end) = request.find("\r\n\r\n") else {
+    fn is_complete(buf: &[u8]) -> bool {
+        let req = String::from_utf8_lossy(buf);
+        let Some(end) = req.find("\r\n\r\n") else {
             return false;
         };
-        let content_length = request[..header_end]
+        let cl = req[..end]
             .lines()
-            .find_map(|line| {
-                let line = line.to_ascii_lowercase();
-                line.strip_prefix("content-length:")
-                    .and_then(|value| value.trim().parse::<usize>().ok())
+            .find_map(|l| {
+                l.to_ascii_lowercase()
+                    .strip_prefix("content-length:")
+                    .and_then(|v| v.trim().parse::<usize>().ok())
             })
             .unwrap_or(0);
-
-        buf.len() >= header_end + 4 + content_length
+        buf.len() >= end + 4 + cl
     }
 }

--- a/src/stream/webhook.rs
+++ b/src/stream/webhook.rs
@@ -106,7 +106,14 @@ impl WebhookSink {
 
         // Validate the URL eagerly so a typo surfaces before the run starts
         // rather than silently dropping every event from the background task.
-        reqwest::Url::parse(&url).map_err(|e| WebhookSinkError::InvalidUrl(e.to_string()))?;
+        let parsed_url =
+            reqwest::Url::parse(&url).map_err(|e| WebhookSinkError::InvalidUrl(e.to_string()))?;
+        if !matches!(parsed_url.scheme(), "http" | "https") {
+            return Err(WebhookSinkError::InvalidUrl(format!(
+                "unsupported scheme `{}`; webhook URL must use http or https",
+                parsed_url.scheme()
+            )));
+        }
 
         let handle = Handle::try_current().map_err(WebhookSinkError::NoRuntime)?;
 

--- a/src/stream/webhook.rs
+++ b/src/stream/webhook.rs
@@ -1,5 +1,5 @@
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use chrono::Utc;
@@ -82,10 +82,7 @@ impl WebhookSink {
     /// correlate events from the same run.
     /// `headers` are injected on every POST (e.g. `Authorization: Bearer …`).
     /// Headers are not logged.
-    pub fn new(
-        url: String,
-        headers: Vec<(String, String)>,
-    ) -> Result<Self, WebhookSinkError> {
+    pub fn new(url: String, headers: Vec<(String, String)>) -> Result<Self, WebhookSinkError> {
         Self::with_buffer_capacity(url, headers, DEFAULT_WEBHOOK_BUFFER_CAPACITY)
     }
 
@@ -101,8 +98,8 @@ impl WebhookSink {
 
         let handle = Handle::try_current().map_err(WebhookSinkError::NoRuntime)?;
 
-        let mut builder = reqwest::Client::builder()
-            .timeout(Duration::from_secs(WEBHOOK_HTTP_TIMEOUT_SECS));
+        let mut builder =
+            reqwest::Client::builder().timeout(Duration::from_secs(WEBHOOK_HTTP_TIMEOUT_SECS));
         // Pre-build the default header map so we don't parse on every request.
         let mut default_headers = reqwest::header::HeaderMap::new();
         for (name, value) in &headers {
@@ -276,12 +273,8 @@ mod tests {
 
     #[test]
     fn with_buffer_capacity_rejects_zero_capacity() {
-        let err = WebhookSink::with_buffer_capacity(
-            "http://127.0.0.1:1".to_owned(),
-            vec![],
-            0,
-        )
-        .unwrap_err();
+        let err = WebhookSink::with_buffer_capacity("http://127.0.0.1:1".to_owned(), vec![], 0)
+            .unwrap_err();
         assert!(matches!(err, WebhookSinkError::InvalidBufferCapacity));
     }
 
@@ -298,9 +291,7 @@ mod tests {
 
         {
             let _guard = rt.enter();
-            let sink_inner = Arc::new(
-                WebhookSink::with_buffer_capacity(url, vec![], 1).unwrap(),
-            );
+            let sink_inner = Arc::new(WebhookSink::with_buffer_capacity(url, vec![], 1).unwrap());
             let sink = WebhookSinkHandle::new(sink_inner.clone(), run_id());
 
             sink.emit(run_started("first"));
@@ -318,8 +309,7 @@ mod tests {
             assert!(request.contains("\"task\":\"first\""));
             assert!(!request.contains("\"task\":\"second\""));
 
-            let second =
-                tokio::time::timeout(Duration::from_millis(150), listener.accept()).await;
+            let second = tokio::time::timeout(Duration::from_millis(150), listener.accept()).await;
             assert!(second.is_err(), "second event must not be delivered");
         });
     }

--- a/src/stream/webhook.rs
+++ b/src/stream/webhook.rs
@@ -75,6 +75,8 @@ pub enum WebhookSinkError {
     NoRuntime(#[source] TryCurrentError),
     #[error("webhook buffer capacity must be greater than zero")]
     InvalidBufferCapacity,
+    #[error("invalid webhook URL: {0}")]
+    InvalidUrl(String),
     #[error("failed to build webhook HTTP client")]
     Client(#[source] reqwest::Error),
     #[error("invalid webhook header `{name}`: {reason}")]
@@ -101,6 +103,10 @@ impl WebhookSink {
         if buffer_capacity == 0 {
             return Err(WebhookSinkError::InvalidBufferCapacity);
         }
+
+        // Validate the URL eagerly so a typo surfaces before the run starts
+        // rather than silently dropping every event from the background task.
+        reqwest::Url::parse(&url).map_err(|e| WebhookSinkError::InvalidUrl(e.to_string()))?;
 
         let handle = Handle::try_current().map_err(WebhookSinkError::NoRuntime)?;
 

--- a/src/stream/webhook.rs
+++ b/src/stream/webhook.rs
@@ -42,9 +42,13 @@ pub struct WebhookEnvelope {
     pub webhook_events_dropped: Option<u64>,
 }
 
-/// The message sent through the bounded channel to the background sender task.
+/// Raw event carried through the bounded channel to the background sender.
+/// The envelope is built inside the background task so that `RunEnded`'s
+/// `webhook_events_dropped` is read *after* all prior HTTP responses have
+/// been processed — giving an accurate final count.
 struct EnvelopeMsg {
-    envelope: WebhookEnvelope,
+    event: StreamEvent,
+    run_id: String,
 }
 
 /// A `StreamSink` that forwards events to an HTTP webhook endpoint via POST.
@@ -73,23 +77,25 @@ pub enum WebhookSinkError {
     InvalidBufferCapacity,
     #[error("failed to build webhook HTTP client")]
     Client(#[source] reqwest::Error),
+    #[error("invalid webhook header `{name}`: {reason}")]
+    InvalidHeader { name: String, reason: String },
 }
 
 impl WebhookSink {
     /// Creates a `WebhookSink` with the default buffer capacity.
     ///
-    /// `run_id` is embedded in every envelope so log-aggregators can
-    /// correlate events from the same run.
     /// `headers` are injected on every POST (e.g. `Authorization: Bearer …`).
-    /// Headers are not logged.
-    pub fn new(url: String, headers: Vec<(String, String)>) -> Result<Self, WebhookSinkError> {
+    /// Headers are not logged.  Returns `Err(InvalidHeader)` if any header
+    /// name or value is not a valid HTTP header — surface this before the
+    /// agent starts rather than silently omitting auth headers.
+    pub fn new(url: String, headers: &[(String, String)]) -> Result<Self, WebhookSinkError> {
         Self::with_buffer_capacity(url, headers, DEFAULT_WEBHOOK_BUFFER_CAPACITY)
     }
 
     /// Creates a `WebhookSink` with a caller-specified buffer capacity.
     pub fn with_buffer_capacity(
         url: String,
-        headers: Vec<(String, String)>,
+        headers: &[(String, String)],
         buffer_capacity: usize,
     ) -> Result<Self, WebhookSinkError> {
         if buffer_capacity == 0 {
@@ -101,14 +107,24 @@ impl WebhookSink {
         let mut builder =
             reqwest::Client::builder().timeout(Duration::from_secs(WEBHOOK_HTTP_TIMEOUT_SECS));
         // Pre-build the default header map so we don't parse on every request.
+        // Reject invalid headers eagerly so misconfigured auth headers surface
+        // at startup rather than causing every POST to be rejected.
         let mut default_headers = reqwest::header::HeaderMap::new();
-        for (name, value) in &headers {
-            if let (Ok(n), Ok(v)) = (
-                reqwest::header::HeaderName::from_bytes(name.as_bytes()),
-                reqwest::header::HeaderValue::from_str(value),
-            ) {
-                default_headers.insert(n, v);
-            }
+        for (name, value) in headers {
+            let header_name =
+                reqwest::header::HeaderName::from_bytes(name.as_bytes()).map_err(|e| {
+                    WebhookSinkError::InvalidHeader {
+                        name: name.clone(),
+                        reason: e.to_string(),
+                    }
+                })?;
+            let header_value = reqwest::header::HeaderValue::from_str(value).map_err(|e| {
+                WebhookSinkError::InvalidHeader {
+                    name: name.clone(),
+                    reason: e.to_string(),
+                }
+            })?;
+            default_headers.insert(header_name, header_value);
         }
         builder = builder.default_headers(default_headers);
         let client = builder.build().map_err(WebhookSinkError::Client)?;
@@ -119,8 +135,20 @@ impl WebhookSink {
         let (tx, mut rx) = mpsc::channel::<EnvelopeMsg>(buffer_capacity);
 
         handle.spawn(async move {
-            while let Some(EnvelopeMsg { envelope }) = rx.recv().await {
-                let event_type = envelope.event.event_name();
+            while let Some(EnvelopeMsg { event, run_id }) = rx.recv().await {
+                let event_type = event.event_name();
+                // Build the envelope here — for RunEnded, the drop count is
+                // read after all prior sends complete, giving an accurate total.
+                let is_run_ended = matches!(event, StreamEvent::RunEnded { .. });
+                let webhook_events_dropped =
+                    is_run_ended.then(|| dropped_bg.load(Ordering::Relaxed));
+                let envelope = WebhookEnvelope {
+                    schema_version: SchemaVersion::default(),
+                    run_id,
+                    event,
+                    emitted_at: Utc::now().to_rfc3339(),
+                    webhook_events_dropped,
+                };
                 match client.post(&url).json(&envelope).send().await {
                     Ok(resp) if !resp.status().is_success() => {
                         warn!(
@@ -131,6 +159,8 @@ impl WebhookSink {
                         dropped_bg.fetch_add(1, Ordering::Relaxed);
                     }
                     Err(e) => {
+                        // Log only the classified error — reqwest::Error's Display
+                        // includes the request URL, which may contain credentials.
                         let error_class = if e.is_timeout() {
                             "timeout"
                         } else if e.is_connect() {
@@ -140,9 +170,7 @@ impl WebhookSink {
                         };
                         warn!(
                             event_type,
-                            error_class,
-                            error = %e,
-                            "webhook POST failed; counting as dropped"
+                            error_class, "webhook POST failed; counting as dropped"
                         );
                         dropped_bg.fetch_add(1, Ordering::Relaxed);
                     }
@@ -168,30 +196,10 @@ impl WebhookSink {
     pub fn dropped_counter(&self) -> Arc<AtomicU64> {
         self.dropped.clone()
     }
-
-    /// Internal: build the envelope for a given event, reading the current
-    /// drop count for `RunEnded`.
-    fn make_envelope(&self, event: StreamEvent, run_id: &str) -> WebhookEnvelope {
-        let is_run_ended = matches!(event, StreamEvent::RunEnded { .. });
-        let webhook_events_dropped = if is_run_ended {
-            Some(self.dropped.load(Ordering::Relaxed))
-        } else {
-            None
-        };
-        WebhookEnvelope {
-            schema_version: SchemaVersion::default(),
-            run_id: run_id.to_owned(),
-            event,
-            emitted_at: Utc::now().to_rfc3339(),
-            webhook_events_dropped,
-        }
-    }
 }
 
-/// Internal wrapper so `WebhookSinkWithRunId` is what actually implements
+/// Internal wrapper so `WebhookSinkHandle` is what actually implements
 /// `StreamSink` — the `run_id` must travel with the sink.
-///
-/// Constructed by [`WebhookSinkHandle::into_sink`].
 pub struct WebhookSinkHandle {
     inner: Arc<WebhookSink>,
     run_id: String,
@@ -205,8 +213,11 @@ impl WebhookSinkHandle {
 
 impl StreamSink for WebhookSinkHandle {
     fn emit(&self, event: StreamEvent) {
-        let envelope = self.inner.make_envelope(event, &self.run_id);
-        match self.inner.tx.try_send(EnvelopeMsg { envelope }) {
+        let msg = EnvelopeMsg {
+            event,
+            run_id: self.run_id.clone(),
+        };
+        match self.inner.tx.try_send(msg) {
             Err(mpsc::error::TrySendError::Full(_)) => {
                 debug!("dropping webhook event: buffer full");
                 self.inner.dropped.fetch_add(1, Ordering::Relaxed);
@@ -236,7 +247,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let url = format!("http://{addr}");
 
-        let sink_inner = Arc::new(WebhookSink::new(url, vec![]).unwrap());
+        let sink_inner = Arc::new(WebhookSink::new(url, &[]).unwrap());
         let sink = WebhookSinkHandle::new(sink_inner, run_id());
 
         let event = StreamEvent::RunStarted {
@@ -267,15 +278,25 @@ mod tests {
 
     #[test]
     fn new_reports_missing_tokio_runtime() {
-        let err = WebhookSink::new("http://127.0.0.1:1".to_owned(), vec![]).unwrap_err();
+        let err = WebhookSink::new("http://127.0.0.1:1".to_owned(), &[]).unwrap_err();
         assert!(matches!(err, WebhookSinkError::NoRuntime(_)));
     }
 
     #[test]
     fn with_buffer_capacity_rejects_zero_capacity() {
-        let err = WebhookSink::with_buffer_capacity("http://127.0.0.1:1".to_owned(), vec![], 0)
-            .unwrap_err();
+        let err =
+            WebhookSink::with_buffer_capacity("http://127.0.0.1:1".to_owned(), &[], 0).unwrap_err();
         assert!(matches!(err, WebhookSinkError::InvalidBufferCapacity));
+    }
+
+    #[tokio::test]
+    async fn invalid_header_name_is_rejected() {
+        let headers = vec![("invalid header name".to_owned(), "value".to_owned())];
+        let err = WebhookSink::new("http://127.0.0.1:1".to_owned(), &headers).unwrap_err();
+        assert!(
+            matches!(err, WebhookSinkError::InvalidHeader { ref name, .. } if name == "invalid header name"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -291,7 +312,7 @@ mod tests {
 
         {
             let _guard = rt.enter();
-            let sink_inner = Arc::new(WebhookSink::with_buffer_capacity(url, vec![], 1).unwrap());
+            let sink_inner = Arc::new(WebhookSink::with_buffer_capacity(url, &[], 1).unwrap());
             let sink = WebhookSinkHandle::new(sink_inner.clone(), run_id());
 
             sink.emit(run_started("first"));
@@ -320,7 +341,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let url = format!("http://{addr}");
 
-        let sink_inner = Arc::new(WebhookSink::new(url, vec![]).unwrap());
+        let sink_inner = Arc::new(WebhookSink::new(url, &[]).unwrap());
         let sink = WebhookSinkHandle::new(sink_inner, run_id());
 
         sink.emit(StreamEvent::RunEnded {
@@ -350,7 +371,7 @@ mod tests {
         let url = format!("http://{addr}");
 
         let headers = vec![("X-Test-Header".to_owned(), "hello-world".to_owned())];
-        let sink_inner = Arc::new(WebhookSink::new(url, headers).unwrap());
+        let sink_inner = Arc::new(WebhookSink::new(url, &headers).unwrap());
         let sink = WebhookSinkHandle::new(sink_inner, run_id());
 
         sink.emit(run_started("hdr-test"));

--- a/tests/checkpointing.rs
+++ b/tests/checkpointing.rs
@@ -544,6 +544,8 @@ async fn mini_run_writes_partial_checkpoint_after_each_step() {
         interactive_mode: maxwells_daemon::run::mini::InteractiveMode::Off,
         resume_from: None,
         trace_id: None,
+        webhook_url: None,
+        webhook_headers: vec![],
     };
 
     mini_run(args).await.unwrap();

--- a/tests/skills.rs
+++ b/tests/skills.rs
@@ -452,6 +452,8 @@ paths = ["{skill_path}"]
         interactive_mode: maxwells_daemon::run::mini::InteractiveMode::Off,
         resume_from: None,
         trace_id: None,
+        webhook_url: None,
+        webhook_headers: vec![],
     })
     .await
     .unwrap();
@@ -523,6 +525,8 @@ secret_literals = ["TOP_SECRET_VALUE", "TOP_SECRET_ROOT"]
         interactive_mode: maxwells_daemon::run::mini::InteractiveMode::Off,
         resume_from: None,
         trace_id: None,
+        webhook_url: None,
+        webhook_headers: vec![],
     })
     .await
     .unwrap();

--- a/tests/verification.rs
+++ b/tests/verification.rs
@@ -38,6 +38,8 @@ fn mini_args(work: &tempfile::TempDir, name: &str, checks: Vec<VerificationCheck
         interactive_mode: InteractiveMode::Off,
         resume_from: None,
         trace_id: None,
+        webhook_url: None,
+        webhook_headers: vec![],
     }
 }
 

--- a/tests/webhook.rs
+++ b/tests/webhook.rs
@@ -7,6 +7,7 @@
 //!  4. `webhook_events_dropped` counter in `RunEnded` envelope.
 //!  5. Redaction applied before POST (`sk-deadbeef` never leaves the process).
 
+#![cfg(feature = "webhook")]
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::collections::VecDeque;

--- a/tests/webhook.rs
+++ b/tests/webhook.rs
@@ -553,3 +553,52 @@ async fn no_webhook_url_adds_zero_overhead() {
     // Should complete without error and without any webhook traffic.
     maxwells_daemon::run::mini::run(args).await.unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// Test 8: unsupported URL scheme is rejected before the run starts
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn webhook_rejects_non_http_url_scheme() {
+    let out = tempfile::tempdir().unwrap();
+    let responses = vec!["COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into()];
+    let args = make_mini_args(
+        responses,
+        out.path(),
+        Some("file:///tmp/not-a-webhook".to_owned()),
+        vec![],
+        None,
+    );
+    let result = maxwells_daemon::run::mini::run(args).await;
+    assert!(result.is_err(), "expected Err for file:// URL, got Ok");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("unsupported scheme") || msg.contains("webhook"),
+        "error message should mention scheme or webhook: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: malformed --webhook-header flag (missing ':') is rejected
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn webhook_rejects_malformed_header_flag() {
+    let out = tempfile::tempdir().unwrap();
+    let responses = vec!["COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into()];
+    let server = MockWebhookServer::bind().await;
+    let args = make_mini_args(
+        responses,
+        out.path(),
+        Some(server.url()),
+        vec!["X-No-Colon-Here".to_owned()],
+        None,
+    );
+    let result = maxwells_daemon::run::mini::run(args).await;
+    assert!(result.is_err(), "expected Err for malformed header, got Ok");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("missing") || msg.contains("separator") || msg.contains("webhook header"),
+        "error should mention missing separator: {msg}"
+    );
+}

--- a/tests/webhook.rs
+++ b/tests/webhook.rs
@@ -1,0 +1,570 @@
+//! Integration tests for `--webhook-url` / `--webhook-header` (issue #324).
+//!
+//! Tests cover:
+//!  1. Full event sequence delivery with schema envelope.
+//!  2. Hung endpoint — buffer fills, agent still completes in step budget.
+//!  3. SSE + webhook composition — both transports see the same event sequence.
+//!  4. `webhook_events_dropped` counter in `RunEnded` envelope.
+//!  5. Redaction applied before POST (`sk-deadbeef` never leaves the process).
+
+#![allow(clippy::unwrap_used)]
+
+use std::collections::VecDeque;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::Value;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+use maxwells_daemon::run::mini::{InteractiveMode, MiniArgs};
+
+// ---------------------------------------------------------------------------
+// Shared mock HTTP server helpers
+// ---------------------------------------------------------------------------
+
+/// A minimal mock HTTP server that accepts POST requests and collects their
+/// JSON bodies.  Each call to `accept_one` blocks until one POST arrives,
+/// writes a 200 OK, and returns the decoded JSON body.
+struct MockWebhookServer {
+    listener: TcpListener,
+    addr: SocketAddr,
+}
+
+impl MockWebhookServer {
+    async fn bind() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        Self { listener, addr }
+    }
+
+    fn url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    /// Accept one incoming connection, read the full HTTP request, reply 200 OK,
+    /// and return the JSON body as `Value`.
+    async fn accept_one(&self) -> Value {
+        let (mut stream, _) = tokio::time::timeout(
+            Duration::from_secs(5),
+            self.listener.accept(),
+        )
+        .await
+        .expect("timed out waiting for webhook POST")
+        .unwrap();
+
+        let body = read_http_request_body(&mut stream).await;
+        write_200_ok(&mut stream).await;
+        serde_json::from_str(&body).expect("webhook body is not valid JSON")
+    }
+
+    /// Accept `n` POST requests concurrently and return their JSON bodies in
+    /// arrival order.
+    async fn accept_n(&self, n: usize) -> Vec<Value> {
+        let mut out = Vec::with_capacity(n);
+        for _ in 0..n {
+            out.push(self.accept_one().await);
+        }
+        out
+    }
+}
+
+async fn read_http_request_body(stream: &mut TcpStream) -> String {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        let n = tokio::time::timeout(Duration::from_secs(5), stream.read(&mut chunk))
+            .await
+            .expect("read timed out")
+            .unwrap();
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if is_http_complete(&buf) {
+            break;
+        }
+    }
+    let req = String::from_utf8_lossy(&buf).into_owned();
+    let body_start = req.find("\r\n\r\n").map_or(req.len(), |i| i + 4);
+    req[body_start..].to_owned()
+}
+
+async fn write_200_ok(stream: &mut TcpStream) {
+    let _ = stream
+        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+        .await;
+}
+
+fn is_http_complete(buf: &[u8]) -> bool {
+    let req = String::from_utf8_lossy(buf);
+    let Some(hdr_end) = req.find("\r\n\r\n") else {
+        return false;
+    };
+    let content_length = req[..hdr_end]
+        .lines()
+        .find_map(|line| {
+            line.to_ascii_lowercase()
+                .strip_prefix("content-length:")
+                .and_then(|v| v.trim().parse::<usize>().ok())
+        })
+        .unwrap_or(0);
+    buf.len() >= hdr_end + 4 + content_length
+}
+
+/// Build a minimal `MiniArgs` that uses a deterministic model (no real API).
+fn make_mini_args(
+    responses: Vec<String>,
+    output: &std::path::Path,
+    webhook_url: Option<String>,
+    webhook_headers: Vec<String>,
+    stream_addr: Option<std::net::SocketAddr>,
+) -> MiniArgs {
+    let mut cfg = maxwells_daemon::Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+    MiniArgs {
+        task: "webhook test task".into(),
+        extra_context: None,
+        config: cfg,
+        output_dir: output.to_path_buf(),
+        trajectory_name: "webhook-test".into(),
+        deterministic_responses: Some(responses),
+        deterministic_usage_per_call: None,
+        task_timeout_secs: Some(30),
+        cancellation: None,
+        stream_addr,
+        patch_capture: None,
+        verification_checks: vec![],
+        verification_timeout_secs: 60,
+        resume_from: None,
+        interactive_mode: InteractiveMode::Off,
+        trace_id: None,
+        webhook_url,
+        webhook_headers,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: full event sequence delivery + schema envelope validation
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn webhook_delivers_full_event_sequence_with_schema_envelope() {
+    let server = MockWebhookServer::bind().await;
+    let url = server.url();
+    let out = tempfile::tempdir().unwrap();
+
+    // Run mini in background; concurrently collect webhook POSTs.
+    let responses = vec![
+        "```bash\necho webhook-works\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\ndone\n```".into(),
+    ];
+    let args = make_mini_args(responses, out.path(), Some(url), vec![], None);
+
+    // We expect at minimum: RunStarted, AssistantMessage×2, BashStart, BashResult,
+    // Observation, RunEnded — so ≥ 7 payloads.
+    let (run_result, bodies) = tokio::join!(
+        maxwells_daemon::run::mini::run(args),
+        server.accept_n(7),
+    );
+    run_result.unwrap();
+
+    // Every body must have the schema envelope fields.
+    for body in &bodies {
+        assert!(
+            body.get("schema_version").is_some(),
+            "missing schema_version in: {body}"
+        );
+        assert!(body.get("run_id").is_some(), "missing run_id in: {body}");
+        assert!(body.get("event").is_some(), "missing event in: {body}");
+        assert!(
+            body.get("emitted_at").is_some(),
+            "missing emitted_at in: {body}"
+        );
+        // Content-Type is verified at the HTTP layer — tested implicitly via reqwest.
+    }
+
+    // schema_version must be { "major": 1, "minor": N }.
+    let sv = &bodies[0]["schema_version"];
+    assert_eq!(sv["major"], 1, "schema_version.major must be 1");
+    assert!(sv.get("minor").is_some(), "schema_version.minor must exist");
+
+    // First event must be run_started.
+    assert_eq!(
+        bodies[0]["event"]["type"].as_str(),
+        Some("run_started"),
+        "first event must be run_started"
+    );
+
+    // Last event must be run_ended.
+    let last = bodies.last().unwrap();
+    assert_eq!(
+        last["event"]["type"].as_str(),
+        Some("run_ended"),
+        "last event must be run_ended"
+    );
+
+    // run_ended envelope must include webhook_events_dropped.
+    assert!(
+        last.get("webhook_events_dropped").is_some(),
+        "run_ended envelope must contain webhook_events_dropped"
+    );
+
+    // All run_ids must be identical across a single run.
+    let run_id = bodies[0]["run_id"].as_str().unwrap();
+    for body in &bodies {
+        assert_eq!(
+            body["run_id"].as_str(),
+            Some(run_id),
+            "run_id must be stable across one run"
+        );
+    }
+
+    // bash_result must carry stdout with our marker.
+    let bash_result = bodies
+        .iter()
+        .find(|b| b["event"]["type"] == "bash_result")
+        .expect("missing bash_result event");
+    assert!(
+        bash_result["event"]["stdout"]
+            .as_str()
+            .unwrap_or("")
+            .contains("webhook-works"),
+        "bash_result stdout should contain 'webhook-works'"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: hung endpoint — agent must complete within step budget
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn webhook_hung_endpoint_does_not_block_agent() {
+    // A listener that accepts connections but never responds.
+    let hung_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let hung_addr = hung_listener.local_addr().unwrap();
+    let url = format!("http://{hung_addr}");
+
+    // Accept connections so they don't get connection-refused (which would be
+    // instant); accept without replying to simulate a truly hung server.
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = hung_listener.accept().await else {
+                break;
+            };
+            // Hold the connection open indefinitely.
+            let mut buf = [0u8; 1];
+            let _ = tokio::time::timeout(Duration::from_secs(60), sock.read(&mut buf)).await;
+        }
+    });
+
+    let out = tempfile::tempdir().unwrap();
+    // Multi-step run so there are many events to queue.
+    let responses = vec![
+        "```bash\necho one\n```".into(),
+        "```bash\necho two\n```".into(),
+        "```bash\necho three\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\ndone\n```".into(),
+    ];
+    let args = make_mini_args(responses, out.path(), Some(url), vec![], None);
+
+    // The 5-second per-request HTTP timeout means the agent MUST complete
+    // well within 30 s, even with a hung server.
+    let start = std::time::Instant::now();
+    let result = maxwells_daemon::run::mini::run(args).await;
+    let elapsed = start.elapsed();
+
+    result.unwrap();
+    // Agent should complete in ≤ 25 s even with multiple hanging requests
+    // (step budget × step latency, not HTTP timeout × event count).
+    assert!(
+        elapsed < Duration::from_secs(25),
+        "agent took too long with hung webhook: {elapsed:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: SSE + webhook composition — same event sequence to both transports
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sse_and_webhook_composition_delivers_same_events() {
+    let webhook_server = MockWebhookServer::bind().await;
+    let webhook_url = webhook_server.url();
+    let out = tempfile::tempdir().unwrap();
+
+    // Bind SSE server address first (use port 0 → OS chooses).
+    let sse_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let sse_addr = sse_listener.local_addr().unwrap();
+    drop(sse_listener); // mini::run will bind it
+
+    let responses = vec![
+        "```bash\necho compose-test\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfin\n```".into(),
+    ];
+    let args = make_mini_args(
+        responses,
+        out.path(),
+        Some(webhook_url),
+        vec![],
+        Some(sse_addr),
+    );
+
+    // Connect SSE client.
+    let sse_events: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let sse_events2 = sse_events.clone();
+
+    let (run_result, webhook_bodies, _) = tokio::join!(
+        maxwells_daemon::run::mini::run(args),
+        webhook_server.accept_n(7),
+        async move {
+            // Small delay so the SSE server can start.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let mut client = tokio::time::timeout(
+                Duration::from_secs(5),
+                TcpStream::connect(sse_addr),
+            )
+            .await
+            .ok()
+            .and_then(|r| r.ok());
+            if let Some(ref mut c) = client {
+                let _ = c.write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n").await;
+                let mut acc = Vec::new();
+                let mut chunk = [0u8; 4096];
+                let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+                loop {
+                    if tokio::time::Instant::now() > deadline {
+                        break;
+                    }
+                    match tokio::time::timeout(Duration::from_secs(2), c.read(&mut chunk)).await {
+                        Ok(Ok(0)) | Err(_) => break,
+                        Ok(Ok(n)) => acc.extend_from_slice(&chunk[..n]),
+                        Ok(Err(_)) => break,
+                    }
+                    let text = String::from_utf8_lossy(&acc);
+                    if text.contains("event: run_ended") {
+                        break;
+                    }
+                }
+                *sse_events2.lock().unwrap() =
+                    String::from_utf8_lossy(&acc)
+                        .lines()
+                        .filter(|l| l.starts_with("event: "))
+                        .map(|l| l.trim_start_matches("event: ").to_owned())
+                        .collect();
+            }
+        },
+    );
+    run_result.unwrap();
+
+    // Extract event types from webhook bodies.
+    let webhook_types: Vec<&str> = webhook_bodies
+        .iter()
+        .filter_map(|b| b["event"]["type"].as_str())
+        .collect();
+
+    // Both should see run_started and run_ended.
+    assert!(
+        webhook_types.contains(&"run_started"),
+        "webhook missing run_started"
+    );
+    assert!(
+        webhook_types.contains(&"run_ended"),
+        "webhook missing run_ended"
+    );
+
+    let sse = sse_events.lock().unwrap();
+    if !sse.is_empty() {
+        assert!(
+            sse.contains(&"run_started".to_owned()),
+            "SSE missing run_started"
+        );
+        assert!(
+            sse.contains(&"run_ended".to_owned()),
+            "SSE missing run_ended"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: webhook_events_dropped counter on RunEnded when events are dropped
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn webhook_run_ended_envelope_includes_drop_count() {
+    // A slow server — accept connections but stall briefly so the tiny buffer fills.
+    let slow_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let slow_addr = slow_listener.local_addr().unwrap();
+    let url = format!("http://{slow_addr}");
+
+    let collected: Arc<Mutex<VecDeque<Value>>> = Arc::new(Mutex::new(VecDeque::new()));
+    let collected2 = collected.clone();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = slow_listener.accept().await else {
+                break;
+            };
+            let body = read_http_request_body(&mut sock).await;
+            write_200_ok(&mut sock).await;
+            if let Ok(v) = serde_json::from_str::<Value>(&body) {
+                collected2.lock().unwrap().push_back(v);
+            }
+        }
+    });
+
+    let out = tempfile::tempdir().unwrap();
+    let responses = vec![
+        "```bash\necho a\n```".into(),
+        "```bash\necho b\n```".into(),
+        "```bash\necho c\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
+    ];
+    let args = make_mini_args(responses, out.path(), Some(url), vec![], None);
+    maxwells_daemon::run::mini::run(args).await.unwrap();
+
+    // Wait for all outstanding HTTP responses.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let bodies = collected.lock().unwrap();
+    let run_ended_body = bodies
+        .iter()
+        .find(|b| b["event"]["type"] == "run_ended")
+        .expect("run_ended envelope not received");
+
+    // The envelope must contain webhook_events_dropped (may be 0 if no drops).
+    assert!(
+        run_ended_body.get("webhook_events_dropped").is_some(),
+        "run_ended envelope must contain webhook_events_dropped; got: {run_ended_body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: --webhook-header injects custom HTTP request headers
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn webhook_header_flag_injects_custom_headers() {
+    let server = MockWebhookServer::bind().await;
+    let url = server.url();
+    let out = tempfile::tempdir().unwrap();
+
+    let headers = vec!["X-Custom-Header: test-value".to_owned()];
+    let responses = vec!["COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into()];
+    let args = make_mini_args(responses, out.path(), Some(url), headers, None);
+
+    // Accept one POST and inspect the raw request to find the custom header.
+    let (run_result, raw_request) = tokio::join!(
+        maxwells_daemon::run::mini::run(args),
+        async {
+            let (mut stream, _) = tokio::time::timeout(
+                Duration::from_secs(10),
+                server.listener.accept(),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 4096];
+            loop {
+                let n = tokio::time::timeout(Duration::from_secs(5), stream.read(&mut chunk))
+                    .await
+                    .unwrap()
+                    .unwrap();
+                if n == 0 {
+                    break;
+                }
+                buf.extend_from_slice(&chunk[..n]);
+                if is_http_complete(&buf) {
+                    break;
+                }
+            }
+            let _ = stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                .await;
+            String::from_utf8_lossy(&buf).into_owned()
+        },
+    );
+    run_result.unwrap();
+
+    let lower = raw_request.to_ascii_lowercase();
+    assert!(
+        lower.contains("x-custom-header: test-value"),
+        "custom header not found in raw HTTP request: {raw_request}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: redactor strips secrets from webhook payloads
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn webhook_redacts_secrets_before_post() {
+    let server = MockWebhookServer::bind().await;
+    let url = server.url();
+    let out = tempfile::tempdir().unwrap();
+
+    // A fake secret literal that the redactor should strip.
+    let secret = "sk-deadbeef-should-not-appear";
+
+    let responses = vec![
+        // bash command that echoes the secret (simulates a tool leaking it).
+        format!("```bash\necho {secret}\n```"),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
+    ];
+
+    let mut cfg = maxwells_daemon::Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+    // Configure the secret as a redaction literal.
+    cfg.root.redaction.secret_literals = vec![secret.to_owned()];
+
+    let args = MiniArgs {
+        task: "redaction test".into(),
+        extra_context: None,
+        config: cfg,
+        output_dir: out.path().to_path_buf(),
+        trajectory_name: "redact-test".into(),
+        deterministic_responses: Some(responses),
+        deterministic_usage_per_call: None,
+        task_timeout_secs: Some(30),
+        cancellation: None,
+        stream_addr: None,
+        patch_capture: None,
+        verification_checks: vec![],
+        verification_timeout_secs: 60,
+        resume_from: None,
+        interactive_mode: InteractiveMode::Off,
+        trace_id: None,
+        webhook_url: Some(url),
+        webhook_headers: vec![],
+    };
+
+    let (run_result, bodies) = tokio::join!(
+        maxwells_daemon::run::mini::run(args),
+        server.accept_n(7),
+    );
+    run_result.unwrap();
+
+    // The secret must never appear in any POSTed body.
+    for body in &bodies {
+        let body_str = serde_json::to_string(body).unwrap();
+        assert!(
+            !body_str.contains(secret),
+            "secret leaked in webhook payload! body: {body_str}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: no webhook_url → zero overhead (no background tasks spawned)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn no_webhook_url_adds_zero_overhead() {
+    let out = tempfile::tempdir().unwrap();
+    let responses = vec!["COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into()];
+    let args = make_mini_args(responses, out.path(), None, vec![], None);
+    // Should complete without error and without any webhook traffic.
+    maxwells_daemon::run::mini::run(args).await.unwrap();
+}

--- a/tests/webhook.rs
+++ b/tests/webhook.rs
@@ -597,8 +597,40 @@ async fn webhook_rejects_malformed_header_flag() {
     let result = maxwells_daemon::run::mini::run(args).await;
     assert!(result.is_err(), "expected Err for malformed header, got Ok");
     let msg = result.unwrap_err().to_string();
+    // Message must not echo the raw header value (could contain bearer tokens).
     assert!(
-        msg.contains("missing") || msg.contains("separator") || msg.contains("webhook header"),
-        "error should mention missing separator: {msg}"
+        !msg.contains("X-No-Colon-Here"),
+        "error must not echo the raw header value: {msg}"
+    );
+    assert!(
+        msg.contains("missing") || msg.contains("separator") || msg.contains("position"),
+        "error should mention missing separator or position: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: --webhook-header without --webhook-url is rejected
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn webhook_header_without_url_is_rejected() {
+    let out = tempfile::tempdir().unwrap();
+    let responses = vec!["COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into()];
+    let args = make_mini_args(
+        responses,
+        out.path(),
+        None, // no URL
+        vec!["Authorization: Bearer token".to_owned()],
+        None,
+    );
+    let result = maxwells_daemon::run::mini::run(args).await;
+    assert!(
+        result.is_err(),
+        "expected Err when header given without URL, got Ok"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("--webhook-url") || msg.contains("webhook"),
+        "error should mention --webhook-url: {msg}"
     );
 }

--- a/tests/webhook.rs
+++ b/tests/webhook.rs
@@ -7,7 +7,7 @@
 //!  4. `webhook_events_dropped` counter in `RunEnded` envelope.
 //!  5. Redaction applied before POST (`sk-deadbeef` never leaves the process).
 
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::collections::VecDeque;
 use std::net::SocketAddr;
@@ -46,13 +46,10 @@ impl MockWebhookServer {
     /// Accept one incoming connection, read the full HTTP request, reply 200 OK,
     /// and return the JSON body as `Value`.
     async fn accept_one(&self) -> Value {
-        let (mut stream, _) = tokio::time::timeout(
-            Duration::from_secs(5),
-            self.listener.accept(),
-        )
-        .await
-        .expect("timed out waiting for webhook POST")
-        .unwrap();
+        let (mut stream, _) = tokio::time::timeout(Duration::from_secs(5), self.listener.accept())
+            .await
+            .expect("timed out waiting for webhook POST")
+            .unwrap();
 
         let body = read_http_request_body(&mut stream).await;
         write_200_ok(&mut stream).await;
@@ -164,10 +161,8 @@ async fn webhook_delivers_full_event_sequence_with_schema_envelope() {
 
     // We expect at minimum: RunStarted, AssistantMessage×2, BashStart, BashResult,
     // Observation, RunEnded — so ≥ 7 payloads.
-    let (run_result, bodies) = tokio::join!(
-        maxwells_daemon::run::mini::run(args),
-        server.accept_n(7),
-    );
+    let (run_result, bodies) =
+        tokio::join!(maxwells_daemon::run::mini::run(args), server.accept_n(7),);
     run_result.unwrap();
 
     // Every body must have the schema envelope fields.
@@ -315,19 +310,17 @@ async fn sse_and_webhook_composition_delivers_same_events() {
     let sse_events: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
     let sse_events2 = sse_events.clone();
 
-    let (run_result, webhook_bodies, _) = tokio::join!(
+    let (run_result, webhook_bodies, ()) = tokio::join!(
         maxwells_daemon::run::mini::run(args),
         webhook_server.accept_n(7),
         async move {
             // Small delay so the SSE server can start.
             tokio::time::sleep(Duration::from_millis(100)).await;
-            let mut client = tokio::time::timeout(
-                Duration::from_secs(5),
-                TcpStream::connect(sse_addr),
-            )
-            .await
-            .ok()
-            .and_then(|r| r.ok());
+            let mut client =
+                tokio::time::timeout(Duration::from_secs(5), TcpStream::connect(sse_addr))
+                    .await
+                    .ok()
+                    .and_then(Result::ok);
             if let Some(ref mut c) = client {
                 let _ = c.write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n").await;
                 let mut acc = Vec::new();
@@ -338,21 +331,19 @@ async fn sse_and_webhook_composition_delivers_same_events() {
                         break;
                     }
                     match tokio::time::timeout(Duration::from_secs(2), c.read(&mut chunk)).await {
-                        Ok(Ok(0)) | Err(_) => break,
+                        Ok(Ok(0) | Err(_)) | Err(_) => break,
                         Ok(Ok(n)) => acc.extend_from_slice(&chunk[..n]),
-                        Ok(Err(_)) => break,
                     }
                     let text = String::from_utf8_lossy(&acc);
                     if text.contains("event: run_ended") {
                         break;
                     }
                 }
-                *sse_events2.lock().unwrap() =
-                    String::from_utf8_lossy(&acc)
-                        .lines()
-                        .filter(|l| l.starts_with("event: "))
-                        .map(|l| l.trim_start_matches("event: ").to_owned())
-                        .collect();
+                *sse_events2.lock().unwrap() = String::from_utf8_lossy(&acc)
+                    .lines()
+                    .filter(|l| l.starts_with("event: "))
+                    .map(|l| l.trim_start_matches("event: ").to_owned())
+                    .collect();
             }
         },
     );
@@ -374,7 +365,7 @@ async fn sse_and_webhook_composition_delivers_same_events() {
         "webhook missing run_ended"
     );
 
-    let sse = sse_events.lock().unwrap();
+    let sse: Vec<String> = sse_events.lock().unwrap().clone();
     if !sse.is_empty() {
         assert!(
             sse.contains(&"run_started".to_owned()),
@@ -427,7 +418,7 @@ async fn webhook_run_ended_envelope_includes_drop_count() {
     // Wait for all outstanding HTTP responses.
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    let bodies = collected.lock().unwrap();
+    let bodies: VecDeque<Value> = collected.lock().unwrap().clone();
     let run_ended_body = bodies
         .iter()
         .find(|b| b["event"]["type"] == "run_ended")
@@ -455,37 +446,32 @@ async fn webhook_header_flag_injects_custom_headers() {
     let args = make_mini_args(responses, out.path(), Some(url), headers, None);
 
     // Accept one POST and inspect the raw request to find the custom header.
-    let (run_result, raw_request) = tokio::join!(
-        maxwells_daemon::run::mini::run(args),
-        async {
-            let (mut stream, _) = tokio::time::timeout(
-                Duration::from_secs(10),
-                server.listener.accept(),
-            )
-            .await
-            .unwrap()
-            .unwrap();
-            let mut buf = Vec::new();
-            let mut chunk = [0u8; 4096];
-            loop {
-                let n = tokio::time::timeout(Duration::from_secs(5), stream.read(&mut chunk))
-                    .await
-                    .unwrap()
-                    .unwrap();
-                if n == 0 {
-                    break;
-                }
-                buf.extend_from_slice(&chunk[..n]);
-                if is_http_complete(&buf) {
-                    break;
-                }
+    let (run_result, raw_request) = tokio::join!(maxwells_daemon::run::mini::run(args), async {
+        let (mut stream, _) =
+            tokio::time::timeout(Duration::from_secs(10), server.listener.accept())
+                .await
+                .unwrap()
+                .unwrap();
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 4096];
+        loop {
+            let n = tokio::time::timeout(Duration::from_secs(5), stream.read(&mut chunk))
+                .await
+                .unwrap()
+                .unwrap();
+            if n == 0 {
+                break;
             }
-            let _ = stream
-                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
-                .await;
-            String::from_utf8_lossy(&buf).into_owned()
-        },
-    );
+            buf.extend_from_slice(&chunk[..n]);
+            if is_http_complete(&buf) {
+                break;
+            }
+        }
+        let _ = stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+            .await;
+        String::from_utf8_lossy(&buf).into_owned()
+    },);
     run_result.unwrap();
 
     let lower = raw_request.to_ascii_lowercase();
@@ -540,10 +526,8 @@ async fn webhook_redacts_secrets_before_post() {
         webhook_headers: vec![],
     };
 
-    let (run_result, bodies) = tokio::join!(
-        maxwells_daemon::run::mini::run(args),
-        server.accept_n(7),
-    );
+    let (run_result, bodies) =
+        tokio::join!(maxwells_daemon::run::mini::run(args), server.accept_n(7),);
     run_result.unwrap();
 
     // The secret must never appear in any POSTed body.


### PR DESCRIPTION
Implements issue #324 end-to-end via TDD (red → green → refactor).

Changes:
- src/stream/webhook.rs: overhaul — schema envelope (SchemaVersion, WebhookEnvelope),
  WebhookSinkHandle (run_id + drop-counter plumbing), 5 s HTTP timeout, warn-level
  logging for 4xx/5xx/network failures, drop counter (buffer-full + HTTP failures),
  custom header injection via reqwest default_headers
- src/stream/mod.rs: export WebhookSinkHandle, SchemaVersion, WebhookEnvelope
- src/run/mini.rs: add webhook_url / webhook_headers to MiniArgs; build WebhookSink +
  wrap in RedactingSink; wire into compose_stream_sinks (4th slot); emit stderr warn
  when webhook_events_dropped ≥ 1; update compose_stream_sinks signature (4 args)
- src/cli/args.rs: add --webhook-url and repeatable --webhook-header to MiniCmd
- src/cli/mod.rs: pass new fields through to MiniArgs
- Cargo.toml: flip webhook feature to default-enabled
- docs/spec-streaming.md: expand to cover webhook transport, envelope schema, delivery
  posture, header injection, redaction, feature flag, SSE+webhook composition
- README.md: add ≤15-line "Live Event Streaming" subsection in Live-Model Quickstart
- tests/webhook.rs: 7 new integration tests (full sequence + envelope, hung endpoint,
  SSE+webhook composition, drop counter, header injection, redaction, no-URL baseline)
- tests/verification.rs, tests/checkpointing.rs, tests/skills.rs,
  src/run/hello_world.rs, src/run/swebench.rs, src/cli/mod.rs (test helper):
  add webhook_url: None / webhook_headers: vec![] to all existing MiniArgs literals

https://github.com/madmax983/rust_swe_agent/issues/324