### PR TITLE
feat: implement bench bisect command with budget & schema breaks

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -520,6 +520,8 @@ pub enum BenchCmd {
     Power(PowerCmd),
     /// Preview SWE-bench dataset composition offline and zero-cost before running a sweep.
     DatasetStats(DatasetStatsCmd),
+    /// Identify the commit that introduced a resolved-rate regression.
+    Bisect(BisectCmd),
 }
 
 /// `bench dataset-stats` — preview SWE-bench dataset composition pre-sweep.
@@ -576,6 +578,42 @@ pub struct DatasetStatsCmd {
     /// Model name to use for TokenCounter offline estimation.
     #[arg(long, default_value = "gpt-4")]
     pub model: String,
+}
+
+/// `bench bisect` — identify the commit that introduced a resolved-rate regression.
+#[derive(Debug, Args, Clone)]
+pub struct BisectCmd {
+    /// Known-good sweep directory containing a results.json with manifest.
+    #[arg(long)]
+    pub good: PathBuf,
+
+    /// Known-bad sweep directory containing a results.json with manifest.
+    #[arg(long)]
+    pub bad: PathBuf,
+
+    /// Number of smoke instances to sample for the sweep.
+    #[arg(long, default_value_t = 5)]
+    pub smoke_instances: usize,
+
+    /// RNG seed for sampling candidate smoke instances (defaults to good manifest hash).
+    #[arg(long)]
+    pub smoke_seed: Option<u64>,
+
+    /// The model to run the smoke sweep against. Defaults to cheapest registered model.
+    #[arg(long)]
+    pub smoke_model: Option<String>,
+
+    /// Margin under which resolved rate is considered a regression.
+    #[arg(long, default_value_t = 0.20)]
+    pub regression_margin: f64,
+
+    /// Maximum USD cost before halting and writing partial results.
+    #[arg(long)]
+    pub max_cost_usd: Option<f64>,
+
+    /// Path to a bisect.json file to resume a previously interrupted run.
+    #[arg(long)]
+    pub resume: Option<PathBuf>,
 }
 
 /// `bench power` — statistical power, sample size, or MDE calculations.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2613,6 +2613,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
 }
 
 #[cfg(feature = "html-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
     Ok(HtmlExporter::export(traj))
@@ -2628,6 +2629,7 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
 }
 
 #[cfg(feature = "csv-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
     Ok(CsvExporter::export(traj))
@@ -2643,6 +2645,7 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
 }
 
 #[cfg(feature = "mermaid-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
     Ok(MermaidExporter::export(traj))

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -109,6 +109,7 @@ pub async fn run() -> Result<(), Error> {
             args::BenchCmd::Fork(f) => Box::pin(crate::run::fork::run(f)).await,
             args::BenchCmd::Power(p) => bench_power(&p),
             args::BenchCmd::DatasetStats(s) => bench_dataset_stats(s),
+            args::BenchCmd::Bisect(b) => Box::pin(bench_bisect(b)).await,
         },
         Command::Agent { cmd } => match *cmd {
             args::AgentCmd::SkillsPreview(s) => agent_skills_preview_cmd(&s),
@@ -4102,6 +4103,10 @@ fn bench_dataset_stats(s: args::DatasetStatsCmd) -> Result<(), Error> {
     }
 
     Ok(())
+}
+
+async fn bench_bisect(b: args::BisectCmd) -> Result<(), Error> {
+    crate::run::bisect::run(&b).await
 }
 
 fn parse_dataset_source_stats(

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,14 @@ pub enum Error {
     /// Preflight gate failure (e.g. config drift with --fail-on-change).
     #[error("{0}")]
     Preflight(String),
+
+    /// bench bisect budget exhausted
+    #[error("bisect budget exhausted")]
+    BisectBudgetExhausted,
+
+    /// bench bisect schema break
+    #[error("bisect schema break")]
+    BisectSchemaBreak,
 }
 
 #[derive(Debug, Error)]

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -82,6 +82,10 @@ pub enum ExitCode {
     /// 17 — `mini --resume` target trajectory is structurally invalid for resume;
     /// the message sequence is empty, too short, or ends in a partial assistant turn.
     ResumeInvalidPrefix = 17,
+    /// 18 — `bench bisect` budget exhausted before identifying the regressing commit.
+    BisectBudgetExhausted = 18,
+    /// 19 — `bench bisect` found only trajectory-schema breaks in the remaining search space.
+    BisectSchemaBreak = 19,
     /// 130 — user interruption (graceful SIGINT / Ctrl-C; 128 + SIGINT(2)).
     Interrupted = 130,
     /// 137 — forced kill (SIGKILL escalation after graceful-cancel deadline; 128 + SIGKILL(9)).
@@ -120,6 +124,8 @@ impl ExitCode {
             Self::ResumeAlreadyTerminal => "resume_already_terminal",
             Self::ResumeManifestMissing => "resume_manifest_missing",
             Self::ResumeInvalidPrefix => "resume_invalid_prefix",
+            Self::BisectBudgetExhausted => "bisect_budget_exhausted",
+            Self::BisectSchemaBreak => "bisect_schema_break",
             Self::Interrupted => "interrupted",
             Self::Killed => "killed",
         }
@@ -340,6 +346,24 @@ mod tests {
         assert_eq!(
             ExitCode::ResumeInvalidPrefix.outcome_class(),
             "resume_invalid_prefix"
+        );
+    }
+
+    #[test]
+    fn bisect_budget_exhausted_exit_code_is_18() {
+        assert_eq!(ExitCode::BisectBudgetExhausted.as_i32(), 18);
+        assert_eq!(
+            ExitCode::BisectBudgetExhausted.outcome_class(),
+            "bisect_budget_exhausted"
+        );
+    }
+
+    #[test]
+    fn bisect_schema_break_exit_code_is_19() {
+        assert_eq!(ExitCode::BisectSchemaBreak.as_i32(), 19);
+        assert_eq!(
+            ExitCode::BisectSchemaBreak.outcome_class(),
+            "bisect_schema_break"
         );
     }
 }

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -156,6 +156,8 @@ impl ExitCode {
                 _ => Self::TaskUnsuccessful,
             },
             Error::AgentStagnation { .. } => Self::AgentStagnation,
+            Error::BisectBudgetExhausted => Self::BisectBudgetExhausted,
+            Error::BisectSchemaBreak => Self::BisectSchemaBreak,
             Error::Template(_)
             | Error::Trajectory(_)
             | Error::Github(_)

--- a/src/run/bisect.rs
+++ b/src/run/bisect.rs
@@ -1,3 +1,10 @@
+#![allow(
+    clippy::uninlined_format_args,
+    clippy::needless_borrows_for_generic_args,
+    clippy::branches_sharing_code,
+    clippy::assigning_clones
+)]
+
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -203,6 +210,7 @@ fn read_current_schema_version_from_file(artifact_file_path: &Path) -> Option<(u
     Some((major, minor))
 }
 
+#[allow(clippy::cast_possible_truncation)]
 fn load_schema_version_from_results_json(dir: &Path) -> Result<(u16, u16), Error> {
     let path = dir.join("results.json");
     if !path.exists() {
@@ -213,8 +221,8 @@ fn load_schema_version_from_results_json(dir: &Path) -> Result<(u16, u16), Error
         serde_json::from_reader(std::io::BufReader::new(file)).unwrap_or_default();
     if let Some(schema) = v.get("schema_version") {
         if let (Some(major), Some(minor)) = (
-            schema.get("major").and_then(|x| x.as_u64()),
-            schema.get("minor").and_then(|x| x.as_u64()),
+            schema.get("major").and_then(serde_json::Value::as_u64),
+            schema.get("minor").and_then(serde_json::Value::as_u64),
         ) {
             return Ok((major as u16, minor as u16));
         }
@@ -227,7 +235,8 @@ fn load_schema_version_from_results_json(dir: &Path) -> Result<(u16, u16), Error
     clippy::too_many_lines,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
-    clippy::cast_precision_loss
+    clippy::cast_precision_loss,
+    clippy::cast_possible_wrap
 )]
 pub async fn run(args: &BisectCmd) -> Result<(), Error> {
     // 1. If not clean, refuse to run (to prevent data loss on checkout)
@@ -416,8 +425,7 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
 
     let smoke_model = args.smoke_model.clone().unwrap_or_else(|| {
         crate::config::Config::defaults()
-            .map(|c| c.root.model.name)
-            .unwrap_or_else(|_| "claude-opus-4-7".to_owned())
+            .map_or_else(|_| "claude-opus-4-7".to_owned(), |c| c.root.model.name)
     });
 
     let good_resolved_count = if good_sweep.instances.is_empty() {
@@ -474,7 +482,7 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
                     let is_marked_break = state
                         .per_commit
                         .get(sha)
-                        .map_or(false, |r| r.status == "schema_break");
+                        .is_some_and(|r| r.status == "schema_break");
                     if !is_marked_break {
                         candidate_idx = cand;
                         found_valid = true;
@@ -489,7 +497,7 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
                     let is_marked_break = state
                         .per_commit
                         .get(sha)
-                        .map_or(false, |r| r.status == "schema_break");
+                        .is_some_and(|r| r.status == "schema_break");
                     if !is_marked_break {
                         candidate_idx = cand;
                         found_valid = true;

--- a/src/run/bisect.rs
+++ b/src/run/bisect.rs
@@ -40,6 +40,14 @@ pub struct BisectState {
     pub cache_reuse_count: usize,
     pub schema_breaks: Vec<String>,
     pub outcome: Option<String>,
+    #[serde(default)]
+    pub smoke_instances: usize,
+    #[serde(default)]
+    pub smoke_seed: Option<u64>,
+    #[serde(default)]
+    pub smoke_model: Option<String>,
+    #[serde(default)]
+    pub regression_margin: Option<f64>,
 }
 
 impl Default for BisectState {
@@ -56,6 +64,10 @@ impl Default for BisectState {
             cache_reuse_count: 0,
             schema_breaks: Vec::new(),
             outcome: None,
+            smoke_instances: 0,
+            smoke_seed: None,
+            smoke_model: None,
+            regression_margin: None,
         }
     }
 }
@@ -256,6 +268,31 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
     };
     let _restore_guard = GitRestoreGuard { original_head };
 
+    // Load good sweep dataset properties for reproducible subset selection
+    let good_sweep = load_sweep_results(&args.good)?;
+    let manifest = good_sweep.manifest.as_ref().ok_or_else(|| {
+        Error::Config(crate::error::ConfigError::Invalid(
+            "Good sweep is missing manifest".to_owned(),
+        ))
+    })?;
+
+    // Derive stable seed if not provided
+    let smoke_seed = args.smoke_seed.unwrap_or_else(|| {
+        let hash = hash_manifest(manifest);
+        parse_hex_seed(&hash)
+    });
+
+    let smoke_model = args.smoke_model.clone().unwrap_or_else(|| {
+        let name = manifest.model.name.to_ascii_lowercase();
+        if name.starts_with("claude") || name.contains("anthropic") {
+            "claude-3-haiku-20240307".to_owned()
+        } else if name.starts_with("gpt") || name.contains("openai") {
+            "gpt-4o-mini".to_owned()
+        } else {
+            "claude-3-haiku-20240307".to_owned()
+        }
+    });
+
     // 3. Load good/bad or resume state
     let mut state = BisectState::default();
     if let Some(ref resume_path) = args.resume {
@@ -265,27 +302,54 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
                 resume_path.display()
             );
             let content = std::fs::read_to_string(resume_path).map_err(Error::Io)?;
-            state = serde_json::from_str(&content).map_err(Error::Json)?;
+            let loaded: BisectState = serde_json::from_str(&content).map_err(Error::Json)?;
+
+            // Validate parameter compatibility on resume!
+            if loaded.smoke_instances > 0 && loaded.smoke_instances != args.smoke_instances {
+                return Err(Error::Preflight(format!(
+                    "Resume parameter mismatch: smoke_instances in state ({}) differs from requested ({})",
+                    loaded.smoke_instances, args.smoke_instances
+                )));
+            }
+            if let Some(state_seed) = loaded.smoke_seed {
+                if state_seed != smoke_seed {
+                    return Err(Error::Preflight(format!(
+                        "Resume parameter mismatch: smoke_seed in state ({}) differs from effective seed ({})",
+                        state_seed, smoke_seed
+                    )));
+                }
+            }
+            if let Some(ref state_model) = loaded.smoke_model {
+                if state_model != &smoke_model {
+                    return Err(Error::Preflight(format!(
+                        "Resume parameter mismatch: smoke_model in state ({:?}) differs from effective model ({:?})",
+                        state_model, smoke_model
+                    )));
+                }
+            }
+            if let Some(state_margin) = loaded.regression_margin {
+                if (state_margin - args.regression_margin).abs() > 1e-5 {
+                    return Err(Error::Preflight(format!(
+                        "Resume parameter mismatch: regression_margin in state ({:.2}) differs from requested ({:.2})",
+                        state_margin, args.regression_margin
+                    )));
+                }
+            }
+
+            state = loaded;
         } else {
             println!(
                 "[bisect] Starting new bisect run, output will be written to: {}",
                 resume_path.display()
             );
-            let good_sweep = load_sweep_results(&args.good)?;
             let bad_sweep = load_sweep_results(&args.bad)?;
-
-            let good_manifest = good_sweep.manifest.ok_or_else(|| {
-                Error::Config(crate::error::ConfigError::Invalid(
-                    "Good sweep directory results.json is missing 'manifest'".to_owned(),
-                ))
-            })?;
             let bad_manifest = bad_sweep.manifest.ok_or_else(|| {
                 Error::Config(crate::error::ConfigError::Invalid(
                     "Bad sweep directory results.json is missing 'manifest'".to_owned(),
                 ))
             })?;
 
-            let good_sha = good_manifest.harness.git_sha.ok_or_else(|| {
+            let good_sha = manifest.harness.git_sha.clone().ok_or_else(|| {
                 Error::Config(crate::error::ConfigError::Invalid(
                     "Good sweep manifest is missing harness git_sha".to_owned(),
                 ))
@@ -300,21 +364,14 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
             state.bad_sha = bad_sha;
         }
     } else {
-        let good_sweep = load_sweep_results(&args.good)?;
         let bad_sweep = load_sweep_results(&args.bad)?;
-
-        let good_manifest = good_sweep.manifest.ok_or_else(|| {
-            Error::Config(crate::error::ConfigError::Invalid(
-                "Good sweep directory results.json is missing 'manifest'".to_owned(),
-            ))
-        })?;
         let bad_manifest = bad_sweep.manifest.ok_or_else(|| {
             Error::Config(crate::error::ConfigError::Invalid(
                 "Bad sweep directory results.json is missing 'manifest'".to_owned(),
             ))
         })?;
 
-        let good_sha = good_manifest.harness.git_sha.ok_or_else(|| {
+        let good_sha = manifest.harness.git_sha.clone().ok_or_else(|| {
             Error::Config(crate::error::ConfigError::Invalid(
                 "Good sweep manifest is missing harness git_sha".to_owned(),
             ))
@@ -380,20 +437,6 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
         commit_list.len()
     );
 
-    // Load good sweep dataset properties for reproducible subset selection
-    let good_sweep = load_sweep_results(&args.good)?;
-    let manifest = good_sweep.manifest.as_ref().ok_or_else(|| {
-        Error::Config(crate::error::ConfigError::Invalid(
-            "Good sweep is missing manifest".to_owned(),
-        ))
-    })?;
-
-    // Derive stable seed if not provided
-    let smoke_seed = args.smoke_seed.unwrap_or_else(|| {
-        let hash = hash_manifest(manifest);
-        parse_hex_seed(&hash)
-    });
-
     // Select N smoke instances reproducibly
     let mut all_instances: Vec<String> = good_sweep
         .instances
@@ -423,11 +466,6 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
 
     let good_schema = load_schema_version_from_results_json(&args.good).unwrap_or((1u16, 10u16));
 
-    let smoke_model = args.smoke_model.clone().unwrap_or_else(|| {
-        crate::config::Config::defaults()
-            .map_or_else(|_| "claude-opus-4-7".to_owned(), |c| c.root.model.name)
-    });
-
     let good_resolved_count = if good_sweep.instances.is_empty() {
         good_sweep.submitted
     } else {
@@ -435,18 +473,26 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
             .instances
             .iter()
             .filter(|inst| {
-                inst.resolved_count > 0
-                    || (inst.outcome.as_deref() == Some("submitted")
-                        && inst.failure_category.is_none())
+                smoke_instances_subset.contains(&inst.instance_id)
+                    && (inst.resolved_count > 0
+                        || (inst.outcome.as_deref() == Some("submitted")
+                            && inst.failure_category.is_none()))
             })
             .count()
     };
 
-    let good_resolved_rate = if good_sweep.total > 0 {
+    let good_resolved_rate = if !smoke_instances_subset.is_empty() {
+        good_resolved_count as f64 / smoke_instances_subset.len() as f64
+    } else if good_sweep.total > 0 {
         good_resolved_count as f64 / good_sweep.total as f64
     } else {
         1.0
     };
+
+    state.smoke_instances = args.smoke_instances;
+    state.smoke_seed = Some(smoke_seed);
+    state.smoke_model = Some(smoke_model.clone());
+    state.regression_margin = Some(args.regression_margin);
     println!(
         "[bisect] Good resolved rate: {:.2}%",
         good_resolved_rate * 100.0
@@ -672,15 +718,10 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
             let mut cmd = Command::new(&target_binary_path);
             cmd.arg("bench").arg("swebench");
 
-            let ds_manifest = &manifest.dataset;
-            if ds_manifest.source_kind == "named" {
-                cmd.arg("--dataset")
-                    .arg(ds_manifest.alias.as_deref().unwrap_or("lite"));
-                if let Some(ref split) = ds_manifest.split {
-                    cmd.arg("--split").arg(split);
-                }
-            } else {
-                cmd.arg("--dataset-path").arg(&ds_manifest.path);
+            cmd.arg("--dataset-path").arg(&manifest.dataset.path);
+
+            if let Some(first_config) = manifest.config.overlay_paths.first() {
+                cmd.arg("--config").arg(first_config);
             }
 
             cmd.arg("--instance-ids")

--- a/src/run/bisect.rs
+++ b/src/run/bisect.rs
@@ -75,18 +75,49 @@ impl Default for BisectState {
 /// A Drop guard to restore the original branch/HEAD commit when exiting
 struct GitRestoreGuard {
     original_head: String,
+    active: bool,
+}
+
+impl GitRestoreGuard {
+    fn new(original_head: String) -> Self {
+        Self {
+            original_head,
+            active: true,
+        }
+    }
+
+    fn defuse(&mut self) {
+        self.active = false;
+    }
 }
 
 impl Drop for GitRestoreGuard {
     fn drop(&mut self) {
-        if !self.original_head.is_empty() {
+        if self.active && !self.original_head.is_empty() {
             println!(
                 "[bisect] Restoring original Git HEAD: {}",
                 self.original_head
             );
-            let _ = Command::new("git")
+            match Command::new("git")
                 .args(["checkout", "-f", &self.original_head])
-                .output();
+                .output()
+            {
+                Ok(out) => {
+                    if !out.status.success() {
+                        eprintln!(
+                            "[bisect] WARNING: Failed to restore original Git HEAD (exit {}): {}",
+                            out.status,
+                            String::from_utf8_lossy(&out.stderr).trim()
+                        );
+                    }
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[bisect] WARNING: Failed to execute git checkout to restore HEAD: {}",
+                        e
+                    );
+                }
+            }
         }
     }
 }
@@ -115,10 +146,36 @@ fn get_current_git_head() -> Result<String, Error> {
 }
 
 fn is_git_working_tree_clean() -> bool {
-    Command::new("git")
-        .args(["status", "--porcelain"])
-        .output()
-        .is_ok_and(|o| o.status.success() && o.stdout.is_empty())
+    if let Ok(o) = Command::new("git").args(["status", "--porcelain"]).output() {
+        if !o.status.success() {
+            return false;
+        }
+        let stdout = String::from_utf8_lossy(&o.stdout);
+        for line in stdout.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            // Untracked or modified files.
+            // If they are known output files (bisect.json or under runs/), we ignore them.
+            let path_part = if trimmed.len() > 3 {
+                &trimmed[3..]
+            } else {
+                trimmed
+            };
+            let normalized = path_part.replace('\\', "/");
+            if normalized == "bisect.json"
+                || normalized.starts_with("runs/")
+                || normalized.starts_with("runs/bisect_smoke/")
+            {
+                continue;
+            }
+            return false;
+        }
+        true
+    } else {
+        false
+    }
 }
 
 fn load_sweep_results(dir: &Path) -> Result<SweepResults, Error> {
@@ -226,11 +283,14 @@ fn read_current_schema_version_from_file(artifact_file_path: &Path) -> Option<(u
 fn load_schema_version_from_results_json(dir: &Path) -> Result<(u16, u16), Error> {
     let path = dir.join("results.json");
     if !path.exists() {
-        return Ok((1u16, 10u16));
+        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "Sweep results file not found at {}",
+            path.display()
+        ))));
     }
     let file = std::fs::File::open(&path).map_err(Error::Io)?;
     let v: serde_json::Value =
-        serde_json::from_reader(std::io::BufReader::new(file)).unwrap_or_default();
+        serde_json::from_reader(std::io::BufReader::new(file)).map_err(Error::Json)?;
     if let Some(schema) = v.get("schema_version") {
         if let (Some(major), Some(minor)) = (
             schema.get("major").and_then(serde_json::Value::as_u64),
@@ -239,7 +299,9 @@ fn load_schema_version_from_results_json(dir: &Path) -> Result<(u16, u16), Error
             return Ok((major as u16, minor as u16));
         }
     }
-    Ok((1u16, 10u16))
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "results.json is missing valid schema_version".to_owned(),
+    )))
 }
 
 #[allow(
@@ -252,7 +314,8 @@ fn load_schema_version_from_results_json(dir: &Path) -> Result<(u16, u16), Error
 )]
 pub async fn run(args: &BisectCmd) -> Result<(), Error> {
     // 1. If not clean, refuse to run (to prevent data loss on checkout)
-    let is_test = std::env::var("MAX_BISECT_TEST_ENV").is_ok();
+    // 1. If not clean, refuse to run (to prevent data loss on checkout)
+    let is_test = cfg!(debug_assertions) && std::env::var("MAX_BISECT_TEST_ENV").is_ok();
     if !is_test && !is_git_working_tree_clean() {
         return Err(Error::Preflight(
             "Git working tree is dirty; commit or stash changes before running bench bisect"
@@ -266,13 +329,31 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
     } else {
         get_current_git_head()?
     };
-    let _restore_guard = GitRestoreGuard { original_head };
+    let mut restore_guard = GitRestoreGuard::new(original_head.clone());
 
     // Load good sweep dataset properties for reproducible subset selection
     let good_sweep = load_sweep_results(&args.good)?;
     let manifest = good_sweep.manifest.as_ref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
             "Good sweep is missing manifest".to_owned(),
+        ))
+    })?;
+
+    let bad_sweep = load_sweep_results(&args.bad)?;
+    let bad_manifest = bad_sweep.manifest.as_ref().ok_or_else(|| {
+        Error::Config(crate::error::ConfigError::Invalid(
+            "Bad sweep is missing manifest".to_owned(),
+        ))
+    })?;
+
+    let good_sha = manifest.harness.git_sha.clone().ok_or_else(|| {
+        Error::Config(crate::error::ConfigError::Invalid(
+            "Good sweep manifest is missing harness git_sha".to_owned(),
+        ))
+    })?;
+    let bad_sha = bad_manifest.harness.git_sha.clone().ok_or_else(|| {
+        Error::Config(crate::error::ConfigError::Invalid(
+            "Bad sweep manifest is missing harness git_sha".to_owned(),
         ))
     })?;
 
@@ -335,6 +416,18 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
                     )));
                 }
             }
+            if !loaded.good_sha.is_empty() && loaded.good_sha != good_sha {
+                return Err(Error::Preflight(format!(
+                    "Resume parameter mismatch: good_sha in state ({}) differs from good sweep manifest SHA ({})",
+                    loaded.good_sha, good_sha
+                )));
+            }
+            if !loaded.bad_sha.is_empty() && loaded.bad_sha != bad_sha {
+                return Err(Error::Preflight(format!(
+                    "Resume parameter mismatch: bad_sha in state ({}) differs from bad sweep manifest SHA ({})",
+                    loaded.bad_sha, bad_sha
+                )));
+            }
 
             state = loaded;
         } else {
@@ -342,46 +435,10 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
                 "[bisect] Starting new bisect run, output will be written to: {}",
                 resume_path.display()
             );
-            let bad_sweep = load_sweep_results(&args.bad)?;
-            let bad_manifest = bad_sweep.manifest.ok_or_else(|| {
-                Error::Config(crate::error::ConfigError::Invalid(
-                    "Bad sweep directory results.json is missing 'manifest'".to_owned(),
-                ))
-            })?;
-
-            let good_sha = manifest.harness.git_sha.clone().ok_or_else(|| {
-                Error::Config(crate::error::ConfigError::Invalid(
-                    "Good sweep manifest is missing harness git_sha".to_owned(),
-                ))
-            })?;
-            let bad_sha = bad_manifest.harness.git_sha.ok_or_else(|| {
-                Error::Config(crate::error::ConfigError::Invalid(
-                    "Bad sweep manifest is missing harness git_sha".to_owned(),
-                ))
-            })?;
-
             state.good_sha = good_sha;
             state.bad_sha = bad_sha;
         }
     } else {
-        let bad_sweep = load_sweep_results(&args.bad)?;
-        let bad_manifest = bad_sweep.manifest.ok_or_else(|| {
-            Error::Config(crate::error::ConfigError::Invalid(
-                "Bad sweep directory results.json is missing 'manifest'".to_owned(),
-            ))
-        })?;
-
-        let good_sha = manifest.harness.git_sha.clone().ok_or_else(|| {
-            Error::Config(crate::error::ConfigError::Invalid(
-                "Good sweep manifest is missing harness git_sha".to_owned(),
-            ))
-        })?;
-        let bad_sha = bad_manifest.harness.git_sha.ok_or_else(|| {
-            Error::Config(crate::error::ConfigError::Invalid(
-                "Bad sweep manifest is missing harness git_sha".to_owned(),
-            ))
-        })?;
-
         state.good_sha = good_sha;
         state.bad_sha = bad_sha;
     }
@@ -394,7 +451,11 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
     let commit_list = if is_test {
         // In test environment, the commit list can be passed via env or mocked
         if let Ok(commits_env) = std::env::var("MAX_BISECT_MOCK_COMMITS") {
-            commits_env.split(',').map(str::to_owned).collect()
+            if commits_env.is_empty() {
+                vec![]
+            } else {
+                commits_env.split(',').map(str::to_owned).collect()
+            }
         } else {
             vec![state.good_sha.clone(), state.bad_sha.clone()]
         }
@@ -426,10 +487,10 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
     };
 
     if commit_list.is_empty() {
-        println!(
-            "[bisect] No commits in the range. Good and Bad commits might be identical or Good is not an ancestor of Bad."
-        );
-        return Ok(());
+        return Err(Error::Preflight(
+            "No commits found in the range. Good commit might not be an ancestor of Bad commit."
+                .to_owned(),
+        ));
     }
 
     println!(
@@ -464,7 +525,7 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
         smoke_instances_subset
     );
 
-    let good_schema = load_schema_version_from_results_json(&args.good).unwrap_or((1u16, 10u16));
+    let good_schema = load_schema_version_from_results_json(&args.good)?;
 
     let good_resolved_count = if good_sweep.instances.is_empty() {
         good_sweep.submitted
@@ -848,6 +909,21 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
 
     state.outcome = Some("success".to_owned());
     write_bisect_json(&state, args.resume.as_deref())?;
+
+    if !is_test && !original_head.is_empty() {
+        println!("[bisect] Restoring original Git HEAD: {}", original_head);
+        let restore_out = Command::new("git")
+            .args(["checkout", "-f", &original_head])
+            .output()
+            .map_err(Error::Io)?;
+        if !restore_out.status.success() {
+            return Err(Error::Preflight(format!(
+                "Failed to restore original Git HEAD: {}",
+                String::from_utf8_lossy(&restore_out.stderr).trim()
+            )));
+        }
+    }
+    restore_guard.defuse();
 
     if let Some(ref culprit) = state.suspect_commit {
         println!("[bisect] Identified suspect commit: {}", culprit);

--- a/src/run/bisect.rs
+++ b/src/run/bisect.rs
@@ -1,0 +1,778 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::Command;
+
+use crate::cli::args::BisectCmd;
+use crate::error::Error;
+use crate::run::swebench::{ProvenanceManifest, SweepResults};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitResult {
+    pub commit_sha: String,
+    pub resolved: usize,
+    pub errored: usize,
+    pub cost_usd: f64,
+    pub wallclock_secs: f64,
+    pub smoke_artifact_path: String,
+    pub cache_reuse_count: usize,
+    pub status: String, // "good" | "bad" | "schema_break" | "errored"
+    pub systemic_halt_category: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BisectState {
+    pub schema_version: String,
+    pub good_sha: String,
+    pub bad_sha: String,
+    pub commits_visited: Vec<String>,
+    pub per_commit: BTreeMap<String, CommitResult>,
+    pub suspect_commit: Option<String>,
+    pub total_cost: f64,
+    pub total_wallclock: f64,
+    pub cache_reuse_count: usize,
+    pub schema_breaks: Vec<String>,
+    pub outcome: Option<String>,
+}
+
+impl Default for BisectState {
+    fn default() -> Self {
+        Self {
+            schema_version: "1.0.0".to_owned(),
+            good_sha: String::new(),
+            bad_sha: String::new(),
+            commits_visited: Vec::new(),
+            per_commit: BTreeMap::new(),
+            suspect_commit: None,
+            total_cost: 0.0,
+            total_wallclock: 0.0,
+            cache_reuse_count: 0,
+            schema_breaks: Vec::new(),
+            outcome: None,
+        }
+    }
+}
+
+/// A Drop guard to restore the original branch/HEAD commit when exiting
+struct GitRestoreGuard {
+    original_head: String,
+}
+
+impl Drop for GitRestoreGuard {
+    fn drop(&mut self) {
+        if !self.original_head.is_empty() {
+            println!(
+                "[bisect] Restoring original Git HEAD: {}",
+                self.original_head
+            );
+            let _ = Command::new("git")
+                .args(["checkout", "-f", &self.original_head])
+                .output();
+        }
+    }
+}
+
+fn get_current_git_head() -> Result<String, Error> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .map_err(Error::Io)?;
+    if !out.status.success() {
+        return Err(Error::Preflight(
+            "failed to get current git HEAD".to_owned(),
+        ));
+    }
+    let ref_name = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+    if ref_name == "HEAD" {
+        // Detached HEAD, get the exact SHA
+        let sha_out = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .map_err(Error::Io)?;
+        Ok(String::from_utf8_lossy(&sha_out.stdout).trim().to_owned())
+    } else {
+        Ok(ref_name)
+    }
+}
+
+fn is_git_working_tree_clean() -> bool {
+    Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .is_ok_and(|o| o.status.success() && o.stdout.is_empty())
+}
+
+fn load_sweep_results(dir: &Path) -> Result<SweepResults, Error> {
+    let path = dir.join("results.json");
+    if !path.exists() {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "Sweep results file not found at {}",
+            path.display()
+        ))));
+    }
+    let file = std::fs::File::open(&path).map_err(Error::Io)?;
+    serde_json::from_reader(std::io::BufReader::new(file)).map_err(Error::Json)
+}
+
+fn hash_manifest(manifest: &ProvenanceManifest) -> String {
+    use sha2::{Digest, Sha256};
+    let json = serde_json::to_string(manifest).unwrap_or_default();
+    let hash = Sha256::digest(json.as_bytes());
+    let mut hex = String::with_capacity(64);
+    for b in hash {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{b:02x}");
+    }
+    format!("sha256:{hex}")
+}
+
+fn parse_hex_seed(hex: &str) -> u64 {
+    let hex_trimmed = hex.strip_prefix("sha256:").unwrap_or(hex);
+    let slice = if hex_trimmed.len() >= 16 {
+        &hex_trimmed[..16]
+    } else {
+        hex_trimmed
+    };
+    u64::from_str_radix(slice, 16).unwrap_or(42)
+}
+
+#[allow(dead_code)]
+fn simple_hash(s: &str) -> u64 {
+    let mut x = 0xcbf2_9ce4_8422_2325u64;
+    for b in s.bytes() {
+        x ^= u64::from(b);
+        x = x.wrapping_mul(0x1000_0000_01b3);
+    }
+    x
+}
+
+struct XorShift64 {
+    state: u64,
+}
+
+impl XorShift64 {
+    fn new(seed: u64) -> Self {
+        let state = if seed == 0 {
+            0x9E37_79B9_7F4A_7C15
+        } else {
+            seed
+        };
+        Self { state }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.state = x;
+        x
+    }
+}
+
+/// Retrieve the CURRENT ArtifactSchemaVersion from the text of src/artifact.rs
+fn read_current_schema_version_from_file(artifact_file_path: &Path) -> Option<(u16, u16)> {
+    if !artifact_file_path.exists() {
+        return None;
+    }
+    let content = std::fs::read_to_string(artifact_file_path).ok()?;
+    // Search for major: <num> and minor: <num> in the definition of CURRENT
+    let re =
+        regex::Regex::new(r"CURRENT:\s*Self\s*=\s*Self\s*\{\s*major:\s*(\d+),\s*minor:\s*(\d+)")
+            .ok()?;
+    if let Some(caps) = re.captures(&content) {
+        let major = caps.get(1)?.as_str().parse::<u16>().ok()?;
+        let minor = caps.get(2)?.as_str().parse::<u16>().ok()?;
+        return Some((major, minor));
+    }
+    // Try simpler search if formatting differs
+    let major_re = regex::Regex::new(r"major:\s*(\d+)").ok()?;
+    let minor_re = regex::Regex::new(r"minor:\s*(\d+)").ok()?;
+    let major = major_re
+        .captures(&content)?
+        .get(1)?
+        .as_str()
+        .parse::<u16>()
+        .ok()?;
+    let minor = minor_re
+        .captures(&content)?
+        .get(1)?
+        .as_str()
+        .parse::<u16>()
+        .ok()?;
+    Some((major, minor))
+}
+
+#[allow(
+    clippy::unused_async,
+    clippy::too_many_lines,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss
+)]
+pub async fn run(args: &BisectCmd) -> Result<(), Error> {
+    // 1. If not clean, refuse to run (to prevent data loss on checkout)
+    let is_test = std::env::var("MAX_BISECT_TEST_ENV").is_ok();
+    if !is_test && !is_git_working_tree_clean() {
+        return Err(Error::Preflight(
+            "Git working tree is dirty; commit or stash changes before running bench bisect"
+                .to_owned(),
+        ));
+    }
+
+    // 2. Load original Git HEAD
+    let original_head = if is_test {
+        String::new()
+    } else {
+        get_current_git_head()?
+    };
+    let _restore_guard = GitRestoreGuard { original_head };
+
+    // 3. Load good/bad or resume state
+    let mut state = BisectState::default();
+    if let Some(ref resume_path) = args.resume {
+        if resume_path.exists() {
+            println!(
+                "[bisect] Resuming from bisect state file: {}",
+                resume_path.display()
+            );
+            let content = std::fs::read_to_string(resume_path).map_err(Error::Io)?;
+            state = serde_json::from_str(&content).map_err(Error::Json)?;
+        } else {
+            println!(
+                "[bisect] Starting new bisect run, output will be written to: {}",
+                resume_path.display()
+            );
+            let good_sweep = load_sweep_results(&args.good)?;
+            let bad_sweep = load_sweep_results(&args.bad)?;
+
+            let good_manifest = good_sweep.manifest.ok_or_else(|| {
+                Error::Config(crate::error::ConfigError::Invalid(
+                    "Good sweep directory results.json is missing 'manifest'".to_owned(),
+                ))
+            })?;
+            let bad_manifest = bad_sweep.manifest.ok_or_else(|| {
+                Error::Config(crate::error::ConfigError::Invalid(
+                    "Bad sweep directory results.json is missing 'manifest'".to_owned(),
+                ))
+            })?;
+
+            let good_sha = good_manifest.harness.git_sha.ok_or_else(|| {
+                Error::Config(crate::error::ConfigError::Invalid(
+                    "Good sweep manifest is missing harness git_sha".to_owned(),
+                ))
+            })?;
+            let bad_sha = bad_manifest.harness.git_sha.ok_or_else(|| {
+                Error::Config(crate::error::ConfigError::Invalid(
+                    "Bad sweep manifest is missing harness git_sha".to_owned(),
+                ))
+            })?;
+
+            state.good_sha = good_sha;
+            state.bad_sha = bad_sha;
+        }
+    } else {
+        let good_sweep = load_sweep_results(&args.good)?;
+        let bad_sweep = load_sweep_results(&args.bad)?;
+
+        let good_manifest = good_sweep.manifest.ok_or_else(|| {
+            Error::Config(crate::error::ConfigError::Invalid(
+                "Good sweep directory results.json is missing 'manifest'".to_owned(),
+            ))
+        })?;
+        let bad_manifest = bad_sweep.manifest.ok_or_else(|| {
+            Error::Config(crate::error::ConfigError::Invalid(
+                "Bad sweep directory results.json is missing 'manifest'".to_owned(),
+            ))
+        })?;
+
+        let good_sha = good_manifest.harness.git_sha.ok_or_else(|| {
+            Error::Config(crate::error::ConfigError::Invalid(
+                "Good sweep manifest is missing harness git_sha".to_owned(),
+            ))
+        })?;
+        let bad_sha = bad_manifest.harness.git_sha.ok_or_else(|| {
+            Error::Config(crate::error::ConfigError::Invalid(
+                "Bad sweep manifest is missing harness git_sha".to_owned(),
+            ))
+        })?;
+
+        state.good_sha = good_sha;
+        state.bad_sha = bad_sha;
+    }
+
+    println!("[bisect] Good commit: {}", state.good_sha);
+    println!("[bisect] Bad commit: {}", state.bad_sha);
+
+    // 4. Retrieve commit list to walk in O(log N)
+    // Runs git rev-list --topo-order --reverse good_sha..bad_sha
+    let commit_list = if is_test {
+        // In test environment, the commit list can be passed via env or mocked
+        if let Ok(commits_env) = std::env::var("MAX_BISECT_MOCK_COMMITS") {
+            commits_env.split(',').map(str::to_owned).collect()
+        } else {
+            vec![state.good_sha.clone(), state.bad_sha.clone()]
+        }
+    } else {
+        let out = Command::new("git")
+            .args([
+                "rev-list",
+                "--topo-order",
+                "--reverse",
+                &format!("{}..{}", state.good_sha, state.bad_sha),
+            ])
+            .output()
+            .map_err(Error::Io)?;
+        if !out.status.success() {
+            return Err(Error::Preflight(format!(
+                "Failed to get commit range: {}",
+                String::from_utf8_lossy(&out.stderr)
+            )));
+        }
+        let list_str = String::from_utf8_lossy(&out.stdout);
+        let list: Vec<String> = list_str
+            .lines()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+            .collect();
+        list
+    };
+
+    if commit_list.is_empty() {
+        println!(
+            "[bisect] No commits in the range. Good and Bad commits might be identical or Good is not an ancestor of Bad."
+        );
+        return Ok(());
+    }
+
+    println!(
+        "[bisect] Range has {} candidate commits to walk.",
+        commit_list.len()
+    );
+
+    // Load good sweep dataset properties for reproducible subset selection
+    let good_sweep = load_sweep_results(&args.good)?;
+    let manifest = good_sweep.manifest.as_ref().ok_or_else(|| {
+        Error::Config(crate::error::ConfigError::Invalid(
+            "Good sweep is missing manifest".to_owned(),
+        ))
+    })?;
+
+    // Derive stable seed if not provided
+    let smoke_seed = args.smoke_seed.unwrap_or_else(|| {
+        let hash = hash_manifest(manifest);
+        parse_hex_seed(&hash)
+    });
+
+    // Select N smoke instances reproducibly
+    let mut all_instances: Vec<String> = good_sweep
+        .instances
+        .iter()
+        .map(|inst| inst.instance_id.clone())
+        .collect();
+    all_instances.sort();
+
+    let mut rng = XorShift64::new(smoke_seed);
+    let mut shuffled = all_instances.clone();
+    for i in (1..shuffled.len()).rev() {
+        let j = (rng.next_u64() as usize) % (i + 1);
+        shuffled.swap(i, j);
+    }
+    let smoke_instances_subset: Vec<String> =
+        shuffled.into_iter().take(args.smoke_instances).collect();
+    if smoke_instances_subset.is_empty() {
+        return Err(Error::Preflight(
+            "No instances found in good sweep to sample for smoke sweep".to_owned(),
+        ));
+    }
+    println!(
+        "[bisect] Reproducible smoke sweep subset of size {} selected: {:?}",
+        smoke_instances_subset.len(),
+        smoke_instances_subset
+    );
+
+    let smoke_model = args
+        .smoke_model
+        .clone()
+        .unwrap_or_else(|| "free-tier-model".to_owned());
+    let good_resolved_rate = if good_sweep.total > 0 {
+        good_sweep.submitted as f64 / good_sweep.total as f64
+    } else {
+        1.0
+    };
+    println!(
+        "[bisect] Good resolved rate: {:.2}%",
+        good_resolved_rate * 100.0
+    );
+
+    // 5. Binary search state machine loop
+    let mut low = 0;
+    let mut high = commit_list.len() - 1;
+
+    // Detect target binary name and path
+    let binary_name = format!("max{}", std::env::consts::EXE_SUFFIX);
+    let target_binary_path = std::env::current_dir()
+        .map_err(Error::Io)?
+        .join("target")
+        .join("debug")
+        .join(&binary_name);
+
+    while low <= high {
+        let mid = low + (high - low) / 2;
+
+        // Verify if we have candidate commit already evaluated (from resume)
+        let mut candidate_idx = mid;
+        let mut found_valid = false;
+
+        // Outward search for non-schema-break candidate commit in [low, high]
+        let mut offset = 0i32;
+        while mid as i32 - offset >= low as i32 || mid as i32 + offset <= high as i32 {
+            if mid as i32 - offset >= low as i32 {
+                let cand = (mid as i32 - offset) as usize;
+                let sha = &commit_list[cand];
+                if !state.schema_breaks.contains(sha) {
+                    // Check if it's already marked as schema break in per_commit
+                    let is_marked_break = state
+                        .per_commit
+                        .get(sha)
+                        .map_or(false, |r| r.status == "schema_break");
+                    if !is_marked_break {
+                        candidate_idx = cand;
+                        found_valid = true;
+                        break;
+                    }
+                }
+            }
+            if mid as i32 + offset <= high as i32 {
+                let cand = (mid as i32 + offset) as usize;
+                let sha = &commit_list[cand];
+                if !state.schema_breaks.contains(sha) {
+                    let is_marked_break = state
+                        .per_commit
+                        .get(sha)
+                        .map_or(false, |r| r.status == "schema_break");
+                    if !is_marked_break {
+                        candidate_idx = cand;
+                        found_valid = true;
+                        break;
+                    }
+                }
+            }
+            offset += 1;
+        }
+
+        if !found_valid {
+            // Every remaining candidate in the window is a schema break!
+            println!(
+                "[bisect] All remaining candidates in window [{}, {}] are trajectory schema breaks.",
+                low, high
+            );
+            state.outcome = Some("schema_break".to_owned());
+            // Write partial bisect.json
+            write_bisect_json(&state, args.resume.as_deref())?;
+            // Exit with bisect_schema_break (19)
+            std::process::exit(crate::exit_code::ExitCode::BisectSchemaBreak.as_i32());
+        }
+
+        let candidate_sha = commit_list[candidate_idx].clone();
+        println!(
+            "[bisect] Evaluating candidate commit index {} / {}: {}",
+            candidate_idx,
+            commit_list.len(),
+            candidate_sha
+        );
+
+        // Check if already completed and recorded
+        if let Some(result) = state.per_commit.get(&candidate_sha) {
+            if result.status == "good" || result.status == "bad" {
+                println!(
+                    "[bisect] Candidate already evaluated: status={}",
+                    result.status
+                );
+                state.commits_visited.push(candidate_sha.clone());
+                if result.status == "bad" {
+                    state.suspect_commit = Some(candidate_sha.clone());
+                    if candidate_idx == 0 {
+                        break;
+                    }
+                    high = candidate_idx - 1;
+                } else {
+                    low = candidate_idx + 1;
+                }
+                continue;
+            }
+        }
+
+        // Checkout candidate commit
+        if !is_test {
+            println!("[bisect] git checkout {}", candidate_sha);
+            let check_out = Command::new("git")
+                .args(["checkout", "-f", &candidate_sha])
+                .output()
+                .map_err(Error::Io)?;
+            if !check_out.status.success() {
+                return Err(Error::Preflight(format!(
+                    "Failed to checkout commit {}: {}",
+                    candidate_sha,
+                    String::from_utf8_lossy(&check_out.stderr)
+                )));
+            }
+        }
+
+        // Read and verify trajectory schema version
+        let good_schema = good_sweep.manifest.as_ref().map_or((1u16, 10u16), |_m| {
+            // We can read it directly from the results.json header if parsed, or default
+            (1u16, 10u16)
+        });
+
+        let artifact_file_path = std::env::current_dir()
+            .map_err(Error::Io)?
+            .join("src")
+            .join("artifact.rs");
+        let candidate_schema =
+            read_current_schema_version_from_file(&artifact_file_path).unwrap_or((0, 0));
+        let mock_schema_break = is_test
+            && std::env::var(&format!("MAX_BISECT_MOCK_SCHEMA_BREAK_{}", candidate_sha)).is_ok();
+        if candidate_schema != good_schema || mock_schema_break {
+            println!(
+                "[bisect] Trajectory schema mismatch: good schema = {:?}, candidate schema = {:?}",
+                good_schema, candidate_schema
+            );
+            state.schema_breaks.push(candidate_sha.clone());
+            state.per_commit.insert(
+                candidate_sha.clone(),
+                CommitResult {
+                    commit_sha: candidate_sha.clone(),
+                    resolved: 0,
+                    errored: 0,
+                    cost_usd: 0.0,
+                    wallclock_secs: 0.0,
+                    smoke_artifact_path: String::new(),
+                    cache_reuse_count: 0,
+                    status: "schema_break".to_owned(),
+                    systemic_halt_category: None,
+                },
+            );
+            // Write partial bisect.json
+            write_bisect_json(&state, args.resume.as_deref())?;
+            continue;
+        }
+
+        // Build the harness
+        if !is_test {
+            println!("[bisect] Building candidate harness: cargo build");
+            let build = Command::new("cargo")
+                .arg("build")
+                .output()
+                .map_err(Error::Io)?;
+            if !build.status.success() {
+                println!("[bisect] Build failed at commit {}", candidate_sha);
+                state.per_commit.insert(
+                    candidate_sha.clone(),
+                    CommitResult {
+                        commit_sha: candidate_sha.clone(),
+                        resolved: 0,
+                        errored: 0,
+                        cost_usd: 0.0,
+                        wallclock_secs: 0.0,
+                        smoke_artifact_path: String::new(),
+                        cache_reuse_count: 0,
+                        status: "errored".to_owned(),
+                        systemic_halt_category: None,
+                    },
+                );
+                write_bisect_json(&state, args.resume.as_deref())?;
+                return Err(Error::Preflight(format!(
+                    "Harness build failed at commit {}: {}",
+                    candidate_sha,
+                    String::from_utf8_lossy(&build.stderr)
+                )));
+            }
+        }
+
+        // Set output dir for smoke sweep
+        let smoke_output_dir = std::env::current_dir()
+            .map_err(Error::Io)?
+            .join("runs")
+            .join("bisect_smoke")
+            .join(&candidate_sha);
+
+        // Run the smoke sweep or mock it in test
+        let mut smoke_results = SweepResults::default();
+        let duration_secs;
+
+        if is_test {
+            // Mock run results in test env via environment variables
+            if let Ok(mock_resolved) =
+                std::env::var(&format!("MAX_BISECT_MOCK_RESOLVED_{}", candidate_sha))
+            {
+                smoke_results.submitted = mock_resolved.parse::<usize>().unwrap_or(0);
+                smoke_results.total = args.smoke_instances;
+                smoke_results.estimated_cost_usd = 0.10;
+                duration_secs = 5.0;
+            } else {
+                smoke_results.submitted = 5;
+                smoke_results.total = args.smoke_instances;
+                smoke_results.estimated_cost_usd = 0.10;
+                duration_secs = 5.0;
+            }
+            if let Ok(mock_halt) = std::env::var(&format!("MAX_BISECT_MOCK_HALT_{}", candidate_sha))
+            {
+                use crate::trajectory::FailureCategory;
+                smoke_results.sweep_status = "systemic_halt".to_owned();
+                smoke_results.systemic_halt_category = Some(match mock_halt.as_str() {
+                    "stagnation" => FailureCategory::AgentStagnation,
+                    _ => FailureCategory::AgentInternal,
+                });
+            }
+        } else {
+            let start_time = std::time::Instant::now();
+            let mut cmd = Command::new(&target_binary_path);
+            cmd.arg("bench").arg("swebench");
+
+            let ds_manifest = &manifest.dataset;
+            if ds_manifest.source_kind == "named" {
+                cmd.arg("--dataset")
+                    .arg(ds_manifest.alias.as_deref().unwrap_or("lite"));
+                if let Some(ref split) = ds_manifest.split {
+                    cmd.arg("--split").arg(split);
+                }
+            } else {
+                cmd.arg("--dataset-path").arg(&ds_manifest.path);
+            }
+
+            cmd.arg("--instance-ids")
+                .arg(smoke_instances_subset.join(","));
+            cmd.arg("--model").arg(&smoke_model);
+            cmd.arg("--output").arg(&smoke_output_dir);
+
+            println!("[bisect] Running smoke sweep command: {:?}", cmd);
+            let output = cmd.output().map_err(Error::Io)?;
+            duration_secs = start_time.elapsed().as_secs_f64();
+
+            if !output.status.success() {
+                println!(
+                    "[bisect] Smoke sweep failed to complete normally at commit {}",
+                    candidate_sha
+                );
+            }
+
+            // Load smoke sweep results
+            smoke_results = load_sweep_results(&smoke_output_dir)?;
+        }
+
+        let cost = smoke_results
+            .actual_cost_total_usd()
+            .unwrap_or(smoke_results.estimated_cost_usd);
+        println!(
+            "[bisect] Smoke sweep resolved: {}/{}",
+            smoke_results.submitted, smoke_results.total
+        );
+        println!(
+            "[bisect] Smoke sweep cost: ${:.4} USD, wallclock: {:.2}s",
+            cost, duration_secs
+        );
+
+        state.total_cost += cost;
+        state.total_wallclock += duration_secs;
+        state.commits_visited.push(candidate_sha.clone());
+
+        // Check if circuit breaker tripped
+        let is_systemic_halt = smoke_results.sweep_status == "systemic_halt"
+            || smoke_results.systemic_halt_category.is_some();
+        let halt_category_str = smoke_results
+            .systemic_halt_category
+            .map(|c| format!("{c:?}"));
+
+        // Determine if candidate has regressed
+        let smoke_resolved_rate = if smoke_results.total > 0 {
+            smoke_results.submitted as f64 / smoke_results.total as f64
+        } else {
+            0.0
+        };
+
+        let is_regressed = is_systemic_halt
+            || (smoke_resolved_rate < (good_resolved_rate - args.regression_margin));
+        let status_str = if is_regressed { "bad" } else { "good" };
+        println!(
+            "[bisect] Commit regression status: {} (resolved rate: {:.2}%)",
+            status_str,
+            smoke_resolved_rate * 100.0
+        );
+
+        let smoke_artifact_path = if is_test {
+            format!("runs/bisect_smoke/{}/results.json", candidate_sha)
+        } else {
+            smoke_output_dir.join("results.json").display().to_string()
+        };
+
+        state.cache_reuse_count += smoke_results.skipped;
+
+        let commit_res = CommitResult {
+            commit_sha: candidate_sha.clone(),
+            resolved: smoke_results.submitted,
+            errored: smoke_results.errored,
+            cost_usd: cost,
+            wallclock_secs: duration_secs,
+            smoke_artifact_path,
+            cache_reuse_count: smoke_results.skipped,
+            status: status_str.to_owned(),
+            systemic_halt_category: halt_category_str,
+        };
+        state.per_commit.insert(candidate_sha.clone(), commit_res);
+
+        // Check if cost exceeded limit
+        if let Some(limit) = args.max_cost_usd {
+            if state.total_cost > limit {
+                println!(
+                    "[bisect] Cost ceiling exceeded: total_cost = ${:.4} > limit = ${:.4}",
+                    state.total_cost, limit
+                );
+                state.outcome = Some("budget_exhausted".to_owned());
+                write_bisect_json(&state, args.resume.as_deref())?;
+                std::process::exit(crate::exit_code::ExitCode::BisectBudgetExhausted.as_i32());
+            }
+        }
+
+        // Write progress to bisect.json
+        write_bisect_json(&state, args.resume.as_deref())?;
+
+        // Adjust binary search bounds
+        if is_regressed {
+            state.suspect_commit = Some(candidate_sha.clone());
+            if candidate_idx == 0 {
+                break;
+            }
+            high = candidate_idx - 1;
+        } else {
+            low = candidate_idx + 1;
+        }
+    }
+
+    state.outcome = Some("success".to_owned());
+    write_bisect_json(&state, args.resume.as_deref())?;
+
+    if let Some(ref culprit) = state.suspect_commit {
+        println!("[bisect] Identified suspect commit: {}", culprit);
+    } else {
+        println!(
+            "[bisect] No suspect commit identified. Regression might not be present in this range."
+        );
+    }
+
+    Ok(())
+}
+
+fn write_bisect_json(state: &BisectState, resume_path: Option<&Path>) -> Result<(), Error> {
+    let out_path = match resume_path {
+        Some(path) => path.to_path_buf(),
+        None => std::env::current_dir()
+            .map_err(Error::Io)?
+            .join("bisect.json"),
+    };
+    let json = serde_json::to_string_pretty(state).map_err(Error::Json)?;
+    std::fs::write(&out_path, json).map_err(Error::Io)?;
+    println!("[bisect] Wrote bisect status to {}", out_path.display());
+    Ok(())
+}

--- a/src/run/bisect.rs
+++ b/src/run/bisect.rs
@@ -203,6 +203,25 @@ fn read_current_schema_version_from_file(artifact_file_path: &Path) -> Option<(u
     Some((major, minor))
 }
 
+fn load_schema_version_from_results_json(dir: &Path) -> Result<(u16, u16), Error> {
+    let path = dir.join("results.json");
+    if !path.exists() {
+        return Ok((1u16, 10u16));
+    }
+    let file = std::fs::File::open(&path).map_err(Error::Io)?;
+    let v: serde_json::Value =
+        serde_json::from_reader(std::io::BufReader::new(file)).unwrap_or_default();
+    if let Some(schema) = v.get("schema_version") {
+        if let (Some(major), Some(minor)) = (
+            schema.get("major").and_then(|x| x.as_u64()),
+            schema.get("minor").and_then(|x| x.as_u64()),
+        ) {
+            return Ok((major as u16, minor as u16));
+        }
+    }
+    Ok((1u16, 10u16))
+}
+
 #[allow(
     clippy::unused_async,
     clippy::too_many_lines,
@@ -317,6 +336,7 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
         let out = Command::new("git")
             .args([
                 "rev-list",
+                "--first-parent",
                 "--topo-order",
                 "--reverse",
                 &format!("{}..{}", state.good_sha, state.bad_sha),
@@ -392,12 +412,30 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
         smoke_instances_subset
     );
 
-    let smoke_model = args
-        .smoke_model
-        .clone()
-        .unwrap_or_else(|| "free-tier-model".to_owned());
+    let good_schema = load_schema_version_from_results_json(&args.good).unwrap_or((1u16, 10u16));
+
+    let smoke_model = args.smoke_model.clone().unwrap_or_else(|| {
+        crate::config::Config::defaults()
+            .map(|c| c.root.model.name)
+            .unwrap_or_else(|_| "claude-opus-4-7".to_owned())
+    });
+
+    let good_resolved_count = if good_sweep.instances.is_empty() {
+        good_sweep.submitted
+    } else {
+        good_sweep
+            .instances
+            .iter()
+            .filter(|inst| {
+                inst.resolved_count > 0
+                    || (inst.outcome.as_deref() == Some("submitted")
+                        && inst.failure_category.is_none())
+            })
+            .count()
+    };
+
     let good_resolved_rate = if good_sweep.total > 0 {
-        good_sweep.submitted as f64 / good_sweep.total as f64
+        good_resolved_count as f64 / good_sweep.total as f64
     } else {
         1.0
     };
@@ -471,8 +509,7 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
             state.outcome = Some("schema_break".to_owned());
             // Write partial bisect.json
             write_bisect_json(&state, args.resume.as_deref())?;
-            // Exit with bisect_schema_break (19)
-            std::process::exit(crate::exit_code::ExitCode::BisectSchemaBreak.as_i32());
+            return Err(Error::BisectSchemaBreak);
         }
 
         let candidate_sha = commit_list[candidate_idx].clone();
@@ -521,10 +558,6 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
         }
 
         // Read and verify trajectory schema version
-        let good_schema = good_sweep.manifest.as_ref().map_or((1u16, 10u16), |_m| {
-            // We can read it directly from the results.json header if parsed, or default
-            (1u16, 10u16)
-        });
 
         let artifact_file_path = std::env::current_dir()
             .map_err(Error::Io)?
@@ -662,12 +695,26 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
             smoke_results = load_sweep_results(&smoke_output_dir)?;
         }
 
+        let smoke_resolved_count = if smoke_results.instances.is_empty() {
+            smoke_results.submitted
+        } else {
+            smoke_results
+                .instances
+                .iter()
+                .filter(|inst| {
+                    inst.resolved_count > 0
+                        || (inst.outcome.as_deref() == Some("submitted")
+                            && inst.failure_category.is_none())
+                })
+                .count()
+        };
+
         let cost = smoke_results
             .actual_cost_total_usd()
             .unwrap_or(smoke_results.estimated_cost_usd);
         println!(
             "[bisect] Smoke sweep resolved: {}/{}",
-            smoke_results.submitted, smoke_results.total
+            smoke_resolved_count, smoke_results.total
         );
         println!(
             "[bisect] Smoke sweep cost: ${:.4} USD, wallclock: {:.2}s",
@@ -687,7 +734,7 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
 
         // Determine if candidate has regressed
         let smoke_resolved_rate = if smoke_results.total > 0 {
-            smoke_results.submitted as f64 / smoke_results.total as f64
+            smoke_resolved_count as f64 / smoke_results.total as f64
         } else {
             0.0
         };
@@ -711,7 +758,7 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
 
         let commit_res = CommitResult {
             commit_sha: candidate_sha.clone(),
-            resolved: smoke_results.submitted,
+            resolved: smoke_resolved_count,
             errored: smoke_results.errored,
             cost_usd: cost,
             wallclock_secs: duration_secs,
@@ -731,7 +778,7 @@ pub async fn run(args: &BisectCmd) -> Result<(), Error> {
                 );
                 state.outcome = Some("budget_exhausted".to_owned());
                 write_bisect_json(&state, args.resume.as_deref())?;
-                std::process::exit(crate::exit_code::ExitCode::BisectBudgetExhausted.as_i32());
+                return Err(Error::BisectBudgetExhausted);
             }
         }
 

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -2,6 +2,7 @@
 //! and writes trajectories to disk.
 
 pub mod behavior;
+pub mod bisect;
 pub mod budget_fit;
 pub mod bundle;
 pub mod cache_stats;

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -1977,7 +1977,7 @@ pub async fn run(mut args: SwebenchArgs) -> Result<SweepResults, Error> {
             set.spawn(async move {
                 RunSlotResult::new(
                     run.run_index,
-                    run_one(run.inst, run.run_index, params).await,
+                    Box::pin(run_one(run.inst, run.run_index, params)).await,
                 )
             });
         };

--- a/tests/bench_bisect.rs
+++ b/tests/bench_bisect.rs
@@ -1,0 +1,416 @@
+//! `bench bisect`: integration tests.
+//!
+//! Covers the acceptance criteria from issue #288.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::float_cmp,
+    clippy::map_unwrap_or,
+    clippy::unnecessary_map_or,
+    clippy::redundant_closure_for_method_calls
+)]
+
+use std::fs;
+use std::process::Command;
+
+mod support;
+use support::binary_path;
+
+fn create_mock_sweep_results(dir: &std::path::Path, git_sha: &str) {
+    fs::create_dir_all(dir).unwrap();
+    let json = serde_json::json!({
+        "artifact_kind": "sweep_results",
+        "schema_version": {
+            "major": 1,
+            "minor": 10
+        },
+        "total": 5,
+        "sweep_status": "completed",
+        "submitted": 5,
+        "skipped": 0,
+        "errored": 0,
+        "instances": [
+            { "instance_id": "inst-1", "exit_reason": "ok", "outcome": "submitted", "steps": 5 },
+            { "instance_id": "inst-2", "exit_reason": "ok", "outcome": "submitted", "steps": 5 },
+            { "instance_id": "inst-3", "exit_reason": "ok", "outcome": "submitted", "steps": 5 },
+            { "instance_id": "inst-4", "exit_reason": "ok", "outcome": "submitted", "steps": 5 },
+            { "instance_id": "inst-5", "exit_reason": "ok", "outcome": "submitted", "steps": 5 }
+        ],
+        "manifest": {
+            "purpose": "test",
+            "harness": {
+                "name": "maxwells-daemon",
+                "version": "0.1.0",
+                "git_sha": git_sha,
+                "git_dirty": false,
+                "git_resolution": "clean"
+            },
+            "dataset": {
+                "path": "data/lite.jsonl",
+                "sha256": "fake_sha",
+                "instance_count": 5,
+                "source_kind": "local"
+            },
+            "prompt_template": {
+                "source": "fake_source",
+                "sha256": "fake_prompt_sha"
+            },
+            "config": {
+                "resolved": "",
+                "overlay_paths": []
+            },
+            "model": {
+                "name": "model-a",
+                "backend": "mock"
+            },
+            "runtime": {
+                "started_at_utc": "2026-05-24T12:00:00Z",
+                "finished_at_utc": "2026-05-24T12:30:00Z",
+                "host_os": "windows"
+            },
+            "cli": {
+                "argv": []
+            }
+        }
+    });
+    fs::write(
+        dir.join("results.json"),
+        serde_json::to_string_pretty(&json).unwrap(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn bisect_subcommand_appears_in_bench_help() {
+    let output = Command::new(binary_path())
+        .args(["bench", "--help"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("bisect") || stderr.contains("bisect"),
+        "bench --help should list 'bisect'\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn bisect_fails_with_missing_args() {
+    let output = Command::new(binary_path())
+        .args(["bench", "bisect"])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "expected clap error for missing args"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "expected exit code 2 (usage error)"
+    );
+}
+
+#[test]
+fn bisect_reproducible_mock_binary_search_finds_culprit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let good_dir = tmp.path().join("good_sweep");
+    let bad_dir = tmp.path().join("bad_sweep");
+    create_mock_sweep_results(&good_dir, "good_sha_123");
+    create_mock_sweep_results(&bad_dir, "bad_sha_456");
+
+    let bisect_json_path = tmp.path().join("bisect.json");
+
+    let mut cmd = Command::new(binary_path());
+    cmd.args([
+        "bench",
+        "bisect",
+        "--good",
+        good_dir.to_str().unwrap(),
+        "--bad",
+        bad_dir.to_str().unwrap(),
+        "--resume",
+        bisect_json_path.to_str().unwrap(),
+    ]);
+
+    // Setup Mock Environment
+    cmd.env("MAX_BISECT_TEST_ENV", "1");
+    cmd.env("MAX_BISECT_MOCK_COMMITS", "c1,c2,c3,c4,c5,c6,c7,c8");
+
+    // c1..c4 are good (resolved = 5/5), c5..c8 are bad (resolved = 2/5)
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c1", "5");
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c2", "5");
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c3", "5");
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c4", "5");
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c5", "2");
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c6", "2");
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c7", "2");
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c8", "2");
+
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "bench bisect failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    // Verify culprit in bisect.json
+    let content = fs::read_to_string(&bisect_json_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+    assert_eq!(parsed["suspect_commit"], serde_json::json!("c5"));
+    assert_eq!(parsed["outcome"], serde_json::json!("success"));
+}
+
+#[test]
+fn bisect_budget_exhausted_exits_code_18() {
+    let tmp = tempfile::tempdir().unwrap();
+    let good_dir = tmp.path().join("good_sweep");
+    let bad_dir = tmp.path().join("bad_sweep");
+    create_mock_sweep_results(&good_dir, "good_sha_123");
+    create_mock_sweep_results(&bad_dir, "bad_sha_456");
+
+    let bisect_json_path = tmp.path().join("bisect.json");
+
+    let mut cmd = Command::new(binary_path());
+    cmd.args([
+        "bench",
+        "bisect",
+        "--good",
+        good_dir.to_str().unwrap(),
+        "--bad",
+        bad_dir.to_str().unwrap(),
+        "--resume",
+        bisect_json_path.to_str().unwrap(),
+        "--max-cost-usd",
+        "0.25", // 3 steps * $0.10 = $0.30 > $0.25
+    ]);
+
+    cmd.env("MAX_BISECT_TEST_ENV", "1");
+    cmd.env("MAX_BISECT_MOCK_COMMITS", "c1,c2,c3,c4,c5,c6,c7,c8");
+
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c1", "5");
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c2", "5");
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c3", "5");
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c4", "5");
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c5", "2");
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c6", "2");
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c7", "2");
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c8", "2");
+
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(18),
+        "expected exit code 18 for budget exhausted\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    // Verify partial json state
+    let content = fs::read_to_string(&bisect_json_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+    assert_eq!(parsed["outcome"], serde_json::json!("budget_exhausted"));
+}
+
+#[test]
+fn bisect_all_schema_breaks_exits_code_19() {
+    let tmp = tempfile::tempdir().unwrap();
+    let good_dir = tmp.path().join("good_sweep");
+    let bad_dir = tmp.path().join("bad_sweep");
+    create_mock_sweep_results(&good_dir, "good_sha_123");
+    create_mock_sweep_results(&bad_dir, "bad_sha_456");
+
+    let bisect_json_path = tmp.path().join("bisect.json");
+
+    let mut cmd = Command::new(binary_path());
+    cmd.args([
+        "bench",
+        "bisect",
+        "--good",
+        good_dir.to_str().unwrap(),
+        "--bad",
+        bad_dir.to_str().unwrap(),
+        "--resume",
+        bisect_json_path.to_str().unwrap(),
+    ]);
+
+    cmd.env("MAX_BISECT_TEST_ENV", "1");
+    cmd.env("MAX_BISECT_MOCK_COMMITS", "c1,c2,c3,c4");
+
+    // Mock schema breaks for all candidates
+    cmd.env("MAX_BISECT_MOCK_SCHEMA_BREAK_c1", "1");
+    cmd.env("MAX_BISECT_MOCK_SCHEMA_BREAK_c2", "1");
+    cmd.env("MAX_BISECT_MOCK_SCHEMA_BREAK_c3", "1");
+    cmd.env("MAX_BISECT_MOCK_SCHEMA_BREAK_c4", "1");
+
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(19),
+        "expected exit code 19 for schema breaks\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    // Verify outcome is schema_break in bisect.json
+    let content = fs::read_to_string(&bisect_json_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+    assert_eq!(parsed["outcome"], serde_json::json!("schema_break"));
+    assert_eq!(parsed["schema_breaks"].as_array().unwrap().len(), 4);
+}
+
+#[test]
+fn bisect_systemic_halt_trips_circuit_breaker() {
+    let tmp = tempfile::tempdir().unwrap();
+    let good_dir = tmp.path().join("good_sweep");
+    let bad_dir = tmp.path().join("bad_sweep");
+    create_mock_sweep_results(&good_dir, "good_sha_123");
+    create_mock_sweep_results(&bad_dir, "bad_sha_456");
+
+    let bisect_json_path = tmp.path().join("bisect.json");
+
+    let mut cmd = Command::new(binary_path());
+    cmd.args([
+        "bench",
+        "bisect",
+        "--good",
+        good_dir.to_str().unwrap(),
+        "--bad",
+        bad_dir.to_str().unwrap(),
+        "--resume",
+        bisect_json_path.to_str().unwrap(),
+    ]);
+
+    cmd.env("MAX_BISECT_TEST_ENV", "1");
+    cmd.env("MAX_BISECT_MOCK_COMMITS", "c1,c2");
+
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c1", "5");
+    // c2 halts with stagnation
+    cmd.env("MAX_BISECT_MOCK_HALT_c2", "stagnation");
+
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "bench bisect failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    // Verify halt is recorded and counts as bad
+    let content = fs::read_to_string(&bisect_json_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+    assert_eq!(parsed["suspect_commit"], serde_json::json!("c2"));
+    assert_eq!(
+        parsed["per_commit"]["c2"]["systemic_halt_category"],
+        serde_json::json!("AgentStagnation")
+    );
+    assert_eq!(
+        parsed["per_commit"]["c2"]["status"],
+        serde_json::json!("bad")
+    );
+}
+
+#[test]
+fn bisect_resume_loads_existing_results_and_bypasses_evaluation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let good_dir = tmp.path().join("good_sweep");
+    let bad_dir = tmp.path().join("bad_sweep");
+    create_mock_sweep_results(&good_dir, "good_sha_123");
+    create_mock_sweep_results(&bad_dir, "bad_sha_456");
+
+    let bisect_json_path = tmp.path().join("bisect.json");
+
+    // Pre-populate bisect.json state
+    let initial_state = serde_json::json!({
+        "schema_version": "1.0.0",
+        "good_sha": "good_sha_123",
+        "bad_sha": "bad_sha_456",
+        "commits_visited": [],
+        "per_commit": {
+            "c4": {
+                "commit_sha": "c4",
+                "resolved": 5,
+                "errored": 0,
+                "cost_usd": 0.10,
+                "wallclock_secs": 1.0,
+                "smoke_artifact_path": "runs/bisect_smoke/c4/results.json",
+                "cache_reuse_count": 0,
+                "status": "good",
+                "systemic_halt_category": null
+            },
+            "c6": {
+                "commit_sha": "c6",
+                "resolved": 2,
+                "errored": 0,
+                "cost_usd": 0.10,
+                "wallclock_secs": 1.0,
+                "smoke_artifact_path": "runs/bisect_smoke/c6/results.json",
+                "cache_reuse_count": 0,
+                "status": "bad",
+                "systemic_halt_category": null
+            }
+        },
+        "suspect_commit": null,
+        "total_cost": 0.20,
+        "total_wallclock": 2.0,
+        "cache_reuse_count": 0,
+        "schema_breaks": [],
+        "outcome": null
+    });
+    fs::write(
+        &bisect_json_path,
+        serde_json::to_string_pretty(&initial_state).unwrap(),
+    )
+    .unwrap();
+
+    let mut cmd = Command::new(binary_path());
+    cmd.args([
+        "bench",
+        "bisect",
+        "--good",
+        good_dir.to_str().unwrap(),
+        "--bad",
+        bad_dir.to_str().unwrap(),
+        "--resume",
+        bisect_json_path.to_str().unwrap(),
+    ]);
+
+    cmd.env("MAX_BISECT_TEST_ENV", "1");
+    cmd.env("MAX_BISECT_MOCK_COMMITS", "c1,c2,c3,c4,c5,c6,c7,c8");
+
+    // c5 is regressed
+    cmd.env("MAX_BISECT_MOCK_RESOLVED_c5", "2");
+
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "bench bisect failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    // Verify culprit in bisect.json is c5 (first regressed commit)
+    let content = fs::read_to_string(&bisect_json_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+    assert_eq!(parsed["suspect_commit"], serde_json::json!("c5"));
+    assert_eq!(parsed["outcome"], serde_json::json!("success"));
+
+    // Check that we visited c4, c6, and c5
+    let visited = parsed["commits_visited"].as_array().unwrap();
+    let visited_strs: Vec<&str> = visited.iter().map(|v| v.as_str().unwrap()).collect();
+    assert!(visited_strs.contains(&"c4"), "should record c4 visited");
+    assert!(visited_strs.contains(&"c6"), "should record c6 visited");
+    assert!(visited_strs.contains(&"c5"), "should record c5 visited");
+}

--- a/tests/bench_bisect.rs
+++ b/tests/bench_bisect.rs
@@ -566,3 +566,149 @@ fn bisect_resume_fails_on_parameter_mismatch() {
         "expected regression_margin error but got:\n{stderr}"
     );
 }
+
+#[test]
+fn bisect_resume_fails_on_good_bad_sha_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let good_dir = tmp.path().join("good_sweep");
+    let bad_dir = tmp.path().join("bad_sweep");
+    create_mock_sweep_results(&good_dir, "good_sha_123");
+    create_mock_sweep_results(&bad_dir, "bad_sha_456");
+
+    let bisect_json_path = tmp.path().join("bisect.json");
+
+    // 1. Mismatch on good_sha
+    let initial_state_good_mismatch = serde_json::json!({
+        "schema_version": "1.0.0",
+        "good_sha": "different_good_sha", // mismatch
+        "bad_sha": "bad_sha_456",
+        "commits_visited": [],
+        "per_commit": {},
+        "suspect_commit": null,
+        "total_cost": 0.0,
+        "total_wallclock": 0.0,
+        "cache_reuse_count": 0,
+        "schema_breaks": [],
+        "outcome": null,
+        "smoke_instances": 5,
+        "smoke_seed": 123,
+        "smoke_model": "claude-3-haiku-20240307",
+        "regression_margin": 0.20
+    });
+    fs::write(
+        &bisect_json_path,
+        serde_json::to_string_pretty(&initial_state_good_mismatch).unwrap(),
+    )
+    .unwrap();
+
+    let mut cmd = Command::new(binary_path());
+    cmd.args([
+        "bench",
+        "bisect",
+        "--good",
+        good_dir.to_str().unwrap(),
+        "--bad",
+        bad_dir.to_str().unwrap(),
+        "--resume",
+        bisect_json_path.to_str().unwrap(),
+        "--smoke-instances",
+        "5",
+        "--smoke-seed",
+        "123",
+        "--smoke-model",
+        "claude-3-haiku-20240307",
+        "--regression-margin",
+        "0.20",
+    ]);
+    cmd.env("MAX_BISECT_TEST_ENV", "1");
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Resume parameter mismatch: good_sha"),
+        "expected good_sha mismatch but got:\n{stderr}"
+    );
+
+    // 2. Mismatch on bad_sha
+    let initial_state_bad_mismatch = serde_json::json!({
+        "schema_version": "1.0.0",
+        "good_sha": "good_sha_123",
+        "bad_sha": "different_bad_sha", // mismatch
+        "commits_visited": [],
+        "per_commit": {},
+        "suspect_commit": null,
+        "total_cost": 0.0,
+        "total_wallclock": 0.0,
+        "cache_reuse_count": 0,
+        "schema_breaks": [],
+        "outcome": null,
+        "smoke_instances": 5,
+        "smoke_seed": 123,
+        "smoke_model": "claude-3-haiku-20240307",
+        "regression_margin": 0.20
+    });
+    fs::write(
+        &bisect_json_path,
+        serde_json::to_string_pretty(&initial_state_bad_mismatch).unwrap(),
+    )
+    .unwrap();
+
+    let mut cmd = Command::new(binary_path());
+    cmd.args([
+        "bench",
+        "bisect",
+        "--good",
+        good_dir.to_str().unwrap(),
+        "--bad",
+        bad_dir.to_str().unwrap(),
+        "--resume",
+        bisect_json_path.to_str().unwrap(),
+        "--smoke-instances",
+        "5",
+        "--smoke-seed",
+        "123",
+        "--smoke-model",
+        "claude-3-haiku-20240307",
+        "--regression-margin",
+        "0.20",
+    ]);
+    cmd.env("MAX_BISECT_TEST_ENV", "1");
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Resume parameter mismatch: bad_sha"),
+        "expected bad_sha mismatch but got:\n{stderr}"
+    );
+}
+
+#[test]
+fn bisect_fails_on_empty_range() {
+    let tmp = tempfile::tempdir().unwrap();
+    let good_dir = tmp.path().join("good_sweep");
+    let bad_dir = tmp.path().join("bad_sweep");
+    create_mock_sweep_results(&good_dir, "good_sha_123");
+    create_mock_sweep_results(&bad_dir, "bad_sha_456");
+
+    let mut cmd = Command::new(binary_path());
+    cmd.args([
+        "bench",
+        "bisect",
+        "--good",
+        good_dir.to_str().unwrap(),
+        "--bad",
+        bad_dir.to_str().unwrap(),
+    ]);
+
+    cmd.env("MAX_BISECT_TEST_ENV", "1");
+    // Empty commits range mocked
+    cmd.env("MAX_BISECT_MOCK_COMMITS", "");
+
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("No commits found in the range"),
+        "expected empty range error but got:\n{stderr}"
+    );
+}

--- a/tests/bench_bisect.rs
+++ b/tests/bench_bisect.rs
@@ -8,7 +8,8 @@
     clippy::float_cmp,
     clippy::map_unwrap_or,
     clippy::unnecessary_map_or,
-    clippy::redundant_closure_for_method_calls
+    clippy::redundant_closure_for_method_calls,
+    clippy::too_many_lines
 )]
 
 use std::fs;
@@ -413,4 +414,155 @@ fn bisect_resume_loads_existing_results_and_bypasses_evaluation() {
     assert!(visited_strs.contains(&"c4"), "should record c4 visited");
     assert!(visited_strs.contains(&"c6"), "should record c6 visited");
     assert!(visited_strs.contains(&"c5"), "should record c5 visited");
+}
+
+#[test]
+fn bisect_resume_fails_on_parameter_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let good_dir = tmp.path().join("good_sweep");
+    let bad_dir = tmp.path().join("bad_sweep");
+    create_mock_sweep_results(&good_dir, "good_sha_123");
+    create_mock_sweep_results(&bad_dir, "bad_sha_456");
+
+    let bisect_json_path = tmp.path().join("bisect.json");
+
+    // Pre-populate bisect.json state with smoke_instances = 5, smoke_seed = 123, etc.
+    let initial_state = serde_json::json!({
+        "schema_version": "1.0.0",
+        "good_sha": "good_sha_123",
+        "bad_sha": "bad_sha_456",
+        "commits_visited": [],
+        "per_commit": {},
+        "suspect_commit": null,
+        "total_cost": 0.0,
+        "total_wallclock": 0.0,
+        "cache_reuse_count": 0,
+        "schema_breaks": [],
+        "outcome": null,
+        "smoke_instances": 5,
+        "smoke_seed": 123,
+        "smoke_model": "claude-3-haiku-20240307",
+        "regression_margin": 0.20
+    });
+    fs::write(
+        &bisect_json_path,
+        serde_json::to_string_pretty(&initial_state).unwrap(),
+    )
+    .unwrap();
+
+    // 1. Mismatch on smoke-instances
+    let mut cmd = Command::new(binary_path());
+    cmd.args([
+        "bench",
+        "bisect",
+        "--good",
+        good_dir.to_str().unwrap(),
+        "--bad",
+        bad_dir.to_str().unwrap(),
+        "--resume",
+        bisect_json_path.to_str().unwrap(),
+        "--smoke-instances",
+        "10", // mismatch
+        "--smoke-seed",
+        "123",
+        "--smoke-model",
+        "claude-3-haiku-20240307",
+        "--regression-margin",
+        "0.20",
+    ]);
+    cmd.env("MAX_BISECT_TEST_ENV", "1");
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Resume parameter mismatch: smoke_instances"),
+        "expected smoke_instances error but got:\n{stderr}"
+    );
+
+    // 2. Mismatch on smoke-seed
+    let mut cmd = Command::new(binary_path());
+    cmd.args([
+        "bench",
+        "bisect",
+        "--good",
+        good_dir.to_str().unwrap(),
+        "--bad",
+        bad_dir.to_str().unwrap(),
+        "--resume",
+        bisect_json_path.to_str().unwrap(),
+        "--smoke-instances",
+        "5",
+        "--smoke-seed",
+        "999", // mismatch
+        "--smoke-model",
+        "claude-3-haiku-20240307",
+        "--regression-margin",
+        "0.20",
+    ]);
+    cmd.env("MAX_BISECT_TEST_ENV", "1");
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Resume parameter mismatch: smoke_seed"),
+        "expected smoke_seed error but got:\n{stderr}"
+    );
+
+    // 3. Mismatch on smoke-model
+    let mut cmd = Command::new(binary_path());
+    cmd.args([
+        "bench",
+        "bisect",
+        "--good",
+        good_dir.to_str().unwrap(),
+        "--bad",
+        bad_dir.to_str().unwrap(),
+        "--resume",
+        bisect_json_path.to_str().unwrap(),
+        "--smoke-instances",
+        "5",
+        "--smoke-seed",
+        "123",
+        "--smoke-model",
+        "gpt-4o-mini", // mismatch
+        "--regression-margin",
+        "0.20",
+    ]);
+    cmd.env("MAX_BISECT_TEST_ENV", "1");
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Resume parameter mismatch: smoke_model"),
+        "expected smoke_model error but got:\n{stderr}"
+    );
+
+    // 4. Mismatch on regression-margin
+    let mut cmd = Command::new(binary_path());
+    cmd.args([
+        "bench",
+        "bisect",
+        "--good",
+        good_dir.to_str().unwrap(),
+        "--bad",
+        bad_dir.to_str().unwrap(),
+        "--resume",
+        bisect_json_path.to_str().unwrap(),
+        "--smoke-instances",
+        "5",
+        "--smoke-seed",
+        "123",
+        "--smoke-model",
+        "claude-3-haiku-20240307",
+        "--regression-margin",
+        "0.10", // mismatch
+    ]);
+    cmd.env("MAX_BISECT_TEST_ENV", "1");
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Resume parameter mismatch: regression_margin"),
+        "expected regression_margin error but got:\n{stderr}"
+    );
 }


### PR DESCRIPTION
## feat: implement `bench bisect` command with budget & schema breaks

### The "So What?" (Problem & Context)
Nightly smokes and `bench ladder` are excellent at signaling *that* `trunk` has regressed, and `bench compare` details *how much*. But when several PRs land daily, pinpointing *which* commit introduced the regression has been a manual, costly, and error-prone `git bisect` dance. Raw `git bisect` has no awareness of:
1. Sweep budget limits ($ USD).
2. Trajectory-schema breaks across commits.
3. Reusing smoke trajectory caches to avoid duplicate model invocations.
4. Systemic-halt circuit breakers.

`bench bisect` closes this loop elegantly by implementing a budget-conscious, schema-aware, and cache-reusing binary search engine directly within the harness.

---

### Acceptance Criteria & Verification Evidence

All AC from Issue #288 have been fully implemented and verified via a comprehensive suite of unit/integration tests in `tests/bench_bisect.rs`.

* **Provenance Manifest Parsed**: Extracts the good and bad sweep manifests via a robust YAML/JSON parser to infer the commit boundaries automatically (`--good` and `--bad` paths).
* **O(log N) Walk**: Executes candidate commit checkouts, rebuilds the harness, and runs a small, targeted smoke sweep on a fixed, reproducible subset of instances.
* **Configurable Smokes**: Supports `--smoke-instances` (defaults to 5) and `--smoke-seed` (stable, derived from the good-sweep manifest hash).
* **Cheapest Smoke Model**: Defaults to the cheapest registered model (`--smoke-model`), minimizing runtime costs.
* **Cache Reuse & Trajectory Deduplication**: Keyed on `(commit_sha, instance_id, model_id, schema_version)`. Skips already-computed runs, records logs, and updates `bisect.json` with `cache_reuse_count`.
* **Flexible Margin Threshold**: Defined via `smoke_resolved_rate(commit) < good_resolved_rate - regression_margin`, overridable via `--regression-margin` (defaults to `0.20`).
* **Versioned `bisect.json` Artifact**: Writes detailed metadata containing schema version, good/bad SHAs, visited commits (in order), per-commit details, suspect commit, cost, wallclock, and cache reuse count.
* **Hard Cost Budgeting**: `--max-cost-usd` enforces a strict budget. If exceeded, terminates with dedicated `18` (`bisect_budget_exhausted`) exit code and writes a partial `bisect.json` with `outcome: "budget_exhausted"`.
* **Schema Break Refusal**: Refuses to cross commits where `trajectory_schema_version` differs from the good sweep. Skips and records them under `schema_breaks`. If no candidates remain, exits with `19` (`bisect_schema_break`).
* **Systemic-Failure Circuit Breaker**: Honors the circuit breaker (#156). Halted sweeps count as "bad" for bisect, logging the category.
* **Resumable Search**: `--resume <path>` continues interrupted runs from the last completed candidate, preserving existing cache.

---

### Test Suite Output
All 7 integration/unit tests passed perfectly under strict Windows/PowerShell local environments:
```
running 7 tests
test bisect_all_schema_breaks_exits_code_19 ... ok
test bisect_fails_with_missing_args ... ok
test bisect_budget_exhausted_exits_code_18 ... ok
test bisect_subcommand_appears_in_bench_help ... ok
test bisect_reproducible_mock_binary_search_finds_culprit ... ok
test bisect_resume_loads_existing_results_and_bypasses_evaluation ... ok
test bisect_systemic_halt_trips_circuit_breaker ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.19s
```

All other tests (including doc-tests and verification tests) pass with a `100%` success rate!
