### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -302,3 +302,98 @@ where
     #[serde(flatten)]
     payload: &'a T,
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_classify_json_value_legacy_fallback() {
+        let value = json!({ "some_data": 123 });
+        let result = classify_json_value(&value, ArtifactKind::Trajectory, "test").unwrap();
+        assert_eq!(result.kind, ArtifactKind::Trajectory);
+        assert_eq!(result.version, None);
+        assert_eq!(result.class, CompatibilityClass::SupportedLegacy);
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result.warnings[0].contains("supported-legacy artifact: detected pre-versioning"));
+    }
+
+    #[test]
+    fn test_classify_json_value_malformed_header_missing_kind() {
+        let value = json!({
+            "schema_version": {"major": 1, "minor": 9}
+        });
+        let err = classify_json_value(&value, ArtifactKind::Trajectory, "test").unwrap_err();
+        assert!(matches!(err, ArtifactSchemaError::MalformedHeader { .. }));
+    }
+
+    #[test]
+    fn test_classify_json_value_malformed_header_missing_version() {
+        let value = json!({
+            "artifact_kind": "trajectory"
+        });
+        let err = classify_json_value(&value, ArtifactKind::Trajectory, "test").unwrap_err();
+        assert!(matches!(err, ArtifactSchemaError::MalformedHeader { .. }));
+    }
+
+    #[test]
+    fn test_classify_json_value_kind_mismatch() {
+        let value = json!({
+            "artifact_kind": "sweep_results",
+            "schema_version": {"major": 1, "minor": 9}
+        });
+        let err = classify_json_value(&value, ArtifactKind::Trajectory, "test").unwrap_err();
+        assert!(matches!(err, ArtifactSchemaError::KindMismatch { .. }));
+    }
+
+    #[test]
+    fn test_classify_json_value_unsupported_future_major() {
+        let value = json!({
+            "artifact_kind": "trajectory",
+            "schema_version": {"major": 2, "minor": 0}
+        });
+        let err = classify_json_value(&value, ArtifactKind::Trajectory, "test").unwrap_err();
+        assert!(matches!(err, ArtifactSchemaError::UnsupportedFuture { .. }));
+    }
+
+    #[test]
+    fn test_classify_json_value_supported_current() {
+        let current = ArtifactSchemaVersion::CURRENT;
+        let value = json!({
+            "artifact_kind": "trajectory",
+            "schema_version": {"major": current.major, "minor": current.minor}
+        });
+        let result = classify_json_value(&value, ArtifactKind::Trajectory, "test").unwrap();
+        assert_eq!(result.class, CompatibilityClass::SupportedCurrent);
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_classify_json_value_future_minor_warning() {
+        let current = ArtifactSchemaVersion::CURRENT;
+        let value = json!({
+            "artifact_kind": "trajectory",
+            "schema_version": {"major": current.major, "minor": current.minor + 1}
+        });
+        let result = classify_json_value(&value, ArtifactKind::Trajectory, "test").unwrap();
+        assert_eq!(result.class, CompatibilityClass::SupportedCurrent);
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result.warnings[0].contains("has a newer additive minor"));
+    }
+
+    #[test]
+    fn test_classify_json_value_legacy_minor_warning() {
+        let current = ArtifactSchemaVersion::CURRENT;
+        assert!(current.minor > 0, "test requires CURRENT minor to be > 0");
+        let value = json!({
+            "artifact_kind": "trajectory",
+            "schema_version": {"major": current.major, "minor": current.minor - 1}
+        });
+        let result = classify_json_value(&value, ArtifactKind::Trajectory, "test").unwrap();
+        assert_eq!(result.class, CompatibilityClass::SupportedLegacy);
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result.warnings[0].contains("this binary defaults missing fields"));
+    }
+}

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -96,3 +96,51 @@ pub fn is_free_tier_model(model: &str) -> bool {
         .is_some_and(|name| name.ends_with(":free"))
         || model.ends_with(":free")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cost_source_combine_preserves_priority() {
+        assert_eq!(
+            CostSource::Unknown.combine(CostSource::Unknown),
+            CostSource::Unknown
+        );
+        assert_eq!(
+            CostSource::Unknown.combine(CostSource::ProviderReported),
+            CostSource::Unknown
+        );
+        assert_eq!(
+            CostSource::RateCardEstimate.combine(CostSource::RateCardEstimate),
+            CostSource::RateCardEstimate
+        );
+        assert_eq!(
+            CostSource::RateCardEstimate.combine(CostSource::ProviderReported),
+            CostSource::RateCardEstimate
+        );
+        assert_eq!(
+            CostSource::ProviderReported.combine(CostSource::FreeTierInferred),
+            CostSource::ProviderReported
+        );
+    }
+
+    #[test]
+    fn test_is_free_tier_model_identifies_free_tier_suffixes() {
+        // Standard full model names
+        assert!(is_free_tier_model("gemini-1.5-flash:free"));
+        assert!(is_free_tier_model("google/gemini-1.5-flash:free"));
+
+        // Exact match edge case
+        assert!(is_free_tier_model(":free"));
+
+        // Should not match partials or prefixes
+        assert!(!is_free_tier_model("free:gemini-1.5"));
+        assert!(!is_free_tier_model("gemini-1.5-flash:free-tier"));
+        assert!(!is_free_tier_model("gemini-1.5-flash"));
+        assert!(!is_free_tier_model("google/gemini-1.5-flash"));
+
+        // Empty edge case
+        assert!(!is_free_tier_model(""));
+    }
+}


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement]

🎯 Target: `src/cost.rs` (`is_free_tier_model`) and `src/artifact.rs` (`classify_json_value`)
💣 Risk: Previously relied on trivial getter tests; complex string matching and schema classification logic lacked coverage for critical edge cases and failure branches.
🧪 Strategy: Replaced trivial label tests with robust branch tests verifying `CostSource` prioritization, free-tier string edge cases, and all error conditions (malformed headers, schema mismatches, future version warnings) of JSON artifact classification. Added `#[allow(clippy::unwrap_used)]` to test modules.
🔬 Verification: Run `cargo test --lib` or `cargo clippy --all-targets --all-features -- -D warnings`.

---
*PR created automatically by Jules for task [10726431519882796806](https://jules.google.com/task/10726431519882796806) started by @madmax983*