### PR TITLE
🎨 Mosaic: UI Polish for Skills Preview

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2611,6 +2611,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
 }
 
 #[cfg(feature = "html-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
     Ok(HtmlExporter::export(traj))
@@ -2626,6 +2627,7 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
 }
 
 #[cfg(feature = "csv-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
     Ok(CsvExporter::export(traj))
@@ -2641,6 +2643,7 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
 }
 
 #[cfg(feature = "mermaid-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
     Ok(MermaidExporter::export(traj))

--- a/src/run/skills_preview.rs
+++ b/src/run/skills_preview.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
 use crate::artifact::{ArtifactKind, ArtifactSchemaVersion};
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+
 use crate::config::Config;
 use crate::error::Error;
 use crate::redaction::{Redactor, surface};
@@ -253,22 +255,29 @@ pub fn format_text(report: &SkillsPreviewReport, redactor: &Redactor) -> String 
     let mut out = String::from("=== agent skills-preview (no model call made) ===\n");
 
     for task in &report.tasks {
-        let _ = write!(out, "\ntask_hash: {}\n", task.task_hash);
+        let _ = writeln!(out, "\ntask_hash: {}", task.task_hash);
         if task.active_skills.is_empty() {
             out.push_str("  (no skills activated)\n");
         } else {
+            let mut table = Table::new();
+            table
+                .load_preset(UTF8_FULL)
+                .apply_modifier(UTF8_ROUND_CORNERS)
+                .set_header(vec!["Skill", "Reason", "SHA256", "Bytes", "Path"]);
             for skill in &task.active_skills {
                 let reason_str = match skill.reason {
                     SkillActivationReason::ExplicitMention => "explicit",
                     SkillActivationReason::AutoMatch => "auto",
                 };
-                let path_str = skill.path.display().to_string();
-                let _ = writeln!(
-                    out,
-                    "  {} | {} | {} | {} bytes | {}",
-                    skill.name, reason_str, skill.sha256_prefix, skill.bytes, path_str,
-                );
+                table.add_row(vec![
+                    skill.name.clone(),
+                    reason_str.to_string(),
+                    skill.sha256_prefix.clone(),
+                    skill.bytes.to_string(),
+                    skill.path.display().to_string(),
+                ]);
             }
+            let _ = writeln!(out, "{table}");
         }
         let _ = writeln!(out, "  total_bytes_injected: {}", task.total_bytes_injected);
         let _ = writeln!(
@@ -283,20 +292,34 @@ pub fn format_text(report: &SkillsPreviewReport, redactor: &Redactor) -> String 
         );
     }
 
-    let _ = writeln!(
-        out,
-        "\n--- summary ---\n\
-         task_count: {}\n\
-         unique_skills_activated: {}\n\
-         p50_bytes_per_task: {}\n\
-         p95_bytes_per_task: {}\n\
-         tasks_hitting_max_active: {}",
-        report.summary.task_count,
-        report.summary.unique_skills_activated,
-        report.summary.p50_bytes_per_task,
-        report.summary.p95_bytes_per_task,
-        report.summary.tasks_hitting_max_active,
-    );
+    let mut summary_table = Table::new();
+    summary_table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec!["Metric", "Value"]);
+
+    summary_table.add_row(vec![
+        "Task Count".to_string(),
+        report.summary.task_count.to_string(),
+    ]);
+    summary_table.add_row(vec![
+        "Unique Skills".to_string(),
+        report.summary.unique_skills_activated.to_string(),
+    ]);
+    summary_table.add_row(vec![
+        "P50 Bytes".to_string(),
+        report.summary.p50_bytes_per_task.to_string(),
+    ]);
+    summary_table.add_row(vec![
+        "P95 Bytes".to_string(),
+        report.summary.p95_bytes_per_task.to_string(),
+    ]);
+    summary_table.add_row(vec![
+        "Cap Hits".to_string(),
+        report.summary.tasks_hitting_max_active.to_string(),
+    ]);
+
+    let _ = writeln!(out, "\n--- summary ---\n{summary_table}");
 
     redactor.redact_text(&out, surface::TRAJECTORY).text
 }


### PR DESCRIPTION
* 🖌️ **Before:** The `max agent skills-preview` command output a raw, linear text stream for both the list of activated skills per task and the final summary statistics, resembling a log file.
* ✨ **After:** The output is now rendered using `comfy_table` with `UTF8_FULL` formatting and `UTF8_ROUND_CORNERS`. Task skills and summary statistics are presented in clear, readable tables.
* 🖼️ **Visuals:** A crisp, Z-pattern scannable dashboard.

Fixes linter complaints in `src/cli/mod.rs` for `clippy::unnecessary_wraps` on HTML, CSV, and Mermaid exporter functions using the `#[allow]` attribute.

---
*PR created automatically by Jules for task [8405761980710752919](https://jules.google.com/task/8405761980710752919) started by @madmax983*