### PR TITLE
🗺️ Atlas: [architectural change] Remove PolicyConfigError

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -515,11 +515,7 @@ impl DefaultAgentBuilder {
                 "invalid agent.test_command_patterns regex: {err}"
             )))
         })?;
-        let policy_engine = PolicyEngine::from_cfg(&self.config.root.policy).map_err(|err| {
-            Error::Config(crate::error::ConfigError::Invalid(format!(
-                "invalid policy config: {err}"
-            )))
-        })?;
+        let policy_engine = PolicyEngine::from_cfg(&self.config.root.policy)?;
         // Validate and build the stagnation detector.
         let agent_cfg = &self.config.root.agent;
         let stagnation_detector = if agent_cfg.detect_stagnation {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,7 @@ pub use model::{
     SamplingParams,
 };
 pub use policy::{
-    PolicyCfg, PolicyConfigError, PolicyCounts, PolicyDecision, PolicyEngine, PolicyProfile,
-    PolicyRule,
+    PolicyCfg, PolicyCounts, PolicyDecision, PolicyEngine, PolicyProfile, PolicyRule,
 };
 pub use prompt_guard::{PromptGuard, UntrustedKind};
 pub use redaction::{RedactionCount, RedactionSummary, Redactor};

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -88,42 +88,6 @@ impl PolicyProfile {
     }
 }
 
-// ── Policy config errors ─────────────────────────────────────────────────────
-
-/// Error raised when an operator-supplied policy config cannot be parsed
-/// into a [`PolicyEngine`].
-#[derive(Debug)]
-pub enum PolicyConfigError {
-    /// `[policy] profile = "..."` was not one of `safe`, `ask`, `yolo`.
-    UnknownProfile(String),
-    /// A regex in `extra_allow_patterns` or `extra_deny_patterns` failed
-    /// to compile.
-    InvalidRegex { label: String, source: regex::Error },
-}
-
-impl std::fmt::Display for PolicyConfigError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::UnknownProfile(p) => write!(
-                f,
-                "unknown policy profile {p:?} (expected one of: safe, ask, yolo)"
-            ),
-            Self::InvalidRegex { label, source } => {
-                write!(f, "invalid regex in policy rule {label:?}: {source}")
-            }
-        }
-    }
-}
-
-impl std::error::Error for PolicyConfigError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::UnknownProfile(_) => None,
-            Self::InvalidRegex { source, .. } => Some(source),
-        }
-    }
-}
-
 // ── Policy decision ───────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1030,11 +994,15 @@ impl PolicyEngine {
     /// `"safe"`, `"ask"`, or `"yolo"` (case-insensitive).  Silently falling
     /// back to `Safe` on a typo would downgrade an operator who selected
     /// `ask` for fail-closed behaviour, so it is treated as a hard error.
-    /// Returns [`PolicyConfigError::InvalidRegex`] if any extra
-    /// allow/deny pattern fails to compile.
-    pub fn from_cfg(cfg: &PolicyCfg) -> Result<Self, PolicyConfigError> {
-        let profile = PolicyProfile::from_str(&cfg.profile)
-            .ok_or_else(|| PolicyConfigError::UnknownProfile(cfg.profile.clone()))?;
+    /// Returns [`crate::error::ConfigError`] if any extra
+    /// allow/deny pattern fails to compile or if the profile is unknown.
+    pub fn from_cfg(cfg: &PolicyCfg) -> Result<Self, crate::error::ConfigError> {
+        let profile = PolicyProfile::from_str(&cfg.profile).ok_or_else(|| {
+            crate::error::ConfigError::Invalid(format!(
+                "unknown policy profile {:?} (expected one of: safe, ask, yolo)",
+                cfg.profile
+            ))
+        })?;
         let extra_allow = cfg
             .extra_allow_patterns
             .iter()
@@ -1047,9 +1015,13 @@ impl PolicyEngine {
                         pattern: r,
                         decision: RuleDecision::Allow,
                     })
-                    .map_err(|source| PolicyConfigError::InvalidRegex { label, source })
+                    .map_err(|source| {
+                        crate::error::ConfigError::Invalid(format!(
+                            "invalid regex in policy rule {label:?}: {source}"
+                        ))
+                    })
             })
-            .collect::<Result<Vec<_>, PolicyConfigError>>()?;
+            .collect::<Result<Vec<_>, crate::error::ConfigError>>()?;
         let extra_deny = cfg
             .extra_deny_patterns
             .iter()
@@ -1062,9 +1034,13 @@ impl PolicyEngine {
                         pattern: r,
                         decision: RuleDecision::Deny,
                     })
-                    .map_err(|source| PolicyConfigError::InvalidRegex { label, source })
+                    .map_err(|source| {
+                        crate::error::ConfigError::Invalid(format!(
+                            "invalid regex in policy rule {label:?}: {source}"
+                        ))
+                    })
             })
-            .collect::<Result<Vec<_>, PolicyConfigError>>()?;
+            .collect::<Result<Vec<_>, crate::error::ConfigError>>()?;
         Ok(Self::with_extra_rules(profile, extra_allow, extra_deny))
     }
 

--- a/tests/policy_engine.rs
+++ b/tests/policy_engine.rs
@@ -3,8 +3,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use maxwells_daemon::policy::{
-    PolicyCfg, PolicyConfigError, PolicyCounts, PolicyDecision, PolicyEngine, PolicyProfile,
-    PolicyRule,
+    PolicyCfg, PolicyCounts, PolicyDecision, PolicyEngine, PolicyProfile, PolicyRule,
 };
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -665,15 +664,21 @@ fn unknown_profile_returns_error_instead_of_silently_defaulting() {
     };
     let result = PolicyEngine::from_cfg(&cfg);
     match result {
-        Err(PolicyConfigError::UnknownProfile(p)) => assert_eq!(p, "aks"),
-        Err(other) => panic!("expected UnknownProfile, got {other:?}"),
+        Err(maxwells_daemon::error::ConfigError::Invalid(msg))
+            if msg.contains("unknown policy profile \"aks\"") => {}
+        Err(other) => panic!("expected ConfigError::Invalid with aks, got {other:?}"),
         Ok(_) => panic!("expected error for typo'd profile, got Ok"),
     }
 }
 
 #[test]
 fn unknown_profile_error_message_lists_valid_options() {
-    let err = PolicyConfigError::UnknownProfile("nonsense".into());
+    let cfg = PolicyCfg {
+        profile: "nonsense".into(),
+        extra_deny_patterns: vec![],
+        extra_allow_patterns: vec![],
+    };
+    let err = PolicyEngine::from_cfg(&cfg).unwrap_err();
     let msg = err.to_string();
     assert!(msg.contains("nonsense"));
     assert!(msg.contains("safe"));
@@ -689,10 +694,10 @@ fn invalid_extra_deny_regex_returns_error() {
         extra_allow_patterns: vec![],
     };
     match PolicyEngine::from_cfg(&cfg) {
-        Err(PolicyConfigError::InvalidRegex { label, .. }) => {
-            assert!(label.starts_with("cfg-deny-"));
+        Err(maxwells_daemon::error::ConfigError::Invalid(msg)) => {
+            assert!(msg.contains("invalid regex in policy rule \"cfg-deny-"));
         }
-        other => panic!("expected InvalidRegex error, got {other:?}"),
+        other => panic!("expected ConfigError::Invalid error, got {other:?}"),
     }
 }
 


### PR DESCRIPTION
🗺️ **Atlas: Remove `PolicyConfigError` in favor of centralized `crate::error::ConfigError`**

🕸️ **Tangle:** `src/policy/mod.rs` was defining its own `PolicyConfigError`, which breaks the pattern of using central, standardized error types across modules.
📐 **Blueprint:** We removed `PolicyConfigError` entirely and updated `PolicyEngine::from_cfg` to return `Result<Self, crate::error::ConfigError>`, mapping regex parsing errors and unknown profiles directly to `ConfigError::Invalid(...)`.
🧱 **Stability:** The change makes the error handling cleaner without introducing new module-specific types. Call sites in `src/agent/default.rs` now simply bubble up `?` instead of manually matching and converting errors.
🔬 **Verification:** Replaced the error structures, adapted `tests/policy_engine.rs` to assert on `ConfigError` variants, and verified compilation and formatting via `cargo test && cargo clippy`. No regressions found.

---
*PR created automatically by Jules for task [17575699271814267715](https://jules.google.com/task/17575699271814267715) started by @madmax983*