### PR TITLE
🌟 Nova: Table Export Format for Trajectories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+table-export = []
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1703,14 +1703,14 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`, and `table`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `table` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2477,7 +2477,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         }
         if i.output.is_some() {
             return Err(Error::Config(crate::error::ConfigError::Invalid(
-                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid)".into(),
+                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/table)".into(),
             )));
         }
         let format = parse_trajectory_diff_format(&i.format)?;
@@ -2492,13 +2492,16 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "table"
+    ) {
         return bench_inspect_export(i);
     }
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/table), not `{}`",
             i.format
         ))));
     }
@@ -2549,7 +2552,8 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     })?;
     let instance_id = i.instance.as_deref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
-            "inspect: --instance is required for export formats (markdown/html/csv/mermaid)".into(),
+            "inspect: --instance is required for export formats (markdown/html/csv/mermaid/table)"
+                .into(),
         ))
     })?;
     let traj_path =
@@ -2571,6 +2575,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "table" => inspect_export_table(&traj)?,
         _ => unreachable!("dispatch guarded by caller"),
     };
 
@@ -2656,6 +2661,22 @@ fn inspect_export_mermaid(_traj: &crate::trajectory::Trajectory) -> Result<Strin
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "format_unavailable: --format mermaid requires the `mermaid-export` Cargo feature; \
          rebuild with `--features mermaid-export`"
+            .into(),
+    )))
+}
+
+#[cfg(feature = "table-export")]
+#[allow(clippy::unnecessary_wraps)]
+fn inspect_export_table(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    use crate::trajectory::export::{TableExporter, TrajectoryExporter};
+    Ok(TableExporter::export(traj))
+}
+
+#[cfg(not(feature = "table-export"))]
+fn inspect_export_table(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "format_unavailable: --format table requires the `table-export` Cargo feature; \
+         rebuild with `--features table-export`"
             .into(),
     )))
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -53,6 +53,9 @@ pub struct MermaidExporter;
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
+#[cfg(feature = "table-export")]
+pub struct TableExporter;
+
 use std::fmt::Write;
 
 #[cfg(feature = "csv-export")]
@@ -194,6 +197,62 @@ impl TrajectoryExporter for HtmlExporter {
     }
 }
 
+#[cfg(feature = "table-export")]
+impl TrajectoryExporter for TableExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut table = comfy_table::Table::new();
+        table
+            .load_preset(comfy_table::presets::UTF8_FULL)
+            .set_header(vec!["Role", "Cost", "Latency (ms)", "Content Snippet"]);
+
+        for msg in &trajectory.messages {
+            let role = msg.role.as_str();
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            let cost = msg.extra.cost.map_or_else(|| "-".to_string(), |u| format!("{u}"));
+
+            let latency = msg
+                .extra
+                .model_latency_ms
+                .map_or_else(|| "-".to_string(), |l| format!("{l}"));
+
+            let snippet = if content.len() > 50 {
+                let mut s = content.chars().take(47).collect::<String>();
+                s.push_str("...");
+                s
+            } else {
+                content.clone()
+            };
+            let snippet = snippet.replace('\n', " ");
+
+            table.add_row(vec![
+                role,
+                cost.as_str(),
+                latency.as_str(),
+                snippet.as_str(),
+            ]);
+        }
+
+        let mut out = String::new();
+        if let Some(task) = &trajectory.info.task {
+            let _ = writeln!(
+                out,
+                "Task: {}",
+                redactor.redact_text(task, surface::EXPORT).text
+            );
+        }
+        if let Some(outcome) = &trajectory.info.outcome {
+            let _ = writeln!(
+                out,
+                "Outcome: {}",
+                redactor.redact_text(outcome, surface::EXPORT).text
+            );
+        }
+        let _ = write!(out, "\n{table}");
+        out
+    }
+}
+
 #[cfg(feature = "mermaid-export")]
 impl TrajectoryExporter for MermaidExporter {
     fn export(trajectory: &Trajectory) -> String {
@@ -319,6 +378,25 @@ mod tests {
         assert!(mermaid.contains("U->>A: Hello \"user\""));
 
         assert!(mermaid.contains("Note over S,T: Outcome: submitted"));
+    }
+
+    #[cfg(feature = "table-export")]
+    #[test]
+    fn test_table_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent\nMulti-line"));
+        t.record_message(&Message::assistant("Hello user"));
+
+        let table_out = TableExporter::export(&t);
+
+        assert!(table_out.contains("Task: Add a feature"));
+        assert!(table_out.contains("Outcome: submitted"));
+        assert!(table_out.contains("System prompt"));
+        assert!(table_out.contains("Hello agent Multi-line"));
     }
 
     #[cfg(feature = "html-export")]


### PR DESCRIPTION
💡 **The Spark:** "I noticed we can export trajectories to JSON, HTML, and Markdown, but it's hard to get a quick summary of tokens and latencies."\n🚀 **The Feature:** "Implemented \`TableExporter\` to print a terminal table summary using \`comfy-table\`."\n🔮 **The Potential:** "Could be used to quickly spot slow or expensive LLM turns."\n⚠️ **Risk:** "Low. Isolated in \`src/trajectory/export.rs\`."

---
*PR created automatically by Jules for task [13834792063945994752](https://jules.google.com/task/13834792063945994752) started by @madmax983*