### PR TITLE
🌟 Nova: JSON Export for Trajectories

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1633,14 +1633,14 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`, and `json-export`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `json-export` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2396,7 +2396,10 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "json-export"
+    ) {
         return bench_inspect_export(i);
     }
 
@@ -2453,7 +2456,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     })?;
     let instance_id = i.instance.as_deref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
-            "inspect: --instance is required for export formats (markdown/html/csv/mermaid)".into(),
+            "inspect: --instance is required for export formats (markdown/html/csv/mermaid/json-export)".into(),
         ))
     })?;
     let traj_path =
@@ -2472,9 +2475,15 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
             use crate::trajectory::export::{MarkdownExporter, TrajectoryExporter};
             MarkdownExporter::export(&traj)
         }
+
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "json-export" => {
+            use crate::trajectory::export::{JsonExporter, TrajectoryExporter};
+            JsonExporter::export(&traj)
+        }
+
         _ => unreachable!("dispatch guarded by caller"),
     };
 
@@ -2517,6 +2526,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
 }
 
 #[cfg(feature = "html-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
     Ok(HtmlExporter::export(traj))
@@ -2532,6 +2542,7 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
 }
 
 #[cfg(feature = "csv-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
     Ok(CsvExporter::export(traj))
@@ -2547,6 +2558,7 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
 }
 
 #[cfg(feature = "mermaid-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
     Ok(MermaidExporter::export(traj))

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -53,6 +53,8 @@ pub struct MermaidExporter;
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
+pub struct JsonExporter;
+
 use std::fmt::Write;
 
 #[cfg(feature = "csv-export")]
@@ -191,6 +193,38 @@ impl TrajectoryExporter for HtmlExporter {
 
         html.push_str("</body>\n</html>");
         html
+    }
+}
+
+impl TrajectoryExporter for JsonExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+
+        let mut messages = Vec::new();
+        for msg in &trajectory.messages {
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            messages.push(serde_json::json!({
+                "role": msg.role,
+                "content": content
+            }));
+        }
+
+        let mut export_obj = serde_json::Map::new();
+        if let Some(task) = &trajectory.info.task {
+            export_obj.insert(
+                "task".to_string(),
+                serde_json::Value::String(redactor.redact_text(task, surface::EXPORT).text),
+            );
+        }
+        if let Some(outcome) = &trajectory.info.outcome {
+            export_obj.insert(
+                "outcome".to_string(),
+                serde_json::Value::String(redactor.redact_text(outcome, surface::EXPORT).text),
+            );
+        }
+        export_obj.insert("messages".to_string(), serde_json::Value::Array(messages));
+
+        serde_json::to_string_pretty(&export_obj).unwrap_or_default()
     }
 }
 
@@ -338,6 +372,28 @@ mod tests {
         assert!(html.contains("Add a feature"));
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
+
         assert!(html.contains("Hello user"));
+    }
+
+    #[allow(clippy::unwrap_used)]
+    #[test]
+    fn test_json_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some("submitted".to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::assistant("Hello user"));
+
+        let json = JsonExporter::export(&t);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["task"], "Add a feature");
+        assert_eq!(parsed["outcome"], "submitted");
+        assert_eq!(parsed["messages"].as_array().unwrap().len(), 3);
+        assert_eq!(parsed["messages"][0]["role"], "system");
+        assert_eq!(parsed["messages"][0]["content"], "System prompt");
     }
 }

--- a/tests/webhook.rs
+++ b/tests/webhook.rs
@@ -140,6 +140,8 @@ fn make_mini_args(
         trace_id: None,
         webhook_url,
         webhook_headers,
+        event_log: None,
+        event_log_instance_id: None,
         local_workdir: None,
         read_only: false,
         allow_mcp_in_read_only: false,


### PR DESCRIPTION
🌟 Nova: JSON Export for Trajectories

💡 **The Spark:** "We have robust machinery to parse trajectories (`Trajectory::load()`) and multiple formats to export to human-readable variants (`markdown`, `csv`, `mermaid`, `html`). But what if someone wants a stripped, programmatically readable version of just the messages and task data to pass into *another* agent, feed to an evaluation script without the `model_latency_ms`/`tool_latency_ms` noise, or use `jq` on for automated analysis? We have `--format text` and `--format json` for printing logs or diffs, but no `--format json-export` for single trajectory exports!"

🚀 **The Feature:** "Implemented `JsonExporter` trait for `TrajectoryExporter`. It transforms the trajectory into a simple, minimized JSON schema (`{'task': ..., 'outcome': ..., 'messages': [...]}`) focused purely on the *content*, stripping away all the harness-specific `extra` keys, `cache_hints`, and performance traces. Adding `--format json-export` support to `agent inspect`."

🔮 **The Potential:** "Could be used as the ultimate piping tool for `maxwells-daemon`. Export the trajectory to stripped JSON, pipe it into `jq` to extract just the `assistant` messages, pipe *that* into a new model for meta-analysis or summarization. It unlocks pure CLI composition."

⚠️ **Risk:** "Extremely Low. Additive implementation of an existing trait pattern (`TrajectoryExporter`) and wiring up a new match branch in `args.rs`/`mod.rs`."

---
*PR created automatically by Jules for task [8766957587039493326](https://jules.google.com/task/8766957587039493326) started by @madmax983*