### PR TITLE
⚒️ Forge: Resolve boolean blindness in run_git

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2517,6 +2517,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
 }
 
 #[cfg(feature = "html-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
     Ok(HtmlExporter::export(traj))
@@ -2532,6 +2533,7 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
 }
 
 #[cfg(feature = "csv-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
     Ok(CsvExporter::export(traj))
@@ -2547,6 +2549,7 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
 }
 
 #[cfg(feature = "mermaid-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
     Ok(MermaidExporter::export(traj))

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -3079,8 +3079,8 @@ fn resolve_harness_manifest() -> HarnessManifest {
 fn resolve_harness_manifest_for_dir(cwd: Option<&Path>) -> HarnessManifest {
     let name = env!("CARGO_PKG_NAME").to_owned();
     let version = env!("CARGO_PKG_VERSION").to_owned();
-    let sha_res = run_git(cwd, &["rev-parse", "HEAD"], false);
-    let status_res = run_git(cwd, &["status", "--porcelain"], true);
+    let sha_res = run_git(cwd, &["rev-parse", "HEAD"], GitEmptyOutput::Deny);
+    let status_res = run_git(cwd, &["status", "--porcelain"], GitEmptyOutput::Allow);
     let sha = sha_res.as_ref().ok().cloned();
     let dirty = status_res.as_ref().ok().map(|s| !s.trim().is_empty());
     let git_resolution = match (&sha_res, &status_res) {
@@ -3098,7 +3098,13 @@ fn resolve_harness_manifest_for_dir(cwd: Option<&Path>) -> HarnessManifest {
     }
 }
 
-fn run_git(cwd: Option<&Path>, args: &[&str], allow_empty: bool) -> Result<String, String> {
+#[derive(Clone, Copy)]
+enum GitEmptyOutput {
+    Allow,
+    Deny,
+}
+
+fn run_git(cwd: Option<&Path>, args: &[&str], allow_empty: GitEmptyOutput) -> Result<String, String> {
     let mut cmd = Command::new("git");
     cmd.args(args);
     if let Some(dir) = cwd {
@@ -3111,7 +3117,7 @@ fn run_git(cwd: Option<&Path>, args: &[&str], allow_empty: bool) -> Result<Strin
     }
     let text = String::from_utf8(out.stdout).map_err(|e| e.to_string())?;
     let trimmed = text.trim().to_owned();
-    if trimmed.is_empty() && !allow_empty {
+    if trimmed.is_empty() && matches!(allow_empty, GitEmptyOutput::Deny) {
         return Err("empty output".into());
     }
     Ok(trimmed)

--- a/tests/webhook.rs
+++ b/tests/webhook.rs
@@ -140,6 +140,8 @@ fn make_mini_args(
         trace_id: None,
         webhook_url,
         webhook_headers,
+        event_log: None,
+        event_log_instance_id: None,
         local_workdir: None,
         read_only: false,
         allow_mcp_in_read_only: false,


### PR DESCRIPTION
    🚮 Smell: `run_git` takes an opaque boolean parameter `allow_empty`, making calls like `run_git(cwd, args, true)` ambiguous at the call site.
    ✨ Solution: Replaced the boolean argument with a strongly typed enum `GitEmptyOutput { Allow, Deny }`.
    🧼 Benefit: Call sites are now explicitly clear: `run_git(cwd, args, GitEmptyOutput::Allow)`.
    🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [8352590966219837566](https://jules.google.com/task/8352590966219837566) started by @madmax983*