### PR TITLE
🌟 Nova: [finetune-export]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+finetune-export = []
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1665,14 +1665,14 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`, and `finetune`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `finetune` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2491,7 +2491,10 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid" | "finetune") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "finetune"
+    ) {
         return bench_inspect_export(i);
     }
 
@@ -4896,13 +4899,15 @@ mod tests {
         }
     }
 
-
     #[allow(clippy::unwrap_used)]
     #[cfg(not(feature = "finetune-export"))]
     #[test]
     fn test_finetune_export_missing_feature() {
         let t = crate::trajectory::Trajectory::new();
         let err = super::inspect_export_finetune(&t).unwrap_err();
-        assert!(err.to_string().contains("requires the `finetune-export` Cargo feature"));
+        assert!(
+            err.to_string()
+                .contains("requires the `finetune-export` Cargo feature")
+        );
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2491,10 +2491,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(
-        i.format.as_str(),
-        "markdown" | "html" | "csv" | "mermaid" | "finetune"
-    ) {
+    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid" | "finetune") {
         return bench_inspect_export(i);
     }
 
@@ -2622,6 +2619,7 @@ fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, E
     Ok(HtmlExporter::export(traj))
 }
 
+#[allow(clippy::unnecessary_wraps)]
 #[cfg(not(feature = "html-export"))]
 fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     Err(Error::Config(crate::error::ConfigError::Invalid(
@@ -2638,6 +2636,7 @@ fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Er
     Ok(CsvExporter::export(traj))
 }
 
+#[allow(clippy::unnecessary_wraps)]
 #[cfg(not(feature = "csv-export"))]
 fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     Err(Error::Config(crate::error::ConfigError::Invalid(
@@ -2654,6 +2653,7 @@ fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String
     Ok(MermaidExporter::export(traj))
 }
 
+#[allow(clippy::unnecessary_wraps)]
 #[cfg(not(feature = "mermaid-export"))]
 fn inspect_export_mermaid(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     Err(Error::Config(crate::error::ConfigError::Invalid(
@@ -2670,6 +2670,7 @@ fn inspect_export_finetune(traj: &crate::trajectory::Trajectory) -> Result<Strin
     Ok(FinetuneExporter::export(traj))
 }
 
+#[allow(clippy::unnecessary_wraps)]
 #[cfg(not(feature = "finetune-export"))]
 fn inspect_export_finetune(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     Err(Error::Config(crate::error::ConfigError::Invalid(
@@ -4893,5 +4894,15 @@ mod tests {
             }
             assert_eq!(path, PathBuf::from(expected));
         }
+    }
+
+
+    #[allow(clippy::unwrap_used)]
+    #[cfg(not(feature = "finetune-export"))]
+    #[test]
+    fn test_finetune_export_missing_feature() {
+        let t = crate::trajectory::Trajectory::new();
+        let err = super::inspect_export_finetune(&t).unwrap_err();
+        assert!(err.to_string().contains("requires the `finetune-export` Cargo feature"));
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2476,7 +2476,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         }
         if i.output.is_some() {
             return Err(Error::Config(crate::error::ConfigError::Invalid(
-                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid)".into(),
+                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/finetune)".into(),
             )));
         }
         let format = parse_trajectory_diff_format(&i.format)?;
@@ -2491,13 +2491,16 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "finetune"
+    ) {
         return bench_inspect_export(i);
     }
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/finetune), not `{}`",
             i.format
         ))));
     }
@@ -2507,7 +2510,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         "json" => crate::run::inspect::InspectFormat::Json,
         other => {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, or `mermaid`)"
+                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, `mermaid`, or `finetune`)"
             ))));
         }
     };
@@ -2548,7 +2551,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     })?;
     let instance_id = i.instance.as_deref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
-            "inspect: --instance is required for export formats (markdown/html/csv/mermaid)".into(),
+            "inspect: --instance is required for export formats (markdown/html/csv/mermaid/finetune)".into(),
         ))
     })?;
     let traj_path =
@@ -2570,6 +2573,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "finetune" => inspect_export_finetune(&traj)?,
         _ => unreachable!("dispatch guarded by caller"),
     };
 
@@ -2611,6 +2615,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     Ok(())
 }
 
+#[allow(clippy::unnecessary_wraps)]
 #[cfg(feature = "html-export")]
 fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
@@ -2626,6 +2631,7 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
     )))
 }
 
+#[allow(clippy::unnecessary_wraps)]
 #[cfg(feature = "csv-export")]
 fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
@@ -2641,6 +2647,7 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
     )))
 }
 
+#[allow(clippy::unnecessary_wraps)]
 #[cfg(feature = "mermaid-export")]
 fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
@@ -2652,6 +2659,22 @@ fn inspect_export_mermaid(_traj: &crate::trajectory::Trajectory) -> Result<Strin
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "format_unavailable: --format mermaid requires the `mermaid-export` Cargo feature; \
          rebuild with `--features mermaid-export`"
+            .into(),
+    )))
+}
+
+#[allow(clippy::unnecessary_wraps)]
+#[cfg(feature = "finetune-export")]
+fn inspect_export_finetune(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    use crate::trajectory::export::{FinetuneExporter, TrajectoryExporter};
+    Ok(FinetuneExporter::export(traj))
+}
+
+#[cfg(not(feature = "finetune-export"))]
+fn inspect_export_finetune(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "format_unavailable: --format finetune requires the `finetune-export` Cargo feature; \
+         rebuild with `--features finetune-export`"
             .into(),
     )))
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -47,7 +47,6 @@ pub struct MarkdownExporter;
 #[cfg(feature = "csv-export")]
 pub struct CsvExporter;
 
-
 #[cfg(feature = "finetune-export")]
 pub struct FinetuneExporter;
 
@@ -328,7 +327,6 @@ mod tests {
         assert!(csv.contains("assistant,\"Hello \"\"user\"\"\""));
     }
 
-
     #[allow(clippy::unwrap_used)]
     #[cfg(feature = "finetune-export")]
     #[test]
@@ -347,7 +345,10 @@ mod tests {
         let msgs = parsed.get("messages").unwrap().as_array().unwrap();
         assert_eq!(msgs.len(), 3);
         assert_eq!(msgs[0].get("role").unwrap().as_str().unwrap(), "system");
-        assert_eq!(msgs[0].get("content").unwrap().as_str().unwrap(), "System prompt");
+        assert_eq!(
+            msgs[0].get("content").unwrap().as_str().unwrap(),
+            "System prompt"
+        );
     }
 
     #[cfg(feature = "mermaid-export")]

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -341,3 +341,67 @@ mod tests {
         assert!(html.contains("Hello user"));
     }
 }
+
+#[cfg(feature = "finetune-export")]
+pub struct FinetuneExporter;
+
+#[cfg(feature = "finetune-export")]
+impl TrajectoryExporter for FinetuneExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut messages = Vec::new();
+
+        for msg in &trajectory.messages {
+            let role = match msg.role.as_str() {
+                "system" => "system",
+                "assistant" => "assistant",
+                "tool" => "tool",
+                _ => "user",
+            };
+
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            let msg_obj = serde_json::json!({
+                "role": role,
+                "content": content
+            });
+            messages.push(msg_obj);
+        }
+
+        let out = serde_json::json!({
+            "messages": messages
+        });
+
+        serde_json::to_string(&out).unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod finetune_tests {
+    use super::*;
+    use crate::model::Message;
+    use crate::trajectory::outcome;
+
+    #[cfg(feature = "finetune-export")]
+    #[test]
+    fn test_finetune_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::assistant("Hello user"));
+
+        let finetune = FinetuneExporter::export(&t);
+        let parsed: serde_json::Value = serde_json::from_str(&finetune).unwrap();
+
+        let msgs = parsed.get("messages").unwrap().as_array().unwrap();
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0].get("role").unwrap().as_str().unwrap(), "system");
+        assert_eq!(
+            msgs[0].get("content").unwrap().as_str().unwrap(),
+            "System prompt"
+        );
+    }
+}

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -47,6 +47,40 @@ pub struct MarkdownExporter;
 #[cfg(feature = "csv-export")]
 pub struct CsvExporter;
 
+
+#[cfg(feature = "finetune-export")]
+pub struct FinetuneExporter;
+
+#[cfg(feature = "finetune-export")]
+impl TrajectoryExporter for FinetuneExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut messages = Vec::new();
+
+        for msg in &trajectory.messages {
+            let role = match msg.role.as_str() {
+                "system" => "system",
+                "assistant" => "assistant",
+                "tool" => "tool",
+                _ => "user",
+            };
+
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            let msg_obj = serde_json::json!({
+                "role": role,
+                "content": content
+            });
+            messages.push(msg_obj);
+        }
+
+        let out = serde_json::json!({
+            "messages": messages
+        });
+
+        serde_json::to_string(&out).unwrap_or_default()
+    }
+}
+
 #[cfg(feature = "mermaid-export")]
 pub struct MermaidExporter;
 
@@ -294,6 +328,28 @@ mod tests {
         assert!(csv.contains("assistant,\"Hello \"\"user\"\"\""));
     }
 
+
+    #[allow(clippy::unwrap_used)]
+    #[cfg(feature = "finetune-export")]
+    #[test]
+    fn test_finetune_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::assistant("Hello user"));
+
+        let finetune = FinetuneExporter::export(&t);
+        let parsed: serde_json::Value = serde_json::from_str(&finetune).unwrap();
+
+        let msgs = parsed.get("messages").unwrap().as_array().unwrap();
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0].get("role").unwrap().as_str().unwrap(), "system");
+        assert_eq!(msgs[0].get("content").unwrap().as_str().unwrap(), "System prompt");
+    }
+
     #[cfg(feature = "mermaid-export")]
     #[test]
     fn test_mermaid_export_format() {
@@ -339,69 +395,5 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
-    }
-}
-
-#[cfg(feature = "finetune-export")]
-pub struct FinetuneExporter;
-
-#[cfg(feature = "finetune-export")]
-impl TrajectoryExporter for FinetuneExporter {
-    fn export(trajectory: &Trajectory) -> String {
-        let redactor = Redactor::default_enabled();
-        let mut messages = Vec::new();
-
-        for msg in &trajectory.messages {
-            let role = match msg.role.as_str() {
-                "system" => "system",
-                "assistant" => "assistant",
-                "tool" => "tool",
-                _ => "user",
-            };
-
-            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
-            let msg_obj = serde_json::json!({
-                "role": role,
-                "content": content
-            });
-            messages.push(msg_obj);
-        }
-
-        let out = serde_json::json!({
-            "messages": messages
-        });
-
-        serde_json::to_string(&out).unwrap_or_default()
-    }
-}
-
-#[cfg(test)]
-#[allow(clippy::unwrap_used)]
-mod finetune_tests {
-    use super::*;
-    use crate::model::Message;
-    use crate::trajectory::outcome;
-
-    #[cfg(feature = "finetune-export")]
-    #[test]
-    fn test_finetune_export_format() {
-        let mut t = Trajectory::new();
-        t.info.task = Some("Add a feature".to_string());
-        t.info.outcome = Some(outcome::SUBMITTED.to_string());
-
-        t.record_message(&Message::system("System prompt"));
-        t.record_message(&Message::user("Hello agent"));
-        t.record_message(&Message::assistant("Hello user"));
-
-        let finetune = FinetuneExporter::export(&t);
-        let parsed: serde_json::Value = serde_json::from_str(&finetune).unwrap();
-
-        let msgs = parsed.get("messages").unwrap().as_array().unwrap();
-        assert_eq!(msgs.len(), 3);
-        assert_eq!(msgs[0].get("role").unwrap().as_str().unwrap(), "system");
-        assert_eq!(
-            msgs[0].get("content").unwrap().as_str().unwrap(),
-            "System prompt"
-        );
     }
 }


### PR DESCRIPTION
💡 **The Spark:** "I noticed we can export trajectories to various formats like Markdown, HTML, CSV, and Mermaid. What if we want to use these trajectories directly for training language models?"
🚀 **The Feature:** "Implemented `FinetuneExporter` which formats the trajectory messages into OpenAI's fine-tuning JSONL format (array of messages with role and content)."
🔮 **The Potential:** "Users can easily dump successful or specific trajectories from their sweeps and use them immediately to fine-tune open-source models or OpenAI models."
⚠️ **Risk:** "Low. Isolated in `src/trajectory/export.rs` and cleanly gated behind the `finetune-export` feature flag."

---
*PR created automatically by Jules for task [15978833127824106674](https://jules.google.com/task/15978833127824106674) started by @madmax983*