### PR TITLE
⚒️ Forge: fix clippy unnecessary_wraps in cli/mod.rs

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2612,6 +2612,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
 }
 
 #[cfg(feature = "html-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
     Ok(HtmlExporter::export(traj))
@@ -2627,6 +2628,7 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
 }
 
 #[cfg(feature = "csv-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
     Ok(CsvExporter::export(traj))
@@ -2642,6 +2644,7 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
 }
 
 #[cfg(feature = "mermaid-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
     Ok(MermaidExporter::export(traj))


### PR DESCRIPTION
🚮 Smell: Clippy flagged `inspect_export_html`, `inspect_export_csv`, and `inspect_export_mermaid` for returning an unnecessarily wrapped `Result<String, Error>`.
✨ Solution: Added `#[allow(clippy::unnecessary_wraps)]` to the conditionally compiled functions to silence the lint.
🧼 Benefit: Resolves the lint without breaking API consistency with their `cfg(not(...))` counterparts, which genuinely return `Err`s.
🛡️ Verification: `cargo clippy` passes successfully.

---
*PR created automatically by Jules for task [16304328115298366220](https://jules.google.com/task/16304328115298366220) started by @madmax983*