### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2612,6 +2612,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
 }
 
 #[cfg(feature = "html-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
     Ok(HtmlExporter::export(traj))
@@ -2627,6 +2628,7 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
 }
 
 #[cfg(feature = "csv-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
     Ok(CsvExporter::export(traj))
@@ -2642,6 +2644,7 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
 }
 
 #[cfg(feature = "mermaid-export")]
+#[allow(clippy::unnecessary_wraps)]
 fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
     use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
     Ok(MermaidExporter::export(traj))

--- a/src/run/power.rs
+++ b/src/run/power.rs
@@ -369,7 +369,7 @@ pub fn run(cmd: &PowerCmd) -> Result<PowerReport, Error> {
                 "Either --baseline-rate or --from-sweep must be provided".to_string(),
             )));
         }
-        _ => unreachable!(),
+        (Some(_), Some(_)) => { return Err(Error::Config(crate::error::ConfigError::Usage("Cannot specify both explicit value and path".to_string()))); }
     };
 
     if cmd.delta.is_none() && cmd.n.is_none() {
@@ -544,7 +544,7 @@ pub fn run(cmd: &PowerCmd) -> Result<PowerReport, Error> {
             Some(point_cost / target_n)
         }
         (None, None) => None,
-        _ => unreachable!(),
+        (Some(_), Some(_)) => { return Err(Error::Config(crate::error::ConfigError::Usage("Cannot specify both explicit value and path".to_string()))); }
     };
 
     let total_cost = if let Some(c) = cost_per_instance {
@@ -660,4 +660,59 @@ pub fn render_text(report: &PowerReport) -> String {
     }
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::args::{PowerCmd};
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_baseline_rate_and_from_sweep_mutually_exclusive() {
+        let cmd = PowerCmd {
+            baseline_rate: Some(0.5),
+            delta: Some(0.1),
+            n: None,
+            from_sweep: Some(PathBuf::from("test")),
+            alpha: 0.05,
+            power: 0.8,
+            one_sided: false,
+            arms: 2,
+            cost_per_instance: None,
+            from_forecast: None,
+            format: "text".to_string(),
+        };
+        let result = run(&cmd);
+        assert!(result.is_err());
+        if let Err(crate::error::Error::Config(crate::error::ConfigError::Usage(msg))) = result {
+            assert_eq!(msg, "Cannot specify both explicit value and path");
+        } else {
+            panic!("Expected ConfigError::Usage");
+        }
+    }
+
+    #[test]
+    fn test_cost_per_instance_and_from_forecast_mutually_exclusive() {
+        let cmd = PowerCmd {
+            baseline_rate: Some(0.5),
+            delta: Some(0.1),
+            n: None,
+            from_sweep: None,
+            alpha: 0.05,
+            power: 0.8,
+            one_sided: false,
+            arms: 2,
+            cost_per_instance: Some(10.0),
+            from_forecast: Some(PathBuf::from("test")),
+            format: "text".to_string(),
+        };
+        let result = run(&cmd);
+        assert!(result.is_err());
+        if let Err(crate::error::Error::Config(crate::error::ConfigError::Usage(msg))) = result {
+            assert_eq!(msg, "Cannot specify both explicit value and path");
+        } else {
+            panic!("Expected ConfigError::Usage");
+        }
+    }
 }


### PR DESCRIPTION
🎯 Target: Fix `unreachable!` panics in `power.rs` and address `clippy` warnings.
💣 Risk: Currently `max power --baseline-rate 0.5 --from-sweep sweeps/some_sweep` triggers an `unreachable!()` panic instead of providing a correct CLI usage error. Same thing for `cost_per_instance` and `from_forecast`.
🔬 Strategy: Replaced `_ => unreachable!()` with `(Some(_), Some(_)) => { return Err(Error::Config(crate::error::ConfigError::Usage("Cannot specify both explicit value and path".to_string()))); }` in `src/run/power.rs`. Added tests to cover these cases. Added `#[allow(clippy::unnecessary_wraps)]` to `src/cli/mod.rs` to remove compile warnings that cause tests to fail.
🔭 Verification: `cargo test --lib` passes and `cargo clippy --all-targets --all-features -- -D warnings` passes.

---
*PR created automatically by Jules for task [9932471280315594941](https://jules.google.com/task/9932471280315594941) started by @madmax983*