### PR TITLE
👺 Havoc: Prevent test suite race conditions and segfaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +1317,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,6 +1378,7 @@ dependencies = [
  "indicatif",
  "insta",
  "litellm-rs",
+ "loom",
  "minijinja",
  "pretty_assertions",
  "proptest",
@@ -1361,6 +1390,7 @@ dependencies = [
  "sha2",
  "similar",
  "tar",
+ "temp-env",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -1976,6 +2006,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,6 +2297,16 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "futures",
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,8 @@ proptest = "1"
 insta = { version = "1", features = ["json"] }
 pretty_assertions = "1"
 tokio = { version = "1", features = ["full", "test-util"] }
+loom = "0.7"
+temp-env = { version = "0.3.6", features = ["async_closure"] }
 
 [features]
 default = ["webhook"]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2612,6 +2612,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
 }
 
 #[cfg(feature = "html-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
     Ok(HtmlExporter::export(traj))
@@ -2627,6 +2628,7 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
 }
 
 #[cfg(feature = "csv-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
     Ok(CsvExporter::export(traj))
@@ -2642,6 +2644,7 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
 }
 
 #[cfg(feature = "mermaid-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
     Ok(MermaidExporter::export(traj))

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -880,16 +880,6 @@ pub(crate) mod build {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
-
-    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        ENV_LOCK
-            .get_or_init(Mutex::default)
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
 
     #[test]
     fn trace_id_is_32_hex_chars() {
@@ -922,65 +912,64 @@ mod tests {
 
     #[test]
     fn resolve_endpoint_prefers_cli_flag() {
-        let _guard = env_lock();
-        // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-host:4318");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
-        let ep = resolve_endpoint(Some("http://cli-host:4318"));
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-        }
-        // CLI flag is a base URL; /v1/traces is appended.
-        assert_eq!(ep.as_deref(), Some("http://cli-host:4318/v1/traces"));
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", Some("http://env-host:4318")),
+                ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None),
+            ],
+            || {
+                let ep = resolve_endpoint(Some("http://cli-host:4318"));
+                // CLI flag is a base URL; /v1/traces is appended.
+                assert_eq!(ep.as_deref(), Some("http://cli-host:4318/v1/traces"));
+            },
+        );
     }
 
     #[test]
     fn resolve_endpoint_falls_back_to_env_var() {
-        let _guard = env_lock();
-        // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-host:4318");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
-        let ep = resolve_endpoint(None);
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-        }
-        // Generic env var is a base URL; /v1/traces is appended.
-        assert_eq!(ep.as_deref(), Some("http://env-host:4318/v1/traces"));
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", Some("http://env-host:4318")),
+                ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None),
+            ],
+            || {
+                let ep = resolve_endpoint(None);
+                // Generic env var is a base URL; /v1/traces is appended.
+                assert_eq!(ep.as_deref(), Some("http://env-host:4318/v1/traces"));
+            },
+        );
     }
 
     #[test]
     fn resolve_endpoint_traces_env_var_used_as_full_url() {
-        let _guard = env_lock();
-        // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-            std::env::set_var(
-                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-                "http://traces-host:4318/v1/traces",
-            );
-        }
-        let ep = resolve_endpoint(None);
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
-        // Trace-specific env var is a full URL; used as-is without appending.
-        assert_eq!(ep.as_deref(), Some("http://traces-host:4318/v1/traces"));
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", None),
+                (
+                    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+                    Some("http://traces-host:4318/v1/traces"),
+                ),
+            ],
+            || {
+                let ep = resolve_endpoint(None);
+                // Trace-specific env var is a full URL; used as-is without appending.
+                assert_eq!(ep.as_deref(), Some("http://traces-host:4318/v1/traces"));
+            },
+        );
     }
 
     #[test]
     fn resolve_endpoint_returns_none_when_unset() {
-        let _guard = env_lock();
-        // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
-        let ep = resolve_endpoint(None);
-        assert!(ep.is_none());
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", None::<&str>),
+                ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None::<&str>),
+            ],
+            || {
+                let ep = resolve_endpoint(None);
+                assert!(ep.is_none());
+            },
+        );
     }
 
     #[test]

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -97,16 +97,13 @@ mod tests {
 
     #[test]
     fn env_global_is_available() {
-        // Safe because tests are single-threaded per tokio::test? No — use
-        // a var we set directly here. But std::env::set_var is unsafe in
-        // multi-threaded contexts; use an already-present var instead.
-        let r = Renderer::new();
-        // PATH is virtually always set in CI.
-        let out = r
-            .render_with("{{ env.PATH is defined }}", context!())
-            .unwrap();
-        // Depending on platform PATH may be absent; accept either outcome.
-        assert!(out == "true" || out == "false");
+        temp_env::with_var("CARGO_PKG_NAME", Some("maxwells-daemon"), || {
+            let r = Renderer::new();
+            let out = r
+                .render_with("{{ env.CARGO_PKG_NAME }}", context!())
+                .unwrap();
+            assert_eq!(out, "maxwells-daemon");
+        });
     }
 
     #[test]

--- a/tests/fuzz_confirm_cli.rs
+++ b/tests/fuzz_confirm_cli.rs
@@ -1,0 +1,9 @@
+use maxwells_daemon::agent::confirm_cli::parse_line_decision;
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn parse_line_decision_does_not_panic(s in "\\\\PC*") {
+        let _ = parse_line_decision(&s);
+    }
+}

--- a/tests/fuzz_evaluate.rs
+++ b/tests/fuzz_evaluate.rs
@@ -3,7 +3,7 @@ use proptest::prelude::*;
 
 proptest! {
     #[test]
-    fn parse_repo_from_instance_id_never_crashes(s in "\\PC*") {
+    fn parse_repo_does_not_panic(s in "\\PC*") {
         let _ = parse_repo_from_instance_id(&s);
     }
 }

--- a/tests/fuzz_telemetry.rs
+++ b/tests/fuzz_telemetry.rs
@@ -1,0 +1,9 @@
+use maxwells_daemon::telemetry::parse_otlp_header_env;
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn parse_otlp_header_env_does_not_panic(s in "\\PC*") {
+        let _ = parse_otlp_header_env(&s);
+    }
+}

--- a/tests/otlp_traces.rs
+++ b/tests/otlp_traces.rs
@@ -311,7 +311,7 @@ async fn no_otlp_traffic_when_endpoint_unset() {
     // Serialize against other tests that mutate OTEL_EXPORTER_OTLP_ENDPOINT.
     let _guard = env_var_lock();
     // Also ensure both OTLP env vars are unset.
-    // SAFETY: test-only, single-threaded context.
+    // SAFETY: Protected by ENV_VAR_MUTEX across all tests mutating these.
     unsafe {
         std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
         std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
@@ -621,7 +621,7 @@ async fn env_var_activates_otlp_tracing() {
     // Serialize against other tests that mutate OTEL_EXPORTER_OTLP_ENDPOINT.
     let _guard = env_var_lock();
     // Set env var to a dead endpoint.
-    // SAFETY: test-only, single-threaded context.
+    // SAFETY: Protected by ENV_VAR_MUTEX across all tests mutating these.
     unsafe {
         std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:1");
     }
@@ -684,7 +684,7 @@ async fn env_var_activates_otlp_tracing() {
     let results = run(args).await.unwrap();
 
     // Unset for subsequent tests.
-    // SAFETY: test-only, single-threaded context.
+    // SAFETY: Protected by ENV_VAR_MUTEX across all tests mutating these.
     unsafe {
         std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
     }


### PR DESCRIPTION
🧨 The Trigger: std::env::set_var is intrinsically unsafe in a multi-threaded process and frequently causes race conditions or outright crashes (SIGABRT) when other threads spawn processes or read environment variables concurrently. This violates Rust's thread-safety guarantees.
📉 The Stack Trace: (Process-level segfaults / unpredictable test flakiness due to env var races, typically showing libc::getenv racing with libc::setenv).
🧪 Reproduction: Run cargo test --lib telemetry or cargo test --test otlp_traces concurrently in a tight loop.
😈 Comment: You assumed setting environment variables in async test harnesses was safe. It is not. Environment variables are process-global state, not thread-local state. The temp_env crate is now enforced for sync tests, and explicit locks are properly documented for async tests where temp_env isn't enough.

---
*PR created automatically by Jules for task [15138000539711498331](https://jules.google.com/task/15138000539711498331) started by @madmax983*