### PR TITLE
feat: Add `bench fork` to retry failing trajectory tails without re-paying prefix (#279)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -498,6 +498,8 @@ pub enum BenchCmd {
     Cascade(CascadeCmd),
     /// Compute per-test partial-credit scores across a completed sweep.
     TestProgress(TestProgressCmd),
+    /// Fork a trajectory at step N and continue with config overrides.
+    Fork(ForkCmd),
 }
 
 /// `bench test-progress` — per-test partial-credit scoring across a sweep.
@@ -1952,6 +1954,55 @@ pub struct SkillsPreviewCmd {
     /// Output format: `text` (default, human-readable) or `json` (schema-versioned).
     #[arg(long, default_value = "text")]
     pub format: String,
+}
+
+/// `bench fork` — fork a trajectory at step N and continue with config overrides.
+#[derive(Debug, Args)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct ForkCmd {
+    /// Completed sweep directory containing the instance trajectory.
+    #[arg(long)]
+    pub sweep: std::path::PathBuf,
+
+    /// Specific instance id to fork.
+    #[arg(long)]
+    pub instance: String,
+
+    /// The step number to fork from (zero-indexed).
+    #[arg(long = "from-step")]
+    pub from_step: u32,
+
+    /// Output directory for the new trajectory.
+    #[arg(long)]
+    pub output: std::path::PathBuf,
+
+    /// Override model name for the tail (e.g. `claude-opus-4-7`).
+    #[arg(long)]
+    pub model: Option<String>,
+
+    /// Override system prompt file for the tail.
+    #[arg(long = "system-prompt-file")]
+    pub system_prompt_file: Option<std::path::PathBuf>,
+
+    /// Override max agent steps.
+    #[arg(long)]
+    pub step_limit: Option<u32>,
+
+    /// Override per-task USD budget cap for the tail.
+    #[arg(long)]
+    pub per_task_budget_usd: Option<f64>,
+
+    /// Override MCP stdio server command(s).
+    #[arg(long = "mcp-server", value_name = "COMMAND")]
+    pub mcp_servers: Vec<String>,
+
+    /// Override path to an MCP config JSON file.
+    #[arg(long = "mcp-config")]
+    pub mcp_config: Option<std::path::PathBuf>,
+
+    /// Allow forking from a parent trajectory that has no stored input fingerprints.
+    #[arg(long, default_value_t = false)]
+    pub allow_unfingerprinted: bool,
 }
 
 #[cfg(test)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -169,6 +169,9 @@ pub async fn run() -> Result<(), Error> {
         Command::Bench {
             cmd: args::BenchCmd::TestProgress(t),
         } => bench_test_progress(t),
+        Command::Bench {
+            cmd: args::BenchCmd::Fork(f),
+        } => Box::pin(crate::run::fork::run(f)).await,
         #[cfg(feature = "docker")]
         Command::Cleanup => cleanup_cmd().await,
         #[cfg(not(feature = "docker"))]

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -4012,6 +4012,7 @@ mod tests {
                 ..Default::default()
             },
             messages: vec![],
+            fork_lineage: None,
         };
         std::fs::write(
             dir.path().join("inst-1.traj.json"),
@@ -4131,6 +4132,7 @@ mod tests {
                 ..Default::default()
             },
             messages: vec![],
+            fork_lineage: None,
         };
         std::fs::write(
             dir.path().join("x.traj.json"),
@@ -4215,6 +4217,7 @@ mod tests {
                 ..Default::default()
             },
             messages: vec![],
+            fork_lineage: None,
         };
         std::fs::write(
             dir.path().join("old.traj.json"),
@@ -4332,6 +4335,7 @@ mod tests {
                 ..Default::default()
             },
             messages: vec![],
+            fork_lineage: None,
         };
         std::fs::write(
             dir.path().join("resume-old.traj.json"),

--- a/src/run/fork.rs
+++ b/src/run/fork.rs
@@ -663,13 +663,38 @@ pub async fn run(args: ForkCmd) -> Result<(), Error> {
         );
     }
 
-    let lineage = ForkLineage {
+    let mut lineage = ForkLineage {
         parent_sweep_path: args.sweep.to_string_lossy().into_owned(),
         parent_instance_id: args.instance.clone(),
         parent_trajectory_sha256,
         fork_step: args.from_step,
         tail_overrides,
     };
+
+    // Redact sensitive values inside fork lineage using the agent's redactor before persisting
+    let parent_sweep_outcome = agent.redactor.redact_text(
+        &lineage.parent_sweep_path,
+        crate::redaction::surface::TRAJECTORY,
+    );
+    lineage.parent_sweep_path = parent_sweep_outcome.text;
+
+    let parent_instance_outcome = agent.redactor.redact_text(
+        &lineage.parent_instance_id,
+        crate::redaction::surface::TRAJECTORY,
+    );
+    lineage.parent_instance_id = parent_instance_outcome.text;
+
+    let parent_sha_outcome = agent.redactor.redact_text(
+        &lineage.parent_trajectory_sha256,
+        crate::redaction::surface::TRAJECTORY,
+    );
+    lineage.parent_trajectory_sha256 = parent_sha_outcome.text;
+
+    for value in lineage.tail_overrides.values_mut() {
+        agent
+            .redactor
+            .redact_json_value(value, crate::redaction::surface::TRAJECTORY);
+    }
 
     agent.trajectory.fork_lineage = Some(lineage);
 
@@ -717,7 +742,16 @@ fn build_live_model(cfg: &Config) -> Arc<dyn Model> {
 
 async fn build_env(cfg: &Config) -> Result<Box<dyn Environment>, Error> {
     match cfg.root.environment.kind {
-        EnvKind::Local => Ok(Box::new(LocalEnvironment::new())),
+        EnvKind::Local => {
+            let mut env = LocalEnvironment::new();
+            if !cfg.root.environment.workdir.is_empty()
+                && cfg.root.environment.workdir != "/workspace"
+            {
+                let wd = std::path::PathBuf::from(&cfg.root.environment.workdir);
+                env = env.with_workdir(Some(wd));
+            }
+            Ok(Box::new(env))
+        }
         EnvKind::Docker => build_docker_env(cfg).await,
     }
 }
@@ -763,13 +797,17 @@ fn current_rust_version() -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-/// Wrap `s` in POSIX single-quotes so it survives `bash -c` without any word
-/// splitting or glob expansion. A single-quote inside `s` is escaped using the
-/// standard `'\''` technique (close quote, escaped literal `'`, reopen quote).
+/// Wrap `s` in Windows-safe double-quotes or POSIX single-quotes so it survives shell execution
+/// without word splitting or glob expansion.
 fn shell_quote_single(s: &str) -> String {
-    // Replace every ' with '\'' and wrap the whole thing in outer single-quotes.
-    let escaped = s.replace('\'', r"'\''");
-    format!("'{escaped}'")
+    if cfg!(windows) {
+        let escaped = s.replace('"', "\\\"");
+        format!("\"{escaped}\"")
+    } else {
+        // Replace every ' with '\'' and wrap the whole thing in outer single-quotes.
+        let escaped = s.replace('\'', r"'\''");
+        format!("'{escaped}'")
+    }
 }
 
 #[cfg(test)]
@@ -778,21 +816,47 @@ mod shell_quote_tests {
 
     #[test]
     fn plain_arg() {
-        assert_eq!(shell_quote_single("hello"), "'hello'");
+        if cfg!(windows) {
+            assert_eq!(shell_quote_single("hello"), "\"hello\"");
+        } else {
+            assert_eq!(shell_quote_single("hello"), "'hello'");
+        }
     }
 
     #[test]
     fn arg_with_spaces() {
-        assert_eq!(shell_quote_single("My Project"), "'My Project'");
+        if cfg!(windows) {
+            assert_eq!(shell_quote_single("My Project"), "\"My Project\"");
+        } else {
+            assert_eq!(shell_quote_single("My Project"), "'My Project'");
+        }
     }
 
     #[test]
     fn arg_with_single_quote() {
-        assert_eq!(shell_quote_single("it's"), "'it'\\''s'");
+        if cfg!(windows) {
+            assert_eq!(shell_quote_single("it's"), "\"it's\"");
+        } else {
+            assert_eq!(shell_quote_single("it's"), "'it'\\''s'");
+        }
+    }
+
+    #[test]
+    fn arg_with_double_quote() {
+        if cfg!(windows) {
+            assert_eq!(
+                shell_quote_single("hello \"world\""),
+                "\"hello \\\"world\\\"\""
+            );
+        }
     }
 
     #[test]
     fn arg_with_shell_metacharacters() {
-        assert_eq!(shell_quote_single("$HOME/bin"), "'$HOME/bin'");
+        if cfg!(windows) {
+            assert_eq!(shell_quote_single("$HOME/bin"), "\"$HOME/bin\"");
+        } else {
+            assert_eq!(shell_quote_single("$HOME/bin"), "'$HOME/bin'");
+        }
     }
 }

--- a/src/run/fork.rs
+++ b/src/run/fork.rs
@@ -1,6 +1,8 @@
 //! `bench fork` runner — re-runs a prefix from a parent trajectory under $0 cost
 //! and prompt/drift verification, then switches to live model calls at step N.
 
+#[cfg(feature = "docker")]
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -447,8 +449,6 @@ pub async fn run(args: ForkCmd) -> Result<(), Error> {
 
     if let Some(limit) = args.step_limit {
         config.root.agent.step_limit = limit;
-    } else {
-        config.root.agent.step_limit = parent_steps.max(50);
     }
 
     if let Some(budget) = args.per_task_budget_usd {

--- a/src/run/fork.rs
+++ b/src/run/fork.rs
@@ -361,7 +361,16 @@ pub async fn run(args: ForkCmd) -> Result<(), Error> {
     }
 
     // 2. Perform environment-drift checks from reproducible sweeps.
-    let drift_records = if let Ok(source_manifest) = load_manifest_from_sweep(&args.sweep) {
+    let results_path = args.sweep.join("results.json");
+    let has_manifest = results_path.exists();
+
+    let drift_records = if has_manifest {
+        let source_manifest = load_manifest_from_sweep(&args.sweep).map_err(|e| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "Failed to load manifest results.json from sweep {}: {e}",
+                args.sweep.display()
+            )))
+        })?;
         let mut current_manifest = source_manifest.clone();
         current_manifest.harness.git_sha = current_git_sha();
         current_manifest.harness.git_dirty = None;
@@ -402,19 +411,24 @@ pub async fn run(args: ForkCmd) -> Result<(), Error> {
     // sees exactly the same prompt/tool/redaction settings as the original run.
     // Fall back to defaults when the manifest is absent (e.g., old sweeps or
     // non-sweep outputs).
-    let mut config = {
-        let from_manifest = load_manifest_from_sweep(&args.sweep)
-            .ok()
-            .and_then(|m| Config::from_toml_str(&m.config.resolved).ok());
-        if let Some(cfg) = from_manifest {
-            cfg
-        } else {
-            tracing::warn!(
-                "bench fork: sweep has no resolvable manifest config; \
-                 falling back to built-in defaults"
-            );
-            Config::defaults()?
-        }
+    let mut config = if has_manifest {
+        let manifest = load_manifest_from_sweep(&args.sweep).map_err(|e| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "Failed to load manifest results.json from sweep {}: {e}",
+                args.sweep.display()
+            )))
+        })?;
+        Config::from_toml_str(&manifest.config.resolved).map_err(|e| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "failed to parse parent resolved config from manifest: {e}"
+            )))
+        })?
+    } else {
+        tracing::warn!(
+            "bench fork: sweep has no resolvable manifest config; \
+             falling back to built-in defaults"
+        );
+        Config::defaults()?
     };
 
     // Config overlays:
@@ -490,8 +504,8 @@ pub async fn run(args: ForkCmd) -> Result<(), Error> {
                     )))
                 })?;
             // Collect optional `args` array; reject non-string entries immediately.
-            let args_suffix: Vec<String> =
-                if let Some(arr) = val.get("args").and_then(serde_json::Value::as_array) {
+            let args_suffix: Vec<String> = match val.get("args") {
+                Some(serde_json::Value::Array(arr)) => {
                     let mut collected = Vec::with_capacity(arr.len());
                     for (i, v) in arr.iter().enumerate() {
                         let s = v.as_str().ok_or_else(|| {
@@ -502,9 +516,14 @@ pub async fn run(args: ForkCmd) -> Result<(), Error> {
                         collected.push(s.to_owned());
                     }
                     collected
-                } else {
-                    Vec::new()
-                };
+                }
+                Some(other) => {
+                    return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                        "--mcp-config: server {name:?} \"args\" must be an array (got {other})"
+                    ))));
+                }
+                None => Vec::new(),
+            };
             // Shell-quote each arg individually so that args containing spaces,
             // quotes, or other metacharacters survive the `bash -c` invocation
             // that env.run() uses to launch the server.
@@ -637,8 +656,7 @@ pub async fn run(args: ForkCmd) -> Result<(), Error> {
                     .collect(),
             ),
         );
-    }
-    if let Some(ref p) = args.mcp_config {
+    } else if let Some(ref p) = args.mcp_config {
         tail_overrides.insert(
             "mcp_config".to_owned(),
             serde_json::Value::String(p.to_string_lossy().into_owned()),

--- a/src/run/fork.rs
+++ b/src/run/fork.rs
@@ -265,12 +265,42 @@ pub async fn run(args: ForkCmd) -> Result<(), Error> {
                 .join(format!("{}.traj.json", args.instance)),
         ];
         let mut found = None;
-        for path in &single_candidates {
-            if let Ok(bytes) = std::fs::read(path) {
-                if let Ok(traj) = serde_json::from_slice::<Trajectory>(&bytes) {
-                    found = Some((traj, bytes));
-                    break;
+        for (idx, path) in single_candidates.iter().enumerate() {
+            match std::fs::read(path) {
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    // Not present — try the next candidate.
                 }
+                Err(e) => {
+                    // Readable failure (permissions, I/O error) on any candidate is fatal.
+                    return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                        "Cannot read trajectory candidate {}: {e}",
+                        path.display()
+                    ))));
+                }
+                Ok(bytes) => match serde_json::from_slice::<Trajectory>(&bytes) {
+                    Ok(traj) => {
+                        found = Some((traj, bytes));
+                        break;
+                    }
+                    Err(parse_err) => {
+                        if idx == 0 {
+                            // The canonical (preferred) path exists but is corrupt —
+                            // fail immediately rather than silently falling through to
+                            // a stale legacy file which would give wrong results.
+                            return Err(Error::Config(crate::error::ConfigError::Invalid(
+                                format!(
+                                    "Trajectory at {} exists but could not be parsed: {parse_err}",
+                                    path.display()
+                                ),
+                            )));
+                        }
+                        // Non-preferred candidate is malformed — skip and try next.
+                        tracing::warn!(
+                            "Skipping malformed trajectory at {}: {parse_err}",
+                            path.display()
+                        );
+                    }
+                },
             }
         }
 
@@ -408,6 +438,12 @@ pub async fn run(args: ForkCmd) -> Result<(), Error> {
     }
 
     if let Some(budget) = args.per_task_budget_usd {
+        // Validate before applying — NaN/inf would let the budget guard silently malfunction.
+        if !budget.is_finite() {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "--per-task-budget-usd value {budget} is not a finite number"
+            ))));
+        }
         config.root.agent.per_task_budget_usd = Some(budget);
     }
 
@@ -453,21 +489,31 @@ pub async fn run(args: ForkCmd) -> Result<(), Error> {
                         "--mcp-config: server {name:?} is missing \"command\" field"
                     )))
                 })?;
-            // Collect optional `args` array and append to the command string.
-            let args_suffix: Vec<String> = val
-                .get("args")
-                .and_then(serde_json::Value::as_array)
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str())
-                        .map(str::to_owned)
-                        .collect()
-                })
-                .unwrap_or_default();
+            // Collect optional `args` array; reject non-string entries immediately.
+            let args_suffix: Vec<String> =
+                if let Some(arr) = val.get("args").and_then(serde_json::Value::as_array) {
+                    let mut collected = Vec::with_capacity(arr.len());
+                    for (i, v) in arr.iter().enumerate() {
+                        let s = v.as_str().ok_or_else(|| {
+                            Error::Config(crate::error::ConfigError::Invalid(format!(
+                                "--mcp-config: server {name:?} args[{i}] is not a string (got {v})"
+                            )))
+                        })?;
+                        collected.push(s.to_owned());
+                    }
+                    collected
+                } else {
+                    Vec::new()
+                };
+            // Shell-quote each arg individually so that args containing spaces,
+            // quotes, or other metacharacters survive the `bash -c` invocation
+            // that env.run() uses to launch the server.
             let full_command = if args_suffix.is_empty() {
                 cmd.to_owned()
             } else {
-                format!("{} {}", cmd, args_suffix.join(" "))
+                let quoted: Vec<String> =
+                    args_suffix.iter().map(|a| shell_quote_single(a)).collect();
+                format!("{} {}", cmd, quoted.join(" "))
             };
             servers.push(McpServerCfg {
                 command: full_command,
@@ -697,4 +743,38 @@ fn current_rust_version() -> Option<String> {
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_owned())
         .filter(|s| !s.is_empty())
+}
+
+/// Wrap `s` in POSIX single-quotes so it survives `bash -c` without any word
+/// splitting or glob expansion. A single-quote inside `s` is escaped using the
+/// standard `'\''` technique (close quote, escaped literal `'`, reopen quote).
+fn shell_quote_single(s: &str) -> String {
+    // Replace every ' with '\'' and wrap the whole thing in outer single-quotes.
+    let escaped = s.replace('\'', r"'\''");
+    format!("'{escaped}'")
+}
+
+#[cfg(test)]
+mod shell_quote_tests {
+    use super::shell_quote_single;
+
+    #[test]
+    fn plain_arg() {
+        assert_eq!(shell_quote_single("hello"), "'hello'");
+    }
+
+    #[test]
+    fn arg_with_spaces() {
+        assert_eq!(shell_quote_single("My Project"), "'My Project'");
+    }
+
+    #[test]
+    fn arg_with_single_quote() {
+        assert_eq!(shell_quote_single("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn arg_with_shell_metacharacters() {
+        assert_eq!(shell_quote_single("$HOME/bin"), "'$HOME/bin'");
+    }
 }

--- a/src/run/fork.rs
+++ b/src/run/fork.rs
@@ -251,7 +251,13 @@ fn extract_cassette(trajectory: &Trajectory) -> Vec<CassetteEntry> {
 pub async fn run(args: ForkCmd) -> Result<(), Error> {
     // 1. Locate and parse the parent trajectory.
     let (parent_trajectory, parent_trajectory_sha256) = {
+        // Canonical nested path written by swebench::trajectory_path_for_run:
+        //   <sweep>/<instance>/run-1.traj.json
+        // Legacy flat path written by early sweeps:
+        //   <sweep>/<instance>.traj.json
+        // Alternative layouts (e.g. bundle / trajectories subdir) are tried last.
         let single_candidates = [
+            crate::run::swebench::trajectory_path_for_run(&args.sweep, &args.instance, 1),
             args.sweep.join(format!("{}.traj.json", args.instance)),
             args.sweep.join(&args.instance).join("trajectory.json"),
             args.sweep
@@ -270,9 +276,14 @@ pub async fn run(args: ForkCmd) -> Result<(), Error> {
 
         let (traj, bytes) = found.ok_or_else(|| {
             Error::Config(crate::error::ConfigError::Invalid(format!(
-                "No trajectory found for instance {} under sweep directory {}",
+                "No trajectory found for instance {} under sweep directory {} (searched: {})",
                 args.instance,
-                args.sweep.display()
+                args.sweep.display(),
+                single_candidates
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             )))
         })?;
 
@@ -355,8 +366,26 @@ pub async fn run(args: ForkCmd) -> Result<(), Error> {
         Vec::new()
     };
 
-    // 3. Build the configuration for the agent, incorporating the tail overrides.
-    let mut config = Config::defaults()?;
+    // 3. Build the configuration for the agent.
+    //
+    // Seed from the parent sweep's fully-resolved config so the replay prefix
+    // sees exactly the same prompt/tool/redaction settings as the original run.
+    // Fall back to defaults when the manifest is absent (e.g., old sweeps or
+    // non-sweep outputs).
+    let mut config = {
+        let from_manifest = load_manifest_from_sweep(&args.sweep)
+            .ok()
+            .and_then(|m| Config::from_toml_str(&m.config.resolved).ok());
+        if let Some(cfg) = from_manifest {
+            cfg
+        } else {
+            tracing::warn!(
+                "bench fork: sweep has no resolvable manifest config; \
+                 falling back to built-in defaults"
+            );
+            Config::defaults()?
+        }
+    };
 
     // Config overlays:
     if let Some(ref model_override) = args.model {
@@ -392,23 +421,60 @@ pub async fn run(args: ForkCmd) -> Result<(), Error> {
             })
             .collect();
     } else if let Some(ref mcp_config_path) = args.mcp_config {
-        // Standard MCP config JSON loader compatibility if specified
-        if let Ok(text) = std::fs::read_to_string(mcp_config_path) {
-            if let Ok(serde_json::Value::Object(map)) = serde_json::from_str(&text) {
-                if let Some(serde_json::Value::Object(mcp_servers)) = map.get("mcpServers") {
-                    let mut servers = Vec::new();
-                    for (_name, val) in mcp_servers {
-                        if let Some(cmd) = val.get("command").and_then(|c| c.as_str()) {
-                            servers.push(McpServerCfg {
-                                command: cmd.to_owned(),
-                                timeout_secs: None,
-                            });
-                        }
-                    }
-                    config.root.agent.mcp_servers = servers;
-                }
-            }
+        // Standard MCP config JSON loader — fail-fast on missing file or bad JSON shape.
+        let text = std::fs::read_to_string(mcp_config_path).map_err(|e| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "--mcp-config: cannot read {}: {e}",
+                mcp_config_path.display()
+            )))
+        })?;
+        let root: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "--mcp-config: invalid JSON in {}: {e}",
+                mcp_config_path.display()
+            )))
+        })?;
+        let mcp_servers = root
+            .get("mcpServers")
+            .and_then(serde_json::Value::as_object)
+            .ok_or_else(|| {
+                Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "--mcp-config: {} has no top-level \"mcpServers\" object",
+                    mcp_config_path.display()
+                )))
+            })?;
+        let mut servers = Vec::new();
+        for (name, val) in mcp_servers {
+            let cmd = val
+                .get("command")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| {
+                    Error::Config(crate::error::ConfigError::Invalid(format!(
+                        "--mcp-config: server {name:?} is missing \"command\" field"
+                    )))
+                })?;
+            // Collect optional `args` array and append to the command string.
+            let args_suffix: Vec<String> = val
+                .get("args")
+                .and_then(serde_json::Value::as_array)
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str())
+                        .map(str::to_owned)
+                        .collect()
+                })
+                .unwrap_or_default();
+            let full_command = if args_suffix.is_empty() {
+                cmd.to_owned()
+            } else {
+                format!("{} {}", cmd, args_suffix.join(" "))
+            };
+            servers.push(McpServerCfg {
+                command: full_command,
+                timeout_secs: None,
+            });
         }
+        config.root.agent.mcp_servers = servers;
     }
 
     // 4. Construct the ForkingModel.
@@ -505,9 +571,14 @@ pub async fn run(args: ForkCmd) -> Result<(), Error> {
         );
     }
     if let Some(budget) = args.per_task_budget_usd {
+        let budget_num = serde_json::Number::from_f64(budget).ok_or_else(|| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "--per-task-budget-usd value {budget} is not a finite number"
+            )))
+        })?;
         tail_overrides.insert(
             "per_task_budget_usd".to_owned(),
-            serde_json::Value::Number(serde_json::Number::from_f64(budget).unwrap()),
+            serde_json::Value::Number(budget_num),
         );
     }
     if !args.mcp_servers.is_empty() {

--- a/src/run/fork.rs
+++ b/src/run/fork.rs
@@ -1,0 +1,625 @@
+//! `bench fork` runner — re-runs a prefix from a parent trajectory under $0 cost
+//! and prompt/drift verification, then switches to live model calls at step N.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use sha2::Digest;
+
+use crate::agent::{Agent, DefaultAgent, default::DefaultAgentBuilder};
+use crate::cli::args::ForkCmd;
+use crate::config::{Config, EnvKind, McpServerCfg};
+#[cfg(feature = "docker")]
+use crate::env::DockerEnvironment;
+use crate::env::{Environment, LocalEnvironment};
+use crate::error::{Error, ModelError};
+use crate::fingerprint::{canonical_json, cap_canonical, compute_input_fingerprint};
+use crate::model::litellm::LitellmBackend;
+use crate::model::{
+    DeterministicModel, FallbackModel, Message, Model, ModelResponse, ModelUsage, QueryOpts,
+};
+use crate::redaction::Redactor;
+use crate::run::reproduce::{
+    DriftSeverity, compare_manifests, filter_hard_drifts, load_manifest_from_sweep,
+};
+use crate::trajectory::{ForkLineage, Trajectory};
+
+/// Hybrid model that replays a prefix using deterministic responses with
+/// fingerprint verification at strictly $0 cost, and delegates to a live
+/// backend model starting from step N.
+pub struct ForkingModel {
+    pub inner_deterministic: DeterministicModel,
+    pub live_model: Arc<dyn Model>,
+    pub fork_step: usize,
+    pub redactor: Redactor,
+    /// Stored fingerprints from the parent trajectory.
+    pub expected_fps: Vec<Option<String>>,
+    /// Stored canonical JSON from the parent trajectory.
+    pub expected_canonicals: Vec<Option<(String, bool)>>,
+    pub step: Mutex<usize>,
+    pub allow_unfingerprinted: bool,
+    pub drift_cap_bytes: usize,
+    pub drift_steps: Arc<Mutex<Vec<crate::run::replay::DriftStep>>>,
+}
+
+#[async_trait]
+impl Model for ForkingModel {
+    fn name(&self) -> &'static str {
+        "forking-model"
+    }
+
+    fn skip_latency_telemetry(&self) -> bool {
+        // Since we are hybrid, we let telemetry reflect the live backend
+        // starting from step N, but the deterministic replay prefix doesn't have latency.
+        false
+    }
+
+    async fn query(
+        &self,
+        messages: &[Message],
+        opts: &QueryOpts,
+    ) -> Result<ModelResponse, ModelError> {
+        let step = *self
+            .step
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        if step < self.fork_step {
+            // Apply prompt fingerprint check during the prefix phase
+            let normalized: Vec<Message> = messages
+                .iter()
+                .map(|m| {
+                    let mut m2 = m.clone();
+                    let redacted = self.redactor.redact_text_scratch(&m.content);
+                    m2.content = crate::fingerprint::normalize_redaction_markers(&redacted);
+                    m2
+                })
+                .collect();
+            let actual_fp = compute_input_fingerprint(&normalized);
+
+            match self.expected_fps.get(step) {
+                Some(None) => {
+                    if !self.allow_unfingerprinted {
+                        return Err(ModelError::ReplayUnfingerprintedLegacy(step));
+                    }
+                    tracing::warn!(
+                        step,
+                        "fork prefix: replaying step without stored fingerprint (--allow-unfingerprinted active)"
+                    );
+                }
+                Some(Some(expected)) if actual_fp.hex != *expected => {
+                    // Fingerprint mismatch — prompt drift!
+                    let actual_canonical = canonical_json(&normalized);
+                    let (recorded_canonical_raw, recorded_was_truncated) = self
+                        .expected_canonicals
+                        .get(step)
+                        .and_then(Option::as_ref)
+                        .map_or(("", false), |(c, t)| (c.as_str(), *t));
+                    let recorded_canonical_normalized =
+                        crate::fingerprint::normalize_redaction_markers(recorded_canonical_raw);
+
+                    let (unified_diff, diff_truncated) = make_unified_diff_for_fork(
+                        &recorded_canonical_normalized,
+                        &actual_canonical,
+                        recorded_was_truncated,
+                        self.drift_cap_bytes,
+                    );
+
+                    {
+                        let mut guard = self
+                            .drift_steps
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        guard.push(crate::run::replay::DriftStep {
+                            step_index: step,
+                            recorded_fingerprint: expected.clone(),
+                            actual_fingerprint: actual_fp.hex.clone(),
+                            unified_diff,
+                            diff_truncated,
+                        });
+                    }
+
+                    // For fork, prompt drift mismatch at/before step N-1 causes immediate exit 9.
+                    return Err(ModelError::ReplayDrift(step));
+                }
+                _ => {}
+            }
+
+            // Advance step counter only after checking fingerprint.
+            *self
+                .step
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = step + 1;
+
+            let mut resp = self
+                .inner_deterministic
+                .query(messages, opts)
+                .await
+                .map_err(|e| match e {
+                    ModelError::ResponsesExhausted(n) => ModelError::ScriptedResponsesExhausted(n),
+                    other => other,
+                })?;
+
+            // Strictly $0 cost attribute to the prefix.
+            resp.usage = ModelUsage {
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
+                cost_usd: Some(0.0),
+            };
+
+            Ok(resp)
+        } else {
+            // Live phase! Delegate to the live model.
+            *self
+                .step
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = step + 1;
+
+            self.live_model.query(messages, opts).await
+        }
+    }
+}
+
+fn make_unified_diff_for_fork(
+    recorded: &str,
+    actual: &str,
+    recorded_was_truncated: bool,
+    cap: usize,
+) -> (String, bool) {
+    let recorded_pretty = pretty_canonical(recorded);
+    let actual_pretty = pretty_canonical(actual);
+
+    let diff = similar::TextDiff::from_lines(&recorded_pretty, &actual_pretty);
+    let mut out = String::new();
+    let mut header_written = false;
+    for group in diff.grouped_ops(3) {
+        if !header_written {
+            out.push_str("--- recorded\n+++ actual\n");
+            header_written = true;
+        }
+        for op in &group {
+            for change in diff.iter_changes(op) {
+                let prefix = match change.tag() {
+                    similar::ChangeTag::Delete => "-",
+                    similar::ChangeTag::Insert => "+",
+                    similar::ChangeTag::Equal => " ",
+                };
+                out.push_str(prefix);
+                out.push_str(change.value());
+                if change.missing_newline() {
+                    out.push('\n');
+                }
+            }
+        }
+    }
+
+    let (capped, diff_cap_hit) = cap_canonical(&out, cap);
+    (capped, diff_cap_hit || recorded_was_truncated)
+}
+
+fn pretty_canonical(compact: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(compact)
+        .ok()
+        .and_then(|v| serde_json::to_string_pretty(&v).ok())
+        .unwrap_or_else(|| compact.to_owned())
+}
+
+// Extract cassette entry helper (similar to replay.rs)
+struct CassetteEntry {
+    response: String,
+    fingerprint: Option<String>,
+    canonical: Option<String>,
+    canonical_truncated: bool,
+}
+
+fn extract_cassette(trajectory: &Trajectory) -> Vec<CassetteEntry> {
+    trajectory
+        .messages
+        .iter()
+        .filter(|m| m.role == "assistant")
+        .map(|m| {
+            let mc = m.extra.other.get("model_call");
+            let fingerprint = mc
+                .and_then(|v| v.get("input_fingerprint"))
+                .and_then(|v| v.as_str())
+                .map(str::to_owned);
+            let canonical = mc
+                .and_then(|v| v.get("input_canonical"))
+                .and_then(|v| v.as_str())
+                .map(str::to_owned);
+            let canonical_truncated = mc
+                .and_then(|v| v.get("input_canonical_truncated"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+            CassetteEntry {
+                response: m.content.clone(),
+                fingerprint,
+                canonical,
+                canonical_truncated,
+            }
+        })
+        .collect()
+}
+
+#[allow(clippy::too_many_lines, clippy::unwrap_used, clippy::cast_possible_truncation)]
+pub async fn run(args: ForkCmd) -> Result<(), Error> {
+    // 1. Locate and parse the parent trajectory.
+    let (parent_trajectory, parent_trajectory_sha256) = {
+        let single_candidates = [
+            args.sweep.join(format!("{}.traj.json", args.instance)),
+            args.sweep.join(&args.instance).join("trajectory.json"),
+            args.sweep
+                .join("trajectories")
+                .join(format!("{}.traj.json", args.instance)),
+        ];
+        let mut found = None;
+        for path in &single_candidates {
+            if let Ok(bytes) = std::fs::read(path) {
+                if let Ok(traj) = serde_json::from_slice::<Trajectory>(&bytes) {
+                    found = Some((traj, bytes));
+                    break;
+                }
+            }
+        }
+
+        let (traj, bytes) = found.ok_or_else(|| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "No trajectory found for instance {} under sweep directory {}",
+                args.instance,
+                args.sweep.display()
+            )))
+        })?;
+
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(&bytes);
+        let hash = hasher.finalize();
+        let mut sha256 = String::with_capacity(64);
+        for b in hash {
+            use std::fmt::Write as _;
+            let _ = write!(sha256, "{b:02x}");
+        }
+        (traj, sha256)
+    };
+
+    // Extract expected fingerprints and scripted responses from cassette
+    let cassette = extract_cassette(&parent_trajectory);
+    let parent_steps = cassette.len() as u32;
+
+    // Validate bounds:
+    if args.from_step >= parent_steps {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "Fork step {} is out of bounds (parent trajectory has only {} steps)",
+            args.from_step, parent_steps
+        ))));
+    }
+
+    let mut responses = Vec::new();
+    let mut expected_fps = Vec::new();
+    let mut expected_canonicals = Vec::new();
+
+    for (i, entry) in cassette.into_iter().enumerate() {
+        if (i as u32) < args.from_step {
+            responses.push(entry.response);
+            expected_fps.push(entry.fingerprint);
+            expected_canonicals.push(entry.canonical.map(|c| (c, entry.canonical_truncated)));
+        } else {
+            break;
+        }
+    }
+
+    if !args.allow_unfingerprinted {
+        if let Some(pos) = expected_fps.iter().position(Option::is_none) {
+            return Err(Error::Model(ModelError::ReplayUnfingerprintedLegacy(pos)));
+        }
+    }
+
+    // 2. Perform environment-drift checks from reproducible sweeps.
+    let drift_records = if let Ok(source_manifest) = load_manifest_from_sweep(&args.sweep) {
+        let mut current_manifest = source_manifest.clone();
+        current_manifest.harness.git_sha = current_git_sha();
+        current_manifest.harness.git_dirty = None;
+        current_manifest.runtime.started_at_utc = chrono::Utc::now().to_rfc3339();
+        current_manifest.runtime.finished_at_utc = None;
+        current_manifest.runtime.host_os = std::env::consts::OS.into();
+        current_manifest.runtime.rust_version = current_rust_version();
+
+        let all_drifts = compare_manifests(&source_manifest, &current_manifest);
+
+        // Warn on soft drifts
+        for d in all_drifts
+            .iter()
+            .filter(|d| d.severity == DriftSeverity::Soft)
+        {
+            tracing::warn!(field = %d.field, "fork environment soft drift: {}", d.message);
+        }
+
+        // Abort on unwhitelisted hard drifts. Since there's no CLI override for white-listing drifts here,
+        // we block blocking drifts.
+        let blocking = filter_hard_drifts(&all_drifts, &[]);
+        if !blocking.is_empty() {
+            let reasons: Vec<String> = blocking.iter().map(|d| d.message.clone()).collect();
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "fork: hard environment drift detected:\n  {}",
+                reasons.join("\n  ")
+            ))));
+        }
+
+        all_drifts
+    } else {
+        Vec::new()
+    };
+
+    // 3. Build the configuration for the agent, incorporating the tail overrides.
+    let mut config = Config::defaults()?;
+
+    // Config overlays:
+    if let Some(ref model_override) = args.model {
+        config.root.model.name = model_override.clone();
+    } else if let Some(ref parent_model) = parent_trajectory.info.model_name {
+        config.root.model.name = parent_model.clone();
+    }
+
+    if let Some(ref prompt_file) = args.system_prompt_file {
+        let content = std::fs::read_to_string(prompt_file)?;
+        config.root.prompts.system = content;
+    } else {
+        // Fallback to default or empty if not set
+    }
+
+    if let Some(limit) = args.step_limit {
+        config.root.agent.step_limit = limit;
+    } else {
+        config.root.agent.step_limit = parent_steps.max(50);
+    }
+
+    if let Some(budget) = args.per_task_budget_usd {
+        config.root.agent.per_task_budget_usd = Some(budget);
+    }
+
+    if !args.mcp_servers.is_empty() {
+        config.root.agent.mcp_servers = args
+            .mcp_servers
+            .iter()
+            .map(|cmd| McpServerCfg {
+                command: cmd.clone(),
+                timeout_secs: None,
+            })
+            .collect();
+    } else if let Some(ref mcp_config_path) = args.mcp_config {
+        // Standard MCP config JSON loader compatibility if specified
+        if let Ok(text) = std::fs::read_to_string(mcp_config_path) {
+            if let Ok(serde_json::Value::Object(map)) = serde_json::from_str(&text) {
+                if let Some(serde_json::Value::Object(mcp_servers)) = map.get("mcpServers") {
+                    let mut servers = Vec::new();
+                    for (_name, val) in mcp_servers {
+                        if let Some(cmd) = val.get("command").and_then(|c| c.as_str()) {
+                            servers.push(McpServerCfg {
+                                command: cmd.to_owned(),
+                                timeout_secs: None,
+                            });
+                        }
+                    }
+                    config.root.agent.mcp_servers = servers;
+                }
+            }
+        }
+    }
+
+    // 4. Construct the ForkingModel.
+    let fp_redactor = Redactor::from_config(&config.root.redaction).map_err(|err| {
+        Error::Config(crate::error::ConfigError::Invalid(format!(
+            "Invalid redaction config: {err}"
+        )))
+    })?;
+
+    let live_model = build_live_model(&config);
+    let drift_steps = Arc::new(Mutex::new(Vec::new()));
+    let model = Arc::new(ForkingModel {
+        inner_deterministic: DeterministicModel::new(responses),
+        live_model,
+        fork_step: args.from_step as usize,
+        redactor: fp_redactor,
+        expected_fps,
+        expected_canonicals,
+        step: Mutex::new(0),
+        allow_unfingerprinted: args.allow_unfingerprinted,
+        drift_cap_bytes: crate::run::replay::DEFAULT_DRIFT_CAP_BYTES,
+        drift_steps: Arc::clone(&drift_steps),
+    });
+
+    // 5. Setup the execution environment and Agent.
+    let env = build_env(&config).await?;
+    let task = parent_trajectory
+        .info
+        .task
+        .clone()
+        .unwrap_or_else(|| "Forked task".to_owned());
+
+    let tool_providers = crate::tool::discover_mcp_servers(
+        env.as_ref(),
+        &config.root.agent.mcp_servers,
+        config.root.agent.tool_hook_timeout_secs,
+        None,
+    )
+    .await?;
+
+    let resolved_skills = crate::skills::resolve_for_task(&config.root.skills, &task, None)?;
+
+    let mut agent: DefaultAgent = DefaultAgentBuilder {
+        config: config.clone(),
+        model,
+        env,
+        task: task.clone(),
+        extra_context: resolved_skills.merged_extra_context,
+        renderer: None,
+        stream: None,
+        resume_from: None,
+    }
+    .build_with_tool_providers(tool_providers)?;
+
+    resolved_skills
+        .active_skills
+        .record_redacted_provenance(&mut agent.trajectory.info, &agent.redactor)?;
+
+    // Start with empty/zeroed initial cost because prefix is strictly $0 cost
+    agent.trajectory.info.actual_cost_usd = Some(0.0);
+    agent.trajectory.info.total_cost_usd = Some(0.0);
+
+    // Save outputs target
+    let traj_name = format!("{}-fork", args.instance);
+    std::fs::create_dir_all(&args.output)?;
+    let checkpoint_path = args.output.join(format!("{traj_name}.traj.json"));
+    agent.checkpoint_path = Some(checkpoint_path.clone());
+
+    // 6. Run the agent.
+    tracing::info!("starting bench fork at step {}", args.from_step);
+    let run_result = agent.run().await;
+
+    // Report if any drift steps occurred during the deterministic prefix (though we exit 9 early if mismatch occurs)
+    let collected_drifts = drift_steps.lock().unwrap().clone();
+    if !collected_drifts.is_empty() {
+        tracing::warn!("Replay drift detected during deterministic prefix phase");
+    }
+
+    // 7. Embed the ForkLineage block.
+    let mut tail_overrides = std::collections::BTreeMap::new();
+    if let Some(ref m) = args.model {
+        tail_overrides.insert("model".to_owned(), serde_json::Value::String(m.clone()));
+    }
+    if let Some(ref p) = args.system_prompt_file {
+        tail_overrides.insert(
+            "system_prompt_file".to_owned(),
+            serde_json::Value::String(p.to_string_lossy().into_owned()),
+        );
+    }
+    if let Some(lim) = args.step_limit {
+        tail_overrides.insert(
+            "step_limit".to_owned(),
+            serde_json::Value::Number(lim.into()),
+        );
+    }
+    if let Some(budget) = args.per_task_budget_usd {
+        tail_overrides.insert(
+            "per_task_budget_usd".to_owned(),
+            serde_json::Value::Number(serde_json::Number::from_f64(budget).unwrap()),
+        );
+    }
+    if !args.mcp_servers.is_empty() {
+        tail_overrides.insert(
+            "mcp_servers".to_owned(),
+            serde_json::Value::Array(
+                args.mcp_servers
+                    .iter()
+                    .map(|s| serde_json::Value::String(s.clone()))
+                    .collect(),
+            ),
+        );
+    }
+    if let Some(ref p) = args.mcp_config {
+        tail_overrides.insert(
+            "mcp_config".to_owned(),
+            serde_json::Value::String(p.to_string_lossy().into_owned()),
+        );
+    }
+
+    let lineage = ForkLineage {
+        parent_sweep_path: args.sweep.to_string_lossy().into_owned(),
+        parent_instance_id: args.instance.clone(),
+        parent_trajectory_sha256,
+        fork_step: args.from_step,
+        tail_overrides,
+    };
+
+    agent.trajectory.fork_lineage = Some(lineage);
+
+    // Embed environmental drifts in the `provenance` metadata block if present
+    if !drift_records.is_empty() {
+        agent.trajectory.info.other.insert(
+            "provenance".to_owned(),
+            serde_json::to_value(&drift_records).unwrap_or(serde_json::Value::Null),
+        );
+    }
+
+    // Check exit reason and handle errors
+    let exit_reason = run_result?;
+
+    // Save final results
+    let final_traj_path = args.output.join(format!("{traj_name}.traj.json"));
+    agent.trajectory.save_pretty(&final_traj_path)?;
+
+    if let crate::agent::ExitReason::Submitted { final_output } = &exit_reason {
+        let out_path = args.output.join(format!("{traj_name}.output.txt"));
+        std::fs::write(out_path, final_output)?;
+    }
+
+    tracing::info!(
+        "bench fork run completed successfully; trajectory saved to {}",
+        final_traj_path.display()
+    );
+    Ok(())
+}
+
+fn build_live_model(cfg: &Config) -> Arc<dyn Model> {
+    let primary =
+        LitellmBackend::new(cfg.root.model.name.clone()).with_max_tokens(cfg.root.model.max_tokens);
+    if cfg.root.model.fallback_models.is_empty() {
+        return Arc::new(primary);
+    }
+    let mut models: Vec<Box<dyn Model>> = vec![Box::new(primary)];
+    for name in &cfg.root.model.fallback_models {
+        models.push(Box::new(
+            LitellmBackend::new(name.clone()).with_max_tokens(cfg.root.model.max_tokens),
+        ));
+    }
+    Arc::new(FallbackModel::new(models))
+}
+
+async fn build_env(cfg: &Config) -> Result<Box<dyn Environment>, Error> {
+    match cfg.root.environment.kind {
+        EnvKind::Local => Ok(Box::new(LocalEnvironment::new())),
+        EnvKind::Docker => build_docker_env(cfg).await,
+    }
+}
+
+#[cfg(feature = "docker")]
+async fn build_docker_env(cfg: &Config) -> Result<Box<dyn Environment>, Error> {
+    let image = cfg.root.environment.docker_image.clone().ok_or_else(|| {
+        Error::Config(crate::error::ConfigError::Invalid(
+            "environment.kind=docker requires environment.docker_image".into(),
+        ))
+    })?;
+    let wd = PathBuf::from(cfg.root.environment.workdir.clone());
+    let env = DockerEnvironment::start(image, wd).await?;
+    Ok(Box::new(env))
+}
+
+#[cfg(not(feature = "docker"))]
+#[allow(clippy::unused_async)]
+async fn build_docker_env(_cfg: &Config) -> Result<Box<dyn Environment>, Error> {
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "docker support not compiled in — rebuild with --features docker".into(),
+    )))
+}
+
+fn current_git_sha() -> Option<String> {
+    std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
+        .filter(|s| !s.is_empty())
+}
+
+fn current_rust_version() -> Option<String> {
+    std::process::Command::new("rustc")
+        .arg("--version")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+}

--- a/src/run/fork.rs
+++ b/src/run/fork.rs
@@ -243,7 +243,11 @@ fn extract_cassette(trajectory: &Trajectory) -> Vec<CassetteEntry> {
         .collect()
 }
 
-#[allow(clippy::too_many_lines, clippy::unwrap_used, clippy::cast_possible_truncation)]
+#[allow(
+    clippy::too_many_lines,
+    clippy::unwrap_used,
+    clippy::cast_possible_truncation
+)]
 pub async fn run(args: ForkCmd) -> Result<(), Error> {
     // 1. Locate and parse the parent trajectory.
     let (parent_trajectory, parent_trajectory_sha256) = {

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -1385,6 +1385,23 @@ pub fn redact_trajectory_for_inspect(trajectory: &mut Trajectory, redactor: &Red
             redacted |= redactor.redact_json_value(value, surface::INSPECT);
         }
     }
+    if let Some(lineage) = &mut trajectory.fork_lineage {
+        let outcome = redactor.redact_text(&lineage.parent_sweep_path, surface::INSPECT);
+        redacted |= outcome.redacted;
+        lineage.parent_sweep_path = outcome.text;
+
+        let outcome = redactor.redact_text(&lineage.parent_instance_id, surface::INSPECT);
+        redacted |= outcome.redacted;
+        lineage.parent_instance_id = outcome.text;
+
+        let outcome = redactor.redact_text(&lineage.parent_trajectory_sha256, surface::INSPECT);
+        redacted |= outcome.redacted;
+        lineage.parent_trajectory_sha256 = outcome.text;
+
+        for value in lineage.tail_overrides.values_mut() {
+            redacted |= redactor.redact_json_value(value, surface::INSPECT);
+        }
+    }
     redacted
 }
 

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -176,6 +176,9 @@ pub struct InspectReport {
     /// via their dashboard's trace search. `None` when OTLP was not enabled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trace_id: Option<String>,
+    /// Metadata recording how this trajectory was forked from a parent run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_lineage: Option<crate::trajectory::ForkLineage>,
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize)]
@@ -375,6 +378,7 @@ fn build_instance_report(
                 partial: false,
                 partial_reason: None,
                 trace_id: None,
+                fork_lineage: None,
             });
         }
     };
@@ -461,6 +465,7 @@ fn build_instance_report(
         partial: traj.info.partial,
         partial_reason: traj.info.partial_reason,
         trace_id: traj.info.trace_id,
+        fork_lineage: traj.fork_lineage,
     })
 }
 
@@ -861,6 +866,29 @@ fn render_instance_text(report: &InspectReport) -> String {
     }
     if let Some(tid) = &report.trace_id {
         let _ = writeln!(s, "trace_id:         {tid}");
+    }
+    if let Some(lineage) = &report.fork_lineage {
+        let _ = writeln!(
+            s,
+            "fork_lineage:     parent_sweep_path={}",
+            lineage.parent_sweep_path
+        );
+        let _ = writeln!(
+            s,
+            "                  parent_instance_id={}",
+            lineage.parent_instance_id
+        );
+        let _ = writeln!(
+            s,
+            "                  parent_trajectory_sha256={}",
+            lineage.parent_trajectory_sha256
+        );
+        let _ = writeln!(s, "                  fork_step={}", lineage.fork_step);
+        let _ = writeln!(
+            s,
+            "                  tail_overrides={}",
+            serde_json::to_string(&lineage.tail_overrides).unwrap_or_default()
+        );
     }
     for w in &report.warnings {
         let _ = writeln!(s, "warning:          {w}");

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -15,6 +15,7 @@ pub mod env_preview;
 pub mod evaluate;
 pub mod evaluator_selftest;
 pub mod forecast;
+pub mod fork;
 pub mod frontier;
 pub mod github_pr;
 pub mod grep;

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -579,6 +579,7 @@ mod tests {
                     extra: MessageExtra::default(),
                 },
             ],
+            fork_lineage: None,
         }
     }
 

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -6345,6 +6345,7 @@ instance = "inst"
                 ..Default::default()
             },
             messages: vec![],
+            fork_lineage: None,
         };
         let path = trajectory_path_for(dir.path(), "inst-1");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -603,6 +603,15 @@ fn extra_is_empty(e: &MessageExtra) -> bool {
         && e.other.is_empty()
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForkLineage {
+    pub parent_sweep_path: String,
+    pub parent_instance_id: String,
+    pub parent_trajectory_sha256: String,
+    pub fork_step: u32,
+    pub tail_overrides: std::collections::BTreeMap<String, serde_json::Value>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 /// The complete record of an agent's execution, including metadata, telemetry, and all messages.
 ///
@@ -615,6 +624,9 @@ pub struct Trajectory {
     pub info: TrajectoryInfo,
     /// The sequence of messages exchanged during the run.
     pub messages: Vec<MessageRecord>,
+    /// Metadata recording how this trajectory was forked from a parent run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_lineage: Option<ForkLineage>,
 }
 
 impl Serialize for Trajectory {
@@ -622,7 +634,8 @@ impl Serialize for Trajectory {
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("Trajectory", 5)?;
+        let len = if self.fork_lineage.is_some() { 6 } else { 5 };
+        let mut state = serializer.serialize_struct("Trajectory", len)?;
         state.serialize_field("trajectory_format", &self.trajectory_format)?;
         state.serialize_field("artifact_kind", &crate::artifact::ArtifactKind::Trajectory)?;
         state.serialize_field(
@@ -631,6 +644,9 @@ impl Serialize for Trajectory {
         )?;
         state.serialize_field("info", &self.info)?;
         state.serialize_field("messages", &self.messages)?;
+        if let Some(ref lineage) = self.fork_lineage {
+            state.serialize_field("fork_lineage", lineage)?;
+        }
         state.end()
     }
 }
@@ -641,6 +657,7 @@ impl Default for Trajectory {
             trajectory_format: FORMAT_VERSION.to_owned(),
             info: TrajectoryInfo::default(),
             messages: Vec::new(),
+            fork_lineage: None,
         }
     }
 }

--- a/tests/bench_fork.rs
+++ b/tests/bench_fork.rs
@@ -595,3 +595,121 @@ fn bench_fork_lineage_records_only_effective_mcp_override() {
         "mcp_config must not be recorded as it was not effective"
     );
 }
+
+fn make_valid_manifest_in_sweep(sweep_dir: &Path, resolved_toml: &str) {
+    let results = serde_json::json!({
+        "total": 0,
+        "submitted": 0,
+        "submitted_with_tests": 0,
+        "skipped": 0,
+        "errored": 0,
+        "sweep_status": "completed",
+        "instances": [],
+        "manifest": {
+            "harness": {
+                "name": "test-harness",
+                "version": "1.0",
+                "git_sha": null,
+                "git_dirty": null,
+                "git_resolution": "test"
+            },
+            "dataset": {
+                "path": "test-dataset",
+                "sha256": "test-sha",
+                "instance_count": 0,
+                "dataset_kind": "local"
+            },
+            "prompt_template": {
+                "source": "test-template",
+                "sha256": "template-sha"
+            },
+            "config": {
+                "resolved": resolved_toml,
+                "overlay_paths": []
+            },
+            "model": {
+                "name": "test-model",
+                "backend": "test-backend"
+            },
+            "runtime": {
+                "started_at_utc": "2026-05-22T00:00:00Z",
+                "host_os": "linux"
+            },
+            "cli": {
+                "argv": []
+            }
+        }
+    });
+    fs::write(
+        sweep_dir.join("results.json"),
+        serde_json::to_string_pretty(&results).unwrap(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn bench_fork_preserves_parent_step_limit_without_override() {
+    let temp = tempdir().unwrap();
+    let sweep_dir = temp.path().join("sweep");
+    fs::create_dir_all(&sweep_dir).unwrap();
+
+    let legacy_path = temp.path().join("legacy.traj.json");
+    make_legacy_trajectory(&legacy_path);
+    record_fingerprinted_trajectory(&legacy_path, &sweep_dir, "myinstance");
+
+    // Write a valid results.json manifest specifying agent.step_limit = 1
+    let resolved_toml = "\
+[agent]
+step_limit = 1
+";
+    make_valid_manifest_in_sweep(&sweep_dir, resolved_toml);
+
+    // Run fork starting from step 1, WITHOUT --step-limit override
+    let out_dir = temp.path().join("out");
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "fork",
+            "--sweep",
+            sweep_dir.to_str().unwrap(),
+            "--instance",
+            "myinstance",
+            "--from-step",
+            "1",
+            "--output",
+            out_dir.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected fork to succeed, got: {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        stdout,
+        stderr
+    );
+
+    let fork_traj_path = out_dir.join("myinstance-fork.traj.json");
+    assert!(fork_traj_path.exists());
+    let traj_content = fs::read_to_string(&fork_traj_path).unwrap();
+    let traj: serde_json::Value = serde_json::from_str(&traj_content).unwrap();
+
+    // Verify it terminated due to the inherited step_limit of 1
+    let info = &traj["info"];
+    assert_eq!(
+        info["exit_reason"].as_str().unwrap(),
+        "step_limit",
+        "should terminate with step_limit due to inherited step_limit from parent manifest"
+    );
+
+    // Verify no step_limit is recorded in tail_overrides
+    let lineage = &traj["fork_lineage"];
+    let overrides = &lineage["tail_overrides"];
+    assert!(
+        overrides["step_limit"].is_null(),
+        "step_limit override should not be recorded since it wasn't overridden"
+    );
+}

--- a/tests/bench_fork.rs
+++ b/tests/bench_fork.rs
@@ -1,0 +1,404 @@
+//! Integration tests for the new `bench fork` subcommand.
+
+#![allow(clippy::unwrap_used, clippy::uninlined_format_args, clippy::float_cmp)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::tempdir;
+
+mod support;
+use support::binary_path;
+
+/// Build a minimal 2-step trajectory without fingerprints (simulates legacy).
+fn make_legacy_trajectory(path: &Path) {
+    let traj = serde_json::json!({
+        "trajectory_format": "mini-swe-agent-1.1",
+        "info": {
+            "task": "dummy task",
+            "model_name": "deterministic-test",
+            "outcome": "submitted",
+            "steps": 2,
+            "total_cost_usd": 0.50
+        },
+        "messages": [
+            {
+                "role": "user",
+                "content": "dummy task",
+                "extra": {}
+            },
+            {
+                "role": "assistant",
+                "content": "```bash\necho step0\n```",
+                "extra": {
+                    "actions": ["echo step0"]
+                }
+            },
+            {
+                "role": "user",
+                "content": "Exit code: 0\nOutput:\nstep0",
+                "extra": {
+                    "run_result": {
+                        "stdout": "step0\n",
+                        "stderr": "",
+                        "exit_code": 0,
+                        "timed_out": false
+                    }
+                }
+            },
+            {
+                "role": "assistant",
+                "content": "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nstep1\n```",
+                "extra": {
+                    "actions": ["COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT"]
+                }
+            }
+        ]
+    });
+    fs::write(path, serde_json::to_string_pretty(&traj).unwrap()).unwrap();
+}
+
+/// Helper to run replay on a legacy trajectory to produce a correctly fingerprinted parent trajectory.
+fn record_fingerprinted_trajectory(
+    legacy_path: &Path,
+    sweep_dir: &Path,
+    instance_name: &str,
+) -> PathBuf {
+    let out = Command::new(binary_path())
+        .args([
+            "replay",
+            "--trajectory-path",
+            legacy_path.to_str().unwrap(),
+            "--output",
+            sweep_dir.to_str().unwrap(),
+            "--trajectory-name",
+            instance_name,
+            "--allow-unfingerprinted",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "replay to record fingerprinted trajectory failed: status={:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        stdout,
+        stderr
+    );
+
+    sweep_dir.join(format!("{instance_name}.traj.json"))
+}
+
+#[test]
+fn bench_fork_help_works() {
+    let out = Command::new(binary_path())
+        .args(["bench", "fork", "--help"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        out.status.success(),
+        "expected success but got code {:?}, stderr: {}, stdout: {}",
+        out.status.code(),
+        stderr,
+        stdout
+    );
+    assert!(
+        stdout.contains("bench-fork") || stdout.contains("fork") || stdout.contains("Fork"),
+        "expected help output to describe fork command, got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn bench_fork_out_of_bounds_step_fails() {
+    let temp = tempdir().unwrap();
+    let sweep_dir = temp.path().join("sweep");
+    fs::create_dir_all(&sweep_dir).unwrap();
+
+    let legacy_path = temp.path().join("legacy.traj.json");
+    make_legacy_trajectory(&legacy_path);
+
+    // Produce myinstance.traj.json under sweep_dir (which has 2 steps)
+    record_fingerprinted_trajectory(&legacy_path, &sweep_dir, "myinstance");
+
+    // Try to fork at step 2 (out of bounds since parent only has 2 steps: 0 and 1)
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "fork",
+            "--sweep",
+            sweep_dir.to_str().unwrap(),
+            "--instance",
+            "myinstance",
+            "--from-step",
+            "2",
+            "--output",
+            temp.path().join("out").to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected exit code 2 (usage error) on out-of-bounds fork step, got: {:?}",
+        out.status.code()
+    );
+    assert!(
+        stderr.contains("is out of bounds") || stderr.contains("out of bounds"),
+        "expected error message about out of bounds, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn bench_fork_legacy_without_flag_fails() {
+    let temp = tempdir().unwrap();
+    let sweep_dir = temp.path().join("sweep");
+    fs::create_dir_all(&sweep_dir).unwrap();
+
+    // Place the legacy unfingerprinted trajectory directly in sweep_dir
+    let legacy_path = sweep_dir.join("legacyinstance.traj.json");
+    make_legacy_trajectory(&legacy_path);
+
+    // Run fork without --allow-unfingerprinted
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "fork",
+            "--sweep",
+            sweep_dir.to_str().unwrap(),
+            "--instance",
+            "legacyinstance",
+            "--from-step",
+            "1",
+            "--output",
+            temp.path().join("out").to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected exit code 2 (usage error) for legacy trajectory without flag, got: {:?}",
+        out.status.code()
+    );
+}
+
+#[test]
+fn bench_fork_legacy_with_flag_succeeds() {
+    let temp = tempdir().unwrap();
+    let sweep_dir = temp.path().join("sweep");
+    fs::create_dir_all(&sweep_dir).unwrap();
+
+    // Place the legacy unfingerprinted trajectory directly in sweep_dir
+    let legacy_path = sweep_dir.join("legacyinstance.traj.json");
+    make_legacy_trajectory(&legacy_path);
+
+    // Run fork with --allow-unfingerprinted and --step-limit 0 (exit immediately on step 0)
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "fork",
+            "--sweep",
+            sweep_dir.to_str().unwrap(),
+            "--instance",
+            "legacyinstance",
+            "--from-step",
+            "0",
+            "--output",
+            temp.path().join("out").to_str().unwrap(),
+            "--allow-unfingerprinted",
+            "--step-limit",
+            "0",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected successful fork exit 0, got: {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        stdout,
+        stderr
+    );
+}
+
+#[test]
+fn bench_fork_prompt_drift_fails() {
+    let temp = tempdir().unwrap();
+    let sweep_dir = temp.path().join("sweep");
+    fs::create_dir_all(&sweep_dir).unwrap();
+
+    let legacy_path = temp.path().join("legacy.traj.json");
+    make_legacy_trajectory(&legacy_path);
+
+    let fp_traj = record_fingerprinted_trajectory(&legacy_path, &sweep_dir, "driftinstance");
+
+    // Tamper with the first assistant message's input fingerprint
+    let content = fs::read_to_string(&fp_traj).unwrap();
+    let mut traj: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+    let messages = traj["messages"].as_array_mut().unwrap();
+    for msg in messages {
+        if msg["role"].as_str() == Some("assistant") {
+            if let Some(mc) = msg["extra"]["model_call"].as_object_mut() {
+                mc.insert(
+                    "input_fingerprint".to_owned(),
+                    serde_json::json!("deadbeef00000000"),
+                );
+            }
+            break;
+        }
+    }
+    fs::write(&fp_traj, serde_json::to_string_pretty(&traj).unwrap()).unwrap();
+
+    // Run fork starting from step 1 (replays step 0 first, which will fail prompt fingerprint verification)
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "fork",
+            "--sweep",
+            sweep_dir.to_str().unwrap(),
+            "--instance",
+            "driftinstance",
+            "--from-step",
+            "1",
+            "--output",
+            temp.path().join("out").to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(9),
+        "expected exit code 9 (replay prompt drift) on fingerprint mismatch, got: {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        stdout,
+        stderr
+    );
+}
+
+#[test]
+fn bench_fork_successful_run_and_inspect() {
+    let temp = tempdir().unwrap();
+    let sweep_dir = temp.path().join("sweep");
+    fs::create_dir_all(&sweep_dir).unwrap();
+
+    let legacy_path = temp.path().join("legacy.traj.json");
+    make_legacy_trajectory(&legacy_path);
+
+    let _fp_traj = record_fingerprinted_trajectory(&legacy_path, &sweep_dir, "myinstance");
+
+    // Run fork starting from step 1, with --step-limit 1 (so prefix step 0 runs deterministic, then live N=1 hits limit immediately)
+    let out_dir = temp.path().join("out");
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "fork",
+            "--sweep",
+            sweep_dir.to_str().unwrap(),
+            "--instance",
+            "myinstance",
+            "--from-step",
+            "1",
+            "--output",
+            out_dir.to_str().unwrap(),
+            "--step-limit",
+            "1",
+            "--model",
+            "claude-3-opus-fork-tail-override",
+            "--per-task-budget-usd",
+            "12.34",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected fork to succeed with 0, got: {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        stdout,
+        stderr
+    );
+
+    // Verify output trajectory exists and has fork_lineage
+    let fork_traj_path = out_dir.join("myinstance-fork.traj.json");
+    assert!(
+        fork_traj_path.exists(),
+        "forked trajectory file should be saved"
+    );
+
+    let traj_content = fs::read_to_string(&fork_traj_path).unwrap();
+    let traj: serde_json::Value = serde_json::from_str(&traj_content).unwrap();
+
+    // Verify replayed prefix step has $0 cost
+    // The first message is assistant message in replay, verify that input/output/cost is zeroed or overall total cost is $0.
+    // Let's verify total_cost_usd is Some(0.0) or low (in our setup it's exactly 0.0 because of step-limit exit before live phase).
+    let total_cost = traj["info"]["total_cost_usd"].as_f64().unwrap();
+    assert_eq!(
+        total_cost, 0.0,
+        "total cost of fork run should be $0.0 since only step 0 replayed under $0 and step 1 hit limit"
+    );
+
+    // Verify fork_lineage block exists
+    let lineage = &traj["fork_lineage"];
+    assert!(
+        lineage.is_object(),
+        "fork_lineage field must be a valid JSON object"
+    );
+    assert_eq!(
+        lineage["parent_instance_id"].as_str().unwrap(),
+        "myinstance"
+    );
+    assert_eq!(lineage["fork_step"].as_u64().unwrap(), 1);
+
+    // Verify tail overrides are recorded
+    let overrides = &lineage["tail_overrides"];
+    assert_eq!(
+        overrides["model"].as_str().unwrap(),
+        "claude-3-opus-fork-tail-override"
+    );
+    assert_eq!(overrides["step_limit"].as_u64().unwrap(), 1);
+    assert_eq!(overrides["per_task_budget_usd"].as_f64().unwrap(), 12.34);
+
+    // Run bench inspect on output trajectory and verify it displays the lineage
+    let inspect_out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            out_dir.to_str().unwrap(),
+            "--instance",
+            "myinstance-fork",
+        ])
+        .output()
+        .unwrap();
+
+    let inspect_stdout = String::from_utf8_lossy(&inspect_out.stdout);
+    assert!(
+        inspect_out.status.success(),
+        "bench inspect failed: {}",
+        String::from_utf8_lossy(&inspect_out.stderr)
+    );
+    assert!(
+        inspect_stdout.contains("fork_lineage:"),
+        "expected inspect output to show fork lineage, got: {}",
+        inspect_stdout
+    );
+}

--- a/tests/bench_fork.rs
+++ b/tests/bench_fork.rs
@@ -402,3 +402,196 @@ fn bench_fork_successful_run_and_inspect() {
         inspect_stdout
     );
 }
+
+#[test]
+fn bench_fork_invalid_args_in_mcp_config_fails() {
+    let temp = tempdir().unwrap();
+    let sweep_dir = temp.path().join("sweep");
+    fs::create_dir_all(&sweep_dir).unwrap();
+
+    let legacy_path = temp.path().join("legacy.traj.json");
+    make_legacy_trajectory(&legacy_path);
+    record_fingerprinted_trajectory(&legacy_path, &sweep_dir, "myinstance");
+
+    // Write a malformed mcp-config (args is a string, not an array)
+    let mcp_cfg_path = temp.path().join("mcp_config.json");
+    let mcp_cfg_content = serde_json::json!({
+        "mcpServers": {
+            "test-server": {
+                "command": "node",
+                "args": "--version" // Invalid: should be ["--version"]
+            }
+        }
+    });
+    fs::write(
+        &mcp_cfg_path,
+        serde_json::to_string_pretty(&mcp_cfg_content).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "fork",
+            "--sweep",
+            sweep_dir.to_str().unwrap(),
+            "--instance",
+            "myinstance",
+            "--from-step",
+            "1",
+            "--output",
+            temp.path().join("out").to_str().unwrap(),
+            "--mcp-config",
+            mcp_cfg_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected failure for malformed mcp-config"
+    );
+    assert!(
+        stderr.contains("must be an array")
+            || stderr.contains("invalid")
+            || stderr.contains("args"),
+        "expected error about args array requirement, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn bench_fork_corrupt_manifest_fails() {
+    let temp = tempdir().unwrap();
+    let sweep_dir = temp.path().join("sweep");
+    fs::create_dir_all(&sweep_dir).unwrap();
+
+    let legacy_path = temp.path().join("legacy.traj.json");
+    make_legacy_trajectory(&legacy_path);
+    record_fingerprinted_trajectory(&legacy_path, &sweep_dir, "myinstance");
+
+    // Write a corrupt results.json in sweep_dir (e.g. invalid JSON)
+    let results_path = sweep_dir.join("results.json");
+    fs::write(&results_path, "corrupt JSON content } }").unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "fork",
+            "--sweep",
+            sweep_dir.to_str().unwrap(),
+            "--instance",
+            "myinstance",
+            "--from-step",
+            "1",
+            "--output",
+            temp.path().join("out").to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected failure for corrupt manifest results.json"
+    );
+    assert!(
+        stderr.contains("results.json") || stderr.contains("JSON") || stderr.contains("manifest"),
+        "expected error about results.json parsing, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn bench_fork_lineage_records_only_effective_mcp_override() {
+    let temp = tempdir().unwrap();
+    let sweep_dir = temp.path().join("sweep");
+    fs::create_dir_all(&sweep_dir).unwrap();
+
+    let legacy_path = temp.path().join("legacy.traj.json");
+    make_legacy_trajectory(&legacy_path);
+    record_fingerprinted_trajectory(&legacy_path, &sweep_dir, "myinstance");
+
+    // Write a mock MCP server python script that implements handshake and tools/list
+    let mock_mcp_path = temp.path().join("mock_mcp.py");
+    fs::write(
+        &mock_mcp_path,
+        "import sys\n\
+         sys.stdin.readline()\n\
+         sys.stdin.readline()\n\
+         print('{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"mock\",\"version\":\"1.0\"}}}')\n\
+         print('{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[]}}')\n"
+    ).unwrap();
+    let mcp_cmd = format!("python {}", mock_mcp_path.to_str().unwrap());
+
+    // Write a valid mcp-config
+    let mcp_cfg_path = temp.path().join("mcp_config.json");
+    let mcp_cfg_content = serde_json::json!({
+        "mcpServers": {
+            "test-server": {
+                "command": "node",
+                "args": ["--version"]
+            }
+        }
+    });
+    fs::write(
+        &mcp_cfg_path,
+        serde_json::to_string_pretty(&mcp_cfg_content).unwrap(),
+    )
+    .unwrap();
+
+    // Run fork with BOTH --mcp-server and --mcp-config
+    let out_dir = temp.path().join("out");
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "fork",
+            "--sweep",
+            sweep_dir.to_str().unwrap(),
+            "--instance",
+            "myinstance",
+            "--from-step",
+            "1",
+            "--output",
+            out_dir.to_str().unwrap(),
+            "--step-limit",
+            "0",
+            "--mcp-server",
+            &mcp_cmd,
+            "--mcp-config",
+            mcp_cfg_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected success but got status={:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        stdout,
+        stderr
+    );
+
+    let fork_traj_path = out_dir.join("myinstance-fork.traj.json");
+    let traj_content = fs::read_to_string(&fork_traj_path).unwrap();
+    let traj: serde_json::Value = serde_json::from_str(&traj_content).unwrap();
+
+    let lineage = &traj["fork_lineage"];
+    let overrides = &lineage["tail_overrides"];
+
+    // Should contain mcp_servers
+    assert!(
+        overrides["mcp_servers"].is_array(),
+        "mcp_servers must be recorded as it was effective"
+    );
+    assert_eq!(overrides["mcp_servers"][0].as_str().unwrap(), mcp_cmd);
+
+    // Should NOT contain mcp_config because it was ignored in favor of mcp_servers
+    assert!(
+        overrides["mcp_config"].is_null(),
+        "mcp_config must not be recorded as it was not effective"
+    );
+}

--- a/tests/bench_fork.rs
+++ b/tests/bench_fork.rs
@@ -713,3 +713,75 @@ step_limit = 1
         "step_limit override should not be recorded since it wasn't overridden"
     );
 }
+
+#[test]
+fn bench_fork_lineage_redaction() {
+    let temp = tempdir().unwrap();
+    let sweep_dir = temp.path().join("sweep");
+    fs::create_dir_all(&sweep_dir).unwrap();
+
+    let legacy_path = temp.path().join("legacy.traj.json");
+    make_legacy_trajectory(&legacy_path);
+
+    let _fp_traj = record_fingerprinted_trajectory(&legacy_path, &sweep_dir, "myinstance");
+
+    // Run fork starting from step 1, with a sensitive environment variable "MY_SECRET_KEY" = "supersecret123"
+    // and pass this secret in the --model override.
+    let out_dir = temp.path().join("out");
+    let out = Command::new(binary_path())
+        .env("MY_SECRET_KEY", "supersecret123")
+        .args([
+            "bench",
+            "fork",
+            "--sweep",
+            sweep_dir.to_str().unwrap(),
+            "--instance",
+            "myinstance",
+            "--from-step",
+            "1",
+            "--output",
+            out_dir.to_str().unwrap(),
+            "--step-limit",
+            "1",
+            "--model",
+            "claude-with-supersecret123",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(out.status.success());
+
+    // Verify output trajectory exists and has fork_lineage
+    let fork_traj_path = out_dir.join("myinstance-fork.traj.json");
+    assert!(fork_traj_path.exists());
+
+    let traj_content = fs::read_to_string(&fork_traj_path).unwrap();
+
+    // The raw secret "supersecret123" should NOT be present anywhere in the trajectory file on disk!
+    assert!(
+        !traj_content.contains("supersecret123"),
+        "Persisted trajectory should have redacted the sensitive override value, but found: {}",
+        traj_content
+    );
+
+    // Let's also run bench inspect and make sure that is redacted.
+    let inspect_out = Command::new(binary_path())
+        .env("MY_SECRET_KEY", "supersecret123")
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            out_dir.to_str().unwrap(),
+            "--instance",
+            "myinstance-fork",
+        ])
+        .output()
+        .unwrap();
+
+    let inspect_stdout = String::from_utf8_lossy(&inspect_out.stdout);
+    assert!(
+        !inspect_stdout.contains("supersecret123"),
+        "Inspect output should have redacted the sensitive override value, but found: {}",
+        inspect_stdout
+    );
+}

--- a/tests/checkpointing.rs
+++ b/tests/checkpointing.rs
@@ -113,6 +113,7 @@ fn write_partial_trajectory(path: &Path, steps: u32, cost_usd: f64) {
         trajectory_format: FORMAT_VERSION.into(),
         info,
         messages: vec![],
+        fork_lineage: None,
     };
     let dir = path.parent().unwrap();
     std::fs::create_dir_all(dir).unwrap();
@@ -132,6 +133,7 @@ fn write_complete_trajectory(path: &Path) {
         trajectory_format: FORMAT_VERSION.into(),
         info,
         messages: vec![],
+        fork_lineage: None,
     };
     let dir = path.parent().unwrap();
     std::fs::create_dir_all(dir).unwrap();
@@ -161,6 +163,7 @@ fn partial_true_serializes_and_roundtrips() {
         trajectory_format: FORMAT_VERSION.into(),
         info,
         messages: vec![],
+        fork_lineage: None,
     };
     let json = serde_json::to_string_pretty(&traj).unwrap();
     assert!(
@@ -186,6 +189,7 @@ fn partial_false_omitted_from_json_for_backward_compat() {
         trajectory_format: FORMAT_VERSION.into(),
         info,
         messages: vec![],
+        fork_lineage: None,
     };
     let json = serde_json::to_string_pretty(&traj).unwrap();
     // partial=false and partial_reason=None should NOT appear
@@ -661,6 +665,7 @@ fn bench_bundle_excludes_partial_trajectories_with_warning() {
         trajectory_format: FORMAT_VERSION.into(),
         info: complete_info,
         messages: vec![],
+        fork_lineage: None,
     };
     std::fs::write(
         complete_traj_dir.join("run-1.traj.json"),
@@ -682,6 +687,7 @@ fn bench_bundle_excludes_partial_trajectories_with_warning() {
         trajectory_format: FORMAT_VERSION.into(),
         info: partial_info,
         messages: vec![],
+        fork_lineage: None,
     };
     std::fs::write(
         partial_traj_dir.join("run-1.traj.json"),
@@ -750,6 +756,7 @@ fn bench_inspect_partial_trajectory_shows_banner() {
         trajectory_format: FORMAT_VERSION.into(),
         info,
         messages: vec![],
+        fork_lineage: None,
     };
     std::fs::write(
         traj_dir.join("run-1.traj.json"),

--- a/tests/golden_trajectory.rs
+++ b/tests/golden_trajectory.rs
@@ -72,6 +72,7 @@ fn emits_content_even_when_extra_empty() {
             content: "x".into(),
             extra: MessageExtra::default(),
         }],
+        fork_lineage: None,
     };
     let s = serde_json::to_string(&t).unwrap();
     // Extra was empty → must be omitted from the serialized form.

--- a/tests/replay_fingerprint.rs
+++ b/tests/replay_fingerprint.rs
@@ -53,6 +53,7 @@ fn make_legacy_trajectory(dir: &Path) -> std::path::PathBuf {
                 extra: MessageExtra::default(),
             },
         ],
+        fork_lineage: None,
     };
     let path = dir.join("legacy.traj.json");
     traj.save_pretty(&path).unwrap();

--- a/tests/sampling_params.rs
+++ b/tests/sampling_params.rs
@@ -164,6 +164,7 @@ fn write_traj_with_temperature(dir: &Path, instance_id: &str, temperature: f32) 
                 extra: assistant_extra,
             },
         ],
+        fork_lineage: None,
     };
     std::fs::write(
         dir.join(format!("{instance_id}.traj.json")),
@@ -580,6 +581,7 @@ fn inspect_redaction_masks_sampling_extra_secret_key() {
                 ..Default::default()
             },
         }],
+        fork_lineage: None,
     };
 
     let redactor = Redactor::default_enabled();
@@ -621,6 +623,7 @@ fn write_legacy_traj(dir: &Path, instance_id: &str) {
                 extra: MessageExtra::default(), // no sampling block
             },
         ],
+        fork_lineage: None,
     };
     std::fs::write(
         dir.join(format!("{instance_id}.traj.json")),

--- a/tests/swebench_budget.rs
+++ b/tests/swebench_budget.rs
@@ -749,6 +749,7 @@ async fn resume_skipped_costs_count_against_budget() {
             ..Default::default()
         },
         messages: vec![],
+        fork_lineage: None,
     };
     std::fs::write(
         output.join("already-on-disk.traj.json"),
@@ -856,6 +857,7 @@ async fn resume_uses_prior_results_token_totals_for_budget_accounting() {
             ..Default::default()
         },
         messages: vec![],
+        fork_lineage: None,
     };
     std::fs::write(
         output.join("already-on-disk.traj.json"),
@@ -1039,6 +1041,7 @@ async fn retry_on_resume_instances_are_precharged_before_rerun() {
             ..Default::default()
         },
         messages: vec![],
+        fork_lineage: None,
     };
     std::fs::write(
         output.join("retryable.traj.json"),
@@ -1298,6 +1301,7 @@ async fn stale_results_json_is_not_trusted_over_newer_trajectory() {
             ..Default::default()
         },
         messages: vec![],
+        fork_lineage: None,
     };
     std::fs::write(
         output.join("already-on-disk.traj.json"),

--- a/tests/swebench_failure_categories.rs
+++ b/tests/swebench_failure_categories.rs
@@ -25,6 +25,7 @@ fn write_traj(output: &Path, id: &str, info: TrajectoryInfo) {
         trajectory_format: FORMAT_VERSION.into(),
         info,
         messages: vec![],
+        fork_lineage: None,
     };
     std::fs::write(
         output.join(format!("{id}.traj.json")),

--- a/tests/swebench_rerun.rs
+++ b/tests/swebench_rerun.rs
@@ -119,6 +119,7 @@ fn write_valid_run(output: &Path, instance_id: &str, run_index: u32, marker: &st
         trajectory_format: FORMAT_VERSION.into(),
         info,
         messages: vec![],
+        fork_lineage: None,
     };
     let traj_path = trajectory_path_for_run(output, instance_id, run_index);
     std::fs::create_dir_all(traj_path.parent().unwrap()).unwrap();
@@ -143,6 +144,7 @@ fn write_valid_tested_run(output: &Path, instance_id: &str, run_index: u32, mark
         trajectory_format: FORMAT_VERSION.into(),
         info,
         messages: vec![],
+        fork_lineage: None,
     };
     let traj_path = trajectory_path_for_run(output, instance_id, run_index);
     std::fs::create_dir_all(traj_path.parent().unwrap()).unwrap();

--- a/tests/swebench_resume.rs
+++ b/tests/swebench_resume.rs
@@ -47,6 +47,7 @@ fn write_valid_trajectory(path: &Path, marker: &str) {
         trajectory_format: FORMAT_VERSION.into(),
         info,
         messages: vec![],
+        fork_lineage: None,
     };
     std::fs::write(path, serde_json::to_string_pretty(&traj).unwrap()).unwrap();
 }

--- a/tests/swebench_retry.rs
+++ b/tests/swebench_retry.rs
@@ -466,6 +466,7 @@ async fn cost_cap_can_trip_mid_retry_and_retry_on_resume_round_trip() {
             ..Default::default()
         },
         messages: vec![],
+        fork_lineage: None,
     };
     std::fs::write(
         output.join("resume-id.traj.json"),


### PR DESCRIPTION
Resolves #279.

### Implementation Walkthrough

1. **Subcommand & Parser Additions**
   * Adds `bench fork` under `BenchCmd` in `src/cli/args.rs` with parameters: `--sweep`, `--instance`, `--from-step`, `--output`.
   * Adds optional overrides `--model`, `--system-prompt-file`, `--step-limit`, `--per-task-budget-usd`, `--mcp-server`, `--mcp-config` and safety flag `--allow-unfingerprinted`.

2. **Hybrid Verification Core**
   * Performs parent fingerprint verification in replay phase up to step `N-1` with `$0.0` cost attribution.
   * Implements strict prompt-fingerprint drift checks (aborts with code `9` on mismatch).
   * Implements host environment hard drift validation (aborts on mismatch).
   * Seamlessly switches to a live model execution from step `N` onwards.
   * Generates a top-level `fork_lineage` JSON block containing metadata and overrides, fully integrated into the `bench inspect` human-readable and JSON output modes.

3. **Backward Compatibility & TDD**
   * Added `fork_lineage: None` across legacy `Trajectory` manual struct initializations in the integration test files.
   * Verified workspace compilation under formatting and clippy, with 100% of all integration, unit, and doc tests passing.