### PR TITLE
⚒️ Forge: Fix unnecessary wraps in cli/mod.rs

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2611,6 +2611,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
 }
 
 #[cfg(feature = "html-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
     Ok(HtmlExporter::export(traj))
@@ -2626,6 +2627,7 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
 }
 
 #[cfg(feature = "csv-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
     Ok(CsvExporter::export(traj))
@@ -2641,6 +2643,7 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
 }
 
 #[cfg(feature = "mermaid-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
     Ok(MermaidExporter::export(traj))


### PR DESCRIPTION
🚮 Smell: Clippy reported `unnecessary_wraps` on `inspect_export_html`, `inspect_export_csv`, and `inspect_export_mermaid` when features are enabled, but they need `Result` to match the non-feature versions.
✨ Solution: Added `#[allow(clippy::unnecessary_wraps)]` to the feature-gated implementations.
🧼 Benefit: Fixes clippy warnings while preserving API consistency across different feature flag combinations.
🛡️ Verification: Ran `cargo clippy` and `cargo test`. No logic changed.

---
*PR created automatically by Jules for task [2077169441111833446](https://jules.google.com/task/2077169441111833446) started by @madmax983*