### PR TITLE
🎨 Mosaic: UI Polish for CLI Previews

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2612,6 +2612,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
 }
 
 #[cfg(feature = "html-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
     Ok(HtmlExporter::export(traj))
@@ -2627,6 +2628,7 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
 }
 
 #[cfg(feature = "csv-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
     Ok(CsvExporter::export(traj))
@@ -2642,6 +2644,7 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
 }
 
 #[cfg(feature = "mermaid-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
     Ok(MermaidExporter::export(traj))

--- a/src/run/render_only.rs
+++ b/src/run/render_only.rs
@@ -268,54 +268,92 @@ pub fn reject_incompatible_flags(flags: &IncompatibleFlags<'_>) -> Result<(), Er
 
 /// Render the report in human-readable text form.
 pub fn format_text(report: &RenderOnlyReport) -> String {
-    let mut sections = vec![
-        "=== render-only preview (no model call made) ===".to_owned(),
-        format!("Model: {}", report.model),
-        format!("Mode: {}", report.mode),
-    ];
+    use comfy_table::Table;
+    use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+    use comfy_table::presets::UTF8_FULL;
+    use std::fmt::Write as _;
 
+    let mut out = String::new();
+    out.push_str("\n=== render-only preview (no model call made) ===\n\n");
+
+    let mut meta_table = Table::new();
+    meta_table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS);
+    meta_table.add_row(vec!["Model", &report.model.as_str()]);
+    meta_table.add_row(vec!["Mode", &report.mode.as_str()]);
     if let Some(ref wd) = report.local_workdir {
-        sections.push(format!("Local workdir: {wd}"));
+        meta_table.add_row(vec!["Local workdir", wd.as_str()]);
     }
+    let _ = writeln!(out, "{meta_table}\n");
 
-    sections.extend(vec![
-        format!("--- System message ---\n{}", report.system_message),
-        format!(
-            "--- User message (instance prompt) ---\n{}",
-            report.user_message
-        ),
-    ]);
+    out.push_str("--- System message ---\n");
+    let _ = writeln!(out, "{}\n", report.system_message);
 
-    let mut tools_lines = vec!["--- Registered tools ---".to_owned()];
+    out.push_str("--- User message (instance prompt) ---\n");
+    let _ = writeln!(out, "{}\n", report.user_message);
+
+    out.push_str("--- Registered tools ---\n");
+    let mut tools_table = Table::new();
+    tools_table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS);
+    tools_table.set_header(vec!["Name", "Description"]);
     for t in &report.tools {
-        tools_lines.push(format!("  {}: {}", t.name, t.description));
+        tools_table.add_row(vec![t.name.as_str(), t.description.as_str()]);
     }
-    sections.push(tools_lines.join("\n"));
+    let _ = writeln!(out, "{tools_table}\n");
 
-    let mut hook_lines = vec!["--- Hook configuration ---".to_owned()];
+    out.push_str("--- Hook configuration ---\n");
     if report.hooks.pre_tool_use.is_empty() && report.hooks.post_tool_use.is_empty() {
-        hook_lines.push("  (no hooks configured)".to_owned());
+        out.push_str("  (no hooks configured)\n\n");
     } else {
+        let mut hooks_table = Table::new();
+        hooks_table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS);
+        hooks_table.set_header(vec!["Phase", "Name", "Command"]);
         for h in &report.hooks.pre_tool_use {
-            hook_lines.push(format!("  PreToolUse [{}]: {}", h.name, h.command));
+            hooks_table.add_row(vec!["PreToolUse", h.name.as_str(), h.command.as_str()]);
         }
         for h in &report.hooks.post_tool_use {
-            hook_lines.push(format!("  PostToolUse [{}]: {}", h.name, h.command));
+            hooks_table.add_row(vec!["PostToolUse", h.name.as_str(), h.command.as_str()]);
         }
+        let _ = writeln!(out, "{hooks_table}\n");
     }
-    sections.push(hook_lines.join("\n"));
 
-    sections.push(format!(
-        "--- Token estimate ---\ninitial_prompt_tokens: {} ({:.2}% of {}-token context window)",
-        report.initial_prompt_tokens, report.context_window_pct, report.context_window_tokens
-    ));
+    out.push_str("--- Token estimate ---\n");
+    let mut token_table = Table::new();
+    token_table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS);
+    token_table.add_row(vec![
+        "Initial Prompt Tokens",
+        &report.initial_prompt_tokens.to_string(),
+    ]);
+    token_table.add_row(vec![
+        "Context Window",
+        &format!("{} tokens", report.context_window_tokens),
+    ]);
+    token_table.add_row(vec![
+        "Consumption",
+        &format!("{:.2}%", report.context_window_pct),
+    ]);
+    let _ = writeln!(out, "{token_table}\n");
 
-    sections.push(format!(
-        "--- Upper-bound cost ---\n${:.6} USD\nNote: {}",
-        report.upper_bound_cost.usd, report.upper_bound_cost.caveat
-    ));
+    out.push_str("--- Upper-bound cost ---\n");
+    let mut cost_table = Table::new();
+    cost_table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS);
+    cost_table.add_row(vec![
+        "Estimated Cost",
+        &format!("${:.6} USD", report.upper_bound_cost.usd),
+    ]);
+    cost_table.add_row(vec!["Note", report.upper_bound_cost.caveat.as_str()]);
+    let _ = writeln!(out, "{cost_table}\n");
 
-    sections.join("\n\n") + "\n"
+    out
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────

--- a/src/run/skills_preview.rs
+++ b/src/run/skills_preview.rs
@@ -250,53 +250,85 @@ fn sha256_prefix_12(bytes: &[u8]) -> String {
 // ── Formatting helpers ────────────────────────────────────────────────────────
 
 pub fn format_text(report: &SkillsPreviewReport, redactor: &Redactor) -> String {
-    let mut out = String::from("=== agent skills-preview (no model call made) ===\n");
+    use comfy_table::Table;
+    use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+    use comfy_table::presets::UTF8_FULL;
+
+    let mut out = String::from("\n=== agent skills-preview (no model call made) ===\n");
 
     for task in &report.tasks {
-        let _ = write!(out, "\ntask_hash: {}\n", task.task_hash);
+        let _ = writeln!(out, "\nTask: {}", task.task_hash);
+
+        let mut meta_table = Table::new();
+        meta_table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS);
+        meta_table.add_row(vec![
+            "total_bytes_injected",
+            &task.total_bytes_injected.to_string(),
+        ]);
+        meta_table.add_row(vec![
+            "merged_extra_context_bytes",
+            &task.merged_extra_context_bytes.to_string(),
+        ]);
+        meta_table.add_row(vec![
+            "max_active_cap_hit",
+            &format!(
+                "{} (dropped: {})",
+                task.max_active_cap_hit, task.dropped_count
+            ),
+        ]);
+        let _ = writeln!(out, "{meta_table}");
+
         if task.active_skills.is_empty() {
             out.push_str("  (no skills activated)\n");
         } else {
+            let mut skills_table = Table::new();
+            skills_table
+                .load_preset(UTF8_FULL)
+                .apply_modifier(UTF8_ROUND_CORNERS);
+            skills_table.set_header(vec!["Name", "Reason", "SHA256", "Bytes", "Path"]);
             for skill in &task.active_skills {
                 let reason_str = match skill.reason {
                     SkillActivationReason::ExplicitMention => "explicit",
                     SkillActivationReason::AutoMatch => "auto",
                 };
                 let path_str = skill.path.display().to_string();
-                let _ = writeln!(
-                    out,
-                    "  {} | {} | {} | {} bytes | {}",
-                    skill.name, reason_str, skill.sha256_prefix, skill.bytes, path_str,
-                );
+                skills_table.add_row(vec![
+                    skill.name.as_str(),
+                    reason_str,
+                    skill.sha256_prefix.as_str(),
+                    skill.bytes.to_string().as_str(),
+                    path_str.as_str(),
+                ]);
             }
+            let _ = writeln!(out, "{skills_table}");
         }
-        let _ = writeln!(out, "  total_bytes_injected: {}", task.total_bytes_injected);
-        let _ = writeln!(
-            out,
-            "  max_active_cap_hit: {} (dropped: {})",
-            task.max_active_cap_hit, task.dropped_count
-        );
-        let _ = writeln!(
-            out,
-            "  merged_extra_context_bytes: {}",
-            task.merged_extra_context_bytes
-        );
     }
 
-    let _ = writeln!(
-        out,
-        "\n--- summary ---\n\
-         task_count: {}\n\
-         unique_skills_activated: {}\n\
-         p50_bytes_per_task: {}\n\
-         p95_bytes_per_task: {}\n\
-         tasks_hitting_max_active: {}",
-        report.summary.task_count,
-        report.summary.unique_skills_activated,
-        report.summary.p50_bytes_per_task,
-        report.summary.p95_bytes_per_task,
-        report.summary.tasks_hitting_max_active,
-    );
+    out.push_str("\n--- Summary ---\n");
+    let mut summary_table = Table::new();
+    summary_table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS);
+    summary_table.add_row(vec!["Task Count", report.summary.task_count.to_string().as_str()]);
+    summary_table.add_row(vec![
+        "Unique Skills Activated",
+        &report.summary.unique_skills_activated.to_string(),
+    ]);
+    summary_table.add_row(vec![
+        "P50 Bytes/Task",
+        &report.summary.p50_bytes_per_task.to_string(),
+    ]);
+    summary_table.add_row(vec![
+        "P95 Bytes/Task",
+        &report.summary.p95_bytes_per_task.to_string(),
+    ]);
+    summary_table.add_row(vec![
+        "Tasks Hitting Max Active",
+        &report.summary.tasks_hitting_max_active.to_string(),
+    ]);
+    let _ = writeln!(out, "{summary_table}");
 
     redactor.redact_text(&out, surface::TRAJECTORY).text
 }


### PR DESCRIPTION
🎨 Mosaic: UI Polish for CLI Previews

🖌️ Before: The `max agent skills-preview` and `max mini --render-only` output dumped data as raw indented text that lacked clear boundaries or structure.
✨ After: We now render all reports for `render-only` and `skills-preview` output using beautiful ASCII-rounded `comfy-table` instances for easy scanning and readability.
🖼️ Visuals: Meta information, registered tools, hook configs, skill outputs, and token/cost estimates are neatly packaged in individual tables!

---
*PR created automatically by Jules for task [7924455278880230719](https://jules.google.com/task/7924455278880230719) started by @madmax983*