### PR TITLE
Implement zero-cost bench dataset-stats subcommand (issue #281)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ cargo run --quiet -- --log error bench inspect --sweep runs/quickstart --instanc
 
 ### 6. Optional Preflight Before SWE-bench
 
+Use `bench dataset-stats` to preview the composition, token distributions (computed completely offline using `litellm-rs`'s `TokenCounter`), expected tests count, languages present, representative slice skewness (warns if unique repos < 50% or median token length difference > 25% compared to the full dataset), and historical resolved rates matching current dataset hash before running a sweep:
+
+```powershell
+cargo run --quiet -- --log error bench dataset-stats --dataset lite --split test --sample 10 --seed 42
+```
+
 Use `doctor` on a local SWE-bench JSONL dataset before launching work. This
 checks the dataset and environment setup; `--skip-model-probe` keeps this
 preflight from touching a model provider.
@@ -360,6 +366,8 @@ a valid trajectory in hand:
 - [`bench power`](docs/spec-power.md): offline statistical power, required sample
   size per arm, or Minimum Detectable Effect (MDE delta) calculations for
   two-proportion z-tests.
+- [`bench dataset-stats`](docs/spec-dataset-stats.md): zero-cost preflight to
+  preview and analyze dataset composition offline before running a sweep.
 
 ## Nightly E2E smoke
 

--- a/docs/plans/2026-05-22-dataset-stats-design.md
+++ b/docs/plans/2026-05-22-dataset-stats-design.md
@@ -1,0 +1,88 @@
+# Zero-Cost Preview of SWE-bench Dataset Composition (`bench dataset-stats`)
+
+This design document outlines the architecture, components, data flows, and testing strategy for implementing the `bench dataset-stats` subcommand in a test-driven (TDD) manner.
+
+## Design Highlights
+
+### 1. Token Estimation Strategy
+Instead of naive word counting or character division, we leverage `litellm-rs`'s built-in `TokenCounter`:
+```rust
+use litellm_rs::utils::ai::counter::token_counter::TokenCounter;
+```
+We initialize the counter and invoke `count_completion_tokens(model, problem_statement)` to calculate accurate, model-specific tokens for each instance's problem statement. This provides highly realistic token counts without making any network/model calls.
+
+### 2. Multi-Tiered Language Detection
+We implement a highly accurate, extension-based language detection mechanism:
+1. **Patch Diff Inspection**: We inspect `patch` and `test_patch` strings in `other` map. We scan for diff header lines starting with `--- a/` or `+++ b/`.
+2. **Extension Extraction**: We extract the file extensions (e.g. `.py` -> Python, `.rs` -> Rust, `.js`/`.ts` -> JavaScript/TypeScript, `.go` -> Go, `.java` -> Java).
+3. **Fallback Registry**: If no diff is present or no standard extensions are found, we fall back to:
+   - Case-insensitive substrings of the `repo` name (e.g., `django`, `sympy`, `pytest` -> Python).
+   - If still undetermined, defaults gracefully to `Python` (as is typical in standard SWE-bench).
+
+### 3. Historical Result Integration
+We scan the local `runs` root directory (defaulting to `./runs`) recursively for completed sweep runs:
+1. Identify all directories containing `results.json`.
+2. Parse `results.json` to verify the `manifest.dataset.sha256` matches the current dataset's hash.
+3. If matched, extract each instance's `resolved_count` and `runs` attempts.
+4. Calculate per-instance historical resolved rates (`sum(resolved_count) / sum(runs)`).
+5. For all instances in the selected slice that have historical data, calculate the `min`, `p50` (median), and `max` resolved rates.
+
+### 4. Representativeness & Skew Analysis
+We compare the selected slice against the entire dataset:
+- **Repo Skew**: If the slice unique repos count is less than 50% of the entire dataset's unique repos count, we warn of a skew.
+- **Median Token Skew**: If the slice median problem-statement token length differs by more than 25% from the entire dataset's median token length, we warn of a skew.
+- In JSON mode, a boolean `slice_skew` field is included. In Text mode, a warning is printed to stdout.
+
+---
+
+## Command Interface
+
+```bash
+bench dataset-stats --dataset-path <PATH> [SUBSET_SELECTORS...] [--format <text|json>]
+```
+or with a dataset alias:
+```bash
+bench dataset-stats --dataset <lite|verified|full> --split <test|dev|train> [SUBSET_SELECTORS...] [--format <text|json>]
+```
+
+## JSON Schema Output
+A stable, schema-versioned, deterministically ordered `dataset-stats.json`:
+```json
+{
+  "schema_version": 1,
+  "dataset_hash": "...",
+  "dataset_path": "...",
+  "subset_selector": {
+    "limit": null,
+    "sample": 10,
+    "seed": 42,
+    "instance_ids": null,
+    "stratify_by": null,
+    "stratify_mode": null
+  },
+  "total_instances": 10,
+  "repos": [
+    { "repo": "django/django", "count": 8, "percent_share": 80.0 },
+    { "repo": "pytest-dev/pytest", "count": 2, "percent_share": 20.0 }
+  ],
+  "problem_statement_tokens": {
+    "min": 10,
+    "p50": 100,
+    "p90": 250,
+    "max": 500
+  },
+  "expected_tests": {
+    "min": 0,
+    "p50": 4,
+    "p90": 12,
+    "max": 20
+  },
+  "languages": ["Python"],
+  "historical_resolved_rate": {
+    "min": 0.0,
+    "p50": 0.5,
+    "max": 1.0
+  },
+  "slice_skew": false
+}
+```

--- a/docs/spec-dataset-stats.md
+++ b/docs/spec-dataset-stats.md
@@ -1,0 +1,89 @@
+# bench dataset-stats Subcommand Specification
+
+`bench dataset-stats` is a zero-cost, offline diagnostic subcommand designed to analyze and preview a SWE-bench dataset's composition before running a sweep. It executes completely offline with **zero** network, model provider, or Docker daemon calls.
+
+---
+
+## Features
+
+### 1. Zero-Cost Token Estimation
+Utilizes `litellm-rs`'s offline `TokenCounter` to compute accurate prompt token estimates for each instance's problem statement based on a chosen model configuration (defaults to `gpt-4`). This provides high-fidelity token statistics without making network calls or incurring API costs.
+
+### 2. Multi-Tiered Language Detection
+To accurately report the languages present:
+1. **Diff Extensions (Primary)**: Parses changed file pathways out of the `patch` and `test_patch` diff headers (e.g. lines starting with `--- a/` or `+++ b/`) to identify file extensions (e.g. `.py` -> `Python`, `.rs` -> `Rust`, `.js`/`.ts` -> `JavaScript`/`TypeScript`).
+2. **Repository Substrings (Fallback)**: Inspects the repository name field (case-insensitively checking against `django`, `pytest`, `pandas`, `sympy`, etc. mapping to `Python`).
+3. **Registry Fallback**: Defaults gracefully to `Python` if still undetermined.
+
+### 3. Representativeness & Skew Analysis
+Ensures that a selected slice/subset is representative of the complete dataset:
+* **Repository Skew**: Flags a skew warning if the unique repositories covered in the slice comprise **less than 50%** of the unique repositories present in the full dataset.
+* **Token Length Skew**: Flags a skew warning if the median problem-statement token length of the slice differs from the full dataset's median by **more than 25%**.
+
+### 4. Historical Sweep Integration
+Traverses the configured sweeps root directory (`--runs-dir`, defaulting to `./runs`) to find `results.json` files from prior completed sweeps.
+* It verifies that the `manifest.dataset.sha256` content hash match.
+* Joins historical `resolved_count` and total attempts/runs.
+* Calculates per-instance historical resolved rates to present the min, p50, and max historical resolved-rates across the selected instances.
+
+---
+
+## Command Reference
+
+### Usage
+```powershell
+bench dataset-stats --dataset-path <PATH_TO_JSONL> [SUBSET_SELECTORS...] [--format <text|json>]
+```
+or with a dataset alias:
+```powershell
+bench dataset-stats --dataset <full|lite|verified> --split <test|dev|train> [SUBSET_SELECTORS...] [--format <text|json>]
+```
+
+### Options
+* `--dataset-path`: Paths to a local JSONL file containing SWE-bench instances.
+* `--dataset`: Named SWE-bench dataset alias: `full`, `lite`, or `verified`.
+* `--split`: Dataset split: `train`, `test`, or `dev`. Defaults to `test`.
+* `--dataset-cache-dir`: Cache directory for named datasets.
+* `--limit <N>`: Truncates the slice to at most N instances.
+* `--sample <N>`: Samples N instances randomly (requires `--seed`).
+* `--seed <SEED>`: RNG seed to ensure stable reproducible sampling.
+* `--instance-ids <IDS>`: Explicit list of instance IDs to select.
+* `--stratify-by <REPO>`: Stratify sampling by repository.
+* `--stratify-mode <proportional|balanced>`: Stratification mode.
+* `--runs-dir <DIR>`: Directory containing prior completed sweeps. Defaults to `./runs`.
+* `--model <MODEL>`: Target model for TokenCounter estimation. Defaults to `gpt-4`.
+* `--format <text|json>`: Output format. Defaults to `text`.
+
+---
+
+## Examples
+
+### Previewing a representative 10-instance slice
+```powershell
+bench dataset-stats --dataset lite --split test --sample 10 --seed 42
+```
+
+Output:
+```text
+=== SWE-bench Dataset Statistics Preview ===
+Total Instances: 10
+Languages Present: Python
+
+--- Repository Share ---
+┌───────────────────┬────────────────┬───────────────┐
+│ Repository        │ Instance Count │ Percent Share │
+├───────────────────┼────────────────┼───────────────┤
+│ django/django     │ 8              │ 80.00%        │
+├───────────────────┼────────────────┼───────────────┤
+│ sympy/sympy       │ 2              │ 20.00%        │
+└───────────────────┴────────────────┴───────────────┘
+
+--- Problem-Statement Tokens Distribution ---
+  Min: 120  |  P50: 250  |  P90: 820  |  Max: 1200
+
+--- Expected Tests Distribution ---
+  Min: 2  |  P50: 8  |  P90: 16  |  Max: 24
+
+--- Historical Sweep Resolved Rates ---
+  Min: 0.0000  |  P50: 0.5000  |  Max: 1.0000
+```

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -510,6 +510,64 @@ pub enum BenchCmd {
     Fork(ForkCmd),
     /// Calculate statistical power or required sample size.
     Power(PowerCmd),
+    /// Preview SWE-bench dataset composition offline and zero-cost before running a sweep.
+    DatasetStats(DatasetStatsCmd),
+}
+
+/// `bench dataset-stats` — preview SWE-bench dataset composition pre-sweep.
+#[derive(Debug, Args, Clone)]
+pub struct DatasetStatsCmd {
+    /// Local JSONL dataset file. Mutually exclusive with `--dataset`.
+    #[arg(long)]
+    pub dataset_path: Option<PathBuf>,
+
+    /// Named SWE-bench dataset alias: `full`, `lite`, or `verified`.
+    #[arg(long, value_name = "ALIAS")]
+    pub dataset: Option<String>,
+
+    /// Dataset split for named aliases: `train`, `test`, or `dev`.
+    #[arg(long, default_value = "test", value_name = "SPLIT")]
+    pub split: Option<String>,
+
+    /// Directory for the named-dataset on-disk cache.
+    #[arg(long, value_name = "DIR")]
+    pub dataset_cache_dir: Option<PathBuf>,
+
+    /// Dataset subset selector: comma-separated id list or `@path/to/file.txt`.
+    #[arg(long)]
+    pub instance_ids: Option<String>,
+
+    /// Keep at most N instances after subsetting.
+    #[arg(long)]
+    pub limit: Option<usize>,
+
+    /// Reproducibly random-subset to N instances.
+    #[arg(long)]
+    pub sample: Option<usize>,
+
+    /// RNG seed used by `--sample`.
+    #[arg(long)]
+    pub seed: Option<u64>,
+
+    /// Stratify `--sample` by key.
+    #[arg(long, value_enum)]
+    pub stratify_by: Option<StratifyByArg>,
+
+    /// Allocation mode used with `--stratify-by`.
+    #[arg(long, value_enum)]
+    pub stratify_mode: Option<StratifyModeArg>,
+
+    /// Runs root directory override for scanning historical sweeps.
+    #[arg(long, default_value = "./runs")]
+    pub runs_dir: PathBuf,
+
+    /// Format: `text` or `json`.
+    #[arg(long, default_value = "text")]
+    pub format: String,
+
+    /// Model name to use for TokenCounter offline estimation.
+    #[arg(long, default_value = "gpt-4")]
+    pub model: String,
 }
 
 /// `bench power` — statistical power, sample size, or MDE calculations.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3893,13 +3893,25 @@ fn bench_dataset_stats(s: args::DatasetStatsCmd) -> Result<(), Error> {
         stratify_mode,
     };
 
+    let mut light_full = Vec::with_capacity(full_instances.len());
+    for inst in &full_instances {
+        light_full.push(crate::run::swebench::SweBenchInstance {
+            instance_id: inst.instance_id.clone(),
+            repo: inst.repo.clone(),
+            base_commit: None,
+            problem_statement: inst.problem_statement.clone(),
+            image: None,
+            other: serde_json::Map::new(),
+        });
+    }
+
     let (slice_instances, _filter_spec) =
-        crate::run::swebench::apply_subset(full_instances.clone(), &params)?;
+        crate::run::swebench::apply_subset(full_instances, &params)?;
 
     // Compute stats
     let mut stats = crate::run::dataset_stats::compute_stats(
         &slice_instances,
-        &full_instances,
+        &light_full,
         &s.model,
         &s.runs_dir,
         &Some(meta.sha256.clone()),
@@ -3915,17 +3927,21 @@ fn bench_dataset_stats(s: args::DatasetStatsCmd) -> Result<(), Error> {
         .instance_ids
         .clone_from(&s.instance_ids);
     stats.subset_selector.stratify_by = s.stratify_by.map(|v| match v {
-        args::StratifyByArg::Repo => "Repo".to_owned(),
+        args::StratifyByArg::Repo => "repo".to_owned(),
     });
-    stats.subset_selector.stratify_mode = Some(
-        match s
-            .stratify_mode
-            .unwrap_or(args::StratifyModeArg::Proportional)
-        {
-            args::StratifyModeArg::Proportional => "Proportional".to_owned(),
-            args::StratifyModeArg::Balanced => "Balanced".to_owned(),
-        },
-    );
+    stats.subset_selector.stratify_mode = if s.stratify_by.is_some() {
+        Some(
+            match s
+                .stratify_mode
+                .unwrap_or(args::StratifyModeArg::Proportional)
+            {
+                args::StratifyModeArg::Proportional => "proportional".to_owned(),
+                args::StratifyModeArg::Balanced => "balanced".to_owned(),
+            },
+        )
+    } else {
+        None
+    };
 
     if s.format == "json" {
         let serialized = serde_json::to_string_pretty(&stats)?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -175,6 +175,9 @@ pub async fn run() -> Result<(), Error> {
         Command::Bench {
             cmd: args::BenchCmd::Power(p),
         } => bench_power(&p),
+        Command::Bench {
+            cmd: args::BenchCmd::DatasetStats(s),
+        } => bench_dataset_stats(s),
         #[cfg(feature = "docker")]
         Command::Cleanup => cleanup_cmd().await,
         #[cfg(not(feature = "docker"))]
@@ -3854,6 +3857,113 @@ fn print_doctor_skills_preview(cfg: &crate::config::Config) {
             );
         }
         Err(e) => eprintln!("skills-preview error (non-fatal): {e}"),
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn bench_dataset_stats(s: args::DatasetStatsCmd) -> Result<(), Error> {
+    let (dataset_source, dataset_cache_dir) = parse_dataset_source_stats(&s)?;
+    let (dataset_bytes, meta) =
+        crate::run::dataset::resolve_dataset(&dataset_source, &dataset_cache_dir)?;
+    let full_instances = crate::run::swebench::load_dataset_from_bytes_pub(&dataset_bytes)?;
+
+    let stratify_by = s.stratify_by.map(|v| match v {
+        args::StratifyByArg::Repo => crate::run::swebench::StratifyBy::Repo,
+    });
+    let stratify_mode = match s
+        .stratify_mode
+        .unwrap_or(args::StratifyModeArg::Proportional)
+    {
+        args::StratifyModeArg::Proportional => crate::run::swebench::StratifyMode::Proportional,
+        args::StratifyModeArg::Balanced => crate::run::swebench::StratifyMode::Balanced,
+    };
+
+    let params = crate::run::swebench::ApplySubsetParams {
+        instance_ids_arg: s.instance_ids.as_deref(),
+        limit: s.limit,
+        sample: s.sample,
+        seed: s.seed,
+        stratify_by,
+        stratify_mode,
+    };
+
+    let (slice_instances, _filter_spec) =
+        crate::run::swebench::apply_subset(full_instances.clone(), &params)?;
+
+    // Compute stats
+    let mut stats = crate::run::dataset_stats::compute_stats(
+        &slice_instances,
+        &full_instances,
+        &s.model,
+        &s.runs_dir,
+        &Some(meta.sha256.clone()),
+    )?;
+
+    // Populate dataset stats fields
+    stats.dataset_path = meta.path.display().to_string();
+    stats.subset_selector.limit = s.limit;
+    stats.subset_selector.sample = s.sample;
+    stats.subset_selector.seed = s.seed;
+    stats
+        .subset_selector
+        .instance_ids
+        .clone_from(&s.instance_ids);
+    stats.subset_selector.stratify_by = s.stratify_by.map(|v| match v {
+        args::StratifyByArg::Repo => "Repo".to_owned(),
+    });
+    stats.subset_selector.stratify_mode = Some(
+        match s
+            .stratify_mode
+            .unwrap_or(args::StratifyModeArg::Proportional)
+        {
+            args::StratifyModeArg::Proportional => "Proportional".to_owned(),
+            args::StratifyModeArg::Balanced => "Balanced".to_owned(),
+        },
+    );
+
+    if s.format == "json" {
+        let serialized = serde_json::to_string_pretty(&stats)?;
+        println!("{serialized}");
+    } else {
+        let text = crate::run::dataset_stats::render_text(&stats);
+        println!("{text}");
+    }
+
+    Ok(())
+}
+
+fn parse_dataset_source_stats(
+    s: &args::DatasetStatsCmd,
+) -> Result<(crate::run::dataset::DatasetSource, std::path::PathBuf), Error> {
+    let cache_dir = s
+        .dataset_cache_dir
+        .clone()
+        .unwrap_or_else(crate::run::dataset::default_cache_dir);
+
+    match (&s.dataset_path, &s.dataset) {
+        (Some(_), Some(_)) => Err(Error::Config(crate::error::ConfigError::Invalid(
+            "--dataset-path and --dataset are mutually exclusive; provide only one".into(),
+        ))),
+        (None, None) => Err(Error::Config(crate::error::ConfigError::Invalid(
+            "one of --dataset-path or --dataset is required".into(),
+        ))),
+        (Some(path), None) => Ok((
+            crate::run::dataset::DatasetSource::LocalPath(path.clone()),
+            cache_dir,
+        )),
+        (None, Some(alias_str)) => {
+            let alias = alias_str
+                .parse::<crate::run::dataset::SwebenchAlias>()
+                .map_err(|e| Error::Config(crate::error::ConfigError::Invalid(e)))?;
+            let split_str = s.split.as_deref().unwrap_or("test");
+            let split = split_str
+                .parse::<crate::run::dataset::SwebenchSplit>()
+                .map_err(|e| Error::Config(crate::error::ConfigError::Invalid(e)))?;
+            Ok((
+                crate::run::dataset::DatasetSource::Named { alias, split },
+                cache_dir,
+            ))
+        }
     }
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3862,6 +3862,12 @@ fn print_doctor_skills_preview(cfg: &crate::config::Config) {
 
 #[allow(clippy::needless_pass_by_value)]
 fn bench_dataset_stats(s: args::DatasetStatsCmd) -> Result<(), Error> {
+    if s.format != "text" && s.format != "json" {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "dataset-stats: unknown --format `{}`; valid values: text, json",
+            s.format
+        ))));
+    }
     let (dataset_source, dataset_cache_dir) = parse_dataset_source_stats(&s)?;
     let (dataset_bytes, meta) =
         crate::run::dataset::resolve_dataset(&dataset_source, &dataset_cache_dir)?;
@@ -4422,5 +4428,31 @@ mod tests {
         let err2 = parse_verify_checks(&["test:".into()]).unwrap_err();
         assert!(matches!(err2, Error::Config(_)));
         assert!(err2.to_string().contains("non-empty"), "{err2}");
+    }
+
+    #[test]
+    fn bench_dataset_stats_rejects_invalid_format() {
+        let cmd = args::DatasetStatsCmd {
+            dataset_path: Some(PathBuf::from("dummy.jsonl")),
+            dataset: None,
+            split: None,
+            dataset_cache_dir: None,
+            instance_ids: None,
+            limit: None,
+            sample: None,
+            seed: None,
+            stratify_by: None,
+            stratify_mode: None,
+            runs_dir: PathBuf::from("./runs"),
+            format: "jsno".to_owned(),
+            model: "gpt-4".to_owned(),
+        };
+        let res = super::bench_dataset_stats(cmd);
+        assert!(res.is_err());
+        let err_str = res.unwrap_err().to_string();
+        assert!(
+            err_str.contains("dataset-stats: unknown --format `jsno`"),
+            "unexpected error string: {err_str}"
+        );
     }
 }

--- a/src/run/dataset_stats.rs
+++ b/src/run/dataset_stats.rs
@@ -225,7 +225,8 @@ fn percentile_90(values: &[usize]) -> usize {
     if values.is_empty() {
         return 0;
     }
-    let idx = (values.len() - 1) * 9 / 10;
+    let rank = (9 * values.len()).div_ceil(10);
+    let idx = rank - 1;
     values[idx]
 }
 
@@ -363,11 +364,12 @@ fn analyze_historical_resolved_rates(
     for path in results_paths {
         if let Ok(text) = std::fs::read_to_string(&path) {
             if let Ok(results) = serde_json::from_str::<SweepResults>(&text) {
-                let matches = match (dataset_hash, &results.manifest) {
-                    (Some(curr_hash), Some(manifest)) => manifest.dataset.sha256 == **curr_hash,
-                    (Some(_), None) => false,
-                    _ => true,
-                };
+                let matches = results.sweep_status == "completed"
+                    && match (dataset_hash, &results.manifest) {
+                        (Some(curr_hash), Some(manifest)) => manifest.dataset.sha256 == **curr_hash,
+                        (Some(_), None) => false,
+                        _ => true,
+                    };
                 if matches {
                     for inst_res in &results.instances {
                         let entry = hist_map

--- a/src/run/dataset_stats.rs
+++ b/src/run/dataset_stats.rs
@@ -1,0 +1,461 @@
+//! Analysis logic for previewing SWE-bench dataset statistics offline (`bench dataset-stats`).
+
+use comfy_table::Table;
+use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+use comfy_table::presets::UTF8_FULL;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::ffi::OsStr;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use crate::error::Error;
+use crate::run::swebench::{SweBenchInstance, SweepResults};
+use litellm_rs::utils::ai::counter::token_counter::TokenCounter;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatsDistribution {
+    pub min: usize,
+    pub p50: usize,
+    pub p90: usize,
+    pub max: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoricalStatsDistribution {
+    pub min: f64,
+    pub p50: f64,
+    pub max: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepoStats {
+    pub repo: String,
+    pub count: usize,
+    pub percent_share: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubsetSelectorStats {
+    pub limit: Option<usize>,
+    pub sample: Option<usize>,
+    pub seed: Option<u64>,
+    pub instance_ids: Option<String>,
+    pub stratify_by: Option<String>,
+    pub stratify_mode: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DatasetStatsReport {
+    pub schema_version: u32,
+    pub dataset_hash: String,
+    pub dataset_path: String,
+    pub subset_selector: SubsetSelectorStats,
+    pub total_instances: usize,
+    pub repos: Vec<RepoStats>,
+    pub problem_statement_tokens: StatsDistribution,
+    pub expected_tests: StatsDistribution,
+    pub languages: Vec<String>,
+    pub historical_resolved_rate: Option<HistoricalStatsDistribution>,
+    pub slice_skew: bool,
+}
+
+impl DatasetStatsReport {
+    pub const SCHEMA_VERSION: u32 = 1;
+}
+
+/// Core function to compute SWE-bench dataset statistics offline.
+#[allow(clippy::too_many_lines)]
+pub fn compute_stats(
+    slice_instances: &[SweBenchInstance],
+    full_instances: &[SweBenchInstance],
+    model: &str,
+    runs_dir: &Path,
+    dataset_hash: &Option<String>,
+) -> Result<DatasetStatsReport, Error> {
+    let total_instances = slice_instances.len();
+
+    // 1. Calculate per-repo instance counts and percent share
+    let mut repo_counts = BTreeMap::new();
+    for inst in slice_instances {
+        let repo = inst.repo.clone().unwrap_or_else(|| "unknown".to_owned());
+        *repo_counts.entry(repo).or_insert(0) += 1;
+    }
+    let mut repos = Vec::new();
+    for (repo, count) in repo_counts {
+        #[allow(clippy::cast_precision_loss)]
+        let percent_share = if total_instances > 0 {
+            (count as f64 / total_instances as f64) * 100.0
+        } else {
+            0.0
+        };
+        repos.push(RepoStats {
+            repo,
+            count,
+            percent_share,
+        });
+    }
+    // Sort repos by count descending, then alphabetically by repo name
+    repos.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.repo.cmp(&b.repo)));
+
+    // 2. Count tokens in problem statement using TokenCounter
+    let counter = TokenCounter::new();
+    let mut slice_tokens = Vec::new();
+    for inst in slice_instances {
+        let text = inst.problem_statement.as_deref().unwrap_or("");
+        let count = match counter.count_completion_tokens(model, text) {
+            Ok(est) => est.total_tokens as usize,
+            Err(_) => text.split_whitespace().count(), // Fallback
+        };
+        slice_tokens.push(count);
+    }
+    slice_tokens.sort_unstable();
+
+    let problem_statement_tokens = StatsDistribution {
+        min: slice_tokens.first().copied().unwrap_or(0),
+        p50: median(&slice_tokens),
+        p90: percentile_90(&slice_tokens),
+        max: slice_tokens.last().copied().unwrap_or(0),
+    };
+
+    // Calculate full dataset median for token length skew checking
+    let mut full_tokens = Vec::new();
+    for inst in full_instances {
+        let text = inst.problem_statement.as_deref().unwrap_or("");
+        let count = match counter.count_completion_tokens(model, text) {
+            Ok(est) => est.total_tokens as usize,
+            Err(_) => text.split_whitespace().count(),
+        };
+        full_tokens.push(count);
+    }
+    full_tokens.sort_unstable();
+    let full_median = median(&full_tokens);
+
+    // 3. Count expected tests from FAIL_TO_PASS and PASS_TO_PASS
+    let mut expected_tests_list = Vec::new();
+    for inst in slice_instances {
+        expected_tests_list.push(get_expected_tests_count(inst));
+    }
+    expected_tests_list.sort_unstable();
+
+    let expected_tests = StatsDistribution {
+        min: expected_tests_list.first().copied().unwrap_or(0),
+        p50: median(&expected_tests_list),
+        p90: percentile_90(&expected_tests_list),
+        max: expected_tests_list.last().copied().unwrap_or(0),
+    };
+
+    // 4. Multi-tiered language detection
+    let languages = detect_languages(slice_instances);
+
+    // 5. Historical resolved-rate
+    let historical_rates =
+        analyze_historical_resolved_rates(slice_instances, runs_dir, dataset_hash.as_ref());
+    let historical_resolved_rate = if historical_rates.is_empty() {
+        None
+    } else {
+        let min = historical_rates.first().copied().unwrap_or(0.0);
+        let max = historical_rates.last().copied().unwrap_or(0.0);
+        let p50 = median_f64(&historical_rates);
+        Some(HistoricalStatsDistribution { min, p50, max })
+    };
+
+    // 6. Skew and representativeness analysis
+    let slice_repos: BTreeSet<_> = slice_instances
+        .iter()
+        .filter_map(|i| i.repo.as_ref())
+        .collect();
+    let full_repos: BTreeSet<_> = full_instances
+        .iter()
+        .filter_map(|i| i.repo.as_ref())
+        .collect();
+
+    #[allow(clippy::cast_precision_loss)]
+    let repo_skew = if full_repos.is_empty() {
+        false
+    } else {
+        (slice_repos.len() as f64) < 0.50 * (full_repos.len() as f64)
+    };
+
+    #[allow(clippy::cast_precision_loss)]
+    let token_skew = if full_median == 0 {
+        false
+    } else {
+        let diff = (problem_statement_tokens.p50 as f64 - full_median as f64).abs();
+        diff > 0.25 * (full_median as f64)
+    };
+
+    let slice_skew = repo_skew || token_skew;
+
+    Ok(DatasetStatsReport {
+        schema_version: DatasetStatsReport::SCHEMA_VERSION,
+        dataset_hash: dataset_hash.clone().unwrap_or_default(),
+        dataset_path: String::new(), // Populated by CLI driver
+        subset_selector: SubsetSelectorStats {
+            limit: None,
+            sample: None,
+            seed: None,
+            instance_ids: None,
+            stratify_by: None,
+            stratify_mode: None,
+        },
+        total_instances,
+        repos,
+        problem_statement_tokens,
+        expected_tests,
+        languages,
+        historical_resolved_rate,
+        slice_skew,
+    })
+}
+
+fn median(values: &[usize]) -> usize {
+    if values.is_empty() {
+        return 0;
+    }
+    let mid = values.len() / 2;
+    if values.len() % 2 == 0 {
+        values[mid - 1].midpoint(values[mid])
+    } else {
+        values[mid]
+    }
+}
+
+fn percentile_90(values: &[usize]) -> usize {
+    if values.is_empty() {
+        return 0;
+    }
+    let idx = (values.len() - 1) * 9 / 10;
+    values[idx]
+}
+
+#[allow(clippy::manual_midpoint)]
+fn median_f64(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = sorted.len() / 2;
+    if sorted.len() % 2 == 0 {
+        (sorted[mid - 1] + sorted[mid]) / 2.0
+    } else {
+        sorted[mid]
+    }
+}
+
+fn get_expected_tests_count(inst: &SweBenchInstance) -> usize {
+    let mut total = 0;
+    for key in &["FAIL_TO_PASS", "PASS_TO_PASS"] {
+        if let Some(val) = inst.other.get(*key) {
+            let items: Vec<serde_json::Value> = if let Some(arr) = val.as_array() {
+                arr.clone()
+            } else if let Some(s) = val.as_str() {
+                serde_json::from_str(s).unwrap_or_default()
+            } else {
+                vec![]
+            };
+            total += items.iter().filter_map(|v| v.as_str()).count();
+        }
+    }
+    total
+}
+
+fn detect_languages(instances: &[SweBenchInstance]) -> Vec<String> {
+    let mut counts = BTreeMap::new();
+    for inst in instances {
+        let mut detected = false;
+        // 1. Scan diff strings (patch and test_patch)
+        for key in &["patch", "test_patch"] {
+            if let Some(val) = inst.other.get(*key).and_then(|v| v.as_str()) {
+                for line in val.lines() {
+                    if line.starts_with("--- a/") || line.starts_with("+++ b/") {
+                        if let Some(ext) = line.split('.').next_back() {
+                            let ext_clean: String =
+                                ext.chars().filter(|c| c.is_alphanumeric()).collect();
+                            let lang = match ext_clean.as_str() {
+                                "py" => Some("Python"),
+                                "rs" => Some("Rust"),
+                                "go" => Some("Go"),
+                                "java" => Some("Java"),
+                                "js" | "jsx" => Some("JavaScript"),
+                                "ts" | "tsx" => Some("TypeScript"),
+                                "c" | "h" => Some("C"),
+                                "cpp" | "hpp" | "cc" | "cxx" => Some("C++"),
+                                _ => None,
+                            };
+                            if let Some(l) = lang {
+                                *counts.entry(l.to_string()).or_insert(0) += 1;
+                                detected = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // 2. Fall back to repository name mapping
+        if !detected {
+            if let Some(repo) = &inst.repo {
+                let repo_lower = repo.to_lowercase();
+                let lang = if repo_lower.contains("django")
+                    || repo_lower.contains("pytest")
+                    || repo_lower.contains("pandas")
+                    || repo_lower.contains("sympy")
+                    || repo_lower.contains("sphinx")
+                    || repo_lower.contains("flask")
+                    || repo_lower.contains("requests")
+                    || repo_lower.contains("pylint")
+                    || repo_lower.contains("matplotlib")
+                    || repo_lower.contains("scikit-learn")
+                    || repo_lower.contains("astropy")
+                {
+                    Some("Python")
+                } else {
+                    None
+                };
+                if let Some(l) = lang {
+                    *counts.entry(l.to_string()).or_insert(0) += 1;
+                    detected = true;
+                }
+            }
+        }
+        // 3. Absolute fallback
+        if !detected {
+            *counts.entry("Python".to_string()).or_insert(0) += 1;
+        }
+    }
+
+    let mut list: Vec<(String, usize)> = counts.into_iter().collect();
+    list.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    list.into_iter().map(|(l, _)| l).collect()
+}
+
+fn find_results_jsons(dir: &Path, paths: &mut Vec<PathBuf>) {
+    if !dir.is_dir() {
+        return;
+    }
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                find_results_jsons(&path, paths);
+            } else if path.file_name() == Some(OsStr::new("results.json")) {
+                paths.push(path);
+            }
+        }
+    }
+}
+
+fn analyze_historical_resolved_rates(
+    instances: &[SweBenchInstance],
+    runs_dir: &Path,
+    dataset_hash: Option<&String>,
+) -> Vec<f64> {
+    if !runs_dir.is_dir() {
+        return Vec::new();
+    }
+    let mut results_paths = Vec::new();
+    find_results_jsons(runs_dir, &mut results_paths);
+
+    // Map instance_id -> (sum_resolved, sum_runs)
+    let mut hist_map = HashMap::new();
+
+    for path in results_paths {
+        if let Ok(text) = std::fs::read_to_string(&path) {
+            if let Ok(results) = serde_json::from_str::<SweepResults>(&text) {
+                let matches = match (dataset_hash, &results.manifest) {
+                    (Some(curr_hash), Some(manifest)) => manifest.dataset.sha256 == **curr_hash,
+                    _ => true,
+                };
+                if matches {
+                    for inst_res in &results.instances {
+                        let entry = hist_map
+                            .entry(inst_res.instance_id.clone())
+                            .or_insert((0u32, 0u32));
+                        let runs = if inst_res.runs == 0 { 1 } else { inst_res.runs };
+                        entry.0 += inst_res.resolved_count;
+                        entry.1 += runs;
+                    }
+                }
+            }
+        }
+    }
+
+    let mut rates = Vec::new();
+    for inst in instances {
+        if let Some(&(resolved, runs)) = hist_map.get(&inst.instance_id) {
+            if runs > 0 {
+                rates.push(f64::from(resolved) / f64::from(runs));
+            }
+        }
+    }
+    rates.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    rates
+}
+
+/// Render statistics Cozy Table format.
+pub fn render_text(report: &DatasetStatsReport) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "\n=== SWE-bench Dataset Statistics Preview ===");
+    let _ = writeln!(out, "Total Instances: {}", report.total_instances);
+    let _ = writeln!(out, "Languages Present: {}", report.languages.join(", "));
+    let _ = writeln!(out, "\n--- Repository Share ---");
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec!["Repository", "Instance Count", "Percent Share"]);
+
+    for repo in &report.repos {
+        table.add_row(vec![
+            repo.repo.clone(),
+            repo.count.to_string(),
+            format!("{:.2}%", repo.percent_share),
+        ]);
+    }
+    let _ = writeln!(out, "{table}");
+
+    let _ = writeln!(out, "\n--- Problem-Statement Tokens Distribution ---");
+    let _ = writeln!(
+        out,
+        "  Min: {}  |  P50: {}  |  P90: {}  |  Max: {}",
+        report.problem_statement_tokens.min,
+        report.problem_statement_tokens.p50,
+        report.problem_statement_tokens.p90,
+        report.problem_statement_tokens.max,
+    );
+
+    let _ = writeln!(out, "\n--- Expected Tests Distribution ---");
+    let _ = writeln!(
+        out,
+        "  Min: {}  |  P50: {}  |  P90: {}  |  Max: {}",
+        report.expected_tests.min,
+        report.expected_tests.p50,
+        report.expected_tests.p90,
+        report.expected_tests.max,
+    );
+
+    let _ = writeln!(out, "\n--- Historical Sweep Resolved Rates ---");
+    if let Some(hist) = &report.historical_resolved_rate {
+        let _ = writeln!(
+            out,
+            "  Min: {:.4}  |  P50: {:.4}  |  Max: {:.4}",
+            hist.min, hist.p50, hist.max,
+        );
+    } else {
+        let _ = writeln!(
+            out,
+            "  No prior completed sweeps found matching current dataset hash."
+        );
+    }
+
+    if report.slice_skew {
+        let _ = writeln!(
+            out,
+            "\n[WARNING] Slice Skew detected! The selected subset may be unrepresentative of the full dataset."
+        );
+    }
+
+    out
+}

--- a/src/run/dataset_stats.rs
+++ b/src/run/dataset_stats.rs
@@ -229,18 +229,15 @@ fn percentile_90(values: &[usize]) -> usize {
     values[idx]
 }
 
-#[allow(clippy::manual_midpoint)]
 fn median_f64(values: &[f64]) -> f64 {
     if values.is_empty() {
         return 0.0;
     }
-    let mut sorted = values.to_vec();
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    let mid = sorted.len() / 2;
-    if sorted.len() % 2 == 0 {
-        (sorted[mid - 1] + sorted[mid]) / 2.0
+    let mid = values.len() / 2;
+    if values.len() % 2 == 0 {
+        values[mid - 1].midpoint(values[mid])
     } else {
-        sorted[mid]
+        values[mid]
     }
 }
 
@@ -271,8 +268,11 @@ fn detect_languages(instances: &[SweBenchInstance]) -> Vec<String> {
                 for line in val.lines() {
                     if line.starts_with("--- a/") || line.starts_with("+++ b/") {
                         if let Some(ext) = line.split('.').next_back() {
-                            let ext_clean: String =
-                                ext.chars().filter(|c| c.is_alphanumeric()).collect();
+                            let ext_clean: String = ext
+                                .chars()
+                                .filter(|c| c.is_alphanumeric())
+                                .flat_map(char::to_lowercase)
+                                .collect();
                             let lang = match ext_clean.as_str() {
                                 "py" => Some("Python"),
                                 "rs" => Some("Rust"),
@@ -365,6 +365,7 @@ fn analyze_historical_resolved_rates(
             if let Ok(results) = serde_json::from_str::<SweepResults>(&text) {
                 let matches = match (dataset_hash, &results.manifest) {
                     (Some(curr_hash), Some(manifest)) => manifest.dataset.sha256 == **curr_hash,
+                    (Some(_), None) => false,
                     _ => true,
                 };
                 if matches {
@@ -373,7 +374,17 @@ fn analyze_historical_resolved_rates(
                             .entry(inst_res.instance_id.clone())
                             .or_insert((0u32, 0u32));
                         let runs = if inst_res.runs == 0 { 1 } else { inst_res.runs };
-                        entry.0 += inst_res.resolved_count;
+                        let resolved = if inst_res.runs == 0 {
+                            u32::from(
+                                inst_res.pass_at_1
+                                    || inst_res.outcome.as_deref() == Some("resolved")
+                                    || (inst_res.outcome.as_deref() == Some("submitted")
+                                        && inst_res.failure_category.is_none()),
+                            )
+                        } else {
+                            inst_res.resolved_count
+                        };
+                        entry.0 += resolved;
                         entry.1 += runs;
                     }
                 }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -10,6 +10,7 @@ pub mod cascade;
 pub mod command_stats;
 pub mod compare;
 pub mod dataset;
+pub mod dataset_stats;
 pub mod diff_config;
 pub mod env_preview;
 pub mod evaluate;

--- a/tests/bench_dataset_stats.rs
+++ b/tests/bench_dataset_stats.rs
@@ -3,7 +3,12 @@
 //! RED-phase: these tests verify the required behavior of `bench dataset-stats`.
 //! They will fail to compile or run until the GREEN phase implements the subcommand.
 
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::float_cmp,
+    clippy::cloned_ref_to_slice_refs
+)]
 
 use std::path::PathBuf;
 
@@ -11,7 +16,11 @@ use std::path::PathBuf;
 // or by mocking the core calculator in `maxwells_daemon::run::dataset_stats`.
 // Let's test the statistical logic directly to ensure maximum TDD precision, and then verify the CLI integration.
 
-use maxwells_daemon::run::swebench::SweBenchInstance;
+use maxwells_daemon::run::swebench::{
+    CliManifest, ConfigManifest, DatasetManifest as SweBenchDatasetManifest, HarnessManifest,
+    InstanceResult, ModelManifest, PromptTemplateManifest, ProvenanceManifest, RuntimeManifest,
+    SweBenchInstance, SweepResults,
+};
 
 #[test]
 fn test_mock_dataset_stats_computation() {
@@ -176,4 +185,257 @@ fn test_skew_detection_token_length() {
         stats.slice_skew,
         "Slice skew must be true due to median token length deviation (>25%)"
     );
+}
+
+#[test]
+fn test_language_detection_case_insensitivity() {
+    let mut other_map = serde_json::Map::new();
+    other_map.insert(
+        "patch".into(),
+        serde_json::json!("--- a/src/main.Rs\n+++ b/src/main.Rs\n"),
+    );
+
+    let inst = SweBenchInstance {
+        instance_id: "inst-1".into(),
+        repo: Some("test/repo".into()),
+        base_commit: Some("commit1".into()),
+        problem_statement: Some("test".into()),
+        image: None,
+        other: other_map,
+    };
+
+    let stats = maxwells_daemon::run::dataset_stats::compute_stats(
+        &[inst.clone()],
+        &[inst],
+        "gpt-4",
+        &PathBuf::from("/nonexistent-runs"),
+        &None,
+    )
+    .unwrap();
+
+    assert!(
+        stats.languages.contains(&"Rust".to_string()),
+        "Languages list should contain Rust even if extension is mixed-case (.Rs): {:?}",
+        stats.languages
+    );
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn test_historical_resolved_rates_legacy_and_hash_handling() {
+    use std::fs::{create_dir_all, write};
+    use tempfile::tempdir;
+
+    let dir = tempdir().unwrap();
+    let runs_dir = dir.path().join("runs");
+    create_dir_all(&runs_dir).unwrap();
+
+    // 1. Construct legacy SweepResults
+    let legacy_results = SweepResults {
+        total: 1,
+        sweep_status: "completed".to_string(),
+        cancelled_at: None,
+        cancel_deadline_at: None,
+        cancel_exit_code: None,
+        completed: 1,
+        in_flight_at_cancel: 0,
+        not_started: 0,
+        submitted: 1,
+        submitted_with_tests: 0,
+        skipped: 0,
+        errored: 0,
+        failures_by_category: Default::default(),
+        budget_halted: 0,
+        with_patch: 1,
+        patch_empty: 0,
+        patch_apply_invalid: 0,
+        github_pr_failures: 0,
+        total_prompt_tokens: 0,
+        total_cache_read_tokens: 0,
+        total_cache_creation_tokens: 0,
+        total_completion_tokens: 0,
+        estimated_cost_usd: 0.0,
+        actual_cost_usd: None,
+        actual_cost_source: None,
+        baseline_cost_usd: None,
+        baseline_cost_model: None,
+        cache_hit_rate: 0.0,
+        retries: 0,
+        retried_instances: 0,
+        pass_at_k: 0.0,
+        filter_spec: Default::default(),
+        manifest: None,
+        cost_limit_usd: None,
+        instances: vec![InstanceResult {
+            instance_id: "inst-1".to_string(),
+            exit_reason: "submitted".to_string(),
+            outcome: Some("submitted".to_string()),
+            failure_category: None,
+            steps: Some(1),
+            cost_usd: Some(0.0),
+            prompt_tokens: Some(0),
+            cache_read_tokens: Some(0),
+            cache_creation_tokens: Some(0),
+            completion_tokens: Some(0),
+            duration_secs: Some(0.0),
+            error: None,
+            github_pr_error: None,
+            patch_present: true,
+            non_empty_patch: true,
+            attempts: 1,
+            retry_reasons: vec![],
+            runs: 0,
+            resolved_count: 0,
+            pass_at_1: false,
+            tests_run_before_submit: false,
+            last_tests_passed: None,
+            fallback_count: None,
+            final_model: None,
+            retry_id: None,
+            previous_failure_category: None,
+            trace_id: None,
+        }],
+        rate_limit_events: None,
+        total_fallbacks: 0,
+        model_mix: Default::default(),
+        systemic_halt_category: None,
+        retry_history: vec![],
+        partial: 0,
+        span_export_dropped: 0,
+    };
+    let legacy_dir = runs_dir.join("legacy");
+    create_dir_all(&legacy_dir).unwrap();
+    let legacy_path = legacy_dir.join("results.json");
+    write(
+        &legacy_path,
+        serde_json::to_string_pretty(&legacy_results).unwrap(),
+    )
+    .unwrap();
+
+    let manifest_template = ProvenanceManifest {
+        purpose: None,
+        harness: HarnessManifest {
+            name: "max".to_string(),
+            version: "0.1.0".to_string(),
+            git_sha: None,
+            git_dirty: Some(false),
+            git_resolution: "exact".to_string(),
+        },
+        dataset: SweBenchDatasetManifest {
+            path: "dataset.jsonl".to_string(),
+            sha256: "matching_hash".to_string(),
+            instance_count: 1,
+            filter_spec: None,
+            source_kind: "local".to_string(),
+            alias: None,
+            split: None,
+            source_revision: None,
+            cache_path: None,
+            selected_row_count: 1,
+            post_filter_row_count: 1,
+        },
+        prompt_template: PromptTemplateManifest {
+            source: "builtin".to_string(),
+            path: None,
+            sha256: "deadbeef".to_string(),
+        },
+        config: ConfigManifest {
+            resolved: String::new(),
+            overlay_paths: vec![],
+        },
+        model: ModelManifest {
+            name: "gpt-4".to_string(),
+            backend: "litellm".to_string(),
+            backend_version: None,
+            base_url: None,
+        },
+        runtime: RuntimeManifest {
+            started_at_utc: "2026-01-01T00:00:00Z".to_string(),
+            finished_at_utc: None,
+            host_os: "linux".to_string(),
+            resume_mode: false,
+            rust_version: None,
+        },
+        cli: CliManifest { argv: vec![] },
+        circuit_breaker: None,
+        reproduced_from: None,
+    };
+
+    // 2. Write a modern results.json that has a manifest matching our expected hash
+    let mut modern_matching_results = legacy_results.clone();
+    modern_matching_results.manifest = Some(manifest_template.clone());
+    modern_matching_results.instances = vec![InstanceResult {
+        runs: 1,
+        resolved_count: 1,
+        ..legacy_results.instances[0].clone()
+    }];
+    let modern_matching_dir = runs_dir.join("modern_matching");
+    create_dir_all(&modern_matching_dir).unwrap();
+    let modern_matching_path = modern_matching_dir.join("results.json");
+    write(
+        &modern_matching_path,
+        serde_json::to_string_pretty(&modern_matching_results).unwrap(),
+    )
+    .unwrap();
+
+    // 3. Write a modern results.json with non-matching manifest hash
+    let mut modern_mismatched_results = legacy_results.clone();
+    let mut mismatched_manifest = manifest_template;
+    mismatched_manifest.dataset.sha256 = "other_hash".to_string();
+    modern_mismatched_results.manifest = Some(mismatched_manifest);
+    modern_mismatched_results.instances = vec![InstanceResult {
+        runs: 1,
+        resolved_count: 0,
+        ..legacy_results.instances[0].clone()
+    }];
+    let modern_mismatched_dir = runs_dir.join("modern_mismatched");
+    create_dir_all(&modern_mismatched_dir).unwrap();
+    let modern_mismatched_path = modern_mismatched_dir.join("results.json");
+    write(
+        &modern_mismatched_path,
+        serde_json::to_string_pretty(&modern_mismatched_results).unwrap(),
+    )
+    .unwrap();
+
+    let inst = SweBenchInstance {
+        instance_id: "inst-1".into(),
+        repo: Some("django/django".into()),
+        base_commit: Some("commit1".into()),
+        problem_statement: Some("test".into()),
+        image: None,
+        other: serde_json::Map::new(),
+    };
+
+    // Case A: dataset hash is known (Some("matching_hash"))
+    // Legacy results.json (manifest: null) should be EXCLUDED, mismatched should be EXCLUDED.
+    // So only modern_matching is included: resolved_count=1, runs=1 -> rate=1.0.
+    let stats_hash_known = maxwells_daemon::run::dataset_stats::compute_stats(
+        &[inst.clone()],
+        &[inst.clone()],
+        "gpt-4",
+        &runs_dir,
+        &Some("matching_hash".to_string()),
+    )
+    .unwrap();
+
+    let hist = stats_hash_known.historical_resolved_rate.unwrap();
+    assert_eq!(hist.min, 1.0);
+    assert_eq!(hist.max, 1.0);
+    assert_eq!(hist.p50, 1.0);
+
+    // Case B: dataset hash is None
+    // Legacy results.json should be INCLUDED and use legacy-aware resolution.
+    // Legacy has runs=0, resolved_count=0, but outcome="submitted" and no failure_category,
+    // so it resolves to resolved=1, runs=1 -> rate=1.0.
+    // Modern matching has resolved_count=1, runs=1 -> rate=1.0.
+    // Modern mismatched has resolved_count=0, runs=1 -> rate=0.0.
+    // All 3 matched runs aggregate to sum_resolved=2, sum_runs=3 -> rate=2/3.
+    let stats_hash_none =
+        maxwells_daemon::run::dataset_stats::compute_stats(&[inst], &[], "gpt-4", &runs_dir, &None)
+            .unwrap();
+
+    let hist_none = stats_hash_none.historical_resolved_rate.unwrap();
+    assert_eq!(hist_none.min, 2.0 / 3.0);
+    assert_eq!(hist_none.max, 2.0 / 3.0);
+    assert_eq!(hist_none.p50, 2.0 / 3.0);
 }

--- a/tests/bench_dataset_stats.rs
+++ b/tests/bench_dataset_stats.rs
@@ -88,6 +88,7 @@ fn test_mock_dataset_stats_computation() {
     // Verify expected tests distribution (3 for inst1, 1 for inst2)
     assert_eq!(stats.expected_tests.min, 1);
     assert_eq!(stats.expected_tests.max, 3);
+    assert_eq!(stats.expected_tests.p90, 3);
 }
 
 #[test]
@@ -380,7 +381,7 @@ fn test_historical_resolved_rates_legacy_and_hash_handling() {
 
     // 3. Write a modern results.json with non-matching manifest hash
     let mut modern_mismatched_results = legacy_results.clone();
-    let mut mismatched_manifest = manifest_template;
+    let mut mismatched_manifest = manifest_template.clone();
     mismatched_manifest.dataset.sha256 = "other_hash".to_string();
     modern_mismatched_results.manifest = Some(mismatched_manifest);
     modern_mismatched_results.instances = vec![InstanceResult {
@@ -394,6 +395,24 @@ fn test_historical_resolved_rates_legacy_and_hash_handling() {
     write(
         &modern_mismatched_path,
         serde_json::to_string_pretty(&modern_mismatched_results).unwrap(),
+    )
+    .unwrap();
+
+    // 4. Write a modern results.json that matches manifest but is not completed ("running")
+    let mut modern_running_results = legacy_results.clone();
+    modern_running_results.sweep_status = "running".to_string();
+    modern_running_results.manifest = Some(manifest_template);
+    modern_running_results.instances = vec![InstanceResult {
+        runs: 1,
+        resolved_count: 0,
+        ..legacy_results.instances[0].clone()
+    }];
+    let modern_running_dir = runs_dir.join("modern_running");
+    create_dir_all(&modern_running_dir).unwrap();
+    let modern_running_path = modern_running_dir.join("results.json");
+    write(
+        &modern_running_path,
+        serde_json::to_string_pretty(&modern_running_results).unwrap(),
     )
     .unwrap();
 

--- a/tests/bench_dataset_stats.rs
+++ b/tests/bench_dataset_stats.rs
@@ -1,0 +1,179 @@
+//! Integration tests for `bench dataset-stats` subcommand (issue #281).
+//!
+//! RED-phase: these tests verify the required behavior of `bench dataset-stats`.
+//! They will fail to compile or run until the GREEN phase implements the subcommand.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::PathBuf;
+
+// We will simulate running the subcommand via argument parsing or calling a public entry point if we expose it,
+// or by mocking the core calculator in `maxwells_daemon::run::dataset_stats`.
+// Let's test the statistical logic directly to ensure maximum TDD precision, and then verify the CLI integration.
+
+use maxwells_daemon::run::swebench::SweBenchInstance;
+
+#[test]
+fn test_mock_dataset_stats_computation() {
+    // Write mock instances representing different repos, problem statement lengths, and expected tests
+    let mut other_map1 = serde_json::Map::new();
+    other_map1.insert(
+        "FAIL_TO_PASS".into(),
+        serde_json::json!(["test_a", "test_b"]),
+    );
+    other_map1.insert("PASS_TO_PASS".into(), serde_json::json!(["test_c"]));
+    other_map1.insert(
+        "patch".into(),
+        serde_json::json!(
+            "--- a/django/contrib/admin/options.py\n+++ b/django/contrib/admin/options.py\n"
+        ),
+    );
+
+    let mut other_map2 = serde_json::Map::new();
+    other_map2.insert("FAIL_TO_PASS".into(), serde_json::json!(["test_d"]));
+    other_map2.insert(
+        "patch".into(),
+        serde_json::json!("--- a/pytest/main.py\n+++ b/pytest/main.py\n"),
+    );
+
+    let inst1 = SweBenchInstance {
+        instance_id: "inst-1".into(),
+        repo: Some("django/django".into()),
+        base_commit: Some("commit1".into()),
+        problem_statement: Some("Short problem statement here".into()), // 4 words
+        image: None,
+        other: other_map1,
+    };
+
+    let inst2 = SweBenchInstance {
+        instance_id: "inst-2".into(),
+        repo: Some("pytest-dev/pytest".into()),
+        base_commit: Some("commit2".into()),
+        problem_statement: Some("This is a much longer problem statement designed to test distribution calculations properly.".into()), // 13 words
+        image: None,
+        other: other_map2,
+    };
+
+    let slice_instances = vec![inst1.clone(), inst2.clone()];
+    let full_instances = vec![inst1, inst2];
+
+    // Core calculator test
+    let stats = maxwells_daemon::run::dataset_stats::compute_stats(
+        &slice_instances,
+        &full_instances,
+        "gpt-4",
+        &PathBuf::from("/nonexistent-runs"),
+        &None, // dataset hash
+    )
+    .unwrap();
+
+    assert_eq!(stats.total_instances, 2);
+    assert_eq!(stats.repos.len(), 2);
+    assert!(stats.languages.contains(&"Python".to_string()));
+
+    // Verify token distribution (using litellm-rs TokenCounter)
+    // gpt-4 has overhead + tokens.
+    assert!(stats.problem_statement_tokens.min > 0);
+    assert!(stats.problem_statement_tokens.max >= stats.problem_statement_tokens.min);
+
+    // Verify expected tests distribution (3 for inst1, 1 for inst2)
+    assert_eq!(stats.expected_tests.min, 1);
+    assert_eq!(stats.expected_tests.max, 3);
+}
+
+#[test]
+fn test_skew_detection_repo_coverage() {
+    let mut other_map = serde_json::Map::new();
+    other_map.insert(
+        "patch".into(),
+        serde_json::json!("--- a/django/contrib/admin/options.py\n"),
+    );
+
+    let inst1 = SweBenchInstance {
+        instance_id: "inst-1".into(),
+        repo: Some("django/django".into()),
+        base_commit: Some("commit1".into()),
+        problem_statement: Some("test".into()),
+        image: None,
+        other: other_map.clone(),
+    };
+    let inst2 = SweBenchInstance {
+        instance_id: "inst-2".into(),
+        repo: Some("pytest-dev/pytest".into()),
+        base_commit: Some("commit2".into()),
+        problem_statement: Some("test".into()),
+        image: None,
+        other: other_map.clone(),
+    };
+    let inst3 = SweBenchInstance {
+        instance_id: "inst-3".into(),
+        repo: Some("pandas-dev/pandas".into()),
+        base_commit: Some("commit3".into()),
+        problem_statement: Some("test".into()),
+        image: None,
+        other: other_map.clone(),
+    };
+
+    let slice_instances = vec![inst1.clone()];
+    let full_instances = vec![inst1, inst2, inst3];
+
+    let stats = maxwells_daemon::run::dataset_stats::compute_stats(
+        &slice_instances,
+        &full_instances,
+        "gpt-4",
+        &PathBuf::from("/nonexistent-runs"),
+        &None,
+    )
+    .unwrap();
+
+    assert!(
+        stats.slice_skew,
+        "Slice skew must be true due to low repo coverage (<50%)"
+    );
+}
+
+#[test]
+fn test_skew_detection_token_length() {
+    let mut other_map = serde_json::Map::new();
+    other_map.insert(
+        "patch".into(),
+        serde_json::json!("--- a/django/contrib/admin/options.py\n"),
+    );
+
+    let inst1 = SweBenchInstance {
+        instance_id: "inst-1".into(),
+        repo: Some("django/django".into()),
+        base_commit: Some("commit1".into()),
+        problem_statement: Some("short".into()), // 1 token
+        image: None,
+        other: other_map.clone(),
+    };
+    let inst2 = SweBenchInstance {
+        instance_id: "inst-2".into(),
+        repo: Some("django/django".into()),
+        base_commit: Some("commit2".into()),
+        problem_statement: Some(
+            "this is a much longer problem statement designed to skew the median length difference"
+                .into(),
+        ), // 13 tokens
+        image: None,
+        other: other_map.clone(),
+    };
+
+    let slice_instances = vec![inst1.clone()]; // median length = 1
+    let full_instances = vec![inst1, inst2]; // median length = 7. Difference is >25%.
+
+    let stats = maxwells_daemon::run::dataset_stats::compute_stats(
+        &slice_instances,
+        &full_instances,
+        "gpt-4",
+        &PathBuf::from("/nonexistent-runs"),
+        &None,
+    )
+    .unwrap();
+
+    assert!(
+        stats.slice_skew,
+        "Slice skew must be true due to median token length deviation (>25%)"
+    );
+}


### PR DESCRIPTION
## Overview
This PR implements the zero-cost offline `bench dataset-stats` subcommand previewing SWE-bench dataset composition prior to launching sweeps (issue #281), written in a strict Red/Green/Refactor TDD manner.

### Key Highlights
1. **Token Estimation**: Integrates `litellm-rs`'s `TokenCounter` to perform high-fidelity offline prompt token estimation for each instance's problem statement.
2. **Multi-Tiered Language Detection**: Parses changed file extensions from diff headers in `patch` and `test_patch` (e.g. `.py` $\to$ Python, `.rs` $\to$ Rust) with case-insensitive repository substring fallbacks.
3. **Slice Skewness & Representativeness Checks**: Emits a warning when unique repository coverage falls below 50% or when the slice's median problem-statement token length deviates from the full dataset's median by more than 25%.
4. **Historical Sweeps Integration**: Recursively matches the `manifest.dataset.sha256` hash against prior completed sweeps in `--runs-dir` to compile historical instance resolved-rate distributions.
5. **Comfy Table & JSON Interfaces**: Outputs markdown-friendly, aligned ASCII Cozy Tables by default, or stable schema-versioned JSON.

### Verification Evidence
* **Integration Tests**: Added `tests/bench_dataset_stats.rs` verifying mock statistics calculations, language extraction, token counter integration, and representativeness skewness flags. All tests pass successfully!
* **Pristine Build**: Passes all `cargo test` and `cargo clippy --all-targets -- -D warnings` checks without any warning or error.