### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2476,6 +2476,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
 }
 
 #[cfg(feature = "html-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
     Ok(HtmlExporter::export(traj))
@@ -2491,6 +2492,7 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
 }
 
 #[cfg(feature = "csv-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
     Ok(CsvExporter::export(traj))
@@ -2506,6 +2508,7 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
 }
 
 #[cfg(feature = "mermaid-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
     Ok(MermaidExporter::export(traj))


### PR DESCRIPTION
🕸️ Tangle: Unnecessary `Result` wrappings in `inspect_export_*` functions in `cli/mod.rs` causing clippy errors.
📐 Blueprint: Add `#[allow(clippy::unnecessary_wraps)]` to maintain API consistency without large-scale refactoring.
🧱 Stability: Fixed build failure due to clippy lints.
🔬 Verification: Builds successfully, passes tests and clippy.

---
*PR created automatically by Jules for task [12877924861585110852](https://jules.google.com/task/12877924861585110852) started by @madmax983*