### PR TITLE
Implement bench triage-diff failure cluster delta analysis with TDD

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ a valid trajectory in hand:
   pass@k, and compare regression gates.
 - [`bench triage`](docs/spec-triage.md): deterministic unresolved-failure
   clustering, ranked stdout tables, and the `triage.json` schema.
+- [`bench triage-diff`](docs/spec-triage-diff.md): diff failure-cluster composition between two sweeps.
 - [`bench command-stats`](docs/spec-command-stats.md): shell-command frequency
   and cost aggregated by outcome bucket, delta view for resolved-vs-unresolved
   comparison, and the `command-stats.json` schema.

--- a/docs/spec-triage-diff.md
+++ b/docs/spec-triage-diff.md
@@ -1,0 +1,77 @@
+# `bench triage-diff` Spec
+
+`bench triage-diff` is a zero-cost, read-only post-processor that compares failure-cluster composition between two completed SWE-bench sweeps.
+
+## CLI
+
+```bash
+max bench triage-diff --baseline <dir> --candidate <dir>
+```
+
+Options:
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--baseline <dir>` | required | Baseline sweep directory. |
+| `--candidate <dir>` | required | Candidate sweep directory. |
+| `--auto-triage` | `false` | Run `bench triage` on baseline and/or candidate if `triage.json` is missing. |
+| `--min-cluster-size <k>` | `1` | Filter cluster deltas; a cluster surfaces if baseline OR candidate count is `>= k`. |
+| `--top <n>` | `10` | Number of entries to print in text lists/tables. |
+| `--output <path>` | `triage-diff.json` in candidate sweep dir | Output path for the JSON report. |
+| `--format text\|json` | `text` | Output format: `text` or `json` (stdout). |
+| `--fail-on-regression` | `false` | Make the command exit with non-zero code `1` when the regression set is non-empty. |
+
+Exit behavior:
+
+- `0`: Success, regardless of whether candidate resolved rate is better, worse, or identical.
+- `1`: When `--fail-on-regression` is enabled and regressions are detected.
+- Non-zero: Missing sweeps, missing `triage.json` artifacts when `--auto-triage` is false, or invalid arguments.
+
+## Inputs
+
+The command reads:
+- `triage.json` from each sweep (generating it if missing and `--auto-triage` is true).
+- `results.json` and `evaluation.json` from each sweep to determine accurate instance resolved/unresolved status.
+- Trajectory files if necessary to dynamically reconstruct signatures for unclustered instances.
+
+## Regression and Win Sets
+
+- **Regression Set**: Instances `resolved: true` in baseline AND `resolved: false` in candidate. They are grouped by the candidate-side failure cluster they fell into.
+- **Win Set**: Instances `resolved: false` in baseline AND `resolved: true` in candidate. They are grouped by the baseline-side failure cluster they escaped.
+
+## Output JSON Schema
+
+Writes `triage-diff.json`:
+
+```json
+{
+  "schema_version": "triage-diff-1.0",
+  "baseline_sweep": "<dir>",
+  "candidate_sweep": "<dir>",
+  "cluster_deltas": [
+    {
+      "cluster_id": "<stable-hash>",
+      "failure_category": "<category>",
+      "signature_summary": "<summary>",
+      "baseline_count": 2,
+      "candidate_count": 5,
+      "delta": 3,
+      "delta_pct": 150.0
+    }
+  ],
+  "new_clusters": [
+    {
+      "cluster_id": "<stable-hash>",
+      "failure_category": "<category>",
+      "signature_summary": "<summary>",
+      "instance_count": 3,
+      "instance_ids": ["<id1>", "<id2>", "<id3>"]
+    }
+  ],
+  "resolved_clusters": [],
+  "regression_instances": [],
+  "win_instances": []
+}
+```
+
+Field names are locked at `v1` to ensure downstream tool integration remains stable.

--- a/docs/spec-triage-diff.md
+++ b/docs/spec-triage-diff.md
@@ -19,12 +19,12 @@ Options:
 | `--top <n>` | `10` | Number of entries to print in text lists/tables. |
 | `--output <path>` | `triage-diff.json` in candidate sweep dir | Output path for the JSON report. |
 | `--format text\|json` | `text` | Output format: `text` or `json` (stdout). |
-| `--fail-on-regression` | `false` | Make the command exit with non-zero code `1` when the regression set is non-empty. |
+| `--fail-on-regression` | `false` | Make the command exit with non-zero code `6` when the regression set is non-empty. |
 
 Exit behavior:
 
 - `0`: Success, regardless of whether candidate resolved rate is better, worse, or identical.
-- `1`: When `--fail-on-regression` is enabled and regressions are detected.
+- `6`: When `--fail-on-regression` is enabled and regressions are detected (corresponds to `ExitCode::RegressionGateFailure`).
 - Non-zero: Missing sweeps, missing `triage.json` artifacts when `--auto-triage` is false, or invalid arguments.
 
 ## Inputs

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -473,6 +473,8 @@ pub enum BenchCmd {
     Watch(WatchCmd),
     /// Cluster unresolved sweep failures into ranked actionable groups.
     Triage(TriageCmd),
+    /// Diff failure-cluster composition between two sweeps.
+    TriageDiff(TriageDiffCmd),
     /// Aggregate shell-command frequency and cost by outcome bucket.
     CommandStats(CommandStatsCmd),
     /// Search every trajectory in a sweep for a regex pattern (zero-cost: reads only on-disk artifacts).
@@ -1762,6 +1764,41 @@ pub struct TriageCmd {
     /// Output format: `text` (default) or `json`.
     #[arg(long, default_value = "text")]
     pub format: String,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct TriageDiffCmd {
+    /// Baseline sweep directory produced by `bench swebench` and scored by `bench evaluate`.
+    #[arg(long)]
+    pub baseline: PathBuf,
+
+    /// Candidate sweep directory produced by `bench swebench` and scored by `bench evaluate`.
+    #[arg(long)]
+    pub candidate: PathBuf,
+
+    /// Run `bench triage` on baseline and/or candidate sweeps if triage.json is missing.
+    #[arg(long = "auto-triage", default_value_t = false)]
+    pub auto_triage: bool,
+
+    /// Filter delta output to clusters with count >= k on either baseline or candidate.
+    #[arg(long, default_value_t = 1)]
+    pub min_cluster_size: usize,
+
+    /// Number of ranked clusters to print in text mode.
+    #[arg(long, default_value_t = 10)]
+    pub top: usize,
+
+    /// Output path for triage-diff.json. Defaults to `triage-diff.json` in candidate sweep dir.
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+
+    /// Output format: `text` (default) or `json`.
+    #[arg(long, default_value = "text")]
+    pub format: String,
+
+    /// Fail with exit code 1 if the regression set is non-empty.
+    #[arg(long = "fail-on-regression", default_value_t = false)]
+    pub fail_on_regression: bool,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -86,6 +86,7 @@ pub async fn run() -> Result<(), Error> {
             args::BenchCmd::Tail(t) => bench_tail(t).await,
             args::BenchCmd::Watch(w) => bench_watch(w).await,
             args::BenchCmd::Triage(t) => bench_triage(t),
+            args::BenchCmd::TriageDiff(t) => bench_triage_diff(t),
             args::BenchCmd::CommandStats(c) => bench_command_stats(c),
             args::BenchCmd::Grep(g) => bench_grep(g),
             args::BenchCmd::Frontier(f) => bench_frontier(f),
@@ -3315,6 +3316,37 @@ fn bench_triage(t: args::TriageCmd) -> Result<(), Error> {
             Ok(())
         }
     }
+}
+
+fn bench_triage_diff(t: args::TriageDiffCmd) -> Result<(), Error> {
+    let is_json = match t.format.as_str() {
+        "text" => false,
+        "json" => true,
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "unknown --format `{other}` (expected `text` or `json`)"
+            ))));
+        }
+    };
+
+    let report = crate::run::triage_diff::run(&crate::run::triage_diff::TriageDiffArgs {
+        baseline_dir: t.baseline,
+        candidate_dir: t.candidate,
+        auto_triage: t.auto_triage,
+        min_cluster_size: t.min_cluster_size,
+        top: t.top,
+        output: t.output,
+        format: t.format,
+        fail_on_regression: t.fail_on_regression,
+    })?;
+
+    if is_json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!("{}", crate::run::triage_diff::render_text(&report, t.top));
+    }
+
+    Ok(())
 }
 
 fn bench_bundle(b: args::BundleCmd) -> Result<(), Error> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3346,6 +3346,16 @@ fn bench_triage_diff(t: args::TriageDiffCmd) -> Result<(), Error> {
         print!("{}", crate::run::triage_diff::render_text(&report, t.top));
     }
 
+    if t.fail_on_regression && !report.regression_instances.is_empty() {
+        exit_with_outcome(
+            ExitCode::RegressionGateFailure,
+            &format!(
+                "Triage diff contains {} regression cluster(s).",
+                report.regression_instances.len()
+            ),
+        );
+    }
+
     Ok(())
 }
 

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -43,4 +43,5 @@ pub mod tool_ablation;
 pub mod tool_coverage;
 pub mod trajectory_diff;
 pub mod triage;
+pub mod triage_diff;
 pub mod watch;

--- a/src/run/triage.rs
+++ b/src/run/triage.rs
@@ -145,7 +145,6 @@ pub fn extract_instance_signature(
     ))
 }
 
-
 #[derive(Debug, Clone)]
 struct ClusterMember {
     instance_id: String,

--- a/src/run/triage.rs
+++ b/src/run/triage.rs
@@ -167,10 +167,10 @@ impl ClusterAccumulator {
 }
 
 #[derive(Debug, Clone)]
-struct TerminalSignals {
-    assistant_message: String,
-    bash_exit_code: Option<i32>,
-    stderr_line: String,
+pub struct TerminalSignals {
+    pub assistant_message: String,
+    pub bash_exit_code: Option<i32>,
+    pub stderr_line: String,
 }
 
 /// Normalize one textual signature component.
@@ -378,9 +378,9 @@ fn build_report(args: &TriageArgs) -> Result<TriageReport, Error> {
     })
 }
 
-fn candidate_instance_ids(
+pub fn candidate_instance_ids<S: std::hash::BuildHasher>(
     evaluation: crate::run::evaluate::EvaluationResults,
-    instances: &HashMap<String, InstanceResult>,
+    instances: &HashMap<String, InstanceResult, S>,
 ) -> BTreeSet<String> {
     let mut candidate_ids: BTreeSet<String> = evaluation
         .instances
@@ -499,7 +499,7 @@ fn cluster_from_accumulator(acc: &ClusterAccumulator) -> TriageCluster {
     }
 }
 
-fn load_trajectory(path: &Path) -> Result<Trajectory, Error> {
+pub fn load_trajectory(path: &Path) -> Result<Trajectory, Error> {
     let text = std::fs::read_to_string(path)?;
     let value: serde_json::Value = serde_json::from_str(&text)?;
     classify_json_value(&value, ArtifactKind::Trajectory, path.display().to_string())
@@ -507,7 +507,7 @@ fn load_trajectory(path: &Path) -> Result<Trajectory, Error> {
     serde_json::from_value(value).map_err(Into::into)
 }
 
-fn terminal_signals(trajectory: &Trajectory) -> TerminalSignals {
+pub fn terminal_signals(trajectory: &Trajectory) -> TerminalSignals {
     let assistant_message = trajectory
         .messages
         .iter()
@@ -542,7 +542,7 @@ fn terminal_signals(trajectory: &Trajectory) -> TerminalSignals {
     }
 }
 
-fn resolve_trajectory_path(sweep: &Path, instance_id: &str) -> Option<PathBuf> {
+pub fn resolve_trajectory_path(sweep: &Path, instance_id: &str) -> Option<PathBuf> {
     let nested = sweep.join(instance_id).join("trajectory.json");
     if nested.exists() {
         return Some(nested);
@@ -573,7 +573,7 @@ fn path_to_forward_slashes(path: &Path) -> String {
         .join("/")
 }
 
-fn failure_label(c: FailureCategory) -> &'static str {
+pub fn failure_label(c: FailureCategory) -> &'static str {
     match c {
         FailureCategory::EnvSetup => "env_setup",
         FailureCategory::ModelApi => "model_api",
@@ -601,7 +601,7 @@ fn message_tail(message: &str, max_chars: usize) -> String {
     message.chars().skip(len - max_chars).collect()
 }
 
-fn truncate_chars(s: &str, max_chars: usize) -> String {
+pub fn truncate_chars(s: &str, max_chars: usize) -> String {
     let mut iter = s.chars();
     let mut out: String = iter.by_ref().take(max_chars).collect();
     if iter.next().is_some() {

--- a/src/run/triage.rs
+++ b/src/run/triage.rs
@@ -119,7 +119,32 @@ impl FailureSignature {
             SUMMARY_MAX_CHARS,
         )
     }
+
+    #[must_use]
+    pub fn failure_category(&self) -> &str {
+        &self.failure_category
+    }
 }
+
+pub fn extract_instance_signature(
+    instance: &InstanceResult,
+    trajectory_path: &Path,
+) -> Result<FailureSignature, Error> {
+    let trajectory = load_trajectory(trajectory_path)?;
+    let failure_category = instance
+        .failure_category
+        .or(trajectory.info.failure_category)
+        .unwrap_or(FailureCategory::Unknown);
+    let category_label = failure_label(failure_category).to_owned();
+    let signals = terminal_signals(&trajectory);
+    Ok(FailureSignature::from_parts(
+        &category_label,
+        &signals.assistant_message,
+        signals.bash_exit_code,
+        &signals.stderr_line,
+    ))
+}
+
 
 #[derive(Debug, Clone)]
 struct ClusterMember {
@@ -415,27 +440,14 @@ fn build_accumulators(
                     "bench triage: trajectory not found for unresolved instance `{instance_id}`"
                 ))
             })?;
-        let trajectory = load_trajectory(&trajectory_path)?;
-        let failure_category = instance
-            .failure_category
-            .or(trajectory.info.failure_category)
-            .unwrap_or(FailureCategory::Unknown);
-        let category_label = failure_label(failure_category).to_owned();
+        let signature = extract_instance_signature(instance, &trajectory_path)?;
         if args
             .bucket
             .as_deref()
-            .is_some_and(|bucket| bucket != category_label)
+            .is_some_and(|bucket| bucket != signature.failure_category())
         {
             continue;
         }
-
-        let signals = terminal_signals(&trajectory);
-        let signature = FailureSignature::from_parts(
-            &category_label,
-            &signals.assistant_message,
-            signals.bash_exit_code,
-            &signals.stderr_line,
-        );
         let key = signature.stable_key();
         let rel_path = relative_path_string(&args.sweep_dir, &trajectory_path);
         let member = ClusterMember {

--- a/src/run/triage_diff.rs
+++ b/src/run/triage_diff.rs
@@ -89,16 +89,24 @@ pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
     let baseline_unresolved = candidate_instance_ids(baseline_eval, &baseline_sweep.instances);
     let candidate_unresolved = candidate_instance_ids(candidate_eval, &candidate_sweep.instances);
 
-    // Helper to verify if an existing triage report is canonical (unfiltered)
-    let is_canonical = |report: &TriageReport, total_unresolved: usize| -> bool {
-        report.totals.unclustered_instances == 0 && report.totals.instances == total_unresolved
+    // Helper to verify if an existing triage report is canonical (unfiltered) and up-to-date (matching unresolved set)
+    let is_canonical = |report: &TriageReport, unresolved_ids: &BTreeSet<String>| -> bool {
+        if report.totals.unclustered_instances != 0 || report.totals.instances != unresolved_ids.len() {
+            return false;
+        }
+        let report_ids: BTreeSet<String> = report
+            .clusters
+            .iter()
+            .flat_map(|c| c.instance_ids.iter().cloned())
+            .collect();
+        &report_ids == unresolved_ids
     };
 
     // 2. Load or generate baseline triage report
     let baseline_triage_path = args.baseline_dir.join("triage.json");
     let baseline_report: TriageReport = if baseline_triage_path.exists() {
         let report: TriageReport = serde_json::from_reader(std::fs::File::open(&baseline_triage_path)?)?;
-        if is_canonical(&report, baseline_unresolved.len()) {
+        if is_canonical(&report, &baseline_unresolved) {
             report
         } else {
             if !args.auto_triage {
@@ -134,7 +142,7 @@ pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
     let candidate_triage_path = args.candidate_dir.join("triage.json");
     let candidate_report: TriageReport = if candidate_triage_path.exists() {
         let report: TriageReport = serde_json::from_reader(std::fs::File::open(&candidate_triage_path)?)?;
-        if is_canonical(&report, candidate_unresolved.len()) {
+        if is_canonical(&report, &candidate_unresolved) {
             report
         } else {
             if !args.auto_triage {

--- a/src/run/triage_diff.rs
+++ b/src/run/triage_diff.rs
@@ -1,0 +1,543 @@
+//! `bench triage-diff`: diff failure-cluster composition between two sweeps.
+
+#![allow(clippy::too_many_lines, clippy::cast_possible_wrap, clippy::cast_precision_loss)]
+
+use std::collections::{BTreeSet, HashMap};
+use std::fmt::Write as _;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Error;
+use crate::run::compare::{load_evaluation_results_checked, load_sweep};
+use crate::run::triage::{
+    candidate_instance_ids, failure_label, load_trajectory, resolve_trajectory_path,
+    terminal_signals, FailureSignature, TriageArgs, TriageCluster, TriageReport,
+};
+
+#[derive(Debug, Clone)]
+pub struct TriageDiffArgs {
+    pub baseline_dir: PathBuf,
+    pub candidate_dir: PathBuf,
+    pub auto_triage: bool,
+    pub min_cluster_size: usize,
+    pub top: usize,
+    pub output: Option<PathBuf>,
+    pub format: String,
+    pub fail_on_regression: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClusterDelta {
+    pub cluster_id: String,
+    pub failure_category: String,
+    pub signature_summary: String,
+    pub baseline_count: usize,
+    pub candidate_count: usize,
+    pub delta: isize,
+    pub delta_pct: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriageDiffClusterInfo {
+    pub cluster_id: String,
+    pub failure_category: String,
+    pub signature_summary: String,
+    pub instance_count: usize,
+    pub instance_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriageDiffGroupedInstances {
+    pub cluster_id: String,
+    pub failure_category: String,
+    pub signature_summary: String,
+    pub instance_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriageDiffReport {
+    pub schema_version: String,
+    pub baseline_sweep: String,
+    pub candidate_sweep: String,
+    pub cluster_deltas: Vec<ClusterDelta>,
+    pub new_clusters: Vec<TriageDiffClusterInfo>,
+    pub resolved_clusters: Vec<TriageDiffClusterInfo>,
+    pub regression_instances: Vec<TriageDiffGroupedInstances>,
+    pub win_instances: Vec<TriageDiffGroupedInstances>,
+}
+
+pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
+    // 1. Check/generate baseline triage.json
+    let baseline_triage_path = args.baseline_dir.join("triage.json");
+    if !baseline_triage_path.exists() {
+        if !args.auto_triage {
+            return Err(Error::Trajectory(format!(
+                "Run `bench triage --sweep {}` first, or pass `--auto-triage`.",
+                args.baseline_dir.display()
+            )));
+        }
+        crate::run::triage::run(&TriageArgs {
+            sweep_dir: args.baseline_dir.clone(),
+            bucket: None,
+            min_cluster_size: 1,
+            top: 10,
+        })?;
+    }
+
+    // 2. Check/generate candidate triage.json
+    let candidate_triage_path = args.candidate_dir.join("triage.json");
+    if !candidate_triage_path.exists() {
+        if !args.auto_triage {
+            return Err(Error::Trajectory(format!(
+                "Run `bench triage --sweep {}` first, or pass `--auto-triage`.",
+                args.candidate_dir.display()
+            )));
+        }
+        crate::run::triage::run(&TriageArgs {
+            sweep_dir: args.candidate_dir.clone(),
+            bucket: None,
+            min_cluster_size: 1,
+            top: 10,
+        })?;
+    }
+
+    // 3. Load triage reports
+    let baseline_report: TriageReport = serde_json::from_reader(std::fs::File::open(&baseline_triage_path)?)?;
+    let candidate_report: TriageReport = serde_json::from_reader(std::fs::File::open(&candidate_triage_path)?)?;
+
+    // 4. Load full sweeps to determine accurate resolved/unresolved status per instance
+    let baseline_sweep = load_sweep(&args.baseline_dir)?;
+    let baseline_eval = load_evaluation_results_checked(&args.baseline_dir)?.ok_or_else(|| {
+        Error::Trajectory(format!(
+            "missing evaluation.json in baseline sweep {}",
+            args.baseline_dir.display()
+        ))
+    })?.results;
+
+    let candidate_sweep = load_sweep(&args.candidate_dir)?;
+    let candidate_eval = load_evaluation_results_checked(&args.candidate_dir)?.ok_or_else(|| {
+        Error::Trajectory(format!(
+            "missing evaluation.json in candidate sweep {}",
+            args.candidate_dir.display()
+        ))
+    })?.results;
+
+    // Use triage candidate logic to determine exactly what failed
+    let baseline_unresolved = candidate_instance_ids(baseline_eval, &baseline_sweep.instances);
+    let candidate_unresolved = candidate_instance_ids(candidate_eval, &candidate_sweep.instances);
+
+    // Maps to look up clusters by id
+    let baseline_clusters_map: HashMap<String, &TriageCluster> = baseline_report
+        .clusters
+        .iter()
+        .map(|c| (c.cluster_id.clone(), c))
+        .collect();
+    let candidate_clusters_map: HashMap<String, &TriageCluster> = candidate_report
+        .clusters
+        .iter()
+        .map(|c| (c.cluster_id.clone(), c))
+        .collect();
+
+    // All unique cluster ids across both reports
+    let mut all_cluster_ids = BTreeSet::new();
+    all_cluster_ids.extend(baseline_clusters_map.keys().cloned());
+    all_cluster_ids.extend(candidate_clusters_map.keys().cloned());
+
+    // 5. Generate Cluster Deltas
+    let mut cluster_deltas = Vec::new();
+    for id in all_cluster_ids {
+        let baseline_count = baseline_clusters_map.get(&id).map_or(0, |c| c.instance_count);
+        let candidate_count = candidate_clusters_map.get(&id).map_or(0, |c| c.instance_count);
+
+        // Apply `--min-cluster-size` filter (surfaces if baseline OR candidate count >= k)
+        if baseline_count < args.min_cluster_size && candidate_count < args.min_cluster_size {
+            continue;
+        }
+
+        let delta = candidate_count as isize - baseline_count as isize;
+        let delta_pct = if baseline_count == 0 {
+            None
+        } else {
+            Some((delta as f64 / baseline_count as f64) * 100.0)
+        };
+
+        let (failure_category, signature_summary) = if let Some(c) = candidate_clusters_map.get(&id) {
+            (c.failure_category.clone(), c.signature_summary.clone())
+        } else if let Some(c) = baseline_clusters_map.get(&id) {
+            (c.failure_category.clone(), c.signature_summary.clone())
+        } else {
+            ("unknown".to_owned(), "unknown".to_owned())
+        };
+
+        cluster_deltas.push(ClusterDelta {
+            cluster_id: id,
+            failure_category,
+            signature_summary,
+            baseline_count,
+            candidate_count,
+            delta,
+            delta_pct,
+        });
+    }
+
+    // Rank deltas by absolute delta descending
+    cluster_deltas.sort_by(|a, b| {
+        b.delta
+            .abs()
+            .cmp(&a.delta.abs())
+            .then_with(|| b.candidate_count.cmp(&a.candidate_count))
+            .then_with(|| b.baseline_count.cmp(&a.baseline_count))
+            .then_with(|| a.cluster_id.cmp(&b.cluster_id))
+    });
+
+    // 6. Identify NEW clusters (present in candidate, absent in baseline)
+    let mut new_clusters = Vec::new();
+    for candidate_cluster in &candidate_report.clusters {
+        if !baseline_clusters_map.contains_key(&candidate_cluster.cluster_id) {
+            new_clusters.push(TriageDiffClusterInfo {
+                cluster_id: candidate_cluster.cluster_id.clone(),
+                failure_category: candidate_cluster.failure_category.clone(),
+                signature_summary: candidate_cluster.signature_summary.clone(),
+                instance_count: candidate_cluster.instance_count,
+                instance_ids: candidate_cluster.instance_ids.clone(),
+            });
+        }
+    }
+    new_clusters.sort_by(|a, b| {
+        b.instance_count
+            .cmp(&a.instance_count)
+            .then_with(|| a.cluster_id.cmp(&b.cluster_id))
+    });
+
+    // 7. Identify RESOLVED clusters (present in baseline, absent in candidate)
+    let mut resolved_clusters = Vec::new();
+    for baseline_cluster in &baseline_report.clusters {
+        if !candidate_clusters_map.contains_key(&baseline_cluster.cluster_id) {
+            resolved_clusters.push(TriageDiffClusterInfo {
+                cluster_id: baseline_cluster.cluster_id.clone(),
+                failure_category: baseline_cluster.failure_category.clone(),
+                signature_summary: baseline_cluster.signature_summary.clone(),
+                instance_count: baseline_cluster.instance_count,
+                instance_ids: baseline_cluster.instance_ids.clone(),
+            });
+        }
+    }
+    resolved_clusters.sort_by(|a, b| {
+        b.instance_count
+            .cmp(&a.instance_count)
+            .then_with(|| a.cluster_id.cmp(&b.cluster_id))
+    });
+
+    // Maps for fast trajectory/signature fallback
+    let mut candidate_inst_to_cluster_info = HashMap::new();
+    for cluster in &candidate_report.clusters {
+        for inst_id in &cluster.instance_ids {
+            candidate_inst_to_cluster_info.insert(
+                inst_id.clone(),
+                (
+                    cluster.cluster_id.clone(),
+                    cluster.failure_category.clone(),
+                    cluster.signature_summary.clone(),
+                ),
+            );
+        }
+    }
+
+    let mut baseline_inst_to_cluster_info = HashMap::new();
+    for cluster in &baseline_report.clusters {
+        for inst_id in &cluster.instance_ids {
+            baseline_inst_to_cluster_info.insert(
+                inst_id.clone(),
+                (
+                    cluster.cluster_id.clone(),
+                    cluster.failure_category.clone(),
+                    cluster.signature_summary.clone(),
+                ),
+            );
+        }
+    }
+
+    // Helper to get signature dynamically if not in report map
+    let get_candidate_signature = |id: &str| -> Result<(String, String, String), Error> {
+        if let Some(info) = candidate_inst_to_cluster_info.get(id) {
+            Ok(info.clone())
+        } else if let Some(traj_path) = resolve_trajectory_path(&args.candidate_dir, id) {
+            let trajectory = load_trajectory(&traj_path)?;
+            let instance = candidate_sweep.instances.get(id).ok_or_else(|| {
+                Error::Trajectory(format!("instance {id} not found in candidate sweep"))
+            })?;
+            let failure_cat = instance
+                .failure_category
+                .or(trajectory.info.failure_category)
+                .unwrap_or(crate::trajectory::FailureCategory::Unknown);
+            let category_label = failure_label(failure_cat).to_owned();
+            let signals = terminal_signals(&trajectory);
+            let signature = FailureSignature::from_parts(
+                &category_label,
+                &signals.assistant_message,
+                signals.bash_exit_code,
+                &signals.stderr_line,
+            );
+            Ok((signature.cluster_id(), category_label, signature.summary()))
+        } else {
+            Ok(("unknown".to_owned(), "unknown".to_owned(), "Trajectory not found".to_owned()))
+        }
+    };
+
+    let get_baseline_signature = |id: &str| -> Result<(String, String, String), Error> {
+        if let Some(info) = baseline_inst_to_cluster_info.get(id) {
+            Ok(info.clone())
+        } else if let Some(traj_path) = resolve_trajectory_path(&args.baseline_dir, id) {
+            let trajectory = load_trajectory(&traj_path)?;
+            let instance = baseline_sweep.instances.get(id).ok_or_else(|| {
+                Error::Trajectory(format!("instance {id} not found in baseline sweep"))
+            })?;
+            let failure_cat = instance
+                .failure_category
+                .or(trajectory.info.failure_category)
+                .unwrap_or(crate::trajectory::FailureCategory::Unknown);
+            let category_label = failure_label(failure_cat).to_owned();
+            let signals = terminal_signals(&trajectory);
+            let signature = FailureSignature::from_parts(
+                &category_label,
+                &signals.assistant_message,
+                signals.bash_exit_code,
+                &signals.stderr_line,
+            );
+            Ok((signature.cluster_id(), category_label, signature.summary()))
+        } else {
+            Ok(("unknown".to_owned(), "unknown".to_owned(), "Trajectory not found".to_owned()))
+        }
+    };
+
+    // 8. Generate Regressions Set: solved in baseline, unresolved/failed in candidate
+    let mut regression_groups: HashMap<String, (String, String, Vec<String>)> = HashMap::new();
+    for id in candidate_sweep.instances.keys() {
+        if baseline_sweep.instances.contains_key(id)
+            && !baseline_unresolved.contains(id)
+            && candidate_unresolved.contains(id)
+        {
+            let (cluster_id, failure_category, signature_summary) = get_candidate_signature(id)?;
+            let entry = regression_groups
+                .entry(cluster_id)
+                .or_insert_with(|| (failure_category, signature_summary, Vec::new()));
+            entry.2.push(id.clone());
+        }
+    }
+
+    let mut regression_instances = Vec::new();
+    for (cluster_id, (failure_category, signature_summary, mut instance_ids)) in regression_groups {
+        instance_ids.sort();
+        regression_instances.push(TriageDiffGroupedInstances {
+            cluster_id,
+            failure_category,
+            signature_summary,
+            instance_ids,
+        });
+    }
+    regression_instances.sort_by(|a, b| {
+        b.instance_ids
+            .len()
+            .cmp(&a.instance_ids.len())
+            .then_with(|| a.cluster_id.cmp(&b.cluster_id))
+    });
+
+    // 9. Generate Wins Set: unresolved/failed in baseline, solved in candidate
+    let mut win_groups: HashMap<String, (String, String, Vec<String>)> = HashMap::new();
+    for id in baseline_sweep.instances.keys() {
+        if candidate_sweep.instances.contains_key(id)
+            && baseline_unresolved.contains(id)
+            && !candidate_unresolved.contains(id)
+        {
+            let (cluster_id, failure_category, signature_summary) = get_baseline_signature(id)?;
+            let entry = win_groups
+                .entry(cluster_id)
+                .or_insert_with(|| (failure_category, signature_summary, Vec::new()));
+            entry.2.push(id.clone());
+        }
+    }
+
+    let mut win_instances = Vec::new();
+    for (cluster_id, (failure_category, signature_summary, mut instance_ids)) in win_groups {
+        instance_ids.sort();
+        win_instances.push(TriageDiffGroupedInstances {
+            cluster_id,
+            failure_category,
+            signature_summary,
+            instance_ids,
+        });
+    }
+    win_instances.sort_by(|a, b| {
+        b.instance_ids
+            .len()
+            .cmp(&a.instance_ids.len())
+            .then_with(|| a.cluster_id.cmp(&b.cluster_id))
+    });
+
+    let report = TriageDiffReport {
+        schema_version: "triage-diff-1.0".to_owned(),
+        baseline_sweep: args.baseline_dir.display().to_string(),
+        candidate_sweep: args.candidate_dir.display().to_string(),
+        cluster_deltas,
+        new_clusters,
+        resolved_clusters,
+        regression_instances,
+        win_instances,
+    };
+
+    // 10. Write JSON report
+    let default_output = args.candidate_dir.join("triage-diff.json");
+    let output_path = args.output.as_ref().unwrap_or(&default_output);
+    let file = std::fs::File::create(output_path)?;
+    serde_json::to_writer_pretty(file, &report)?;
+
+    // Handle `--fail-on-regression` exit gate
+    if args.fail_on_regression && !report.regression_instances.is_empty() {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "Triage diff contains {} regression cluster(s).",
+            report.regression_instances.len()
+        ))));
+    }
+
+    Ok(report)
+}
+
+pub fn render_text(report: &TriageDiffReport, top: usize) -> String {
+    use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+    use comfy_table::presets::UTF8_FULL;
+    use comfy_table::Table;
+
+    let mut out = String::new();
+    out.push_str("\n=== bench triage-diff ===\n");
+    let _ = writeln!(out, "Baseline:  {}", report.baseline_sweep);
+    let _ = writeln!(out, "Candidate: {}", report.candidate_sweep);
+    out.push('\n');
+
+    // 1. Regressions Set
+    out.push_str("=== Regressions ===\n");
+    if report.regression_instances.is_empty() {
+        out.push_str("None\n");
+    } else {
+        out.push_str("Grouped by candidate-side failure cluster:\n");
+        for group in &report.regression_instances {
+            let _ = writeln!(
+                out,
+                "- {}  {:<14}  \"{}\"",
+                group.cluster_id, group.failure_category, group.signature_summary
+            );
+            let _ = writeln!(out, "  Instances: {:?}", group.instance_ids);
+        }
+    }
+    out.push('\n');
+
+    // 2. Wins Set
+    out.push_str("=== Wins ===\n");
+    if report.win_instances.is_empty() {
+        out.push_str("None\n");
+    } else {
+        out.push_str("Grouped by baseline-side failure cluster:\n");
+        for group in &report.win_instances {
+            let _ = writeln!(
+                out,
+                "- {}  {:<14}  \"{}\"",
+                group.cluster_id, group.failure_category, group.signature_summary
+            );
+            let _ = writeln!(out, "  Instances: {:?}", group.instance_ids);
+        }
+    }
+    out.push('\n');
+
+    // 3. Cluster Deltas Table
+    out.push_str("=== Failure Cluster Deltas ===\n");
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec![
+            "rank",
+            "cluster_signature_short",
+            "failure_category",
+            "baseline",
+            "candidate",
+            "delta",
+            "delta_pct",
+            "signature_summary",
+        ]);
+
+    for (idx, delta) in report.cluster_deltas.iter().take(top).enumerate() {
+        let pct_str = delta.delta_pct.map_or_else(
+            || {
+                if delta.candidate_count > 0 {
+                    "+inf%".to_owned()
+                } else {
+                    "0.0%".to_owned()
+                }
+            },
+            |pct| {
+                if pct == 0.0 {
+                    "0.0%".to_owned()
+                } else {
+                    format!("{pct:+.1}%")
+                }
+            },
+        );
+
+        table.add_row(vec![
+            (idx + 1).to_string(),
+            delta.cluster_id.clone(),
+            delta.failure_category.clone(),
+            delta.baseline_count.to_string(),
+            delta.candidate_count.to_string(),
+            if delta.delta == 0 {
+                "0".to_owned()
+            } else {
+                format!("{:+}", delta.delta)
+            },
+            pct_str,
+            crate::run::triage::truncate_chars(&delta.signature_summary, 64),
+        ]);
+    }
+    out.push_str(&table.to_string());
+    out.push_str("\n\n");
+
+    // 4. New Clusters
+    out.push_str("=== New Clusters ===\n");
+    if report.new_clusters.is_empty() {
+        out.push_str("None\n");
+    } else {
+        for cluster in report.new_clusters.iter().take(top) {
+            let _ = writeln!(
+                out,
+                "- {}  {:<14} (count: {})  \"{}\"",
+                cluster.cluster_id,
+                cluster.failure_category,
+                cluster.instance_count,
+                cluster.signature_summary
+            );
+            let _ = writeln!(out, "  Instances: {:?}", cluster.instance_ids);
+        }
+    }
+    out.push('\n');
+
+    // 5. Resolved Clusters
+    out.push_str("=== Resolved Clusters ===\n");
+    if report.resolved_clusters.is_empty() {
+        out.push_str("None\n");
+    } else {
+        for cluster in report.resolved_clusters.iter().take(top) {
+            let _ = writeln!(
+                out,
+                "- {}  {:<14} (count: {})  \"{}\"",
+                cluster.cluster_id,
+                cluster.failure_category,
+                cluster.instance_count,
+                cluster.signature_summary
+            );
+            let _ = writeln!(out, "  Instances: {:?}", cluster.instance_ids);
+        }
+    }
+    out.push('\n');
+
+    out
+}

--- a/src/run/triage_diff.rs
+++ b/src/run/triage_diff.rs
@@ -11,8 +11,8 @@ use serde::{Deserialize, Serialize};
 use crate::error::Error;
 use crate::run::compare::{load_evaluation_results_checked, load_sweep};
 use crate::run::triage::{
-    candidate_instance_ids, failure_label, load_trajectory, resolve_trajectory_path,
-    terminal_signals, FailureSignature, TriageArgs, TriageCluster, TriageReport,
+    candidate_instance_ids, extract_instance_signature, resolve_trajectory_path, TriageArgs,
+    TriageCluster, TriageReport,
 };
 
 #[derive(Debug, Clone)]
@@ -68,45 +68,7 @@ pub struct TriageDiffReport {
 }
 
 pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
-    // 1. Check/generate baseline triage.json
-    let baseline_triage_path = args.baseline_dir.join("triage.json");
-    if !baseline_triage_path.exists() {
-        if !args.auto_triage {
-            return Err(Error::Trajectory(format!(
-                "Run `bench triage --sweep {}` first, or pass `--auto-triage`.",
-                args.baseline_dir.display()
-            )));
-        }
-        crate::run::triage::run(&TriageArgs {
-            sweep_dir: args.baseline_dir.clone(),
-            bucket: None,
-            min_cluster_size: 1,
-            top: 10,
-        })?;
-    }
-
-    // 2. Check/generate candidate triage.json
-    let candidate_triage_path = args.candidate_dir.join("triage.json");
-    if !candidate_triage_path.exists() {
-        if !args.auto_triage {
-            return Err(Error::Trajectory(format!(
-                "Run `bench triage --sweep {}` first, or pass `--auto-triage`.",
-                args.candidate_dir.display()
-            )));
-        }
-        crate::run::triage::run(&TriageArgs {
-            sweep_dir: args.candidate_dir.clone(),
-            bucket: None,
-            min_cluster_size: 1,
-            top: 10,
-        })?;
-    }
-
-    // 3. Load triage reports
-    let baseline_report: TriageReport = serde_json::from_reader(std::fs::File::open(&baseline_triage_path)?)?;
-    let candidate_report: TriageReport = serde_json::from_reader(std::fs::File::open(&candidate_triage_path)?)?;
-
-    // 4. Load full sweeps to determine accurate resolved/unresolved status per instance
+    // 1. Load full sweeps to determine accurate resolved/unresolved status per instance
     let baseline_sweep = load_sweep(&args.baseline_dir)?;
     let baseline_eval = load_evaluation_results_checked(&args.baseline_dir)?.ok_or_else(|| {
         Error::Trajectory(format!(
@@ -126,6 +88,83 @@ pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
     // Use triage candidate logic to determine exactly what failed
     let baseline_unresolved = candidate_instance_ids(baseline_eval, &baseline_sweep.instances);
     let candidate_unresolved = candidate_instance_ids(candidate_eval, &candidate_sweep.instances);
+
+    // Helper to verify if an existing triage report is canonical (unfiltered)
+    let is_canonical = |report: &TriageReport, total_unresolved: usize| -> bool {
+        report.totals.unclustered_instances == 0 && report.totals.instances == total_unresolved
+    };
+
+    // 2. Load or generate baseline triage report
+    let baseline_triage_path = args.baseline_dir.join("triage.json");
+    let baseline_report: TriageReport = if baseline_triage_path.exists() {
+        let report: TriageReport = serde_json::from_reader(std::fs::File::open(&baseline_triage_path)?)?;
+        if is_canonical(&report, baseline_unresolved.len()) {
+            report
+        } else {
+            if !args.auto_triage {
+                return Err(Error::Trajectory(format!(
+                    "Existing triage.json at {} is filtered or partial. Run `bench triage --sweep {}` without filters first, or pass `--auto-triage`.",
+                    args.baseline_dir.display(),
+                    args.baseline_dir.display()
+                )));
+            }
+            crate::run::triage::run(&TriageArgs {
+                sweep_dir: args.baseline_dir.clone(),
+                bucket: None,
+                min_cluster_size: 1,
+                top: 10,
+            })?
+        }
+    } else {
+        if !args.auto_triage {
+            return Err(Error::Trajectory(format!(
+                "Run `bench triage --sweep {}` first, or pass `--auto-triage`.",
+                args.baseline_dir.display()
+            )));
+        }
+        crate::run::triage::run(&TriageArgs {
+            sweep_dir: args.baseline_dir.clone(),
+            bucket: None,
+            min_cluster_size: 1,
+            top: 10,
+        })?
+    };
+
+    // 3. Load or generate candidate triage report
+    let candidate_triage_path = args.candidate_dir.join("triage.json");
+    let candidate_report: TriageReport = if candidate_triage_path.exists() {
+        let report: TriageReport = serde_json::from_reader(std::fs::File::open(&candidate_triage_path)?)?;
+        if is_canonical(&report, candidate_unresolved.len()) {
+            report
+        } else {
+            if !args.auto_triage {
+                return Err(Error::Trajectory(format!(
+                    "Existing triage.json at {} is filtered or partial. Run `bench triage --sweep {}` without filters first, or pass `--auto-triage`.",
+                    args.candidate_dir.display(),
+                    args.candidate_dir.display()
+                )));
+            }
+            crate::run::triage::run(&TriageArgs {
+                sweep_dir: args.candidate_dir.clone(),
+                bucket: None,
+                min_cluster_size: 1,
+                top: 10,
+            })?
+        }
+    } else {
+        if !args.auto_triage {
+            return Err(Error::Trajectory(format!(
+                "Run `bench triage --sweep {}` first, or pass `--auto-triage`.",
+                args.candidate_dir.display()
+            )));
+        }
+        crate::run::triage::run(&TriageArgs {
+            sweep_dir: args.candidate_dir.clone(),
+            bucket: None,
+            min_cluster_size: 1,
+            top: 10,
+        })?
+    };
 
     // Maps to look up clusters by id
     let baseline_clusters_map: HashMap<String, &TriageCluster> = baseline_report
@@ -263,23 +302,15 @@ pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
         if let Some(info) = candidate_inst_to_cluster_info.get(id) {
             Ok(info.clone())
         } else if let Some(traj_path) = resolve_trajectory_path(&args.candidate_dir, id) {
-            let trajectory = load_trajectory(&traj_path)?;
             let instance = candidate_sweep.instances.get(id).ok_or_else(|| {
                 Error::Trajectory(format!("instance {id} not found in candidate sweep"))
             })?;
-            let failure_cat = instance
-                .failure_category
-                .or(trajectory.info.failure_category)
-                .unwrap_or(crate::trajectory::FailureCategory::Unknown);
-            let category_label = failure_label(failure_cat).to_owned();
-            let signals = terminal_signals(&trajectory);
-            let signature = FailureSignature::from_parts(
-                &category_label,
-                &signals.assistant_message,
-                signals.bash_exit_code,
-                &signals.stderr_line,
-            );
-            Ok((signature.cluster_id(), category_label, signature.summary()))
+            let signature = extract_instance_signature(instance, &traj_path)?;
+            Ok((
+                signature.cluster_id(),
+                signature.failure_category().to_owned(),
+                signature.summary(),
+            ))
         } else {
             Ok(("unknown".to_owned(), "unknown".to_owned(), "Trajectory not found".to_owned()))
         }
@@ -289,23 +320,15 @@ pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
         if let Some(info) = baseline_inst_to_cluster_info.get(id) {
             Ok(info.clone())
         } else if let Some(traj_path) = resolve_trajectory_path(&args.baseline_dir, id) {
-            let trajectory = load_trajectory(&traj_path)?;
             let instance = baseline_sweep.instances.get(id).ok_or_else(|| {
                 Error::Trajectory(format!("instance {id} not found in baseline sweep"))
             })?;
-            let failure_cat = instance
-                .failure_category
-                .or(trajectory.info.failure_category)
-                .unwrap_or(crate::trajectory::FailureCategory::Unknown);
-            let category_label = failure_label(failure_cat).to_owned();
-            let signals = terminal_signals(&trajectory);
-            let signature = FailureSignature::from_parts(
-                &category_label,
-                &signals.assistant_message,
-                signals.bash_exit_code,
-                &signals.stderr_line,
-            );
-            Ok((signature.cluster_id(), category_label, signature.summary()))
+            let signature = extract_instance_signature(instance, &traj_path)?;
+            Ok((
+                signature.cluster_id(),
+                signature.failure_category().to_owned(),
+                signature.summary(),
+            ))
         } else {
             Ok(("unknown".to_owned(), "unknown".to_owned(), "Trajectory not found".to_owned()))
         }
@@ -392,14 +415,6 @@ pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
     let file = std::fs::File::create(output_path)?;
     serde_json::to_writer_pretty(file, &report)?;
 
-    // Handle `--fail-on-regression` exit gate
-    if args.fail_on_regression && !report.regression_instances.is_empty() {
-        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "Triage diff contains {} regression cluster(s).",
-            report.regression_instances.len()
-        ))));
-    }
-
     Ok(report)
 }
 
@@ -420,13 +435,17 @@ pub fn render_text(report: &TriageDiffReport, top: usize) -> String {
         out.push_str("None\n");
     } else {
         out.push_str("Grouped by candidate-side failure cluster:\n");
-        for group in &report.regression_instances {
+        let len = report.regression_instances.len();
+        for group in report.regression_instances.iter().take(top) {
             let _ = writeln!(
                 out,
                 "- {}  {:<14}  \"{}\"",
                 group.cluster_id, group.failure_category, group.signature_summary
             );
             let _ = writeln!(out, "  Instances: {:?}", group.instance_ids);
+        }
+        if len > top {
+            let _ = writeln!(out, "... and {} more regression cluster(s)", len - top);
         }
     }
     out.push('\n');
@@ -437,13 +456,17 @@ pub fn render_text(report: &TriageDiffReport, top: usize) -> String {
         out.push_str("None\n");
     } else {
         out.push_str("Grouped by baseline-side failure cluster:\n");
-        for group in &report.win_instances {
+        let len = report.win_instances.len();
+        for group in report.win_instances.iter().take(top) {
             let _ = writeln!(
                 out,
                 "- {}  {:<14}  \"{}\"",
                 group.cluster_id, group.failure_category, group.signature_summary
             );
             let _ = writeln!(out, "  Instances: {:?}", group.instance_ids);
+        }
+        if len > top {
+            let _ = writeln!(out, "... and {} more win cluster(s)", len - top);
         }
     }
     out.push('\n');

--- a/src/run/triage_diff.rs
+++ b/src/run/triage_diff.rs
@@ -1,6 +1,10 @@
 //! `bench triage-diff`: diff failure-cluster composition between two sweeps.
 
-#![allow(clippy::too_many_lines, clippy::cast_possible_wrap, clippy::cast_precision_loss)]
+#![allow(
+    clippy::too_many_lines,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss
+)]
 
 use std::collections::{BTreeSet, HashMap};
 use std::fmt::Write as _;
@@ -11,8 +15,8 @@ use serde::{Deserialize, Serialize};
 use crate::error::Error;
 use crate::run::compare::{load_evaluation_results_checked, load_sweep};
 use crate::run::triage::{
-    candidate_instance_ids, extract_instance_signature, resolve_trajectory_path, TriageArgs,
-    TriageCluster, TriageReport,
+    TriageArgs, TriageCluster, TriageReport, candidate_instance_ids, extract_instance_signature,
+    resolve_trajectory_path,
 };
 
 #[derive(Debug, Clone)]
@@ -70,20 +74,24 @@ pub struct TriageDiffReport {
 pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
     // 1. Load full sweeps to determine accurate resolved/unresolved status per instance
     let baseline_sweep = load_sweep(&args.baseline_dir)?;
-    let baseline_eval = load_evaluation_results_checked(&args.baseline_dir)?.ok_or_else(|| {
-        Error::Trajectory(format!(
-            "missing evaluation.json in baseline sweep {}",
-            args.baseline_dir.display()
-        ))
-    })?.results;
+    let baseline_eval = load_evaluation_results_checked(&args.baseline_dir)?
+        .ok_or_else(|| {
+            Error::Trajectory(format!(
+                "missing evaluation.json in baseline sweep {}",
+                args.baseline_dir.display()
+            ))
+        })?
+        .results;
 
     let candidate_sweep = load_sweep(&args.candidate_dir)?;
-    let candidate_eval = load_evaluation_results_checked(&args.candidate_dir)?.ok_or_else(|| {
-        Error::Trajectory(format!(
-            "missing evaluation.json in candidate sweep {}",
-            args.candidate_dir.display()
-        ))
-    })?.results;
+    let candidate_eval = load_evaluation_results_checked(&args.candidate_dir)?
+        .ok_or_else(|| {
+            Error::Trajectory(format!(
+                "missing evaluation.json in candidate sweep {}",
+                args.candidate_dir.display()
+            ))
+        })?
+        .results;
 
     // Use triage candidate logic to determine exactly what failed
     let baseline_unresolved = candidate_instance_ids(baseline_eval, &baseline_sweep.instances);
@@ -91,7 +99,9 @@ pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
 
     // Helper to verify if an existing triage report is canonical (unfiltered) and up-to-date (matching unresolved set)
     let is_canonical = |report: &TriageReport, unresolved_ids: &BTreeSet<String>| -> bool {
-        if report.totals.unclustered_instances != 0 || report.totals.instances != unresolved_ids.len() {
+        if report.totals.unclustered_instances != 0
+            || report.totals.instances != unresolved_ids.len()
+        {
             return false;
         }
         let report_ids: BTreeSet<String> = report
@@ -105,7 +115,8 @@ pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
     // 2. Load or generate baseline triage report
     let baseline_triage_path = args.baseline_dir.join("triage.json");
     let baseline_report: TriageReport = if baseline_triage_path.exists() {
-        let report: TriageReport = serde_json::from_reader(std::fs::File::open(&baseline_triage_path)?)?;
+        let report: TriageReport =
+            serde_json::from_reader(std::fs::File::open(&baseline_triage_path)?)?;
         if is_canonical(&report, &baseline_unresolved) {
             report
         } else {
@@ -141,7 +152,8 @@ pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
     // 3. Load or generate candidate triage report
     let candidate_triage_path = args.candidate_dir.join("triage.json");
     let candidate_report: TriageReport = if candidate_triage_path.exists() {
-        let report: TriageReport = serde_json::from_reader(std::fs::File::open(&candidate_triage_path)?)?;
+        let report: TriageReport =
+            serde_json::from_reader(std::fs::File::open(&candidate_triage_path)?)?;
         if is_canonical(&report, &candidate_unresolved) {
             report
         } else {
@@ -194,8 +206,12 @@ pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
     // 5. Generate Cluster Deltas
     let mut cluster_deltas = Vec::new();
     for id in all_cluster_ids {
-        let baseline_count = baseline_clusters_map.get(&id).map_or(0, |c| c.instance_count);
-        let candidate_count = candidate_clusters_map.get(&id).map_or(0, |c| c.instance_count);
+        let baseline_count = baseline_clusters_map
+            .get(&id)
+            .map_or(0, |c| c.instance_count);
+        let candidate_count = candidate_clusters_map
+            .get(&id)
+            .map_or(0, |c| c.instance_count);
 
         // Apply `--min-cluster-size` filter (surfaces if baseline OR candidate count >= k)
         if baseline_count < args.min_cluster_size && candidate_count < args.min_cluster_size {
@@ -209,7 +225,8 @@ pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
             Some((delta as f64 / baseline_count as f64) * 100.0)
         };
 
-        let (failure_category, signature_summary) = if let Some(c) = candidate_clusters_map.get(&id) {
+        let (failure_category, signature_summary) = if let Some(c) = candidate_clusters_map.get(&id)
+        {
             (c.failure_category.clone(), c.signature_summary.clone())
         } else if let Some(c) = baseline_clusters_map.get(&id) {
             (c.failure_category.clone(), c.signature_summary.clone())
@@ -320,7 +337,11 @@ pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
                 signature.summary(),
             ))
         } else {
-            Ok(("unknown".to_owned(), "unknown".to_owned(), "Trajectory not found".to_owned()))
+            Ok((
+                "unknown".to_owned(),
+                "unknown".to_owned(),
+                "Trajectory not found".to_owned(),
+            ))
         }
     };
 
@@ -338,7 +359,11 @@ pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
                 signature.summary(),
             ))
         } else {
-            Ok(("unknown".to_owned(), "unknown".to_owned(), "Trajectory not found".to_owned()))
+            Ok((
+                "unknown".to_owned(),
+                "unknown".to_owned(),
+                "Trajectory not found".to_owned(),
+            ))
         }
     };
 
@@ -427,9 +452,9 @@ pub fn run(args: &TriageDiffArgs) -> Result<TriageDiffReport, Error> {
 }
 
 pub fn render_text(report: &TriageDiffReport, top: usize) -> String {
+    use comfy_table::Table;
     use comfy_table::modifiers::UTF8_ROUND_CORNERS;
     use comfy_table::presets::UTF8_FULL;
-    use comfy_table::Table;
 
     let mut out = String::new();
     out.push_str("\n=== bench triage-diff ===\n");

--- a/tests/bench_triage_diff.rs
+++ b/tests/bench_triage_diff.rs
@@ -157,6 +157,10 @@ fn triage_diff_fail_on_regression_flag() {
         !output.status.success(),
         "should have failed with regression set non-empty"
     );
+    assert_eq!(output.status.code().unwrap(), 6, "Expected exit code 6 (RegressionGateFailure)");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("=== bench triage-diff ==="), "Output should still be printed before exiting");
+    assert!(stdout.contains("resolved-1"), "Output should contain the regression instance");
 }
 
 #[test]
@@ -344,3 +348,79 @@ fn mutate_candidate_win_and_regression(sweep: &Path) {
     )
     .unwrap();
 }
+
+#[test]
+fn triage_diff_filtered_triage_json_errors_unless_auto_triage() {
+    let baseline = tempfile::tempdir().unwrap();
+    let candidate = tempfile::tempdir().unwrap();
+    copy_triage_fixture_sweep(baseline.path());
+    copy_triage_fixture_sweep(candidate.path());
+
+    // Generate partial/filtered triage.json by running triage with --min-cluster-size 9999
+    // This will result in 0 clustered instances and some unclustered instances, making it non-canonical!
+    let output_triage = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "triage",
+            "--sweep",
+            baseline.path().to_str().unwrap(),
+            "--min-cluster-size",
+            "9999",
+        ])
+        .output()
+        .unwrap();
+    assert!(output_triage.status.success());
+
+    // Generate normal/canonical triage for candidate
+    run_triage(candidate.path());
+
+    // Run triage-diff WITHOUT --auto-triage: should fail because baseline triage.json is not canonical (filtered)!
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "triage-diff",
+            "--baseline",
+            baseline.path().to_str().unwrap(),
+            "--candidate",
+            candidate.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "should have failed due to filtered/partial triage.json"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("filtered or partial"), "Stderr did not contain expected warning: {}", stderr);
+
+    // Run WITH --auto-triage: should succeed because it automatically regenerates the canonical report!
+    let output_auto = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "triage-diff",
+            "--baseline",
+            baseline.path().to_str().unwrap(),
+            "--candidate",
+            candidate.path().to_str().unwrap(),
+            "--auto-triage",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output_auto.status.success(),
+        "should have successfully auto-triaged and re-run canonically\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output_auto.stdout),
+        String::from_utf8_lossy(&output_auto.stderr)
+    );
+}
+

--- a/tests/bench_triage_diff.rs
+++ b/tests/bench_triage_diff.rs
@@ -1,0 +1,346 @@
+//! `bench triage-diff`: diff failure-cluster composition between two sweeps.
+
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::json;
+
+mod support;
+use support::binary_path;
+
+#[test]
+fn triage_diff_identical_sweeps() {
+    let baseline = tempfile::tempdir().unwrap();
+    let candidate = tempfile::tempdir().unwrap();
+    copy_triage_fixture_sweep(baseline.path());
+    copy_triage_fixture_sweep(candidate.path());
+
+    // Generate triage.json in baseline and candidate first
+    run_triage(baseline.path());
+    run_triage(candidate.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "triage-diff",
+            "--baseline",
+            baseline.path().to_str().unwrap(),
+            "--candidate",
+            candidate.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench triage-diff failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["schema_version"], "triage-diff-1.0");
+    assert_eq!(
+        report["baseline_sweep"],
+        baseline.path().display().to_string()
+    );
+    assert_eq!(
+        report["candidate_sweep"],
+        candidate.path().display().to_string()
+    );
+
+    let deltas = report["cluster_deltas"].as_array().unwrap();
+    assert!(!deltas.is_empty());
+    for delta in deltas {
+        assert_eq!(delta["delta"], 0);
+        assert_eq!(delta["delta_pct"], json!(0.0));
+    }
+
+    assert!(report["new_clusters"].as_array().unwrap().is_empty());
+    assert!(report["resolved_clusters"].as_array().unwrap().is_empty());
+    assert!(
+        report["regression_instances"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+    assert!(report["win_instances"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn triage_diff_wins_and_regressions() {
+    let baseline = tempfile::tempdir().unwrap();
+    let candidate = tempfile::tempdir().unwrap();
+    copy_triage_fixture_sweep(baseline.path());
+    copy_triage_fixture_sweep(candidate.path());
+
+    // In candidate, mutate:
+    // 1. Solve 'model-a-2' (unresolved in baseline). This makes it a Win!
+    // 2. Fail 'resolved-1' (resolved in baseline). This makes it a Regression!
+    mutate_candidate_win_and_regression(candidate.path());
+
+    // Generate triage.json in baseline and candidate
+    run_triage(baseline.path());
+    run_triage(candidate.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "triage-diff",
+            "--baseline",
+            baseline.path().to_str().unwrap(),
+            "--candidate",
+            candidate.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "bench triage-diff failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    let win_instances = report["win_instances"].as_array().unwrap();
+    assert_eq!(win_instances.len(), 1);
+    assert_eq!(win_instances[0]["instance_ids"], json!(["model-a-2"]));
+
+    let regression_instances = report["regression_instances"].as_array().unwrap();
+    assert_eq!(regression_instances.len(), 1);
+    assert_eq!(
+        regression_instances[0]["instance_ids"],
+        json!(["resolved-1"])
+    );
+}
+
+#[test]
+fn triage_diff_fail_on_regression_flag() {
+    let baseline = tempfile::tempdir().unwrap();
+    let candidate = tempfile::tempdir().unwrap();
+    copy_triage_fixture_sweep(baseline.path());
+    copy_triage_fixture_sweep(candidate.path());
+
+    mutate_candidate_win_and_regression(candidate.path());
+
+    run_triage(baseline.path());
+    run_triage(candidate.path());
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "triage-diff",
+            "--baseline",
+            baseline.path().to_str().unwrap(),
+            "--candidate",
+            candidate.path().to_str().unwrap(),
+            "--fail-on-regression",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "should have failed with regression set non-empty"
+    );
+}
+
+#[test]
+fn triage_diff_missing_triage_json_errors_if_no_auto_triage() {
+    let baseline = tempfile::tempdir().unwrap();
+    let candidate = tempfile::tempdir().unwrap();
+    copy_triage_fixture_sweep(baseline.path());
+    copy_triage_fixture_sweep(candidate.path());
+
+    // Do NOT generate triage.json
+    // Explicitly delete it since the copy_triage_fixture_sweep copies triage.json from the fixture
+    std::fs::remove_file(baseline.path().join("triage.json")).unwrap();
+    std::fs::remove_file(candidate.path().join("triage.json")).unwrap();
+
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "triage-diff",
+            "--baseline",
+            baseline.path().to_str().unwrap(),
+            "--candidate",
+            candidate.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "should have failed due to missing triage.json"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Run `bench triage --sweep"));
+
+    // Now run WITH --auto-triage
+    let output2 = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "triage-diff",
+            "--baseline",
+            baseline.path().to_str().unwrap(),
+            "--candidate",
+            candidate.path().to_str().unwrap(),
+            "--auto-triage",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output2.status.success(),
+        "bench triage-diff --auto-triage failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output2.stdout),
+        String::from_utf8_lossy(&output2.stderr)
+    );
+}
+
+fn copy_triage_fixture_sweep(dir: &Path) {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/triage/sweep");
+    copy_dir(&fixture, dir);
+}
+
+fn copy_dir(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        let target = dst.join(entry.file_name());
+        if path.is_dir() {
+            copy_dir(&path, &target);
+        } else {
+            std::fs::copy(&path, &target).unwrap();
+        }
+    }
+}
+
+fn run_triage(sweep: &Path) {
+    let output = Command::new(binary_path())
+        .args([
+            "--log",
+            "error",
+            "bench",
+            "triage",
+            "--sweep",
+            sweep.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "failed to run triage on {}",
+        sweep.display()
+    );
+}
+
+fn mutate_candidate_win_and_regression(sweep: &Path) {
+    // 1. Solve 'model-a-2' by changing its entry in evaluation.json to resolved: true
+    let eval_path = sweep.join("evaluation.json");
+    let mut eval: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&eval_path).unwrap()).unwrap();
+    for inst in eval["instances"].as_array_mut().unwrap() {
+        if inst["instance_id"] == "model-a-2" {
+            inst["resolved"] = json!(true);
+            inst["eval_exit_reason"] = json!("resolved");
+        }
+    }
+    std::fs::write(&eval_path, serde_json::to_string_pretty(&eval).unwrap()).unwrap();
+
+    let results_path = sweep.join("results.json");
+    let mut results: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&results_path).unwrap()).unwrap();
+    for inst in results["instances"].as_array_mut().unwrap() {
+        if inst["instance_id"] == "model-a-2" {
+            inst["resolved_count"] = json!(1);
+            inst["pass_at_1"] = json!(true);
+            inst["outcome"] = json!("submitted");
+            inst["exit_reason"] = json!("submitted");
+            inst["failure_category"] = json!(null);
+        }
+    }
+
+    // 2. Fail 'resolved-1' by:
+    //   - setting resolved: false in evaluation.json
+    //   - and setting outcome: "error" in results.json
+    //   - and creating a trajectory file 'resolved-1.traj.json'
+    for inst in eval["instances"].as_array_mut().unwrap() {
+        if inst["instance_id"] == "resolved-1" {
+            inst["resolved"] = json!(false);
+            inst["eval_exit_reason"] = json!("unresolved");
+        }
+    }
+    std::fs::write(&eval_path, serde_json::to_string_pretty(&eval).unwrap()).unwrap();
+
+    for inst in results["instances"].as_array_mut().unwrap() {
+        if inst["instance_id"] == "resolved-1" {
+            inst["resolved_count"] = json!(0);
+            inst["pass_at_1"] = json!(false);
+            inst["outcome"] = json!("error");
+            inst["failure_category"] = json!("step_limit");
+        }
+    }
+    std::fs::write(
+        &results_path,
+        serde_json::to_string_pretty(&results).unwrap(),
+    )
+    .unwrap();
+
+    std::fs::write(
+        sweep.join("resolved-1.traj.json"),
+        serde_json::to_string_pretty(&json!({
+            "trajectory_format": "mini-swe-agent-1.1",
+            "artifact_kind": "trajectory",
+            "schema_version": {"major": 1, "minor": 4},
+            "info": {
+                "task": "resolved-1",
+                "model_name": "fixture-model",
+                "outcome": "error",
+                "failure_category": "step_limit",
+                "total_cost_usd": 1.0,
+                "steps": 20,
+                "test_invocations": [],
+                "tests_run_before_submit": false
+            },
+            "messages": [
+                {"role": "assistant", "content": "Stuck in a loop"},
+                {
+                    "role": "user",
+                    "content": "observation",
+                    "extra": {
+                        "run_result": {
+                            "stdout": "",
+                            "stderr": "Max steps exceeded",
+                            "exit_code": 1,
+                            "timed_out": true
+                        }
+                    }
+                }
+            ]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+}

--- a/tests/bench_triage_diff.rs
+++ b/tests/bench_triage_diff.rs
@@ -157,10 +157,20 @@ fn triage_diff_fail_on_regression_flag() {
         !output.status.success(),
         "should have failed with regression set non-empty"
     );
-    assert_eq!(output.status.code().unwrap(), 6, "Expected exit code 6 (RegressionGateFailure)");
+    assert_eq!(
+        output.status.code().unwrap(),
+        6,
+        "Expected exit code 6 (RegressionGateFailure)"
+    );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("=== bench triage-diff ==="), "Output should still be printed before exiting");
-    assert!(stdout.contains("resolved-1"), "Output should contain the regression instance");
+    assert!(
+        stdout.contains("=== bench triage-diff ==="),
+        "Output should still be printed before exiting"
+    );
+    assert!(
+        stdout.contains("resolved-1"),
+        "Output should contain the regression instance"
+    );
 }
 
 #[test]
@@ -396,7 +406,10 @@ fn triage_diff_filtered_triage_json_errors_unless_auto_triage() {
         "should have failed due to filtered/partial triage.json"
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("filtered or partial"), "Stderr did not contain expected warning: {}", stderr);
+    assert!(
+        stderr.contains("filtered or partial"),
+        "Stderr did not contain expected warning: {stderr}"
+    );
 
     // Run WITH --auto-triage: should succeed because it automatically regenerates the canonical report!
     let output_auto = Command::new(binary_path())
@@ -423,4 +436,3 @@ fn triage_diff_filtered_triage_json_errors_unless_auto_triage() {
         String::from_utf8_lossy(&output_auto.stderr)
     );
 }
-


### PR DESCRIPTION
## Summary
This pull request implements the new `bench triage-diff` subcommand for failure cluster delta analysis between two completed SWE-bench sweeps, conforming to the TDD and requirements specified in issue #283.

### Features Implemented
- **Subcommand parser and args (`src/cli/args.rs`, `src/cli/mod.rs`)**:
  - `bench triage-diff --baseline <dir> --candidate <dir>`
  - `--auto-triage` to automatically perform triage if `triage.json` is missing.
  - `--min-cluster-size` to filter out tiny clusters.
  - `--top` to limit printed clusters.
  - `--output` to specify custom output location.
  - `--format` supporting `text` (tabular delta presentation) and `json`.
  - `--fail-on-regression` to return a non-zero exit code if regressions exist.
- **Delta Analysis Core Logic (`src/run/triage_diff.rs`)**:
  - Computes deltas for identical clusters (before count vs after count).
  - Identifies **New failure clusters** (present in candidate, not baseline).
  - Identifies **Resolved failure clusters** (present in baseline, not candidate).
  - Formats nice comfortable stdout tables showing top regressions, wins, and deltas.
  - Saves the JSON report to `triage-diff.json` in candidate sweep dir by default.
- **Exposed Triage Helpers (`src/run/triage.rs`)**:
  - Refactored internal triage parsing and normalization helper structures to `pub` so they can be reused by delta analysis.
- **Spec Documentation (`docs/spec-triage-diff.md`, `README.md`)**:
  - Detailed spec document covering implementation, CLI design, and JSON schemas.
- **Strict TDD Integration Tests (`tests/bench_triage_diff.rs`)**:
  - Complete integration tests proving identical sweeps delta (0), regression detection, fail-on-regression exit codes, missing triage.json error handling, and auto-triage workflows.

## Test Plan
All changes have been developed under strict TDD and verified with the newly added integration tests:
- `cargo test --test bench_triage_diff`
- The entire project test suite has been run and passes cleanly with zero warnings or errors.