### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2473,6 +2473,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
 }
 
 #[cfg(feature = "html-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
     Ok(HtmlExporter::export(traj))
@@ -2488,6 +2489,7 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
 }
 
 #[cfg(feature = "csv-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
     Ok(CsvExporter::export(traj))
@@ -2503,6 +2505,7 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
 }
 
 #[cfg(feature = "mermaid-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
     Ok(MermaidExporter::export(traj))

--- a/src/run/calibrate.rs
+++ b/src/run/calibrate.rs
@@ -582,8 +582,18 @@ fn build_mismatches(
     mismatches
 }
 
+/// Joins sorted values without intermediate `Vec` allocations.
 fn sorted_join(values: BTreeSet<&str>) -> String {
-    values.into_iter().collect::<Vec<_>>().join(",")
+    let mut res = String::new();
+    let mut first = true;
+    for v in values {
+        if !first {
+            res.push(',');
+        }
+        res.push_str(v);
+        first = false;
+    }
+    res
 }
 
 fn compare_field(

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -4715,9 +4715,17 @@ pub fn apply_subset(
             .filter(|id| !dataset_ids.contains(id))
             .collect();
         if !unknown.is_empty() {
+            let mut unknown_str = String::new();
+            let mut first = true;
+            for id in unknown {
+                if !first {
+                    unknown_str.push_str(", ");
+                }
+                unknown_str.push_str(id);
+                first = false;
+            }
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "--instance-ids references unknown id(s): {}",
-                unknown.into_iter().collect::<Vec<_>>().join(", ")
+                "--instance-ids references unknown id(s): {unknown_str}"
             ))));
         }
         let include: HashSet<&str> = ids.iter().map(String::as_str).collect();

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -540,16 +540,23 @@ fn searchable_tokens(name: &str, description: &str) -> BTreeSet<String> {
         .collect()
 }
 
+/// Normalizes search text in a single pass without intermediate allocations.
+/// Reduces 2 heap allocations (Vec and intermediate String).
 fn normalize_search_text(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
+    let mut needs_space = false;
     for ch in text.chars() {
         if ch.is_ascii_alphanumeric() || ch == '$' || ch == '@' || ch == '/' {
+            if needs_space && !out.is_empty() {
+                out.push(' ');
+            }
             out.push(ch.to_ascii_lowercase());
+            needs_space = false;
         } else {
-            out.push(' ');
+            needs_space = true;
         }
     }
-    out.split_whitespace().collect::<Vec<_>>().join(" ")
+    out
 }
 
 fn is_stopword(token: &str) -> bool {


### PR DESCRIPTION
💡 What: Replaced `.collect::<Vec<_>>().join()` calls with allocation-free iterators/loops and improved `normalize_search_text` to execute in a single pass without splitting.\n🎯 Why: The intermediate `.collect::<Vec<_>>()` created unnecessary heap allocations just to construct string representations.\n📊 Impact: Removes redundant `Vec` memory allocations and intermediate strings on string formatting paths.\n🔬 Measurement: Run `cargo test --lib` to verify.

---
*PR created automatically by Jules for task [16466422833688540755](https://jules.google.com/task/16466422833688540755) started by @madmax983*