### PR TITLE
feat: implement bench audit subcommand to verify sweep aggregates

### DIFF
--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -62,6 +62,7 @@ pub enum ArtifactKind {
     CacheStatsReport,
     LadderReport,
     SkillsPreview,
+    AuditReport,
 }
 
 impl ArtifactKind {
@@ -81,6 +82,7 @@ impl ArtifactKind {
             Self::CacheStatsReport => "cache_stats_report",
             Self::LadderReport => "ladder_report",
             Self::SkillsPreview => "skills_preview",
+            Self::AuditReport => "audit_report",
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -522,6 +522,8 @@ pub enum BenchCmd {
     DatasetStats(DatasetStatsCmd),
     /// Identify the commit that introduced a resolved-rate regression.
     Bisect(BisectCmd),
+    /// Re-derive and verify sweep aggregates against trajectories.
+    Audit(AuditCmd),
 }
 
 /// `bench dataset-stats` — preview SWE-bench dataset composition pre-sweep.
@@ -614,6 +616,30 @@ pub struct BisectCmd {
     /// Path to a bisect.json file to resume a previously interrupted run.
     #[arg(long)]
     pub resume: Option<PathBuf>,
+}
+
+/// `bench audit` — re-derive and verify sweep aggregates against trajectories.
+#[derive(Debug, Args, Clone)]
+pub struct AuditCmd {
+    /// Path to a completed sweep directory or extracted bench bundle directory.
+    #[arg(long)]
+    pub sweep: PathBuf,
+
+    /// Local dataset file to verify the recorded manifest hash.
+    #[arg(long)]
+    pub dataset_path: Option<PathBuf>,
+
+    /// USD tolerance for cost reconciliation.
+    #[arg(long, default_value_t = 0.0001)]
+    pub cost_tolerance_usd: f64,
+
+    /// Seconds tolerance for wall-clock reconciliation.
+    #[arg(long, default_value_t = 1.0)]
+    pub wallclock_tolerance_secs: f64,
+
+    /// Output format: `text` or `json`.
+    #[arg(long, default_value = "text")]
+    pub format: String,
 }
 
 /// `bench power` — statistical power, sample size, or MDE calculations.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -110,6 +110,7 @@ pub async fn run() -> Result<(), Error> {
             args::BenchCmd::Power(p) => bench_power(&p),
             args::BenchCmd::DatasetStats(s) => bench_dataset_stats(s),
             args::BenchCmd::Bisect(b) => Box::pin(bench_bisect(b)).await,
+            args::BenchCmd::Audit(a) => bench_audit(a),
         },
         Command::Agent { cmd } => match *cmd {
             args::AgentCmd::SkillsPreview(s) => agent_skills_preview_cmd(&s),
@@ -4110,6 +4111,11 @@ fn bench_dataset_stats(s: args::DatasetStatsCmd) -> Result<(), Error> {
 
 async fn bench_bisect(b: args::BisectCmd) -> Result<(), Error> {
     crate::run::bisect::run(&b).await
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn bench_audit(a: args::AuditCmd) -> Result<(), Error> {
+    crate::run::audit::run(&a)
 }
 
 fn parse_dataset_source_stats(

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,6 +54,10 @@ pub enum Error {
     /// bench bisect schema break
     #[error("bisect schema break")]
     BisectSchemaBreak,
+
+    /// bench audit failure
+    #[error("audit: {0}")]
+    Audit(String),
 }
 
 #[derive(Debug, Error)]

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -86,6 +86,8 @@ pub enum ExitCode {
     BisectBudgetExhausted = 18,
     /// 19 — `bench bisect` found only trajectory-schema breaks in the remaining search space.
     BisectSchemaBreak = 19,
+    /// 20 — `bench audit` detected a divergence exceeding tolerance or a bijection/evaluator contradiction.
+    AuditFailure = 20,
     /// 130 — user interruption (graceful SIGINT / Ctrl-C; 128 + SIGINT(2)).
     Interrupted = 130,
     /// 137 — forced kill (SIGKILL escalation after graceful-cancel deadline; 128 + SIGKILL(9)).
@@ -126,6 +128,7 @@ impl ExitCode {
             Self::ResumeInvalidPrefix => "resume_invalid_prefix",
             Self::BisectBudgetExhausted => "bisect_budget_exhausted",
             Self::BisectSchemaBreak => "bisect_schema_break",
+            Self::AuditFailure => "audit_failure",
             Self::Interrupted => "interrupted",
             Self::Killed => "killed",
         }
@@ -158,6 +161,7 @@ impl ExitCode {
             Error::AgentStagnation { .. } => Self::AgentStagnation,
             Error::BisectBudgetExhausted => Self::BisectBudgetExhausted,
             Error::BisectSchemaBreak => Self::BisectSchemaBreak,
+            Error::Audit(_) => Self::AuditFailure,
             Error::Template(_)
             | Error::Trajectory(_)
             | Error::Github(_)
@@ -367,5 +371,11 @@ mod tests {
             ExitCode::BisectSchemaBreak.outcome_class(),
             "bisect_schema_break"
         );
+    }
+
+    #[test]
+    fn audit_failure_exit_code_is_20() {
+        assert_eq!(ExitCode::AuditFailure.as_i32(), 20);
+        assert_eq!(ExitCode::AuditFailure.outcome_class(), "audit_failure");
     }
 }

--- a/src/run/audit.rs
+++ b/src/run/audit.rs
@@ -1,9 +1,9 @@
-use serde_json::Value;
-use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 use crate::cli::args::AuditCmd;
 use crate::error::Error;
@@ -33,19 +33,21 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     // Recursively collect all *.traj.json and trajectory.json files
     let all_trajectories = collect_trajectories_on_disk(&args.sweep)?;
     if all_trajectories.is_empty() {
-        return Err(Error::Audit(
-            "No trajectories found in sweep directory".to_string(),
-        ));
+        return Err(Error::Audit("No trajectories found in sweep directory".to_string()));
     }
 
-    // Map files to (instance_id, run_index)
-    let mut instances_runs: HashMap<String, Vec<(u32, PathBuf)>> = HashMap::new();
+    // Map files to (instance_id, run_index) with deduplication (preferring nested paths)
+    let mut instances_runs: HashMap<String, BTreeMap<u32, PathBuf>> = HashMap::new();
     for path in &all_trajectories {
         if let Some((inst_id, run_index)) = parse_trajectory_path(&args.sweep, path) {
-            instances_runs
-                .entry(inst_id)
-                .or_default()
-                .push((run_index, path.clone()));
+            let existing = instances_runs.entry(inst_id.clone()).or_default().get(&run_index).cloned();
+            if let Some(existing_path) = existing {
+                if path.components().count() > existing_path.components().count() {
+                    instances_runs.entry(inst_id).or_default().insert(run_index, path.clone());
+                }
+            } else {
+                instances_runs.entry(inst_id).or_default().insert(run_index, path.clone());
+            }
         }
     }
 
@@ -55,25 +57,22 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     let mut results_instances = HashSet::new();
     let mut budget_halted_or_skipped_results = HashSet::new();
     let mut instance_exit_reasons = HashMap::new();
-    if let Some(instances) = results.get("instances").and_then(|i| i.as_array()) {
+    let mut instance_expected_runs = HashMap::new();
+    let mut results_outcomes = HashMap::new();
+    if let Some(instances) = results.get("instances").and_then(serde_json::Value::as_array) {
         for inst in instances {
-            if let Some(id) = inst.get("instance_id").and_then(|id| id.as_str()) {
+            if let Some(id) = inst.get("instance_id").and_then(serde_json::Value::as_str) {
                 results_instances.insert(id.to_string());
-
-                let exit_reason = inst
-                    .get("exit_reason")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let outcome = inst.get("outcome").and_then(|v| v.as_str()).unwrap_or("");
+                
+                let exit_reason = inst.get("exit_reason").and_then(serde_json::Value::as_str).unwrap_or("");
+                let outcome = inst.get("outcome").and_then(serde_json::Value::as_str).unwrap_or("");
                 instance_exit_reasons.insert(id.to_string(), exit_reason.to_string());
+                results_outcomes.insert(id.to_string(), outcome.to_string());
 
-                if exit_reason == "budget_halt"
-                    || exit_reason == "budget_halted"
-                    || outcome == "budget_halted"
-                    || outcome == "skipped"
-                    || exit_reason == "skipped"
-                    || exit_reason == "skipped_resume"
-                {
+                let expected_runs = inst.get("runs").and_then(serde_json::Value::as_u64).unwrap_or(1);
+                instance_expected_runs.insert(id.to_string(), expected_runs);
+                
+                if exit_reason == "budget_halt" || exit_reason == "budget_halted" || outcome == "budget_halted" || outcome == "skipped" || exit_reason == "skipped" || exit_reason == "skipped_resume" {
                     budget_halted_or_skipped_results.insert(id.to_string());
                 }
             }
@@ -106,18 +105,34 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         }
     }
 
-    // Bijective checks: Trajectories vs Evaluation
+    // Bijective checks: Trajectories vs Evaluation (supporting legacy sb-cli format)
     let mut eval_instances = HashSet::new();
     let mut eval_resolved = HashMap::new();
     if let Some(eval) = &evaluation {
-        if let Some(instances) = eval.get("instances").and_then(|i| i.as_array()) {
+        if let Some(instances) = eval.get("instances").and_then(serde_json::Value::as_array) {
             for inst in instances {
-                if let Some(id) = inst.get("instance_id").and_then(|id| id.as_str()) {
+                if let Some(id) = inst.get("instance_id").and_then(serde_json::Value::as_str) {
                     eval_instances.insert(id.to_string());
-                    if let Some(resolved) =
-                        inst.get("resolved").and_then(serde_json::Value::as_bool)
-                    {
+                    if let Some(resolved) = inst.get("resolved").and_then(serde_json::Value::as_bool) {
                         eval_resolved.insert(id.to_string(), resolved);
+                    }
+                }
+            }
+        } else {
+            // Support legacy sb-cli resolved_ids / submitted_ids structure
+            if let Some(resolved_ids) = eval.get("resolved_ids").and_then(serde_json::Value::as_array) {
+                for id_val in resolved_ids {
+                    if let Some(id) = id_val.as_str() {
+                        eval_instances.insert(id.to_string());
+                        eval_resolved.insert(id.to_string(), true);
+                    }
+                }
+            }
+            if let Some(submitted_ids) = eval.get("submitted_ids").and_then(serde_json::Value::as_array) {
+                for id_val in submitted_ids {
+                    if let Some(id) = id_val.as_str() {
+                        eval_instances.insert(id.to_string());
+                        eval_resolved.entry(id.to_string()).or_insert(false);
                     }
                 }
             }
@@ -134,7 +149,25 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
 
         for inst_id in &eval_instances {
             if !traj_instances.contains(inst_id) {
+                if budget_halted_or_skipped_results.contains(inst_id) {
+                    continue;
+                }
                 let msg = format!("audit:missing:evaluation:{inst_id}");
+                println!("{msg}");
+                divergences.push(msg);
+                failed = true;
+            }
+        }
+    }
+
+    // Validate rerun trajectory slot completeness per instance
+    for (inst_id, runs) in &instances_runs {
+        if let Some(&expected_runs) = instance_expected_runs.get(inst_id) {
+            let actual_runs = runs.len() as u64;
+            if actual_runs != expected_runs {
+                let msg = format!(
+                    "audit:mismatch:instance:runs:{inst_id} expected={expected_runs} actual={actual_runs}"
+                );
                 println!("{msg}");
                 divergences.push(msg);
                 failed = true;
@@ -159,29 +192,32 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     let mut recomputed_budget_halted = 0;
 
     for (inst_id, runs) in &instances_runs {
-        // Compute outcomes based on skipped_resume semantics or active runs
-        if instance_exit_reasons
-            .get(inst_id)
-            .map(std::string::String::as_str)
-            == Some("skipped_resume")
-        {
+        let is_skipped_resume = instance_exit_reasons.get(inst_id).map(String::as_str) == Some("skipped_resume");
+        if is_skipped_resume {
             recomputed_skipped += 1;
-        } else {
-            // Count outcomes from all runs of this instance
-            for (_run_index, path) in runs {
-                if let Ok(content) = fs::read_to_string(path) {
-                    if let Ok(val) = serde_json::from_str::<Value>(&content) {
-                        if let Some(info) = val.get("info") {
-                            if let Some(outcome) = info.get("outcome").and_then(|o| o.as_str()) {
-                                match outcome {
-                                    "submitted" => recomputed_submitted += 1,
-                                    "errored" | "error" => recomputed_errored += 1,
-                                    "skipped" => recomputed_skipped += 1,
-                                    "budget_halted" | "budget_halt" => {
-                                        recomputed_budget_halted += 1;
-                                    }
-                                    _ => {}
+        }
+
+        // Count outcomes from all runs of this instance
+        for path in runs.values() {
+            if let Ok(content) = fs::read_to_string(path) {
+                if let Ok(val) = serde_json::from_str::<Value>(&content) {
+                    if let Some(info) = val.get("info") {
+                        if let Some(outcome) = info.get("outcome").and_then(serde_json::Value::as_str) {
+                            match outcome {
+                                "submitted" if !is_skipped_resume => {
+                                    recomputed_submitted += 1;
                                 }
+                                "errored" | "error" => {
+                                    // Counted in errored regardless of whether it's a skipped resume
+                                    recomputed_errored += 1;
+                                }
+                                "skipped" if !is_skipped_resume => {
+                                    recomputed_skipped += 1;
+                                }
+                                "budget_halted" | "budget_halt" => {
+                                    recomputed_budget_halted += 1;
+                                }
+                                _ => {}
                             }
                         }
                     }
@@ -192,39 +228,23 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         let mut inst_total_dur = 0.0;
         let mut inst_has_dur = false;
 
-        for (_run_index, path) in runs {
+        for path in runs.values() {
             if let Ok(content) = fs::read_to_string(path) {
                 if let Ok(val) = serde_json::from_str::<Value>(&content) {
                     if let Some(info) = val.get("info") {
                         // Aggregate cost across all attempts
-                        let cost = info
-                            .get("actual_cost_usd")
+                        let cost = info.get("actual_cost_usd")
                             .and_then(serde_json::Value::as_f64)
-                            .or_else(|| {
-                                info.get("total_cost_usd")
-                                    .and_then(serde_json::Value::as_f64)
-                            })
+                            .or_else(|| info.get("total_cost_usd").and_then(serde_json::Value::as_f64))
                             .unwrap_or(0.0);
                         recomputed_total_cost += cost;
 
                         // Aggregate tokens if available
                         if let Some(token_usage) = info.get("token_usage") {
-                            let prompt = token_usage
-                                .get("prompt_tokens")
-                                .and_then(serde_json::Value::as_u64)
-                                .unwrap_or(0);
-                            let read = token_usage
-                                .get("cache_read_tokens")
-                                .and_then(serde_json::Value::as_u64)
-                                .unwrap_or(0);
-                            let create = token_usage
-                                .get("cache_creation_tokens")
-                                .and_then(serde_json::Value::as_u64)
-                                .unwrap_or(0);
-                            let completion = token_usage
-                                .get("completion_tokens")
-                                .and_then(serde_json::Value::as_u64)
-                                .unwrap_or(0);
+                            let prompt = token_usage.get("prompt_tokens").and_then(serde_json::Value::as_u64).unwrap_or(0);
+                            let read = token_usage.get("cache_read_tokens").and_then(serde_json::Value::as_u64).unwrap_or(0);
+                            let create = token_usage.get("cache_creation_tokens").and_then(serde_json::Value::as_u64).unwrap_or(0);
+                            let completion = token_usage.get("completion_tokens").and_then(serde_json::Value::as_u64).unwrap_or(0);
 
                             recomputed_prompt_tokens += prompt;
                             recomputed_cache_read_tokens += read;
@@ -238,10 +258,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
                         }
 
                         // Aggregate durations
-                        if let Some(dur) = info
-                            .get("duration_secs")
-                            .and_then(serde_json::Value::as_f64)
-                        {
+                        if let Some(dur) = info.get("duration_secs").and_then(serde_json::Value::as_f64) {
                             inst_total_dur += dur;
                             inst_has_dur = true;
                         }
@@ -257,6 +274,20 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         }
     }
 
+    // Count budget-halted or skipped rows without trajectories in recomputation
+    for inst_id in &results_instances {
+        if !traj_instances.contains(inst_id) {
+            let exit_reason = instance_exit_reasons.get(inst_id).map_or("", String::as_str);
+            let outcome = results_outcomes.get(inst_id).map_or("", String::as_str);
+            
+            if exit_reason == "budget_halt" || exit_reason == "budget_halted" || outcome == "budget_halted" {
+                recomputed_budget_halted += 1;
+            } else if exit_reason == "skipped" || exit_reason == "skipped_resume" || outcome == "skipped" {
+                recomputed_skipped += 1;
+            }
+        }
+    }
+
     if has_partial_durations {
         let msg = "audit:partial:trajectory:duration_secs".to_string();
         println!("{msg}");
@@ -267,11 +298,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     let expected_cost = results
         .get("actual_cost_usd")
         .and_then(serde_json::Value::as_f64)
-        .or_else(|| {
-            results
-                .get("total_cost_usd")
-                .and_then(serde_json::Value::as_f64)
-        })
+        .or_else(|| results.get("total_cost_usd").and_then(serde_json::Value::as_f64))
         .unwrap_or(0.0);
 
     if (recomputed_total_cost - expected_cost).abs() > args.cost_tolerance_usd {
@@ -284,22 +311,10 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     }
 
     // Reconcile Outcomes
-    let expected_submitted = results
-        .get("submitted")
-        .and_then(serde_json::Value::as_u64)
-        .unwrap_or(0);
-    let expected_errored = results
-        .get("errored")
-        .and_then(serde_json::Value::as_u64)
-        .unwrap_or(0);
-    let expected_skipped = results
-        .get("skipped")
-        .and_then(serde_json::Value::as_u64)
-        .unwrap_or(0);
-    let expected_budget_halted = results
-        .get("budget_halted")
-        .and_then(serde_json::Value::as_u64)
-        .unwrap_or(0);
+    let expected_submitted = results.get("submitted").and_then(serde_json::Value::as_u64).unwrap_or(0);
+    let expected_errored = results.get("errored").and_then(serde_json::Value::as_u64).unwrap_or(0);
+    let expected_skipped = results.get("skipped").and_then(serde_json::Value::as_u64).unwrap_or(0);
+    let expected_budget_halted = results.get("budget_halted").and_then(serde_json::Value::as_u64).unwrap_or(0);
 
     if recomputed_submitted != expected_submitted {
         let msg = format!(
@@ -339,24 +354,11 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         let expected_input_tokens = results
             .get("total_input_tokens")
             .and_then(serde_json::Value::as_u64)
-            .or_else(|| {
-                results
-                    .get("total_prompt_tokens")
-                    .and_then(serde_json::Value::as_u64)
-            })
+            .or_else(|| results.get("total_prompt_tokens").and_then(serde_json::Value::as_u64))
             .unwrap_or(0);
-        let expected_cache_read_tokens = results
-            .get("total_cache_read_tokens")
-            .and_then(serde_json::Value::as_u64)
-            .unwrap_or(0);
-        let expected_cache_creation_tokens = results
-            .get("total_cache_creation_tokens")
-            .and_then(serde_json::Value::as_u64)
-            .unwrap_or(0);
-        let expected_completion_tokens = results
-            .get("total_completion_tokens")
-            .and_then(serde_json::Value::as_u64)
-            .unwrap_or(0);
+        let expected_cache_read_tokens = results.get("total_cache_read_tokens").and_then(serde_json::Value::as_u64).unwrap_or(0);
+        let expected_cache_creation_tokens = results.get("total_cache_creation_tokens").and_then(serde_json::Value::as_u64).unwrap_or(0);
+        let expected_completion_tokens = results.get("total_completion_tokens").and_then(serde_json::Value::as_u64).unwrap_or(0);
 
         if recomputed_prompt_tokens != expected_input_tokens {
             let msg = format!(
@@ -398,13 +400,11 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
             if resolved {
                 let mut has_submitted_run = false;
                 if let Some(runs) = instances_runs.get(inst_id) {
-                    for (_run_index, path) in runs {
+                    for path in runs.values() {
                         if let Ok(content) = fs::read_to_string(path) {
                             if let Ok(val) = serde_json::from_str::<Value>(&content) {
                                 if let Some(info) = val.get("info") {
-                                    if let Some(outcome) =
-                                        info.get("outcome").and_then(|o| o.as_str())
-                                    {
+                                    if let Some(outcome) = info.get("outcome").and_then(serde_json::Value::as_str) {
                                         if outcome == "submitted" {
                                             has_submitted_run = true;
                                             break;
@@ -427,13 +427,10 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
 
     // Reconcile Durations
     if !has_partial_durations {
-        if let Some(instances) = results.get("instances").and_then(|i| i.as_array()) {
+        if let Some(instances) = results.get("instances").and_then(serde_json::Value::as_array) {
             for inst in instances {
-                if let Some(id) = inst.get("instance_id").and_then(|id| id.as_str()) {
-                    let expected_dur = inst
-                        .get("duration_secs")
-                        .and_then(serde_json::Value::as_f64)
-                        .unwrap_or(0.0);
+                if let Some(id) = inst.get("instance_id").and_then(serde_json::Value::as_str) {
+                    let expected_dur = inst.get("duration_secs").and_then(serde_json::Value::as_f64).unwrap_or(0.0);
                     let actual_dur = instance_durations.get(id).copied().unwrap_or(0.0);
                     if (actual_dur - expected_dur).abs() > args.wallclock_tolerance_secs {
                         let msg = format!(
@@ -455,11 +452,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         let manifest_path = args.sweep.join("manifest.json");
         if let Ok(manifest_content) = fs::read_to_string(&manifest_path) {
             if let Ok(val) = serde_json::from_str::<Value>(&manifest_content) {
-                if let Some(sha) = val
-                    .get("dataset")
-                    .and_then(|d| d.get("sha256"))
-                    .and_then(|s| s.as_str())
-                {
+                if let Some(sha) = val.get("dataset").and_then(|d| d.get("sha256")).and_then(serde_json::Value::as_str) {
                     expected_dataset_sha256 = Some(sha.to_string());
                 }
             }
@@ -467,11 +460,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
 
         if expected_dataset_sha256.is_none() {
             if let Some(manifest) = results.get("manifest") {
-                if let Some(sha) = manifest
-                    .get("dataset")
-                    .and_then(|d| d.get("sha256"))
-                    .and_then(|s| s.as_str())
-                {
+                if let Some(sha) = manifest.get("dataset").and_then(|d| d.get("sha256")).and_then(serde_json::Value::as_str) {
                     expected_dataset_sha256 = Some(sha.to_string());
                 }
             }
@@ -480,8 +469,9 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         if let Some(expected) = expected_dataset_sha256 {
             let actual = compute_sha256(dataset_path)?;
             if actual != expected {
-                let msg =
-                    format!("audit:mismatch:dataset:sha256 expected={expected} actual={actual}");
+                let msg = format!(
+                    "audit:mismatch:dataset:sha256 expected={expected} actual={actual}"
+                );
                 println!("{msg}");
                 divergences.push(msg);
                 failed = true;
@@ -549,8 +539,7 @@ fn collect_trajectories_on_disk(dir: &Path) -> Result<Vec<PathBuf>, std::io::Err
 /// 3. Bundled: <sweep_dir>/trajectories/<instance_id>.traj.json
 fn parse_trajectory_path(sweep_dir: &Path, path: &Path) -> Option<(String, u32)> {
     let rel = path.strip_prefix(sweep_dir).ok()?;
-    let components: Vec<_> = rel
-        .components()
+    let components: Vec<_> = rel.components()
         .map(|c| c.as_os_str().to_str())
         .collect::<Option<Vec<_>>>()?;
 

--- a/src/run/audit.rs
+++ b/src/run/audit.rs
@@ -1,0 +1,547 @@
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use crate::cli::args::AuditCmd;
+use crate::error::Error;
+
+/// Recompute sweep-wide aggregates and reconcile with results.json and evaluation.json.
+#[allow(clippy::too_many_lines)]
+pub fn run(args: &AuditCmd) -> Result<(), Error> {
+    let results_path = args.sweep.join("results.json");
+    if !results_path.exists() {
+        return Err(Error::Audit(format!(
+            "results.json not found in sweep directory: {}",
+            args.sweep.display()
+        )));
+    }
+
+    let results_content = fs::read_to_string(&results_path)?;
+    let results: Value = serde_json::from_str(&results_content)?;
+
+    let evaluation_path = args.sweep.join("evaluation.json");
+    let evaluation: Option<Value> = if evaluation_path.exists() {
+        let eval_content = fs::read_to_string(&evaluation_path)?;
+        Some(serde_json::from_str(&eval_content)?)
+    } else {
+        None
+    };
+
+    // Recursively collect all *.traj.json and trajectory.json files
+    let all_trajectories = collect_trajectories_on_disk(&args.sweep)?;
+    if all_trajectories.is_empty() {
+        return Err(Error::Audit(
+            "No trajectories found in sweep directory".to_string(),
+        ));
+    }
+
+    // Map files to (instance_id, run_index)
+    let mut instances_runs: HashMap<String, Vec<(u32, PathBuf)>> = HashMap::new();
+    for path in &all_trajectories {
+        if let Some((inst_id, run_index)) = parse_trajectory_path(&args.sweep, path) {
+            instances_runs
+                .entry(inst_id)
+                .or_default()
+                .push((run_index, path.clone()));
+        }
+    }
+
+    let traj_instances: HashSet<String> = instances_runs.keys().cloned().collect();
+
+    // Parse instances from results.json
+    let mut results_instances = HashSet::new();
+    if let Some(instances) = results.get("instances").and_then(|i| i.as_array()) {
+        for inst in instances {
+            if let Some(id) = inst.get("instance_id").and_then(|id| id.as_str()) {
+                results_instances.insert(id.to_string());
+            }
+        }
+    }
+
+    let mut failed = false;
+    let mut divergences = Vec::new();
+
+    // Bijective checks: Trajectories vs Results
+    for inst_id in &traj_instances {
+        if !results_instances.contains(inst_id) {
+            let msg = format!("audit:orphan:trajectory:{inst_id}");
+            println!("{msg}");
+            divergences.push(msg);
+            failed = true;
+        }
+    }
+
+    for inst_id in &results_instances {
+        if !traj_instances.contains(inst_id) {
+            let msg = format!("audit:missing:trajectory:{inst_id}");
+            println!("{msg}");
+            divergences.push(msg);
+            failed = true;
+        }
+    }
+
+    // Bijective checks: Trajectories vs Evaluation
+    let mut eval_instances = HashSet::new();
+    let mut eval_resolved = HashMap::new();
+    if let Some(eval) = &evaluation {
+        if let Some(instances) = eval.get("instances").and_then(|i| i.as_array()) {
+            for inst in instances {
+                if let Some(id) = inst.get("instance_id").and_then(|id| id.as_str()) {
+                    eval_instances.insert(id.to_string());
+                    if let Some(resolved) =
+                        inst.get("resolved").and_then(serde_json::Value::as_bool)
+                    {
+                        eval_resolved.insert(id.to_string(), resolved);
+                    }
+                }
+            }
+        }
+
+        for inst_id in &traj_instances {
+            if !eval_instances.contains(inst_id) {
+                let msg = format!("audit:orphan:evaluation:{inst_id}");
+                println!("{msg}");
+                divergences.push(msg);
+                failed = true;
+            }
+        }
+
+        for inst_id in &eval_instances {
+            if !traj_instances.contains(inst_id) {
+                let msg = format!("audit:missing:evaluation:{inst_id}");
+                println!("{msg}");
+                divergences.push(msg);
+                failed = true;
+            }
+        }
+    }
+
+    // Recompute aggregates across all trajectories
+    let mut recomputed_total_cost = 0.0;
+    let mut recomputed_prompt_tokens = 0;
+    let mut recomputed_cache_read_tokens = 0;
+    let mut recomputed_cache_creation_tokens = 0;
+    let mut recomputed_completion_tokens = 0;
+    let mut has_partial_tokens = false;
+    let mut has_partial_durations = false;
+
+    let mut instance_outcomes = HashMap::new();
+    let mut instance_durations = HashMap::new();
+
+    for (inst_id, runs) in &instances_runs {
+        // Find outcome from run with highest run_index (latest attempt)
+        if let Some(latest_run) = runs.iter().max_by_key(|r| r.0) {
+            let path = &latest_run.1;
+            if let Ok(content) = fs::read_to_string(path) {
+                if let Ok(val) = serde_json::from_str::<Value>(&content) {
+                    if let Some(info) = val.get("info") {
+                        if let Some(outcome) = info.get("outcome").and_then(|o| o.as_str()) {
+                            instance_outcomes.insert(inst_id.clone(), outcome.to_string());
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut inst_total_dur = 0.0;
+        let mut inst_has_dur = false;
+
+        for (_run_index, path) in runs {
+            if let Ok(content) = fs::read_to_string(path) {
+                if let Ok(val) = serde_json::from_str::<Value>(&content) {
+                    if let Some(info) = val.get("info") {
+                        // Aggregate cost across all attempts
+                        let cost = info
+                            .get("actual_cost_usd")
+                            .and_then(serde_json::Value::as_f64)
+                            .or_else(|| {
+                                info.get("total_cost_usd")
+                                    .and_then(serde_json::Value::as_f64)
+                            })
+                            .unwrap_or(0.0);
+                        recomputed_total_cost += cost;
+
+                        // Aggregate tokens if available
+                        if let Some(token_usage) = info.get("token_usage") {
+                            let prompt = token_usage
+                                .get("prompt_tokens")
+                                .and_then(serde_json::Value::as_u64)
+                                .unwrap_or(0);
+                            let read = token_usage
+                                .get("cache_read_tokens")
+                                .and_then(serde_json::Value::as_u64)
+                                .unwrap_or(0);
+                            let create = token_usage
+                                .get("cache_creation_tokens")
+                                .and_then(serde_json::Value::as_u64)
+                                .unwrap_or(0);
+                            let completion = token_usage
+                                .get("completion_tokens")
+                                .and_then(serde_json::Value::as_u64)
+                                .unwrap_or(0);
+
+                            recomputed_prompt_tokens += prompt;
+                            recomputed_cache_read_tokens += read;
+                            recomputed_cache_creation_tokens += create;
+                            recomputed_completion_tokens += completion;
+                        } else if !has_partial_tokens {
+                            has_partial_tokens = true;
+                            let msg = "audit:partial:trajectory:token_usage".to_string();
+                            println!("{msg}");
+                            divergences.push(msg);
+                        }
+
+                        // Aggregate durations
+                        if let Some(dur) = info
+                            .get("duration_secs")
+                            .and_then(serde_json::Value::as_f64)
+                        {
+                            inst_total_dur += dur;
+                            inst_has_dur = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        if inst_has_dur {
+            instance_durations.insert(inst_id.clone(), inst_total_dur);
+        } else {
+            has_partial_durations = true;
+        }
+    }
+
+    if has_partial_durations {
+        let msg = "audit:partial:trajectory:duration_secs".to_string();
+        println!("{msg}");
+        divergences.push(msg);
+    }
+
+    // Reconcile Cost
+    let expected_cost = results
+        .get("total_cost_usd")
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(0.0);
+
+    if (recomputed_total_cost - expected_cost).abs() > args.cost_tolerance_usd {
+        let msg = format!(
+            "audit:mismatch:sweep:total_cost_usd expected={expected_cost} actual={recomputed_total_cost}"
+        );
+        println!("{msg}");
+        divergences.push(msg);
+        failed = true;
+    }
+
+    // Reconcile Outcomes
+    let mut recomputed_submitted = 0;
+    let mut recomputed_errored = 0;
+    let mut recomputed_skipped = 0;
+    let mut recomputed_budget_halted = 0;
+
+    for outcome in instance_outcomes.values() {
+        match outcome.as_str() {
+            "submitted" => recomputed_submitted += 1,
+            "errored" | "error" => recomputed_errored += 1,
+            "skipped" => recomputed_skipped += 1,
+            "budget_halted" | "budget_halt" => recomputed_budget_halted += 1,
+            _ => {}
+        }
+    }
+
+    let expected_submitted = results
+        .get("submitted")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let expected_errored = results
+        .get("errored")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let expected_skipped = results
+        .get("skipped")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let expected_budget_halted = results
+        .get("budget_halted")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+
+    if recomputed_submitted != expected_submitted {
+        let msg = format!(
+            "audit:mismatch:sweep:submitted expected={expected_submitted} actual={recomputed_submitted}"
+        );
+        println!("{msg}");
+        divergences.push(msg);
+        failed = true;
+    }
+    if recomputed_errored != expected_errored {
+        let msg = format!(
+            "audit:mismatch:sweep:errored expected={expected_errored} actual={recomputed_errored}"
+        );
+        println!("{msg}");
+        divergences.push(msg);
+        failed = true;
+    }
+    if recomputed_skipped != expected_skipped {
+        let msg = format!(
+            "audit:mismatch:sweep:skipped expected={expected_skipped} actual={recomputed_skipped}"
+        );
+        println!("{msg}");
+        divergences.push(msg);
+        failed = true;
+    }
+    if recomputed_budget_halted != expected_budget_halted {
+        let msg = format!(
+            "audit:mismatch:sweep:budget_halted expected={expected_budget_halted} actual={recomputed_budget_halted}"
+        );
+        println!("{msg}");
+        divergences.push(msg);
+        failed = true;
+    }
+
+    // Reconcile Tokens
+    if !has_partial_tokens {
+        let expected_input_tokens = results
+            .get("total_input_tokens")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        let expected_cache_read_tokens = results
+            .get("total_cache_read_tokens")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        let expected_cache_creation_tokens = results
+            .get("total_cache_creation_tokens")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        let expected_completion_tokens = results
+            .get("total_completion_tokens")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+
+        if recomputed_prompt_tokens != expected_input_tokens {
+            let msg = format!(
+                "audit:mismatch:sweep:total_input_tokens expected={expected_input_tokens} actual={recomputed_prompt_tokens}"
+            );
+            println!("{msg}");
+            divergences.push(msg);
+            failed = true;
+        }
+        if recomputed_cache_read_tokens != expected_cache_read_tokens {
+            let msg = format!(
+                "audit:mismatch:sweep:total_cache_read_tokens expected={expected_cache_read_tokens} actual={recomputed_cache_read_tokens}"
+            );
+            println!("{msg}");
+            divergences.push(msg);
+            failed = true;
+        }
+        if recomputed_cache_creation_tokens != expected_cache_creation_tokens {
+            let msg = format!(
+                "audit:mismatch:sweep:total_cache_creation_tokens expected={expected_cache_creation_tokens} actual={recomputed_cache_creation_tokens}"
+            );
+            println!("{msg}");
+            divergences.push(msg);
+            failed = true;
+        }
+        if recomputed_completion_tokens != expected_completion_tokens {
+            let msg = format!(
+                "audit:mismatch:sweep:total_completion_tokens expected={expected_completion_tokens} actual={recomputed_completion_tokens}"
+            );
+            println!("{msg}");
+            divergences.push(msg);
+            failed = true;
+        }
+    }
+
+    // Contradiction checks
+    if evaluation.is_some() {
+        for (inst_id, &resolved) in &eval_resolved {
+            if resolved {
+                if let Some(outcome) = instance_outcomes.get(inst_id) {
+                    if outcome != "submitted" {
+                        let msg = format!("audit:contradiction:instance:{inst_id}");
+                        println!("{msg}");
+                        divergences.push(msg);
+                        failed = true;
+                    }
+                }
+            }
+        }
+    }
+
+    // Reconcile Durations
+    if !has_partial_durations {
+        if let Some(instances) = results.get("instances").and_then(|i| i.as_array()) {
+            for inst in instances {
+                if let Some(id) = inst.get("instance_id").and_then(|id| id.as_str()) {
+                    let expected_dur = inst
+                        .get("duration_secs")
+                        .and_then(serde_json::Value::as_f64)
+                        .unwrap_or(0.0);
+                    let actual_dur = instance_durations.get(id).copied().unwrap_or(0.0);
+                    if (actual_dur - expected_dur).abs() > args.wallclock_tolerance_secs {
+                        let msg = format!(
+                            "audit:mismatch:instance:duration_secs:{id} expected={expected_dur} actual={actual_dur}"
+                        );
+                        println!("{msg}");
+                        divergences.push(msg);
+                        failed = true;
+                    }
+                }
+            }
+        }
+    }
+
+    // Dataset Hash Check
+    if let Some(dataset_path) = &args.dataset_path {
+        let mut expected_dataset_sha256 = None;
+
+        let manifest_path = args.sweep.join("manifest.json");
+        if let Ok(manifest_content) = fs::read_to_string(&manifest_path) {
+            if let Ok(val) = serde_json::from_str::<Value>(&manifest_content) {
+                if let Some(sha) = val
+                    .get("dataset")
+                    .and_then(|d| d.get("sha256"))
+                    .and_then(|s| s.as_str())
+                {
+                    expected_dataset_sha256 = Some(sha.to_string());
+                }
+            }
+        }
+
+        if expected_dataset_sha256.is_none() {
+            if let Some(manifest) = results.get("manifest") {
+                if let Some(sha) = manifest
+                    .get("dataset")
+                    .and_then(|d| d.get("sha256"))
+                    .and_then(|s| s.as_str())
+                {
+                    expected_dataset_sha256 = Some(sha.to_string());
+                }
+            }
+        }
+
+        if let Some(expected) = expected_dataset_sha256 {
+            let actual = compute_sha256(dataset_path)?;
+            if actual != expected {
+                let msg =
+                    format!("audit:mismatch:dataset:sha256 expected={expected} actual={actual}");
+                println!("{msg}");
+                divergences.push(msg);
+                failed = true;
+            }
+        } else {
+            let msg = "audit:mismatch:dataset:sha256:expected_missing".to_string();
+            println!("{msg}");
+            divergences.push(msg);
+            failed = true;
+        }
+    } else {
+        println!("audit:dataset:skipped");
+    }
+
+    let overall_pass_fail = if failed { "fail" } else { "pass" };
+    let audit_report = serde_json::json!({
+        "artifact_kind": "audit_report",
+        "schema_version": {
+            "major": 1,
+            "minor": 10
+        },
+        "overall_pass_fail": overall_pass_fail,
+        "divergences": divergences,
+    });
+
+    let audit_json_path = args.sweep.join("audit.json");
+    let audit_report_str = serde_json::to_string_pretty(&audit_report)?;
+    fs::write(&audit_json_path, &audit_report_str)?;
+
+    if args.format == "json" {
+        println!("{audit_report_str}");
+    }
+
+    if failed {
+        Err(Error::Audit("Audit validation failed".to_string()))
+    } else {
+        Ok(())
+    }
+}
+
+/// Recursively collect all trajectory files in the sweep directory.
+fn collect_trajectories_on_disk(dir: &Path) -> Result<Vec<PathBuf>, std::io::Error> {
+    let mut files = Vec::new();
+    if dir.is_dir() {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                files.extend(collect_trajectories_on_disk(&path)?);
+            } else {
+                let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                if name.ends_with(".traj.json") || name == "trajectory.json" {
+                    files.push(path);
+                }
+            }
+        }
+    }
+    Ok(files)
+}
+
+/// Parse trajectory paths into (instance_id, run_index).
+/// Layouts supported:
+/// 1. Root: <sweep_dir>/<instance_id>.traj.json
+/// 2. Nested: <sweep_dir>/<instance_id>/run-<run_index>.traj.json or trajectory.json
+/// 3. Bundled: <sweep_dir>/trajectories/<instance_id>.traj.json
+fn parse_trajectory_path(sweep_dir: &Path, path: &Path) -> Option<(String, u32)> {
+    let rel = path.strip_prefix(sweep_dir).ok()?;
+    let components: Vec<_> = rel
+        .components()
+        .map(|c| c.as_os_str().to_str())
+        .collect::<Option<Vec<_>>>()?;
+
+    let file_name = components.last()?;
+    if !file_name.ends_with(".traj.json") && *file_name != "trajectory.json" {
+        return None;
+    }
+
+    match components.len() {
+        1 => {
+            let inst_id = file_name.strip_suffix(".traj.json")?;
+            Some((inst_id.to_string(), 1))
+        }
+        2 => {
+            let parent = components[0];
+            if parent == "trajectories" {
+                let inst_id = file_name.strip_suffix(".traj.json")?;
+                Some((inst_id.to_string(), 1))
+            } else {
+                let run_index = if *file_name == "trajectory.json" {
+                    1
+                } else {
+                    file_name
+                        .strip_prefix("run-")
+                        .and_then(|s| s.strip_suffix(".traj.json"))
+                        .and_then(|s| s.parse::<u32>().ok())?
+                };
+                Some((parent.to_string(), run_index))
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Calculate SHA-256 of a file.
+fn compute_sha256(path: &Path) -> Result<String, std::io::Error> {
+    let mut file = fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0; 8192];
+    loop {
+        let n = file.read(&mut buffer)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buffer[..n]);
+    }
+    let result = hasher.finalize();
+    Ok(format!("{result:x}"))
+}

--- a/src/run/audit.rs
+++ b/src/run/audit.rs
@@ -1,9 +1,9 @@
+use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use serde_json::Value;
-use sha2::{Digest, Sha256};
 
 use crate::cli::args::AuditCmd;
 use crate::error::Error;
@@ -33,20 +33,32 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     // Recursively collect all *.traj.json and trajectory.json files
     let all_trajectories = collect_trajectories_on_disk(&args.sweep)?;
     if all_trajectories.is_empty() {
-        return Err(Error::Audit("No trajectories found in sweep directory".to_string()));
+        return Err(Error::Audit(
+            "No trajectories found in sweep directory".to_string(),
+        ));
     }
 
     // Map files to (instance_id, run_index) with deduplication (preferring nested paths)
     let mut instances_runs: HashMap<String, BTreeMap<u32, PathBuf>> = HashMap::new();
     for path in &all_trajectories {
         if let Some((inst_id, run_index)) = parse_trajectory_path(&args.sweep, path) {
-            let existing = instances_runs.entry(inst_id.clone()).or_default().get(&run_index).cloned();
+            let existing = instances_runs
+                .entry(inst_id.clone())
+                .or_default()
+                .get(&run_index)
+                .cloned();
             if let Some(existing_path) = existing {
                 if path.components().count() > existing_path.components().count() {
-                    instances_runs.entry(inst_id).or_default().insert(run_index, path.clone());
+                    instances_runs
+                        .entry(inst_id)
+                        .or_default()
+                        .insert(run_index, path.clone());
                 }
             } else {
-                instances_runs.entry(inst_id).or_default().insert(run_index, path.clone());
+                instances_runs
+                    .entry(inst_id)
+                    .or_default()
+                    .insert(run_index, path.clone());
             }
         }
     }
@@ -59,20 +71,38 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     let mut instance_exit_reasons = HashMap::new();
     let mut instance_expected_runs = HashMap::new();
     let mut results_outcomes = HashMap::new();
-    if let Some(instances) = results.get("instances").and_then(serde_json::Value::as_array) {
+    if let Some(instances) = results
+        .get("instances")
+        .and_then(serde_json::Value::as_array)
+    {
         for inst in instances {
             if let Some(id) = inst.get("instance_id").and_then(serde_json::Value::as_str) {
                 results_instances.insert(id.to_string());
-                
-                let exit_reason = inst.get("exit_reason").and_then(serde_json::Value::as_str).unwrap_or("");
-                let outcome = inst.get("outcome").and_then(serde_json::Value::as_str).unwrap_or("");
+
+                let exit_reason = inst
+                    .get("exit_reason")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("");
+                let outcome = inst
+                    .get("outcome")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("");
                 instance_exit_reasons.insert(id.to_string(), exit_reason.to_string());
                 results_outcomes.insert(id.to_string(), outcome.to_string());
 
-                let expected_runs = inst.get("runs").and_then(serde_json::Value::as_u64).unwrap_or(1);
+                let expected_runs = inst
+                    .get("runs")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(1);
                 instance_expected_runs.insert(id.to_string(), expected_runs);
-                
-                if exit_reason == "budget_halt" || exit_reason == "budget_halted" || outcome == "budget_halted" || outcome == "skipped" || exit_reason == "skipped" || exit_reason == "skipped_resume" {
+
+                if exit_reason == "budget_halt"
+                    || exit_reason == "budget_halted"
+                    || outcome == "budget_halted"
+                    || outcome == "skipped"
+                    || exit_reason == "skipped"
+                    || exit_reason == "skipped_resume"
+                {
                     budget_halted_or_skipped_results.insert(id.to_string());
                 }
             }
@@ -113,14 +143,19 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
             for inst in instances {
                 if let Some(id) = inst.get("instance_id").and_then(serde_json::Value::as_str) {
                     eval_instances.insert(id.to_string());
-                    if let Some(resolved) = inst.get("resolved").and_then(serde_json::Value::as_bool) {
+                    if let Some(resolved) =
+                        inst.get("resolved").and_then(serde_json::Value::as_bool)
+                    {
                         eval_resolved.insert(id.to_string(), resolved);
                     }
                 }
             }
         } else {
             // Support legacy sb-cli resolved_ids / submitted_ids structure
-            if let Some(resolved_ids) = eval.get("resolved_ids").and_then(serde_json::Value::as_array) {
+            if let Some(resolved_ids) = eval
+                .get("resolved_ids")
+                .and_then(serde_json::Value::as_array)
+            {
                 for id_val in resolved_ids {
                     if let Some(id) = id_val.as_str() {
                         eval_instances.insert(id.to_string());
@@ -128,7 +163,10 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
                     }
                 }
             }
-            if let Some(submitted_ids) = eval.get("submitted_ids").and_then(serde_json::Value::as_array) {
+            if let Some(submitted_ids) = eval
+                .get("submitted_ids")
+                .and_then(serde_json::Value::as_array)
+            {
                 for id_val in submitted_ids {
                     if let Some(id) = id_val.as_str() {
                         eval_instances.insert(id.to_string());
@@ -192,7 +230,8 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     let mut recomputed_budget_halted = 0;
 
     for (inst_id, runs) in &instances_runs {
-        let is_skipped_resume = instance_exit_reasons.get(inst_id).map(String::as_str) == Some("skipped_resume");
+        let is_skipped_resume =
+            instance_exit_reasons.get(inst_id).map(String::as_str) == Some("skipped_resume");
         if is_skipped_resume {
             recomputed_skipped += 1;
         }
@@ -202,7 +241,9 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
             if let Ok(content) = fs::read_to_string(path) {
                 if let Ok(val) = serde_json::from_str::<Value>(&content) {
                     if let Some(info) = val.get("info") {
-                        if let Some(outcome) = info.get("outcome").and_then(serde_json::Value::as_str) {
+                        if let Some(outcome) =
+                            info.get("outcome").and_then(serde_json::Value::as_str)
+                        {
                             match outcome {
                                 "submitted" if !is_skipped_resume => {
                                     recomputed_submitted += 1;
@@ -233,18 +274,34 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
                 if let Ok(val) = serde_json::from_str::<Value>(&content) {
                     if let Some(info) = val.get("info") {
                         // Aggregate cost across all attempts
-                        let cost = info.get("actual_cost_usd")
+                        let cost = info
+                            .get("actual_cost_usd")
                             .and_then(serde_json::Value::as_f64)
-                            .or_else(|| info.get("total_cost_usd").and_then(serde_json::Value::as_f64))
+                            .or_else(|| {
+                                info.get("total_cost_usd")
+                                    .and_then(serde_json::Value::as_f64)
+                            })
                             .unwrap_or(0.0);
                         recomputed_total_cost += cost;
 
                         // Aggregate tokens if available
                         if let Some(token_usage) = info.get("token_usage") {
-                            let prompt = token_usage.get("prompt_tokens").and_then(serde_json::Value::as_u64).unwrap_or(0);
-                            let read = token_usage.get("cache_read_tokens").and_then(serde_json::Value::as_u64).unwrap_or(0);
-                            let create = token_usage.get("cache_creation_tokens").and_then(serde_json::Value::as_u64).unwrap_or(0);
-                            let completion = token_usage.get("completion_tokens").and_then(serde_json::Value::as_u64).unwrap_or(0);
+                            let prompt = token_usage
+                                .get("prompt_tokens")
+                                .and_then(serde_json::Value::as_u64)
+                                .unwrap_or(0);
+                            let read = token_usage
+                                .get("cache_read_tokens")
+                                .and_then(serde_json::Value::as_u64)
+                                .unwrap_or(0);
+                            let create = token_usage
+                                .get("cache_creation_tokens")
+                                .and_then(serde_json::Value::as_u64)
+                                .unwrap_or(0);
+                            let completion = token_usage
+                                .get("completion_tokens")
+                                .and_then(serde_json::Value::as_u64)
+                                .unwrap_or(0);
 
                             recomputed_prompt_tokens += prompt;
                             recomputed_cache_read_tokens += read;
@@ -258,7 +315,10 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
                         }
 
                         // Aggregate durations
-                        if let Some(dur) = info.get("duration_secs").and_then(serde_json::Value::as_f64) {
+                        if let Some(dur) = info
+                            .get("duration_secs")
+                            .and_then(serde_json::Value::as_f64)
+                        {
                             inst_total_dur += dur;
                             inst_has_dur = true;
                         }
@@ -277,12 +337,20 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     // Count budget-halted or skipped rows without trajectories in recomputation
     for inst_id in &results_instances {
         if !traj_instances.contains(inst_id) {
-            let exit_reason = instance_exit_reasons.get(inst_id).map_or("", String::as_str);
+            let exit_reason = instance_exit_reasons
+                .get(inst_id)
+                .map_or("", String::as_str);
             let outcome = results_outcomes.get(inst_id).map_or("", String::as_str);
-            
-            if exit_reason == "budget_halt" || exit_reason == "budget_halted" || outcome == "budget_halted" {
+
+            if exit_reason == "budget_halt"
+                || exit_reason == "budget_halted"
+                || outcome == "budget_halted"
+            {
                 recomputed_budget_halted += 1;
-            } else if exit_reason == "skipped" || exit_reason == "skipped_resume" || outcome == "skipped" {
+            } else if exit_reason == "skipped"
+                || exit_reason == "skipped_resume"
+                || outcome == "skipped"
+            {
                 recomputed_skipped += 1;
             }
         }
@@ -298,7 +366,11 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     let expected_cost = results
         .get("actual_cost_usd")
         .and_then(serde_json::Value::as_f64)
-        .or_else(|| results.get("total_cost_usd").and_then(serde_json::Value::as_f64))
+        .or_else(|| {
+            results
+                .get("total_cost_usd")
+                .and_then(serde_json::Value::as_f64)
+        })
         .unwrap_or(0.0);
 
     if (recomputed_total_cost - expected_cost).abs() > args.cost_tolerance_usd {
@@ -311,10 +383,22 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     }
 
     // Reconcile Outcomes
-    let expected_submitted = results.get("submitted").and_then(serde_json::Value::as_u64).unwrap_or(0);
-    let expected_errored = results.get("errored").and_then(serde_json::Value::as_u64).unwrap_or(0);
-    let expected_skipped = results.get("skipped").and_then(serde_json::Value::as_u64).unwrap_or(0);
-    let expected_budget_halted = results.get("budget_halted").and_then(serde_json::Value::as_u64).unwrap_or(0);
+    let expected_submitted = results
+        .get("submitted")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let expected_errored = results
+        .get("errored")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let expected_skipped = results
+        .get("skipped")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let expected_budget_halted = results
+        .get("budget_halted")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
 
     if recomputed_submitted != expected_submitted {
         let msg = format!(
@@ -354,11 +438,24 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         let expected_input_tokens = results
             .get("total_input_tokens")
             .and_then(serde_json::Value::as_u64)
-            .or_else(|| results.get("total_prompt_tokens").and_then(serde_json::Value::as_u64))
+            .or_else(|| {
+                results
+                    .get("total_prompt_tokens")
+                    .and_then(serde_json::Value::as_u64)
+            })
             .unwrap_or(0);
-        let expected_cache_read_tokens = results.get("total_cache_read_tokens").and_then(serde_json::Value::as_u64).unwrap_or(0);
-        let expected_cache_creation_tokens = results.get("total_cache_creation_tokens").and_then(serde_json::Value::as_u64).unwrap_or(0);
-        let expected_completion_tokens = results.get("total_completion_tokens").and_then(serde_json::Value::as_u64).unwrap_or(0);
+        let expected_cache_read_tokens = results
+            .get("total_cache_read_tokens")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        let expected_cache_creation_tokens = results
+            .get("total_cache_creation_tokens")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        let expected_completion_tokens = results
+            .get("total_completion_tokens")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
 
         if recomputed_prompt_tokens != expected_input_tokens {
             let msg = format!(
@@ -404,7 +501,9 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
                         if let Ok(content) = fs::read_to_string(path) {
                             if let Ok(val) = serde_json::from_str::<Value>(&content) {
                                 if let Some(info) = val.get("info") {
-                                    if let Some(outcome) = info.get("outcome").and_then(serde_json::Value::as_str) {
+                                    if let Some(outcome) =
+                                        info.get("outcome").and_then(serde_json::Value::as_str)
+                                    {
                                         if outcome == "submitted" {
                                             has_submitted_run = true;
                                             break;
@@ -427,10 +526,16 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
 
     // Reconcile Durations
     if !has_partial_durations {
-        if let Some(instances) = results.get("instances").and_then(serde_json::Value::as_array) {
+        if let Some(instances) = results
+            .get("instances")
+            .and_then(serde_json::Value::as_array)
+        {
             for inst in instances {
                 if let Some(id) = inst.get("instance_id").and_then(serde_json::Value::as_str) {
-                    let expected_dur = inst.get("duration_secs").and_then(serde_json::Value::as_f64).unwrap_or(0.0);
+                    let expected_dur = inst
+                        .get("duration_secs")
+                        .and_then(serde_json::Value::as_f64)
+                        .unwrap_or(0.0);
                     let actual_dur = instance_durations.get(id).copied().unwrap_or(0.0);
                     if (actual_dur - expected_dur).abs() > args.wallclock_tolerance_secs {
                         let msg = format!(
@@ -452,7 +557,11 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         let manifest_path = args.sweep.join("manifest.json");
         if let Ok(manifest_content) = fs::read_to_string(&manifest_path) {
             if let Ok(val) = serde_json::from_str::<Value>(&manifest_content) {
-                if let Some(sha) = val.get("dataset").and_then(|d| d.get("sha256")).and_then(serde_json::Value::as_str) {
+                if let Some(sha) = val
+                    .get("dataset")
+                    .and_then(|d| d.get("sha256"))
+                    .and_then(serde_json::Value::as_str)
+                {
                     expected_dataset_sha256 = Some(sha.to_string());
                 }
             }
@@ -460,7 +569,11 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
 
         if expected_dataset_sha256.is_none() {
             if let Some(manifest) = results.get("manifest") {
-                if let Some(sha) = manifest.get("dataset").and_then(|d| d.get("sha256")).and_then(serde_json::Value::as_str) {
+                if let Some(sha) = manifest
+                    .get("dataset")
+                    .and_then(|d| d.get("sha256"))
+                    .and_then(serde_json::Value::as_str)
+                {
                     expected_dataset_sha256 = Some(sha.to_string());
                 }
             }
@@ -469,9 +582,8 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         if let Some(expected) = expected_dataset_sha256 {
             let actual = compute_sha256(dataset_path)?;
             if actual != expected {
-                let msg = format!(
-                    "audit:mismatch:dataset:sha256 expected={expected} actual={actual}"
-                );
+                let msg =
+                    format!("audit:mismatch:dataset:sha256 expected={expected} actual={actual}");
                 println!("{msg}");
                 divergences.push(msg);
                 failed = true;
@@ -539,7 +651,8 @@ fn collect_trajectories_on_disk(dir: &Path) -> Result<Vec<PathBuf>, std::io::Err
 /// 3. Bundled: <sweep_dir>/trajectories/<instance_id>.traj.json
 fn parse_trajectory_path(sweep_dir: &Path, path: &Path) -> Option<(String, u32)> {
     let rel = path.strip_prefix(sweep_dir).ok()?;
-    let components: Vec<_> = rel.components()
+    let components: Vec<_> = rel
+        .components()
         .map(|c| c.as_os_str().to_str())
         .collect::<Option<Vec<_>>>()?;
 

--- a/src/run/audit.rs
+++ b/src/run/audit.rs
@@ -11,6 +11,14 @@ use crate::error::Error;
 /// Recompute sweep-wide aggregates and reconcile with results.json and evaluation.json.
 #[allow(clippy::too_many_lines)]
 pub fn run(args: &AuditCmd) -> Result<(), Error> {
+    let log_msg = |msg: &str| {
+        if args.format == "json" {
+            eprintln!("{msg}");
+        } else {
+            println!("{msg}");
+        }
+    };
+
     let results_path = args.sweep.join("results.json");
     if !results_path.exists() {
         return Err(Error::Audit(format!(
@@ -32,11 +40,6 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
 
     // Recursively collect all *.traj.json and trajectory.json files
     let all_trajectories = collect_trajectories_on_disk(&args.sweep)?;
-    if all_trajectories.is_empty() {
-        return Err(Error::Audit(
-            "No trajectories found in sweep directory".to_string(),
-        ));
-    }
 
     // Map files to (instance_id, run_index) with deduplication (preferring nested paths)
     let mut instances_runs: HashMap<String, BTreeMap<u32, PathBuf>> = HashMap::new();
@@ -48,11 +51,26 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
                 .get(&run_index)
                 .cloned();
             if let Some(existing_path) = existing {
-                if path.components().count() > existing_path.components().count() {
+                let current_count = path.components().count();
+                let existing_count = existing_path.components().count();
+                if current_count > existing_count {
                     instances_runs
                         .entry(inst_id)
                         .or_default()
                         .insert(run_index, path.clone());
+                } else if current_count == existing_count {
+                    // Explicitly prefer run-1.traj.json over trajectory.json if they have same depth
+                    let current_file = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    let existing_file = existing_path
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("");
+                    if current_file.contains("run-1") && existing_file.contains("trajectory.json") {
+                        instances_runs
+                            .entry(inst_id)
+                            .or_default()
+                            .insert(run_index, path.clone());
+                    }
                 }
             } else {
                 instances_runs
@@ -90,10 +108,13 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
                 instance_exit_reasons.insert(id.to_string(), exit_reason.to_string());
                 results_outcomes.insert(id.to_string(), outcome.to_string());
 
-                let expected_runs = inst
+                let mut expected_runs = inst
                     .get("runs")
                     .and_then(serde_json::Value::as_u64)
                     .unwrap_or(1);
+                if expected_runs == 0 {
+                    expected_runs = 1;
+                }
                 instance_expected_runs.insert(id.to_string(), expected_runs);
 
                 if exit_reason == "budget_halt"
@@ -116,7 +137,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     for inst_id in &traj_instances {
         if !results_instances.contains(inst_id) {
             let msg = format!("audit:orphan:trajectory:{inst_id}");
-            println!("{msg}");
+            log_msg(&msg);
             divergences.push(msg);
             failed = true;
         }
@@ -129,7 +150,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
                 continue;
             }
             let msg = format!("audit:missing:trajectory:{inst_id}");
-            println!("{msg}");
+            log_msg(&msg);
             divergences.push(msg);
             failed = true;
         }
@@ -138,6 +159,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     // Bijective checks: Trajectories vs Evaluation (supporting legacy sb-cli format)
     let mut eval_instances = HashSet::new();
     let mut eval_resolved = HashMap::new();
+    let mut is_legacy_format = false;
     if let Some(eval) = &evaluation {
         if let Some(instances) = eval.get("instances").and_then(serde_json::Value::as_array) {
             for inst in instances {
@@ -152,6 +174,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
             }
         } else {
             // Support legacy sb-cli resolved_ids / submitted_ids structure
+            is_legacy_format = true;
             if let Some(resolved_ids) = eval
                 .get("resolved_ids")
                 .and_then(serde_json::Value::as_array)
@@ -177,9 +200,9 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         }
 
         for inst_id in &traj_instances {
-            if !eval_instances.contains(inst_id) {
+            if !is_legacy_format && !eval_instances.contains(inst_id) {
                 let msg = format!("audit:orphan:evaluation:{inst_id}");
-                println!("{msg}");
+                log_msg(&msg);
                 divergences.push(msg);
                 failed = true;
             }
@@ -191,7 +214,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
                     continue;
                 }
                 let msg = format!("audit:missing:evaluation:{inst_id}");
-                println!("{msg}");
+                log_msg(&msg);
                 divergences.push(msg);
                 failed = true;
             }
@@ -199,16 +222,42 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     }
 
     // Validate rerun trajectory slot completeness per instance
+    #[allow(clippy::cast_possible_truncation)]
     for (inst_id, runs) in &instances_runs {
         if let Some(&expected_runs) = instance_expected_runs.get(inst_id) {
-            let actual_runs = runs.len() as u64;
-            if actual_runs != expected_runs {
-                let msg = format!(
-                    "audit:mismatch:instance:runs:{inst_id} expected={expected_runs} actual={actual_runs}"
-                );
-                println!("{msg}");
-                divergences.push(msg);
-                failed = true;
+            let is_exempt = budget_halted_or_skipped_results.contains(inst_id);
+            if is_exempt {
+                // If exempt, we just verify that all keys present are contiguous from 1
+                let actual_count = runs.len() as u32;
+                for r in 1..=actual_count {
+                    if !runs.contains_key(&r) {
+                        let msg =
+                            format!("audit:mismatch:instance:runs:{inst_id} missing run index {r}");
+                        log_msg(&msg);
+                        divergences.push(msg);
+                        failed = true;
+                    }
+                }
+            } else {
+                // If not exempt, we require all indices 1..=expected_runs to be present
+                for r in 1..=(expected_runs as u32) {
+                    if !runs.contains_key(&r) {
+                        let msg =
+                            format!("audit:mismatch:instance:runs:{inst_id} missing run index {r}");
+                        log_msg(&msg);
+                        divergences.push(msg);
+                        failed = true;
+                    }
+                }
+                let actual_runs = runs.len() as u64;
+                if actual_runs != expected_runs {
+                    let msg = format!(
+                        "audit:mismatch:instance:runs:{inst_id} expected={expected_runs} actual={actual_runs}"
+                    );
+                    log_msg(&msg);
+                    divergences.push(msg);
+                    failed = true;
+                }
             }
         }
     }
@@ -310,7 +359,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
                         } else if !has_partial_tokens {
                             has_partial_tokens = true;
                             let msg = "audit:partial:trajectory:token_usage".to_string();
-                            println!("{msg}");
+                            log_msg(&msg);
                             divergences.push(msg);
                         }
 
@@ -358,7 +407,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
 
     if has_partial_durations {
         let msg = "audit:partial:trajectory:duration_secs".to_string();
-        println!("{msg}");
+        log_msg(&msg);
         divergences.push(msg);
     }
 
@@ -377,7 +426,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         let msg = format!(
             "audit:mismatch:sweep:total_cost_usd expected={expected_cost} actual={recomputed_total_cost}"
         );
-        println!("{msg}");
+        log_msg(&msg);
         divergences.push(msg);
         failed = true;
     }
@@ -404,7 +453,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         let msg = format!(
             "audit:mismatch:sweep:submitted expected={expected_submitted} actual={recomputed_submitted}"
         );
-        println!("{msg}");
+        log_msg(&msg);
         divergences.push(msg);
         failed = true;
     }
@@ -412,7 +461,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         let msg = format!(
             "audit:mismatch:sweep:errored expected={expected_errored} actual={recomputed_errored}"
         );
-        println!("{msg}");
+        log_msg(&msg);
         divergences.push(msg);
         failed = true;
     }
@@ -420,7 +469,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         let msg = format!(
             "audit:mismatch:sweep:skipped expected={expected_skipped} actual={recomputed_skipped}"
         );
-        println!("{msg}");
+        log_msg(&msg);
         divergences.push(msg);
         failed = true;
     }
@@ -428,7 +477,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         let msg = format!(
             "audit:mismatch:sweep:budget_halted expected={expected_budget_halted} actual={recomputed_budget_halted}"
         );
-        println!("{msg}");
+        log_msg(&msg);
         divergences.push(msg);
         failed = true;
     }
@@ -461,7 +510,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
             let msg = format!(
                 "audit:mismatch:sweep:total_input_tokens expected={expected_input_tokens} actual={recomputed_prompt_tokens}"
             );
-            println!("{msg}");
+            log_msg(&msg);
             divergences.push(msg);
             failed = true;
         }
@@ -469,7 +518,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
             let msg = format!(
                 "audit:mismatch:sweep:total_cache_read_tokens expected={expected_cache_read_tokens} actual={recomputed_cache_read_tokens}"
             );
-            println!("{msg}");
+            log_msg(&msg);
             divergences.push(msg);
             failed = true;
         }
@@ -477,7 +526,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
             let msg = format!(
                 "audit:mismatch:sweep:total_cache_creation_tokens expected={expected_cache_creation_tokens} actual={recomputed_cache_creation_tokens}"
             );
-            println!("{msg}");
+            log_msg(&msg);
             divergences.push(msg);
             failed = true;
         }
@@ -485,7 +534,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
             let msg = format!(
                 "audit:mismatch:sweep:total_completion_tokens expected={expected_completion_tokens} actual={recomputed_completion_tokens}"
             );
-            println!("{msg}");
+            log_msg(&msg);
             divergences.push(msg);
             failed = true;
         }
@@ -516,7 +565,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
                 }
                 if !has_submitted_run {
                     let msg = format!("audit:contradiction:instance:{inst_id}");
-                    println!("{msg}");
+                    log_msg(&msg);
                     divergences.push(msg);
                     failed = true;
                 }
@@ -541,7 +590,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
                         let msg = format!(
                             "audit:mismatch:instance:duration_secs:{id} expected={expected_dur} actual={actual_dur}"
                         );
-                        println!("{msg}");
+                        log_msg(&msg);
                         divergences.push(msg);
                         failed = true;
                     }
@@ -584,18 +633,18 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
             if actual != expected {
                 let msg =
                     format!("audit:mismatch:dataset:sha256 expected={expected} actual={actual}");
-                println!("{msg}");
+                log_msg(&msg);
                 divergences.push(msg);
                 failed = true;
             }
         } else {
             let msg = "audit:mismatch:dataset:sha256:expected_missing".to_string();
-            println!("{msg}");
+            log_msg(&msg);
             divergences.push(msg);
             failed = true;
         }
     } else {
-        println!("audit:dataset:skipped");
+        log_msg("audit:dataset:skipped");
     }
 
     let overall_pass_fail = if failed { "fail" } else { "pass" };

--- a/src/run/audit.rs
+++ b/src/run/audit.rs
@@ -53,10 +53,29 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
 
     // Parse instances from results.json
     let mut results_instances = HashSet::new();
+    let mut budget_halted_or_skipped_results = HashSet::new();
+    let mut instance_exit_reasons = HashMap::new();
     if let Some(instances) = results.get("instances").and_then(|i| i.as_array()) {
         for inst in instances {
             if let Some(id) = inst.get("instance_id").and_then(|id| id.as_str()) {
                 results_instances.insert(id.to_string());
+
+                let exit_reason = inst
+                    .get("exit_reason")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let outcome = inst.get("outcome").and_then(|v| v.as_str()).unwrap_or("");
+                instance_exit_reasons.insert(id.to_string(), exit_reason.to_string());
+
+                if exit_reason == "budget_halt"
+                    || exit_reason == "budget_halted"
+                    || outcome == "budget_halted"
+                    || outcome == "skipped"
+                    || exit_reason == "skipped"
+                    || exit_reason == "skipped_resume"
+                {
+                    budget_halted_or_skipped_results.insert(id.to_string());
+                }
             }
         }
     }
@@ -76,6 +95,10 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
 
     for inst_id in &results_instances {
         if !traj_instances.contains(inst_id) {
+            // Exempt if it was budget halted or skipped before starting
+            if budget_halted_or_skipped_results.contains(inst_id) {
+                continue;
+            }
             let msg = format!("audit:missing:trajectory:{inst_id}");
             println!("{msg}");
             divergences.push(msg);
@@ -128,18 +151,38 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     let mut has_partial_tokens = false;
     let mut has_partial_durations = false;
 
-    let mut instance_outcomes = HashMap::new();
     let mut instance_durations = HashMap::new();
 
+    let mut recomputed_submitted = 0;
+    let mut recomputed_errored = 0;
+    let mut recomputed_skipped = 0;
+    let mut recomputed_budget_halted = 0;
+
     for (inst_id, runs) in &instances_runs {
-        // Find outcome from run with highest run_index (latest attempt)
-        if let Some(latest_run) = runs.iter().max_by_key(|r| r.0) {
-            let path = &latest_run.1;
-            if let Ok(content) = fs::read_to_string(path) {
-                if let Ok(val) = serde_json::from_str::<Value>(&content) {
-                    if let Some(info) = val.get("info") {
-                        if let Some(outcome) = info.get("outcome").and_then(|o| o.as_str()) {
-                            instance_outcomes.insert(inst_id.clone(), outcome.to_string());
+        // Compute outcomes based on skipped_resume semantics or active runs
+        if instance_exit_reasons
+            .get(inst_id)
+            .map(std::string::String::as_str)
+            == Some("skipped_resume")
+        {
+            recomputed_skipped += 1;
+        } else {
+            // Count outcomes from all runs of this instance
+            for (_run_index, path) in runs {
+                if let Ok(content) = fs::read_to_string(path) {
+                    if let Ok(val) = serde_json::from_str::<Value>(&content) {
+                        if let Some(info) = val.get("info") {
+                            if let Some(outcome) = info.get("outcome").and_then(|o| o.as_str()) {
+                                match outcome {
+                                    "submitted" => recomputed_submitted += 1,
+                                    "errored" | "error" => recomputed_errored += 1,
+                                    "skipped" => recomputed_skipped += 1,
+                                    "budget_halted" | "budget_halt" => {
+                                        recomputed_budget_halted += 1
+                                    }
+                                    _ => {}
+                                }
+                            }
                         }
                     }
                 }
@@ -220,10 +263,15 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         divergences.push(msg);
     }
 
-    // Reconcile Cost
+    // Reconcile Cost (Reconcile against actual_cost_usd when available)
     let expected_cost = results
-        .get("total_cost_usd")
+        .get("actual_cost_usd")
         .and_then(serde_json::Value::as_f64)
+        .or_else(|| {
+            results
+                .get("total_cost_usd")
+                .and_then(serde_json::Value::as_f64)
+        })
         .unwrap_or(0.0);
 
     if (recomputed_total_cost - expected_cost).abs() > args.cost_tolerance_usd {
@@ -236,21 +284,6 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
     }
 
     // Reconcile Outcomes
-    let mut recomputed_submitted = 0;
-    let mut recomputed_errored = 0;
-    let mut recomputed_skipped = 0;
-    let mut recomputed_budget_halted = 0;
-
-    for outcome in instance_outcomes.values() {
-        match outcome.as_str() {
-            "submitted" => recomputed_submitted += 1,
-            "errored" | "error" => recomputed_errored += 1,
-            "skipped" => recomputed_skipped += 1,
-            "budget_halted" | "budget_halt" => recomputed_budget_halted += 1,
-            _ => {}
-        }
-    }
-
     let expected_submitted = results
         .get("submitted")
         .and_then(serde_json::Value::as_u64)
@@ -301,11 +334,16 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         failed = true;
     }
 
-    // Reconcile Tokens
+    // Reconcile Tokens (supports total_prompt_tokens legacy alias)
     if !has_partial_tokens {
         let expected_input_tokens = results
             .get("total_input_tokens")
             .and_then(serde_json::Value::as_u64)
+            .or_else(|| {
+                results
+                    .get("total_prompt_tokens")
+                    .and_then(serde_json::Value::as_u64)
+            })
             .unwrap_or(0);
         let expected_cache_read_tokens = results
             .get("total_cache_read_tokens")
@@ -354,17 +392,34 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
         }
     }
 
-    // Contradiction checks
+    // Contradiction checks (rerun-aware checking if ANY run had outcome "submitted")
     if evaluation.is_some() {
         for (inst_id, &resolved) in &eval_resolved {
             if resolved {
-                if let Some(outcome) = instance_outcomes.get(inst_id) {
-                    if outcome != "submitted" {
-                        let msg = format!("audit:contradiction:instance:{inst_id}");
-                        println!("{msg}");
-                        divergences.push(msg);
-                        failed = true;
+                let mut has_submitted_run = false;
+                if let Some(runs) = instances_runs.get(inst_id) {
+                    for (_run_index, path) in runs {
+                        if let Ok(content) = fs::read_to_string(path) {
+                            if let Ok(val) = serde_json::from_str::<Value>(&content) {
+                                if let Some(info) = val.get("info") {
+                                    if let Some(outcome) =
+                                        info.get("outcome").and_then(|o| o.as_str())
+                                    {
+                                        if outcome == "submitted" {
+                                            has_submitted_run = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
+                }
+                if !has_submitted_run {
+                    let msg = format!("audit:contradiction:instance:{inst_id}");
+                    println!("{msg}");
+                    divergences.push(msg);
+                    failed = true;
                 }
             }
         }

--- a/src/run/audit.rs
+++ b/src/run/audit.rs
@@ -178,7 +178,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
                                     "errored" | "error" => recomputed_errored += 1,
                                     "skipped" => recomputed_skipped += 1,
                                     "budget_halted" | "budget_halt" => {
-                                        recomputed_budget_halted += 1
+                                        recomputed_budget_halted += 1;
                                     }
                                     _ => {}
                                 }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,6 +1,7 @@
 //! Runners: thin glue that wires (config + model + env + agent) together
 //! and writes trajectories to disk.
 
+pub mod audit;
 pub mod behavior;
 pub mod bisect;
 pub mod budget_fit;

--- a/tests/bench_audit.rs
+++ b/tests/bench_audit.rs
@@ -1,0 +1,293 @@
+//! `bench audit`: verify aggregates reconcile to trajectories and datasets.
+
+#![allow(clippy::unwrap_used)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+mod support;
+use support::binary_path;
+
+const FIXTURE_SWEEP: &str = "tests/fixtures/bundle/sweep";
+
+fn copy_fixture_sweep(root: &Path) -> PathBuf {
+    let dst = root.join("sweep");
+    copy_dir(Path::new(FIXTURE_SWEEP), &dst);
+    dst
+}
+
+fn copy_dir(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let ty = entry.file_type().unwrap();
+        let target = dst.join(entry.file_name());
+        if ty.is_dir() {
+            copy_dir(&entry.path(), &target);
+        } else {
+            fs::copy(entry.path(), target).unwrap();
+        }
+    }
+}
+
+#[test]
+fn help_lists_audit_subcommand_and_flags() {
+    let out = Command::new(binary_path())
+        .args(["bench", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("audit"), "stdout:\n{stdout}");
+
+    let out = Command::new(binary_path())
+        .args(["bench", "audit", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in [
+        "--sweep",
+        "--dataset-path",
+        "--cost-tolerance-usd",
+        "--wallclock-tolerance-secs",
+        "--format",
+    ] {
+        assert!(stdout.contains(flag), "missing {flag} in:\n{stdout}");
+    }
+}
+
+#[test]
+fn audit_clean_sweep_passes_successfully() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+
+    let out = Command::new(binary_path())
+        .args(["bench", "audit", "--sweep"])
+        .arg(&sweep)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "bench audit failed on clean sweep!\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    // Verify it written audit.json
+    assert!(sweep.join("audit.json").exists());
+    let audit_json = fs::read_to_string(sweep.join("audit.json")).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&audit_json).unwrap();
+    assert_eq!(parsed["artifact_kind"], "audit_report");
+    assert_eq!(parsed["overall_pass_fail"], "pass");
+
+    // Skip dataset verification logs skipped note
+    assert!(stdout.contains("audit:dataset:skipped"));
+}
+
+#[test]
+fn audit_tampered_cost_exceeds_tolerance_fails() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+
+    // Mutate total_cost_usd in results.json
+    let results_path = sweep.join("results.json");
+    let mut results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&results_path).unwrap()).unwrap();
+    results["total_cost_usd"] = serde_json::json!(1.5);
+    fs::write(
+        &results_path,
+        serde_json::to_string_pretty(&results).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args(["bench", "audit", "--sweep"])
+        .arg(&sweep)
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(20)); // exit code 20
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("audit:mismatch:sweep:total_cost_usd"));
+}
+
+#[test]
+fn audit_tampered_tokens_fails() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+
+    // Mutate total_input_tokens in results.json
+    let results_path = sweep.join("results.json");
+    let mut results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&results_path).unwrap()).unwrap();
+    results["total_input_tokens"] = serde_json::json!(12345);
+    fs::write(
+        &results_path,
+        serde_json::to_string_pretty(&results).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args(["bench", "audit", "--sweep"])
+        .arg(&sweep)
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(20));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("audit:mismatch:sweep:total_input_tokens"));
+}
+
+#[test]
+fn audit_tampered_outcome_counts_fails() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+
+    // Mutate submitted count in results.json
+    let results_path = sweep.join("results.json");
+    let mut results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&results_path).unwrap()).unwrap();
+    results["submitted"] = serde_json::json!(5);
+    fs::write(
+        &results_path,
+        serde_json::to_string_pretty(&results).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args(["bench", "audit", "--sweep"])
+        .arg(&sweep)
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(20));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("audit:mismatch:sweep:submitted"));
+}
+
+#[test]
+fn audit_orphan_trajectory_fails() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+
+    // Write a dummy trajectory that has no row in results.json
+    let orphan_path = sweep.join("gamma.traj.json");
+    let dummy_traj = serde_json::json!({
+        "trajectory_format": "mini-swe-agent-1.1",
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 3 },
+        "info": {
+            "task": "gamma",
+            "model_name": "deterministic",
+            "outcome": "submitted",
+            "total_cost_usd": 0.0
+        },
+        "messages": []
+    });
+    fs::write(
+        &orphan_path,
+        serde_json::to_string_pretty(&dummy_traj).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args(["bench", "audit", "--sweep"])
+        .arg(&sweep)
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(20));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("audit:orphan:trajectory:gamma"));
+}
+
+#[test]
+fn audit_missing_trajectory_fails() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+
+    // Remove beta trajectory which is defined as errored in results.json
+    fs::remove_file(sweep.join("beta.traj.json")).unwrap();
+
+    let out = Command::new(binary_path())
+        .args(["bench", "audit", "--sweep"])
+        .arg(&sweep)
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(20));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("audit:missing:trajectory:beta"));
+}
+
+#[test]
+fn audit_evaluator_contradiction_fails() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+
+    // Change evaluation.json so beta is marked resolved=true,
+    // but beta's trajectory outcome in results.json is outcome="error"
+    let eval_path = sweep.join("evaluation.json");
+    let mut eval: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&eval_path).unwrap()).unwrap();
+    eval["instances"][1]["resolved"] = serde_json::json!(true);
+    fs::write(&eval_path, serde_json::to_string_pretty(&eval).unwrap()).unwrap();
+
+    let out = Command::new(binary_path())
+        .args(["bench", "audit", "--sweep"])
+        .arg(&sweep)
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(20));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("audit:contradiction:instance:beta"));
+}
+
+#[test]
+fn audit_dataset_hash_mismatch_fails() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+
+    // Provide a dummy dataset file that does not match the manifest dataset sha256 ("fixture-dataset-hash")
+    let dataset_file = work.path().join("dummy_dataset.jsonl");
+    fs::write(&dataset_file, "wrong hash content").unwrap();
+
+    let out = Command::new(binary_path())
+        .args(["bench", "audit", "--sweep"])
+        .arg(&sweep)
+        .arg("--dataset-path")
+        .arg(&dataset_file)
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(20));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("audit:mismatch:dataset:sha256"));
+}
+
+#[test]
+fn audit_old_schema_trajectory_yields_partial_logs() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = copy_fixture_sweep(work.path());
+
+    // Modify alpha trajectory to omit "token_usage" completely, which represents an old schema
+    let alpha_path = sweep.join("alpha.traj.json");
+    let mut alpha: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&alpha_path).unwrap()).unwrap();
+    alpha["info"].as_object_mut().unwrap().remove("token_usage");
+    fs::write(&alpha_path, serde_json::to_string_pretty(&alpha).unwrap()).unwrap();
+
+    let out = Command::new(binary_path())
+        .args(["bench", "audit", "--sweep"])
+        .arg(&sweep)
+        .output()
+        .unwrap();
+
+    // Recomputation doesn't trigger false mismatch for missing optional fields
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("audit:partial:trajectory:token_usage"));
+}


### PR DESCRIPTION
This pull request implements the new `bench audit --sweep <sweep_path>` subcommand to recompute and verify sweep metrics and aggregates against raw trajectory and evaluation files.

### Summary of Changes:
- **CLI & Core routing**: Routed the subcommand, parsed input args (`--sweep`, `--dataset-path`, `--cost-tolerance-usd`, `--wallclock-tolerance-secs`, `--format`).
- **Orchestration & Validation**: Implemented raw trajectory layout scanning, bijective checks, aggregate calculations (cost, tokens, outcomes, durations), contradiction detection, and dataset SHA-256 validation.
- **Reporting**: Writes a versioned JSON artifact (`audit.json`) of type `ArtifactKind::AuditReport`.
- **Integrations Tests**: 10 comprehensive tests covered under `tests/bench_audit.rs` (clean sweeps, orphans, missing files, contradictions, dataset matching, partial legacy logs).
- **Standards & Lints**: 100% clean Clippy / Rust fmt on edition 2024. Zero `unwrap()` or `expect()` in production paths.