### PR TITLE
⚒️ Forge: Fix unnecessary wraps in cli/mod.rs

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2400,6 +2400,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
 }
 
 #[cfg(feature = "html-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
     Ok(HtmlExporter::export(traj))
@@ -2415,6 +2416,7 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
 }
 
 #[cfg(feature = "csv-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
     Ok(CsvExporter::export(traj))
@@ -2430,6 +2432,7 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
 }
 
 #[cfg(feature = "mermaid-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
     Ok(MermaidExporter::export(traj))


### PR DESCRIPTION
🚮 Smell: Clippy warnings for unnecessary wraps in `inspect_export_html`, `inspect_export_csv`, and `inspect_export_mermaid`.
✨ Solution: Added `#[allow(clippy::unnecessary_wraps)]` to silence warnings as these functions need to return `Result<String, Error>` due to API constraints.
🧼 Benefit: Eliminates clippy warnings without breaking the API contract or requiring invasive refactoring.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [4872065554629084466](https://jules.google.com/task/4872065554629084466) started by @madmax983*