### PR TITLE
⚒️ Forge: Fix unnecessary_wraps clippy warnings in cli mod

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2508,6 +2508,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
 }
 
 #[cfg(feature = "html-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
     Ok(HtmlExporter::export(traj))
@@ -2523,6 +2524,7 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
 }
 
 #[cfg(feature = "csv-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
     Ok(CsvExporter::export(traj))
@@ -2538,6 +2540,7 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
 }
 
 #[cfg(feature = "mermaid-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
     Ok(MermaidExporter::export(traj))


### PR DESCRIPTION
🚮 Smell: `clippy::unnecessary_wraps` warnings in `inspect_export_html`, `inspect_export_csv`, and `inspect_export_mermaid`.
✨ Solution: Added `#[allow(clippy::unnecessary_wraps)]` since these functions need to return `Result` for consistency with their `#[cfg(not(feature = \"...\"))]` counterparts which return `Err`.
🧼 Benefit: Fixes clippy warnings on feature-enabled builds without changing consistent API types.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [16504323673047132552](https://jules.google.com/task/16504323673047132552) started by @madmax983*