### PR TITLE
🌟 Nova: [JSONL Trajectory Export]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+jsonl-export = []
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1502,14 +1502,14 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`, and `jsonl`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `jsonl` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2355,13 +2355,13 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid" | "jsonl") {
         return bench_inspect_export(i);
     }
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/jsonl), not `{}`",
             i.format
         ))));
     }
@@ -2371,7 +2371,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         "json" => crate::run::inspect::InspectFormat::Json,
         other => {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, or `mermaid`)"
+                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, `mermaid`, or `jsonl`)"
             ))));
         }
     };
@@ -2412,7 +2412,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     })?;
     let instance_id = i.instance.as_deref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
-            "inspect: --instance is required for export formats (markdown/html/csv/mermaid)".into(),
+            "inspect: --instance is required for export formats (markdown/html/csv/mermaid/jsonl)".into(),
         ))
     })?;
     let traj_path =
@@ -2434,6 +2434,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "jsonl" => inspect_export_jsonl(&traj)?,
         _ => unreachable!("dispatch guarded by caller"),
     };
 
@@ -2476,6 +2477,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
 }
 
 #[cfg(feature = "html-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
     Ok(HtmlExporter::export(traj))
@@ -2491,6 +2493,7 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
 }
 
 #[cfg(feature = "csv-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
     Ok(CsvExporter::export(traj))
@@ -2506,6 +2509,7 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
 }
 
 #[cfg(feature = "mermaid-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
     Ok(MermaidExporter::export(traj))
@@ -2516,6 +2520,22 @@ fn inspect_export_mermaid(_traj: &crate::trajectory::Trajectory) -> Result<Strin
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "format_unavailable: --format mermaid requires the `mermaid-export` Cargo feature; \
          rebuild with `--features mermaid-export`"
+            .into(),
+    )))
+}
+
+#[cfg(feature = "jsonl-export")]
+#[allow(clippy::unnecessary_wraps)]
+fn inspect_export_jsonl(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    use crate::trajectory::export::{JsonlExporter, TrajectoryExporter};
+    Ok(JsonlExporter::export(traj))
+}
+
+#[cfg(not(feature = "jsonl-export"))]
+fn inspect_export_jsonl(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "format_unavailable: --format jsonl requires the `jsonl-export` Cargo feature; \
+         rebuild with `--features jsonl-export`"
             .into(),
     )))
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -53,6 +53,9 @@ pub struct MermaidExporter;
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
+#[cfg(feature = "jsonl-export")]
+pub struct JsonlExporter;
+
 use std::fmt::Write;
 
 #[cfg(feature = "csv-export")]
@@ -194,6 +197,21 @@ impl TrajectoryExporter for HtmlExporter {
     }
 }
 
+#[cfg(feature = "jsonl-export")]
+impl TrajectoryExporter for JsonlExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let mut jsonl = String::new();
+        for msg in &trajectory.messages {
+            let line = serde_json::to_string(&msg).unwrap_or_default();
+            if !line.is_empty() {
+                jsonl.push_str(&line);
+                jsonl.push('\n');
+            }
+        }
+        jsonl
+    }
+}
+
 #[cfg(feature = "mermaid-export")]
 impl TrajectoryExporter for MermaidExporter {
     fn export(trajectory: &Trajectory) -> String {
@@ -292,6 +310,24 @@ mod tests {
         assert!(csv.contains("system,System prompt"));
         assert!(csv.contains("user,\"Hello agent\nMulti-line\""));
         assert!(csv.contains("assistant,\"Hello \"\"user\"\"\""));
+    }
+
+    #[cfg(feature = "jsonl-export")]
+    #[test]
+    fn test_jsonl_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::assistant("Hello user"));
+
+        let jsonl = JsonlExporter::export(&t);
+        let lines: Vec<&str> = jsonl.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].contains(r#""role":"system""#));
+        assert!(lines[0].contains(r#""content":"System prompt""#));
     }
 
     #[cfg(feature = "mermaid-export")]


### PR DESCRIPTION
💡 **The Spark:** I noticed we calculate trajectories and output them in various formats, but we don't have a format that exports it as a JSON Lines (JSONL) file. JSONL is heavily used in machine learning for training data and data processing pipelines.
🚀 **The Feature:** Implemented `JsonlExporter` trait in `src/trajectory/export.rs` alongside existing format support in `src/cli/mod.rs` and `src/cli/args.rs`.
🔮 **The Potential:** Could be used for machine learning models and dataset building pipelines.
⚠️ **Risk:** Low. Isolated in `src/trajectory/export.rs` behind `jsonl-export` feature flag. Note: The failure in `run::swebench::tests::timed_sync_times_out` is a known pre-existing concurrency flake.

---
*PR created automatically by Jules for task [13614156988986812672](https://jules.google.com/task/13614156988986812672) started by @madmax983*