### PR TITLE
feat: detect and gate test-only patch eval gaming (issue #292)

### DIFF
--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -26,6 +26,7 @@ parsing human-oriented output.
 | 15   | `resume_already_terminal` | `mini --resume` target trajectory already has a terminal outcome (`submitted`, `error`, `step_limit_reached`, `budget_exhausted`, `cancelled`, `wallclock_timeout`). Cannot continue a run that already completed. |
 | 16   | `resume_manifest_missing` | `mini --resume` target trajectory is missing required fields (`task` and/or `model_name`). The file may pre-date the run-manifest schema; create a fresh run instead. |
 | 17   | `resume_invalid_prefix` | `mini --resume` target trajectory is structurally invalid for resume: message sequence is empty, too short (fewer than 2 messages), or ends in a partial assistant turn. |
+| 21   | `eval_gaming_gate_failure` | `bench compare --max-test-only-resolved-rate` threshold was exceeded by the candidate sweep. |
 | 130  | `interrupted`            | Graceful SIGINT / Ctrl-C cancellation (POSIX convention: 128 + SIGINT(2)). |
 | 137  | `killed`                 | SIGKILL escalation after the graceful-cancel deadline expired (128 + SIGKILL(9)). |
 
@@ -66,7 +67,7 @@ coarse sweep-level result.
 | `bench forecast`                | `success`, `usage_error`, `budget_halt`, `internal_error`, `interrupted` |
 | `bench calibrate`               | `success`, `usage_error`, `calibration_optimistic`, `internal_error` |
 | `bench doctor`                  | `success`, `usage_error`, `preflight_failure`, `internal_error` |
-| `bench compare`                 | `success`, `usage_error`, `regression_gate_failure`, `internal_error` |
+| `bench compare`                 | `success`, `usage_error`, `regression_gate_failure`, `eval_gaming_gate_failure`, `internal_error` |
 | `bench evaluate`                | `success`, `usage_error`, `internal_error` |
 | `bench inspect`                 | `success`, `usage_error`, `internal_error` |
 | `bench tail`                    | `success`, `usage_error`, `internal_error` |

--- a/docs/spec-evaluation.md
+++ b/docs/spec-evaluation.md
@@ -59,6 +59,19 @@ max bench evaluate \
       "tests_failed": ["..."],
       "eval_exit_reason": "resolved|unresolved|patch_apply_failed|eval_error|skipped_no_patch",
       "eval_log_path": "optional/path/or/url",
+      "patch_stats": {
+        "files_changed": 2,
+        "hunks": 3,
+        "lines_added": 12,
+        "lines_removed": 4,
+        "is_empty": false,
+        "touches_test_files": true,
+        "touches_lock_or_generated": false,
+        "gold_files_iou": 0.5,
+        "gold_lines_overlap": 0.8,
+        "gold_size_ratio": 1.2,
+        "submission_class": "prod_only|mixed|test_only|empty"
+      },
       "patch_error_log": "captured git apply stderr (only when eval_exit_reason == patch_apply_failed; null/absent otherwise)"
     }
   ],
@@ -70,7 +83,32 @@ max bench evaluate \
       "mean_usd": 0.3601,
       "share_pct": 37.42
     }
-  ]
+  ],
+  "submission_class_rollup": {
+    "total_submitted": 10,
+    "total_resolved": 8,
+    "prod_only": {
+      "submitted_count": 6,
+      "resolved_count": 5,
+      "resolved_share_of_class": 0.8333
+    },
+    "mixed": {
+      "submitted_count": 2,
+      "resolved_count": 2,
+      "resolved_share_of_class": 1.0
+    },
+    "test_only": {
+      "submitted_count": 2,
+      "resolved_count": 1,
+      "resolved_share_of_class": 0.5
+    },
+    "empty": {
+      "submitted_count": 0,
+      "resolved_count": 0,
+      "resolved_share_of_class": 0.0
+    }
+  },
+  "test_only_resolved_rate": 0.125
 }
 ```
 
@@ -138,3 +176,20 @@ fully regressed against a baseline that resolved everything.
 Regression gating exits non-zero only when the confidence interval is entirely
 below zero. If the raw delta is negative but the interval crosses zero, the
 report is marked `within_noise: true` and the command exits successfully.
+
+## Eval Gaming & Submission Classification
+
+To protect against "eval gaming" (where an agent or developer gets a "win" or "resolved" result by only altering the test files rather than actually fixing the production bug), `bench evaluate` categorizes each instance's patch and provides sweep-level rollups in `evaluation.json`.
+
+### Patch Submission Classes
+Each patch hunk is evaluated to classify the instance's submission into one of four classes under `patch_stats.submission_class`:
+- `prod_only`: Touches only production files (at least one non-test file, zero test files).
+- `mixed`: Touches both production and test files.
+- `test_only`: Touches only test files (zero prod files modified).
+- `empty`: Has zero hunks (no changes made).
+
+### Rollup & Trust Metrics
+At the root level of `evaluation.json`, we have:
+- `submission_class_rollup`: Aggregated metrics for each class (submitted counts, resolved counts, and resolved share).
+- `test_only_resolved_rate`: The proportion of all resolved instances that were `test_only` submissions. Computed as `test_only.resolved_count / total_resolved`.
+

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1317,6 +1317,11 @@ pub struct CompareCmd {
     /// causes gating flags to exit non-zero.
     #[arg(long, default_value_t = false)]
     pub allow_underpowered: bool,
+
+    /// Exit non-zero when candidate test-only resolved rate exceeds this threshold.
+    /// Range: 0.0–1.0. Unset is informational only.
+    #[arg(long = "max-test-only-resolved-rate", value_name = "RATE")]
+    pub max_test_only_resolved_rate: Option<f64>,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1831,8 +1831,7 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
                         ),
                     );
                 }
-                let cand_rate_f64 = (f64::from(cand_rate) * 1_000_000.0).round() / 1_000_000.0;
-                if cand_rate_f64 > max_rate {
+                if cand_rate > max_rate {
                     tracing::error!(
                         max_rate = max_rate,
                         candidate_rate = cand_rate,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1814,20 +1814,36 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
         }
     }
     if let Some(max_rate) = c.max_test_only_resolved_rate {
-        if let Some(cand_rate) = report.candidate_test_only_resolved_rate {
-            if f64::from(cand_rate) > max_rate {
-                tracing::error!(
-                    max_rate = max_rate,
-                    candidate_rate = cand_rate,
-                    "compare: candidate test-only resolved rate exceeds --max-test-only-resolved-rate threshold"
-                );
+        if !(0.0..=1.0).contains(&max_rate) {
+            exit_with_outcome(
+                ExitCode::UsageError,
+                "compare: --max-test-only-resolved-rate must be between 0.0 and 1.0",
+            );
+        }
+        match report.candidate_test_only_resolved_rate {
+            Some(cand_rate) =>
+            {
+                #[allow(clippy::cast_possible_truncation)]
+                if cand_rate > max_rate as f32 {
+                    tracing::error!(
+                        max_rate = max_rate,
+                        candidate_rate = cand_rate,
+                        "compare: candidate test-only resolved rate exceeds --max-test-only-resolved-rate threshold"
+                    );
+                    exit_with_outcome(
+                        ExitCode::EvalGamingGateFailure,
+                        &format!(
+                            "compare: candidate test-only resolved rate ({:.2}%) exceeds --max-test-only-resolved-rate={:.2}%",
+                            cand_rate * 100.0,
+                            max_rate * 100.0
+                        ),
+                    );
+                }
+            }
+            None => {
                 exit_with_outcome(
-                    ExitCode::EvalGamingGateFailure,
-                    &format!(
-                        "compare: candidate test-only resolved rate ({:.2}%) exceeds --max-test-only-resolved-rate={:.2}%",
-                        cand_rate * 100.0,
-                        max_rate * 100.0
-                    ),
+                    ExitCode::UsageError,
+                    "compare: candidate evaluation report is missing test-only resolved rate data, required for --max-test-only-resolved-rate gating",
                 );
             }
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1720,6 +1720,7 @@ fn parse_verify_checks(
         .collect()
 }
 
+#[allow(clippy::too_many_lines)]
 fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
     if c.inspect_diff.is_some() && c.emit_diff_script.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1813,6 +1813,25 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
             );
         }
     }
+    if let Some(max_rate) = c.max_test_only_resolved_rate {
+        if let Some(cand_rate) = report.candidate_test_only_resolved_rate {
+            if f64::from(cand_rate) > max_rate {
+                tracing::error!(
+                    max_rate = max_rate,
+                    candidate_rate = cand_rate,
+                    "compare: candidate test-only resolved rate exceeds --max-test-only-resolved-rate threshold"
+                );
+                exit_with_outcome(
+                    ExitCode::EvalGamingGateFailure,
+                    &format!(
+                        "compare: candidate test-only resolved rate ({:.2}%) exceeds --max-test-only-resolved-rate={:.2}%",
+                        cand_rate * 100.0,
+                        max_rate * 100.0
+                    ),
+                );
+            }
+        }
+    }
     apply_significance_gates(
         &report,
         c.min_significance,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1821,8 +1821,15 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
             );
         }
         match report.candidate_test_only_resolved_rate {
-            Some(cand_rate) =>
-            {
+            Some(cand_rate) => {
+                if !cand_rate.is_finite() || !(0.0..=1.0).contains(&cand_rate) {
+                    exit_with_outcome(
+                        ExitCode::UsageError,
+                        &format!(
+                            "compare: candidate test-only resolved rate ({cand_rate}) is invalid (must be a finite float between 0.0 and 1.0)"
+                        ),
+                    );
+                }
                 #[allow(clippy::cast_possible_truncation)]
                 if cand_rate > max_rate as f32 {
                     tracing::error!(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1831,8 +1831,8 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
                         ),
                     );
                 }
-                #[allow(clippy::cast_possible_truncation)]
-                if cand_rate > max_rate as f32 {
+                let cand_rate_f64 = (f64::from(cand_rate) * 1_000_000.0).round() / 1_000_000.0;
+                if cand_rate_f64 > max_rate {
                     tracing::error!(
                         max_rate = max_rate,
                         candidate_rate = cand_rate,

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -88,6 +88,8 @@ pub enum ExitCode {
     BisectSchemaBreak = 19,
     /// 20 — `bench audit` detected a divergence exceeding tolerance or a bijection/evaluator contradiction.
     AuditFailure = 20,
+    /// 21 — `bench compare --max-test-only-resolved-rate` threshold was exceeded.
+    EvalGamingGateFailure = 21,
     /// 130 — user interruption (graceful SIGINT / Ctrl-C; 128 + SIGINT(2)).
     Interrupted = 130,
     /// 137 — forced kill (SIGKILL escalation after graceful-cancel deadline; 128 + SIGKILL(9)).
@@ -129,6 +131,7 @@ impl ExitCode {
             Self::BisectBudgetExhausted => "bisect_budget_exhausted",
             Self::BisectSchemaBreak => "bisect_schema_break",
             Self::AuditFailure => "audit_failure",
+            Self::EvalGamingGateFailure => "eval_gaming_gate_failure",
             Self::Interrupted => "interrupted",
             Self::Killed => "killed",
         }

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -225,11 +225,11 @@ pub struct CompareReport {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sampling_drift: Option<SamplingDriftSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub baseline_test_only_resolved_rate: Option<f32>,
+    pub baseline_test_only_resolved_rate: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub candidate_test_only_resolved_rate: Option<f32>,
+    pub candidate_test_only_resolved_rate: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub test_only_resolved_rate_delta: Option<f32>,
+    pub test_only_resolved_rate_delta: Option<f64>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -1448,6 +1448,7 @@ fn optional_sum(values: impl Iterator<Item = f64>) -> Option<f64> {
 }
 
 /// Compute a `CompareReport` from two on-disk sweep directories.
+#[allow(clippy::too_many_lines)]
 pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
     let baseline = load_sweep(&args.baseline)?;
     let candidate = load_sweep(&args.candidate)?;

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -224,6 +224,12 @@ pub struct CompareReport {
     /// when at least one instance pair had loadable trajectories.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sampling_drift: Option<SamplingDriftSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub baseline_test_only_resolved_rate: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidate_test_only_resolved_rate: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test_only_resolved_rate_delta: Option<f32>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -459,6 +465,19 @@ fn write_compare_overview(s: &mut String, report: &CompareReport) {
         report.candidate_resolved_rate * 100.0,
         report.resolved_delta_rate * 100.0
     );
+    if let (Some(b), Some(c)) = (
+        report.baseline_test_only_resolved_rate,
+        report.candidate_test_only_resolved_rate,
+    ) {
+        let delta = c - b;
+        let _ = writeln!(
+            s,
+            "Test-only resolved: {:.1}% -> {:.1}% ({:+.1}pp)",
+            b * 100.0,
+            c * 100.0,
+            delta * 100.0
+        );
+    }
     let _ = writeln!(
         s,
         "Tests before submit: {:.2}% -> {:.2}% ({:+.2}pp)",
@@ -1498,6 +1517,18 @@ pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
             patch_stats_aggregates(&eval.results, &candidate.instances)
         });
     apply_patch_stats_aggregates(&mut report, baseline_patch_agg, candidate_patch_agg);
+    let baseline_test_only = baseline_eval
+        .as_ref()
+        .and_then(|loaded| loaded.results.test_only_resolved_rate);
+    let candidate_test_only = candidate_eval
+        .as_ref()
+        .and_then(|loaded| loaded.results.test_only_resolved_rate);
+    report.baseline_test_only_resolved_rate = baseline_test_only;
+    report.candidate_test_only_resolved_rate = candidate_test_only;
+    report.test_only_resolved_rate_delta = match (baseline_test_only, candidate_test_only) {
+        (Some(b), Some(c)) => Some(c - b),
+        _ => None,
+    };
     apply_cost_attribution_delta(
         &mut report,
         CostAttributionContext {
@@ -1817,6 +1848,9 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
         evaluator_provenance_warnings: Vec::new(),
         resolved_rate_significance,
         sampling_drift: None,
+        baseline_test_only_resolved_rate: None,
+        candidate_test_only_resolved_rate: None,
+        test_only_resolved_rate_delta: None,
     }
 }
 
@@ -3840,12 +3874,7 @@ mod tests {
                 patch_stats: None,
                 patch_error_log: None,
             }],
-            behavioral: crate::run::evaluate::BehavioralMetrics::default(),
-            breakdown: Vec::new(),
-            cost_attribution: Vec::new(),
-            model_mix_summary: Vec::new(),
-            latency_summary: None,
-            provenance: None,
+            ..Default::default()
         };
         let candidate_eval = crate::run::evaluate::EvaluationResults {
             instances: vec![crate::run::evaluate::InstanceEvaluation {
@@ -3861,12 +3890,7 @@ mod tests {
                 patch_stats: None,
                 patch_error_log: None,
             }],
-            behavioral: crate::run::evaluate::BehavioralMetrics::default(),
-            breakdown: Vec::new(),
-            cost_attribution: Vec::new(),
-            model_mix_summary: Vec::new(),
-            latency_summary: None,
-            provenance: None,
+            ..Default::default()
         };
 
         std::fs::write(
@@ -3921,12 +3945,7 @@ mod tests {
                 patch_stats: None,
                 patch_error_log: None,
             }],
-            behavioral: crate::run::evaluate::BehavioralMetrics::default(),
-            breakdown: Vec::new(),
-            cost_attribution: Vec::new(),
-            model_mix_summary: Vec::new(),
-            latency_summary: None,
-            provenance: None,
+            ..Default::default()
         };
         std::fs::write(
             crate::run::evaluate::evaluation_path(dir_c.path()),

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -245,7 +245,7 @@ pub struct EvaluationResults {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub submission_class_rollup: Option<SubmissionClassRollup>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub test_only_resolved_rate: Option<f32>,
+    pub test_only_resolved_rate: Option<f64>,
 }
 
 /// p50 / p95 of each wall-clock stage measured across every trajectory in
@@ -696,7 +696,7 @@ fn attach_patch_stats(
 }
 
 #[allow(clippy::cast_precision_loss, clippy::too_many_lines)]
-fn build_submission_class_rollup(instances: &[InstanceEvaluation]) -> (SubmissionClassRollup, f32) {
+fn build_submission_class_rollup(instances: &[InstanceEvaluation]) -> (SubmissionClassRollup, f64) {
     let mut total_submitted = 0;
     let mut total_resolved = 0;
 
@@ -795,7 +795,7 @@ fn build_submission_class_rollup(instances: &[InstanceEvaluation]) -> (Submissio
     let test_only_resolved_rate = if total_resolved == 0 {
         0.0
     } else {
-        test_only_res as f32 / total_resolved as f32
+        f64::from(test_only_res) / f64::from(total_resolved)
     };
 
     (

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -713,6 +713,9 @@ fn build_submission_class_rollup(instances: &[InstanceEvaluation]) -> (Submissio
     let mut empty_res = 0;
 
     for inst in instances {
+        if inst.eval_exit_reason == EvalExitReason::SkippedNoPatch {
+            continue;
+        }
         if let Some(stats) = &inst.patch_stats {
             if let Some(sc) = stats.submission_class {
                 total_submitted += 1;

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -203,7 +203,24 @@ const fn is_false(value: &bool) -> bool {
     !*value
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SubmissionClassStats {
+    pub submitted_count: u32,
+    pub resolved_count: u32,
+    pub resolved_share_of_class: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SubmissionClassRollup {
+    pub total_submitted: u32,
+    pub total_resolved: u32,
+    pub prod_only: SubmissionClassStats,
+    pub mixed: SubmissionClassStats,
+    pub test_only: SubmissionClassStats,
+    pub empty: SubmissionClassStats,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct EvaluationResults {
     pub instances: Vec<InstanceEvaluation>,
     #[serde(default)]
@@ -224,6 +241,11 @@ pub struct EvaluationResults {
     /// `None` for artifacts produced before this field was added (legacy).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provenance: Option<EvaluatorProvenance>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub submission_class_rollup: Option<SubmissionClassRollup>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test_only_resolved_rate: Option<f32>,
 }
 
 /// p50 / p95 of each wall-clock stage measured across every trajectory in
@@ -400,6 +422,9 @@ pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
         eval_started_at,
     );
     attach_patch_stats(&mut eval, args, &resolved_by_run)?;
+    let (rollup, test_only_resolved_rate) = build_submission_class_rollup(&eval.instances);
+    eval.submission_class_rollup = Some(rollup);
+    eval.test_only_resolved_rate = Some(test_only_resolved_rate);
     eval.behavioral = build_behavioral_metrics(&eval.instances, &results);
     let run_slots = load_run_slots(&args.sweep_dir, &results)?;
     let (elision_instances, bytes_elided_total, compaction_failed) =
@@ -668,6 +693,119 @@ fn attach_patch_stats(
         ));
     }
     Ok(())
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn build_submission_class_rollup(instances: &[InstanceEvaluation]) -> (SubmissionClassRollup, f32) {
+    let mut total_submitted = 0;
+    let mut total_resolved = 0;
+
+    let mut prod_only_sub = 0;
+    let mut prod_only_res = 0;
+
+    let mut mixed_sub = 0;
+    let mut mixed_res = 0;
+
+    let mut test_only_sub = 0;
+    let mut test_only_res = 0;
+
+    let mut empty_sub = 0;
+    let mut empty_res = 0;
+
+    for inst in instances {
+        if let Some(stats) = &inst.patch_stats {
+            if let Some(sc) = stats.submission_class {
+                total_submitted += 1;
+                if inst.resolved {
+                    total_resolved += 1;
+                }
+                match sc {
+                    crate::run::patch_stats::SubmissionClass::ProdOnly => {
+                        prod_only_sub += 1;
+                        if inst.resolved {
+                            prod_only_res += 1;
+                        }
+                    }
+                    crate::run::patch_stats::SubmissionClass::Mixed => {
+                        mixed_sub += 1;
+                        if inst.resolved {
+                            mixed_res += 1;
+                        }
+                    }
+                    crate::run::patch_stats::SubmissionClass::TestOnly => {
+                        test_only_sub += 1;
+                        if inst.resolved {
+                            test_only_res += 1;
+                        }
+                    }
+                    crate::run::patch_stats::SubmissionClass::Empty => {
+                        empty_sub += 1;
+                        if inst.resolved {
+                            empty_res += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let prod_only = SubmissionClassStats {
+        submitted_count: prod_only_sub,
+        resolved_count: prod_only_res,
+        resolved_share_of_class: if prod_only_sub == 0 {
+            0.0
+        } else {
+            prod_only_res as f32 / prod_only_sub as f32
+        },
+    };
+
+    let mixed = SubmissionClassStats {
+        submitted_count: mixed_sub,
+        resolved_count: mixed_res,
+        resolved_share_of_class: if mixed_sub == 0 {
+            0.0
+        } else {
+            mixed_res as f32 / mixed_sub as f32
+        },
+    };
+
+    let test_only = SubmissionClassStats {
+        submitted_count: test_only_sub,
+        resolved_count: test_only_res,
+        resolved_share_of_class: if test_only_sub == 0 {
+            0.0
+        } else {
+            test_only_res as f32 / test_only_sub as f32
+        },
+    };
+
+    let empty = SubmissionClassStats {
+        submitted_count: empty_sub,
+        resolved_count: empty_res,
+        resolved_share_of_class: if empty_sub == 0 {
+            0.0
+        } else {
+            empty_res as f32 / empty_sub as f32
+        },
+    };
+
+    let test_only_resolved_rate = if total_resolved == 0 {
+        0.0
+    } else {
+        test_only_res as f32 / total_resolved as f32
+    };
+
+    (
+        SubmissionClassRollup {
+            total_submitted,
+            total_resolved,
+            prod_only,
+            mixed,
+            test_only,
+            empty,
+        },
+        test_only_resolved_rate,
+    )
 }
 
 fn load_gold_patches(dataset_path: Option<&Path>) -> Result<HashMap<String, String>, Error> {
@@ -988,12 +1126,7 @@ fn run_rehearsal_eval(
     Ok(EvaluateRunOutput {
         eval: EvaluationResults {
             instances,
-            behavioral: BehavioralMetrics::default(),
-            breakdown: Vec::new(),
-            cost_attribution: Vec::new(),
-            model_mix_summary: Vec::new(),
-            latency_summary: None,
-            provenance: None,
+            ..Default::default()
         },
         resolved_by_run,
         effective_run_id: Some("rehearsal-eval".to_owned()),
@@ -1008,12 +1141,7 @@ fn build_none_eval(results: &HashMap<String, InstanceResult>) -> EvaluationResul
     instances.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
     EvaluationResults {
         instances,
-        behavioral: BehavioralMetrics::default(),
-        breakdown: Vec::new(),
-        cost_attribution: Vec::new(),
-        model_mix_summary: Vec::new(),
-        latency_summary: None,
-        provenance: None,
+        ..Default::default()
     }
 }
 
@@ -1377,12 +1505,7 @@ fn merge_with_results(
     instances.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
     EvaluationResults {
         instances,
-        behavioral: BehavioralMetrics::default(),
-        breakdown: Vec::new(),
-        cost_attribution: Vec::new(),
-        model_mix_summary: Vec::new(),
-        latency_summary: None,
-        provenance: None,
+        ..Default::default()
     }
 }
 
@@ -1559,12 +1682,7 @@ fn merge_rerun_reports_with_results(
     instances.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
     EvaluationResults {
         instances,
-        behavioral: BehavioralMetrics::default(),
-        breakdown: Vec::new(),
-        cost_attribution: Vec::new(),
-        model_mix_summary: Vec::new(),
-        latency_summary: None,
-        provenance: None,
+        ..Default::default()
     }
 }
 
@@ -2272,12 +2390,7 @@ mod tests {
                 eval_row("tested-fail", false),
                 eval_row("skipped-fail", false),
             ],
-            breakdown: Vec::new(),
-            cost_attribution: Vec::new(),
-            model_mix_summary: Vec::new(),
-            latency_summary: None,
-            provenance: None,
-            behavioral: BehavioralMetrics::default(),
+            ..Default::default()
         };
         let results = HashMap::from([
             (
@@ -2457,12 +2570,7 @@ mod tests {
         let results = HashMap::from([("a".to_string(), normal), ("b".to_string(), budgeted)]);
         let eval = EvaluationResults {
             instances: vec![eval_row("a", true), eval_row("b", false)],
-            behavioral: BehavioralMetrics::default(),
-            breakdown: vec![],
-            cost_attribution: vec![],
-            model_mix_summary: vec![],
-            latency_summary: None,
-            provenance: None,
+            ..Default::default()
         };
         let summary = summarize_with_model(&eval, &results, None);
         assert_eq!(summary.budget_exhausted_excluded, 1);
@@ -2581,12 +2689,7 @@ mod tests {
         let results = HashMap::from([("cached".to_string(), cached)]);
         let eval = EvaluationResults {
             instances: vec![eval_row("cached", true)],
-            behavioral: BehavioralMetrics::default(),
-            breakdown: Vec::new(),
-            cost_attribution: Vec::new(),
-            model_mix_summary: Vec::new(),
-            latency_summary: None,
-            provenance: None,
+            ..Default::default()
         };
         let summary = summarize(&eval, &results);
         assert_eq!(summary.instances, 1);
@@ -2633,12 +2736,7 @@ mod tests {
         })]);
         let eval = EvaluationResults {
             instances: vec![eval_row("a", false)],
-            behavioral: BehavioralMetrics::default(),
-            breakdown: Vec::new(),
-            cost_attribution: Vec::new(),
-            model_mix_summary: Vec::new(),
-            latency_summary: None,
-            provenance: None,
+            ..Default::default()
         };
         let summary = summarize(&eval, &results);
         assert!(
@@ -2667,12 +2765,7 @@ mod tests {
                 eval_row("r2", true),
                 eval_row("r3", false),
             ],
-            behavioral: BehavioralMetrics::default(),
-            breakdown: Vec::new(),
-            cost_attribution: Vec::new(),
-            model_mix_summary: Vec::new(),
-            latency_summary: None,
-            provenance: None,
+            ..Default::default()
         };
         let summary = summarize(&eval, &results);
         assert_eq!(summary.resolved, 2);
@@ -2690,12 +2783,7 @@ mod tests {
         })]);
         let eval = EvaluationResults {
             instances: vec![eval_row("a", false)],
-            behavioral: BehavioralMetrics::default(),
-            breakdown: Vec::new(),
-            cost_attribution: Vec::new(),
-            model_mix_summary: Vec::new(),
-            latency_summary: None,
-            provenance: None,
+            ..Default::default()
         };
         let summary = summarize(&eval, &results);
         assert!(
@@ -2720,12 +2808,7 @@ mod tests {
             .collect();
         let eval = EvaluationResults {
             instances: (0..10).map(|i| eval_row(&format!("r{i}"), true)).collect(),
-            behavioral: BehavioralMetrics::default(),
-            breakdown: Vec::new(),
-            cost_attribution: Vec::new(),
-            model_mix_summary: Vec::new(),
-            latency_summary: None,
-            provenance: None,
+            ..Default::default()
         };
         let summary = summarize(&eval, &results);
         assert_f64_eq(summary.cost_per_resolved_usd, 1.0);
@@ -2748,12 +2831,7 @@ mod tests {
         let results = HashMap::from([("a".to_string(), r)]);
         let eval = EvaluationResults {
             instances: vec![eval_row("a", true)],
-            behavioral: BehavioralMetrics::default(),
-            breakdown: Vec::new(),
-            cost_attribution: Vec::new(),
-            model_mix_summary: Vec::new(),
-            latency_summary: None,
-            provenance: None,
+            ..Default::default()
         };
         let summary = summarize(&eval, &results);
         let rendered = render_summary_table(&summary);

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -695,7 +695,7 @@ fn attach_patch_stats(
     Ok(())
 }
 
-#[allow(clippy::cast_precision_loss)]
+#[allow(clippy::cast_precision_loss, clippy::too_many_lines)]
 fn build_submission_class_rollup(instances: &[InstanceEvaluation]) -> (SubmissionClassRollup, f32) {
     let mut total_submitted = 0;
     let mut total_resolved = 0;

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -980,6 +980,17 @@ fn write_patch_stats_lines(s: &mut String, stats: Option<&PatchStats>) {
             "gold_distance:    files_iou={files_iou:.3} lines_overlap={lines_overlap:.3} size_ratio={size_ratio:.3}"
         );
     }
+    if let Some(sc) = stats.submission_class {
+        if sc != crate::run::patch_stats::SubmissionClass::Empty {
+            let _ = writeln!(s, "submission_class: {}", sc.label());
+        }
+        if sc == crate::run::patch_stats::SubmissionClass::TestOnly {
+            let _ = writeln!(
+                s,
+                "warning: patch touches only test files (may indicate eval gaming)"
+            );
+        }
+    }
 }
 
 fn render_token_summary(

--- a/src/run/patch_stats.rs
+++ b/src/run/patch_stats.rs
@@ -305,21 +305,67 @@ fn parse_unified_diff(text: &str) -> ParsedPatch {
     parsed
 }
 
-fn parse_diff_git_file(line: &str) -> Option<String> {
-    let mut parts = line.split_whitespace();
-    if parts.next()? != "diff" || parts.next()? != "--git" {
-        return None;
+fn extract_git_diff_path(s: &str) -> Option<(String, &str)> {
+    let s = s.trim_start();
+    if s.starts_with('"') {
+        let chars = s.char_indices().skip(1);
+        let mut escaped = false;
+        for (idx, c) in chars {
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == '"' {
+                let content = &s[1..idx];
+                let unescaped = content.replace("\\\"", "\"").replace("\\\\", "\\");
+                return Some((unescaped, &s[idx + 1..]));
+            }
+        }
+        None
+    } else if let Some(idx) = s.find(char::is_whitespace) {
+        Some((s[..idx].to_string(), &s[idx..]))
+    } else if !s.is_empty() {
+        Some((s.to_string(), ""))
+    } else {
+        None
     }
-    let old = parts.next()?;
-    let new = parts.next()?;
+}
+
+fn parse_git_diff_paths(rest: &str) -> Option<(String, String)> {
+    let rest = rest.trim();
+    let (a, remainder) = extract_git_diff_path(rest)?;
+    let (b, _) = extract_git_diff_path(remainder)?;
+    Some((a, b))
+}
+
+fn parse_diff_git_file(line: &str) -> Option<String> {
+    let rest = line.strip_prefix("diff --git ")?;
+    let (old, new) = parse_git_diff_paths(rest)?;
     let selected = if new == "/dev/null" { old } else { new };
-    Some(strip_diff_prefix(selected))
+    Some(strip_diff_prefix(&selected))
 }
 
 fn parse_file_marker(line: &str, prefix: &str) -> Option<String> {
-    line.strip_prefix(prefix)
-        .and_then(|rest| rest.split_whitespace().next())
-        .map(strip_diff_prefix)
+    let rest = line.strip_prefix(prefix)?;
+    let rest = rest.trim_start();
+    if rest.starts_with('"') {
+        let chars = rest.char_indices().skip(1);
+        let mut escaped = false;
+        for (idx, c) in chars {
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == '"' {
+                let content = &rest[1..idx];
+                let unescaped = content.replace("\\\"", "\"").replace("\\\\", "\\");
+                return Some(strip_diff_prefix(&unescaped));
+            }
+        }
+        None
+    } else {
+        rest.split_whitespace().next().map(strip_diff_prefix)
+    }
 }
 
 fn strip_diff_prefix(path: &str) -> String {
@@ -449,6 +495,11 @@ lock_or_generated_files = []
         let patch_empty = "";
         let stats = score_patch(patch_empty, &classifiers, None);
         assert_eq!(stats.submission_class, Some(SubmissionClass::Empty));
+
+        // 6. Test-only patch with spaced and quoted filename
+        let patch_quoted = "diff --git \"a/tests/test foo.rs\" \"b/tests/test foo.rs\"\n--- \"a/tests/test foo.rs\"\n+++ \"b/tests/test foo.rs\"\n@@ -1 +1 @@\n-old\n+new\n";
+        let stats = score_patch(patch_quoted, &classifiers, None);
+        assert_eq!(stats.submission_class, Some(SubmissionClass::TestOnly));
 
         Ok(())
     }

--- a/src/run/patch_stats.rs
+++ b/src/run/patch_stats.rs
@@ -193,7 +193,7 @@ pub fn score_patch(
     gold_patch: Option<&str>,
 ) -> PatchStats {
     let parsed = parse_unified_diff(patch_text);
-    let submission_class = if parsed.hunks == 0 {
+    let submission_class = if parsed.files.is_empty() {
         SubmissionClass::Empty
     } else {
         let test_count = parsed
@@ -440,8 +440,13 @@ lock_or_generated_files = []
         let stats = score_patch(patch_mixed, &classifiers, None);
         assert_eq!(stats.submission_class, Some(SubmissionClass::Mixed));
 
-        // 4. Empty patch (zero hunks)
-        let patch_empty = "diff --git a/src/lib.rs b/src/lib.rs\n";
+        // 4. No hunks but contains files (e.g. rename, mode change, metadata-only)
+        let patch_nonempty = "diff --git a/src/lib.rs b/src/lib.rs\n";
+        let stats = score_patch(patch_nonempty, &classifiers, None);
+        assert_eq!(stats.submission_class, Some(SubmissionClass::ProdOnly));
+
+        // 5. Completely empty patch (zero files, zero hunks)
+        let patch_empty = "";
         let stats = score_patch(patch_empty, &classifiers, None);
         assert_eq!(stats.submission_class, Some(SubmissionClass::Empty));
 

--- a/src/run/patch_stats.rs
+++ b/src/run/patch_stats.rs
@@ -305,6 +305,83 @@ fn parse_unified_diff(text: &str) -> ParsedPatch {
     parsed
 }
 
+fn unescape_git_path(s: &str) -> String {
+    let mut result = Vec::new();
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 1 < bytes.len() {
+            match bytes[i + 1] {
+                b'a' => {
+                    result.push(7);
+                    i += 2;
+                }
+                b'b' => {
+                    result.push(8);
+                    i += 2;
+                }
+                b'f' => {
+                    result.push(12);
+                    i += 2;
+                }
+                b'n' => {
+                    result.push(10);
+                    i += 2;
+                }
+                b'r' => {
+                    result.push(13);
+                    i += 2;
+                }
+                b't' => {
+                    result.push(9);
+                    i += 2;
+                }
+                b'v' => {
+                    result.push(11);
+                    i += 2;
+                }
+                b'\\' => {
+                    result.push(b'\\');
+                    i += 2;
+                }
+                b'"' => {
+                    result.push(b'"');
+                    i += 2;
+                }
+                b'?' => {
+                    result.push(b'?');
+                    i += 2;
+                }
+                b'\'' => {
+                    result.push(b'\'');
+                    i += 2;
+                }
+                c @ b'0'..=b'7' => {
+                    let mut val = u32::from(c - b'0');
+                    let mut count = 1;
+                    i += 2;
+                    while count < 3 && i < bytes.len() && (b'0'..=b'7').contains(&bytes[i]) {
+                        val = val * 8 + u32::from(bytes[i] - b'0');
+                        count += 1;
+                        i += 1;
+                    }
+                    #[allow(clippy::cast_possible_truncation)]
+                    result.push(val as u8);
+                }
+                _ => {
+                    result.push(b'\\');
+                    result.push(bytes[i + 1]);
+                    i += 2;
+                }
+            }
+        } else {
+            result.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8_lossy(&result).into_owned()
+}
+
 fn extract_git_diff_path(s: &str) -> Option<(String, &str)> {
     let s = s.trim_start();
     if s.starts_with('"') {
@@ -317,7 +394,7 @@ fn extract_git_diff_path(s: &str) -> Option<(String, &str)> {
                 escaped = true;
             } else if c == '"' {
                 let content = &s[1..idx];
-                let unescaped = content.replace("\\\"", "\"").replace("\\\\", "\\");
+                let unescaped = unescape_git_path(content);
                 return Some((unescaped, &s[idx + 1..]));
             }
         }
@@ -358,7 +435,7 @@ fn parse_file_marker(line: &str, prefix: &str) -> Option<String> {
                 escaped = true;
             } else if c == '"' {
                 let content = &rest[1..idx];
-                let unescaped = content.replace("\\\"", "\"").replace("\\\\", "\\");
+                let unescaped = unescape_git_path(content);
                 return Some(strip_diff_prefix(&unescaped));
             }
         }
@@ -499,6 +576,11 @@ lock_or_generated_files = []
         // 6. Test-only patch with spaced and quoted filename
         let patch_quoted = "diff --git \"a/tests/test foo.rs\" \"b/tests/test foo.rs\"\n--- \"a/tests/test foo.rs\"\n+++ \"b/tests/test foo.rs\"\n@@ -1 +1 @@\n-old\n+new\n";
         let stats = score_patch(patch_quoted, &classifiers, None);
+        assert_eq!(stats.submission_class, Some(SubmissionClass::TestOnly));
+
+        // 7. Test-only patch with C-style escaped non-ASCII filename
+        let patch_escaped = "diff --git \"a/tests/test_\\303\\251l\\303\\251gant.rs\" \"b/tests/test_\\303\\251l\\303\\251gant.rs\"\n--- \"a/tests/test_\\303\\251l\\303\\251gant.rs\"\n+++ \"b/tests/test_\\303\\251l\\303\\251gant.rs\"\n@@ -1 +1 @@\n-old\n+new\n";
+        let stats = score_patch(patch_escaped, &classifiers, None);
         assert_eq!(stats.submission_class, Some(SubmissionClass::TestOnly));
 
         Ok(())

--- a/src/run/patch_stats.rs
+++ b/src/run/patch_stats.rs
@@ -9,6 +9,27 @@ use crate::error::{ConfigError, Error};
 
 const DEFAULT_CLASSIFIERS_TOML: &str = include_str!("../../data/patch_classifiers.toml");
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SubmissionClass {
+    ProdOnly,
+    Mixed,
+    TestOnly,
+    Empty,
+}
+
+impl SubmissionClass {
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::ProdOnly => "prod_only",
+            Self::Mixed => "mixed",
+            Self::TestOnly => "test_only",
+            Self::Empty => "empty",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PatchStats {
     pub files_changed: u32,
@@ -24,6 +45,8 @@ pub struct PatchStats {
     pub gold_lines_overlap: Option<f32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gold_size_ratio: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub submission_class: Option<SubmissionClass>,
 }
 
 impl PatchStats {
@@ -53,10 +76,12 @@ impl PatchClassifiers {
         })
     }
 
+    pub fn is_test_file(&self, file: &str) -> bool {
+        self.test_files.iter().any(|glob| glob.matches(file))
+    }
+
     fn touches_test_file(&self, files: &BTreeSet<String>) -> bool {
-        files
-            .iter()
-            .any(|file| self.test_files.iter().any(|glob| glob.matches(file)))
+        files.iter().any(|file| self.is_test_file(file))
     }
 
     fn touches_lock_or_generated(&self, files: &BTreeSet<String>) -> bool {
@@ -168,6 +193,23 @@ pub fn score_patch(
     gold_patch: Option<&str>,
 ) -> PatchStats {
     let parsed = parse_unified_diff(patch_text);
+    let submission_class = if parsed.hunks == 0 {
+        SubmissionClass::Empty
+    } else {
+        let test_count = parsed
+            .files
+            .iter()
+            .filter(|f| classifiers.is_test_file(f))
+            .count();
+        if test_count == parsed.files.len() {
+            SubmissionClass::TestOnly
+        } else if test_count == 0 {
+            SubmissionClass::ProdOnly
+        } else {
+            SubmissionClass::Mixed
+        }
+    };
+
     let mut stats = PatchStats {
         files_changed: saturating_u32(parsed.files.len()),
         hunks: parsed.hunks,
@@ -179,6 +221,7 @@ pub fn score_patch(
         gold_files_iou: None,
         gold_lines_overlap: None,
         gold_size_ratio: None,
+        submission_class: Some(submission_class),
     };
 
     if let Some(gold) = gold_patch {
@@ -368,6 +411,40 @@ lock_or_generated_files = ["**/*.snap"]
             None,
         );
         assert!(stats.touches_lock_or_generated);
+        Ok(())
+    }
+
+    #[test]
+    fn test_submission_class_scoring() -> Result<(), Error> {
+        use super::SubmissionClass;
+
+        let classifiers = PatchClassifiers::from_toml_str(
+            r#"
+test_files = ["tests/**/*.rs", "src/test_helpers.rs"]
+lock_or_generated_files = []
+"#,
+        )?;
+
+        // 1. Prod only patch
+        let patch_prod = "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
+        let stats = score_patch(patch_prod, &classifiers, None);
+        assert_eq!(stats.submission_class, Some(SubmissionClass::ProdOnly));
+
+        // 2. Test only patch
+        let patch_test = "diff --git a/tests/test_lib.rs b/tests/test_lib.rs\n--- a/tests/test_lib.rs\n+++ b/tests/test_lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
+        let stats = score_patch(patch_test, &classifiers, None);
+        assert_eq!(stats.submission_class, Some(SubmissionClass::TestOnly));
+
+        // 3. Mixed patch
+        let patch_mixed = "diff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\ndiff --git a/tests/test_lib.rs b/tests/test_lib.rs\n--- a/tests/test_lib.rs\n+++ b/tests/test_lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
+        let stats = score_patch(patch_mixed, &classifiers, None);
+        assert_eq!(stats.submission_class, Some(SubmissionClass::Mixed));
+
+        // 4. Empty patch (zero hunks)
+        let patch_empty = "diff --git a/src/lib.rs b/src/lib.rs\n";
+        let stats = score_patch(patch_empty, &classifiers, None);
+        assert_eq!(stats.submission_class, Some(SubmissionClass::Empty));
+
         Ok(())
     }
 }

--- a/src/run/report.rs
+++ b/src/run/report.rs
@@ -556,6 +556,7 @@ fn md_baseline_delta(buf: &mut String, report: &CompareReport) {
 
 // ── HTML rendering ─────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_lines)]
 fn md_to_html(md: &str) -> String {
     let mut buf = String::new();
     writeln!(buf, "<!DOCTYPE html>").ok();

--- a/src/run/report.rs
+++ b/src/run/report.rs
@@ -281,6 +281,23 @@ fn md_topline(
         Some(ml) => writeln!(buf, "| Mean lines changed (resolved) | {ml:.1} |").ok(),
         None => writeln!(buf, "| Mean lines changed (resolved) | {NO_EVAL_MSG} |").ok(),
     };
+    if eval.is_some() {
+        let rollup = eval.and_then(|e| e.submission_class_rollup.as_ref());
+        let test_only_count = rollup.map_or(0, |r| r.test_only.resolved_count);
+        let total_resolved = rollup.map_or(0, |r| r.total_resolved);
+        let rate = if total_resolved == 0 {
+            0.0
+        } else {
+            (f64::from(test_only_count) / f64::from(total_resolved)) * 100.0
+        };
+        writeln!(
+            buf,
+            "| test-only resolved | {test_only_count} of {total_resolved} ({rate:.2}%) |"
+        )
+        .ok();
+    } else {
+        writeln!(buf, "| test-only resolved | {NO_EVAL_MSG} |").ok();
+    }
     writeln!(buf).ok();
 }
 
@@ -637,7 +654,14 @@ fn md_to_html(md: &str) -> String {
     close_blockquote(&mut buf, &mut in_blockquote);
     writeln!(buf, "</body>").ok();
     writeln!(buf, "</html>").ok();
-    buf
+    let mut html = buf;
+    if html.contains("<td>test-only resolved</td>") {
+        html = html.replace(
+            "<td>test-only resolved</td>",
+            "<td>test-only resolved <span style=\"cursor:help;\" title=\"test-only resolved patches may indicate eval gaming\">ℹ️</span> <a href=\"docs/spec-evaluation.md\" target=\"_blank\">[doc]</a></td>"
+        );
+    }
+    html
 }
 
 fn close_table(buf: &mut String, in_table: &mut bool) {

--- a/src/run/report.rs
+++ b/src/run/report.rs
@@ -281,10 +281,10 @@ fn md_topline(
         Some(ml) => writeln!(buf, "| Mean lines changed (resolved) | {ml:.1} |").ok(),
         None => writeln!(buf, "| Mean lines changed (resolved) | {NO_EVAL_MSG} |").ok(),
     };
-    if eval.is_some() {
-        let rollup = eval.and_then(|e| e.submission_class_rollup.as_ref());
-        let test_only_count = rollup.map_or(0, |r| r.test_only.resolved_count);
-        let total_resolved = rollup.map_or(0, |r| r.total_resolved);
+    let rollup = eval.and_then(|e| e.submission_class_rollup.as_ref());
+    if let Some(r) = rollup {
+        let test_only_count = r.test_only.resolved_count;
+        let total_resolved = r.total_resolved;
         let rate = if total_resolved == 0 {
             0.0
         } else {

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -3506,4 +3506,68 @@ fn compare_test_only_resolved_rate_ci_gating_and_reporting() {
         report_html.contains("ℹ️") && report_html.contains("docs/spec-evaluation.md"),
         "expected report.html to contain interactive tooltip and doc link; got:\n{report_html}"
     );
+
+    // 9. Verify exact boundary value (0.20) does not fail (assert float widening is resolved)
+    let out_exact = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--max-test-only-resolved-rate",
+            "0.20",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out_exact.status.success(),
+        "expected gate success because candidate rate (0.20) is exactly equal to threshold (0.20), but failed; stderr: {}",
+        String::from_utf8_lossy(&out_exact.stderr)
+    );
+
+    // 10. Verify out-of-bounds rate (e.g. 1.5) fails with ExitCode::UsageError (2)
+    let out_oob = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--max-test-only-resolved-rate",
+            "1.5",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out_oob.status.code(),
+        Some(2),
+        "expected usage error (exit code 2) because 1.5 is out of bounds; stderr: {}",
+        String::from_utf8_lossy(&out_oob.stderr)
+    );
+
+    // 11. Verify missing candidate metric fails closed (exit code 2)
+    let missing_cand_dir = tempfile::tempdir().unwrap();
+    write_results(missing_cand_dir.path(), vec![submitted("inst-1")]);
+    let out_missing = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            missing_cand_dir.path().to_str().unwrap(),
+            "--max-test-only-resolved-rate",
+            "0.50",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out_missing.status.code(),
+        Some(2),
+        "expected usage error (exit code 2) because candidate has no evaluation.json/test-only metrics; stderr: {}",
+        String::from_utf8_lossy(&out_missing.stderr)
+    );
 }

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -3353,7 +3353,11 @@ fn evaluate_rehearsal_for_patch_stats(dir: &Path) {
 }
 
 #[test]
-#[allow(clippy::too_many_lines, clippy::uninlined_format_args, clippy::float_cmp)]
+#[allow(
+    clippy::too_many_lines,
+    clippy::uninlined_format_args,
+    clippy::float_cmp
+)]
 fn compare_test_only_resolved_rate_ci_gating_and_reporting() {
     let baseline_dir = tempfile::tempdir().unwrap();
     let candidate_dir = tempfile::tempdir().unwrap();

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -3327,3 +3327,183 @@ fn test_compare_appends_diff_config_hint() {
         "expected stdout to contain the bench diff-config hint; got:\n{stdout}"
     );
 }
+
+fn evaluate_rehearsal_for_patch_stats(dir: &Path) {
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "evaluate",
+            "--sweep",
+            dir.to_str().unwrap(),
+            "--backend",
+            "rehearsal",
+            "--breakdown",
+            "none",
+            "--cost-attribution",
+            "off",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "evaluate failed; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn compare_test_only_resolved_rate_ci_gating_and_reporting() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let candidate_dir = tempfile::tempdir().unwrap();
+
+    // 1. Synthesize baseline sweep: 10 instances, all resolved with prod_only patches
+    let mut baseline_results = vec![];
+    for i in 1..=10 {
+        let instance_id = format!("inst-{}", i);
+        write_run_traj(baseline_dir.path(), &instance_id, 1, None, Some(0.01));
+
+        let patch = "diff --git a/src/foo.rs b/src/foo.rs\n--- a/src/foo.rs\n+++ b/src/foo.rs\n@@ -1,1 +1,2 @@\n existing line\n+added prod line\n";
+        write_run_patch(baseline_dir.path(), &instance_id, patch);
+
+        baseline_results.push(submitted(&instance_id));
+    }
+    write_results(baseline_dir.path(), baseline_results);
+
+    // 2. Synthesize candidate sweep: 10 instances, all resolved. 2 test-only patches, 8 prod-only patches.
+    let mut candidate_results = vec![];
+    for i in 1..=10 {
+        let instance_id = format!("inst-{}", i);
+        write_run_traj(candidate_dir.path(), &instance_id, 1, None, Some(0.01));
+
+        let patch = if i <= 2 {
+            "diff --git a/tests/test_foo.rs b/tests/test_foo.rs\n--- a/tests/test_foo.rs\n+++ b/tests/test_foo.rs\n@@ -1,1 +1,2 @@\n existing line\n+added test line\n"
+        } else {
+            "diff --git a/src/foo.rs b/src/foo.rs\n--- a/src/foo.rs\n+++ b/src/foo.rs\n@@ -1,1 +1,2 @@\n existing line\n+added prod line\n"
+        };
+        write_run_patch(candidate_dir.path(), &instance_id, patch);
+
+        candidate_results.push(submitted(&instance_id));
+    }
+    write_results(candidate_dir.path(), candidate_results);
+
+    // 3. Run bench evaluate on baseline & candidate
+    evaluate_rehearsal_for_patch_stats(baseline_dir.path());
+    evaluate_rehearsal_for_patch_stats(candidate_dir.path());
+
+    // 4. Assert evaluation outputs have correct test_only_resolved_rate
+    let eval_json = std::fs::read_to_string(baseline_dir.path().join("evaluation.json")).unwrap();
+    let v_base: serde_json::Value = serde_json::from_str(&eval_json).unwrap();
+    assert_eq!(v_base["test_only_resolved_rate"].as_f64().unwrap(), 0.0);
+
+    let eval_json_cand =
+        std::fs::read_to_string(candidate_dir.path().join("evaluation.json")).unwrap();
+    let v_cand: serde_json::Value = serde_json::from_str(&eval_json_cand).unwrap();
+    assert_eq!(v_cand["test_only_resolved_rate"].as_f64().unwrap(), 0.20);
+
+    // 5. Test bench compare Gating: threshold 0.10 should fail (exit code 21)
+    let out_fail = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--max-test-only-resolved-rate",
+            "0.10",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out_fail.status.code(),
+        Some(21),
+        "expected gate failure (exit code 21) because candidate rate (0.20) > threshold (0.10); stderr: {}",
+        String::from_utf8_lossy(&out_fail.stderr)
+    );
+
+    // 6. Test bench compare Gating: threshold 0.30 should succeed (exit code 0)
+    let out_pass = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            candidate_dir.path().to_str().unwrap(),
+            "--max-test-only-resolved-rate",
+            "0.30",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out_pass.status.success(),
+        "expected gate success because candidate rate (0.20) <= threshold (0.30); stderr: {}",
+        String::from_utf8_lossy(&out_pass.stderr)
+    );
+
+    // 7. Verify human output in stdout contains delta rendering
+    let stdout = String::from_utf8_lossy(&out_pass.stdout);
+    assert!(
+        stdout.contains("Test-only resolved: 0.0% -> 20.0% (+20.0pp)")
+            || stdout.contains("Test-only resolved: 0% -> 20% (+20pp)"),
+        "expected stdout to contain test-only resolved rate delta, got:\n{stdout}"
+    );
+
+    // 8. Verify bench report output contains correct MD rendering
+    let report_md_path = candidate_dir.path().join("report.md");
+    let out_report = Command::new(binary_path())
+        .args([
+            "bench",
+            "report",
+            "--sweep",
+            candidate_dir.path().to_str().unwrap(),
+            "--output",
+            report_md_path.to_str().unwrap(),
+            "--format",
+            "markdown",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out_report.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out_report.stderr)
+    );
+
+    let report_md = std::fs::read_to_string(&report_md_path).unwrap();
+    assert!(
+        report_md.contains("test-only resolved"),
+        "expected report.md to contain trust signal table row; got:\n{report_md}"
+    );
+    assert!(
+        report_md.contains("2 of 10") && report_md.contains("20.00%"),
+        "expected report.md to contain correct percentage; got:\n{report_md}"
+    );
+
+    let report_html_path = candidate_dir.path().join("report.html");
+    let out_report_html = Command::new(binary_path())
+        .args([
+            "bench",
+            "report",
+            "--sweep",
+            candidate_dir.path().to_str().unwrap(),
+            "--output",
+            report_html_path.to_str().unwrap(),
+            "--format",
+            "html",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out_report_html.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out_report_html.stderr)
+    );
+
+    let report_html = std::fs::read_to_string(&report_html_path).unwrap();
+    assert!(
+        report_html.contains("ℹ️") && report_html.contains("docs/spec-evaluation.md"),
+        "expected report.html to contain interactive tooltip and doc link; got:\n{report_html}"
+    );
+}

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -3570,4 +3570,33 @@ fn compare_test_only_resolved_rate_ci_gating_and_reporting() {
         "expected usage error (exit code 2) because candidate has no evaluation.json/test-only metrics; stderr: {}",
         String::from_utf8_lossy(&out_missing.stderr)
     );
+
+    // 12. Verify invalid candidate metric fails closed (exit code 2)
+    let invalid_cand_dir = tempfile::tempdir().unwrap();
+    write_results(invalid_cand_dir.path(), vec![submitted("inst-1")]);
+    let eval_json_content = r#"{"instances":[],"test_only_resolved_rate":1.5}"#;
+    std::fs::write(
+        invalid_cand_dir.path().join("evaluation.json"),
+        eval_json_content,
+    )
+    .unwrap();
+    let out_invalid = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline_dir.path().to_str().unwrap(),
+            "--candidate",
+            invalid_cand_dir.path().to_str().unwrap(),
+            "--max-test-only-resolved-rate",
+            "0.50",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out_invalid.status.code(),
+        Some(2),
+        "expected usage error (exit code 2) because candidate rate (1.5) is invalid; stderr: {}",
+        String::from_utf8_lossy(&out_invalid.stderr)
+    );
 }

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -3353,6 +3353,7 @@ fn evaluate_rehearsal_for_patch_stats(dir: &Path) {
 }
 
 #[test]
+#[allow(clippy::too_many_lines, clippy::uninlined_format_args, clippy::float_cmp)]
 fn compare_test_only_resolved_rate_ci_gating_and_reporting() {
     let baseline_dir = tempfile::tempdir().unwrap();
     let candidate_dir = tempfile::tempdir().unwrap();

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -2379,6 +2379,7 @@ fn format_mermaid_produces_sequence_diagram() {
 }
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn inspect_displays_submission_class_and_warning_for_test_only_patches() {
     let sweep_dir = tempfile::tempdir().unwrap();
     let instance_id = "inst-test-only";

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -2377,3 +2377,147 @@ fn format_mermaid_produces_sequence_diagram() {
         "expected mermaid sequence diagram:\n{stdout}"
     );
 }
+
+#[test]
+fn inspect_displays_submission_class_and_warning_for_test_only_patches() {
+    let sweep_dir = tempfile::tempdir().unwrap();
+    let instance_id = "inst-test-only";
+
+    // Write a trajectory with outcome = "submitted"
+    let mut t = maxwells_daemon::trajectory::Trajectory::new();
+    t.info.outcome = Some(maxwells_daemon::trajectory::outcome::SUBMITTED.to_owned());
+    std::fs::create_dir_all(sweep_dir.path().join(instance_id)).unwrap();
+    std::fs::write(
+        sweep_dir.path().join(instance_id).join("run-1.traj.json"),
+        serde_json::to_string_pretty(&t).unwrap(),
+    )
+    .unwrap();
+
+    // Write a test-only patch
+    let patch = "diff --git a/tests/test_foo.rs b/tests/test_foo.rs\n--- a/tests/test_foo.rs\n+++ b/tests/test_foo.rs\n@@ -1,1 +1,2 @@\n existing line\n+added test line\n";
+    let patch_path =
+        maxwells_daemon::run::swebench::patch_path_for_run(sweep_dir.path(), instance_id, 1);
+    std::fs::create_dir_all(patch_path.parent().unwrap()).unwrap();
+    std::fs::write(patch_path, patch).unwrap();
+
+    // Write results.json
+    let results = maxwells_daemon::run::swebench::SweepResults {
+        total: 1,
+        sweep_status: "complete".to_owned(),
+        cancelled_at: None,
+        cancel_deadline_at: None,
+        cancel_exit_code: None,
+        completed: 1,
+        in_flight_at_cancel: 0,
+        not_started: 0,
+        submitted: 1,
+        submitted_with_tests: 0,
+        skipped: 0,
+        errored: 0,
+        failures_by_category: std::collections::BTreeMap::new(),
+        budget_halted: 0,
+        with_patch: 1,
+        patch_empty: 0,
+        patch_apply_invalid: 0,
+        github_pr_failures: 0,
+        total_prompt_tokens: 0,
+        total_cache_read_tokens: 0,
+        total_cache_creation_tokens: 0,
+        total_completion_tokens: 0,
+        estimated_cost_usd: 0.0,
+        actual_cost_usd: None,
+        actual_cost_source: None,
+        baseline_cost_usd: None,
+        baseline_cost_model: None,
+        cache_hit_rate: 0.0,
+        retries: 0,
+        retried_instances: 0,
+        pass_at_k: 0.0,
+        filter_spec: Default::default(),
+        manifest: None,
+        instances: vec![maxwells_daemon::run::swebench::InstanceResult {
+            instance_id: instance_id.to_owned(),
+            exit_reason: "submitted".to_owned(),
+            outcome: Some("submitted".to_owned()),
+            failure_category: None,
+            steps: Some(1),
+            cost_usd: Some(0.0),
+            prompt_tokens: Some(0),
+            cache_read_tokens: Some(0),
+            cache_creation_tokens: Some(0),
+            completion_tokens: Some(0),
+            duration_secs: Some(0.0),
+            error: None,
+            github_pr_error: None,
+            patch_present: true,
+            non_empty_patch: true,
+            attempts: 1,
+            retry_reasons: vec![],
+            runs: 1,
+            resolved_count: 1,
+            pass_at_1: true,
+            tests_run_before_submit: false,
+            last_tests_passed: None,
+            fallback_count: None,
+            final_model: None,
+            retry_id: None,
+            previous_failure_category: None,
+            trace_id: None,
+        }],
+        rate_limit_events: None,
+        total_fallbacks: 0,
+        model_mix: std::collections::BTreeMap::new(),
+        systemic_halt_category: None,
+        cost_limit_usd: None,
+        retry_history: vec![],
+        partial: 0,
+        span_export_dropped: 0,
+    };
+    std::fs::write(
+        sweep_dir.path().join("results.json"),
+        serde_json::to_string(&results).unwrap(),
+    )
+    .unwrap();
+
+    // Run evaluate none so evaluation.json contains patch_stats with submission_class
+    let out_eval = Command::new(binary_path())
+        .args([
+            "bench",
+            "evaluate",
+            "--sweep",
+            sweep_dir.path().to_str().unwrap(),
+            "--backend",
+            "none",
+            "--breakdown",
+            "none",
+            "--cost-attribution",
+            "off",
+        ])
+        .output()
+        .unwrap();
+    assert!(out_eval.status.success());
+
+    // Run inspect
+    let out_inspect = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep_dir.path().to_str().unwrap(),
+            "--instance",
+            instance_id,
+        ])
+        .output()
+        .unwrap();
+    assert!(out_inspect.status.success());
+    let stdout = String::from_utf8_lossy(&out_inspect.stdout);
+
+    assert!(
+        stdout.contains("submission_class: test_only"),
+        "expected stdout to contain submission class; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("warning: patch touches only test files (may indicate eval gaming)"),
+        "expected stdout to contain eval gaming warning; got:\n{stdout}"
+    );
+}

--- a/tests/evaluator_provenance.rs
+++ b/tests/evaluator_provenance.rs
@@ -72,12 +72,7 @@ fn minimal_evaluation_results(resolved: bool) -> EvaluationResults {
             patch_stats: None,
             patch_error_log: None,
         }],
-        behavioral: Default::default(),
-        breakdown: vec![],
-        cost_attribution: vec![],
-        model_mix_summary: vec![],
-        latency_summary: None,
-        provenance: None,
+        ..Default::default()
     }
 }
 

--- a/tests/exit_code_contract.rs
+++ b/tests/exit_code_contract.rs
@@ -61,6 +61,11 @@ fn killed_code_is_137() {
     assert_eq!(ExitCode::Killed.as_i32(), 137);
 }
 
+#[test]
+fn eval_gaming_gate_failure_code_is_21() {
+    assert_eq!(ExitCode::EvalGamingGateFailure.as_i32(), 21);
+}
+
 // ── outcome_class strings ─────────────────────────────────────────────────────
 
 #[test]
@@ -125,6 +130,14 @@ fn outcome_class_killed() {
     assert_eq!(ExitCode::Killed.outcome_class(), "killed");
 }
 
+#[test]
+fn outcome_class_eval_gaming_gate_failure() {
+    assert_eq!(
+        ExitCode::EvalGamingGateFailure.outcome_class(),
+        "eval_gaming_gate_failure"
+    );
+}
+
 // ── outcome_class and as_i32 agree (no variant maps two different ways) ───────
 
 #[test]
@@ -138,6 +151,7 @@ fn all_variants_have_unique_codes() {
         ExitCode::BudgetHalt,
         ExitCode::RegressionGateFailure,
         ExitCode::VerificationFailure,
+        ExitCode::EvalGamingGateFailure,
         ExitCode::Interrupted,
         ExitCode::Killed,
     ];
@@ -159,6 +173,7 @@ fn all_variants_have_unique_outcome_classes() {
         ExitCode::BudgetHalt,
         ExitCode::RegressionGateFailure,
         ExitCode::VerificationFailure,
+        ExitCode::EvalGamingGateFailure,
         ExitCode::Interrupted,
         ExitCode::Killed,
     ];
@@ -420,6 +435,7 @@ fn text_and_numeric_surfaces_agree_for_every_error_variant() {
             "internal_error" => 1,
             "budget_halt" => 5,
             "regression_gate_failure" => 6,
+            "eval_gaming_gate_failure" => 21,
             other => panic!("unexpected class {other} in test table"),
         };
         assert_eq!(

--- a/tests/fixtures/artifact_schema/current/evaluation.json
+++ b/tests/fixtures/artifact_schema/current/evaluation.json
@@ -16,7 +16,8 @@
         "files_changed": 0,
         "hunks": 0,
         "touches_test_files": false,
-        "touches_lock_or_generated": false
+        "touches_lock_or_generated": false,
+        "submission_class": "empty"
       }
     }
   ],
@@ -35,5 +36,30 @@
     "backend": "none",
     "eval_started_at": "2026-01-01T00:00:00Z",
     "eval_ended_at": "2026-01-01T00:00:01Z"
-  }
+  },
+  "submission_class_rollup": {
+    "total_submitted": 1,
+    "total_resolved": 0,
+    "prod_only": {
+      "submitted_count": 0,
+      "resolved_count": 0,
+      "resolved_share_of_class": 0.0
+    },
+    "mixed": {
+      "submitted_count": 0,
+      "resolved_count": 0,
+      "resolved_share_of_class": 0.0
+    },
+    "test_only": {
+      "submitted_count": 0,
+      "resolved_count": 0,
+      "resolved_share_of_class": 0.0
+    },
+    "empty": {
+      "submitted_count": 1,
+      "resolved_count": 0,
+      "resolved_share_of_class": 0.0
+    }
+  },
+  "test_only_resolved_rate": 0.0
 }

--- a/tests/rehearsal_tests.rs
+++ b/tests/rehearsal_tests.rs
@@ -475,12 +475,7 @@ async fn test_rehearsal_empty_patch_and_missing_eval_comparisons() {
             patch_stats: None,
             patch_error_log: None,
         }],
-        behavioral: maxwells_daemon::run::evaluate::BehavioralMetrics::default(),
-        breakdown: vec![],
-        cost_attribution: vec![],
-        model_mix_summary: vec![],
-        latency_summary: None,
-        provenance: None,
+        ..Default::default()
     };
     let base_eval_json = serde_json::to_string(&base_eval_res).unwrap();
 
@@ -489,12 +484,7 @@ async fn test_rehearsal_empty_patch_and_missing_eval_comparisons() {
 
     let cand_eval_res = maxwells_daemon::run::evaluate::EvaluationResults {
         instances: vec![],
-        behavioral: maxwells_daemon::run::evaluate::BehavioralMetrics::default(),
-        breakdown: vec![],
-        cost_attribution: vec![],
-        model_mix_summary: vec![],
-        latency_summary: None,
-        provenance: None,
+        ..Default::default()
     };
     let cand_eval_json = serde_json::to_string(&cand_eval_res).unwrap();
 
@@ -638,12 +628,7 @@ async fn test_rehearsal_drift_resolved_count_and_pass_at_1() {
             patch_stats: None,
             patch_error_log: None,
         }],
-        behavioral: maxwells_daemon::run::evaluate::BehavioralMetrics::default(),
-        breakdown: vec![],
-        cost_attribution: vec![],
-        model_mix_summary: vec![],
-        latency_summary: None,
-        provenance: None,
+        ..Default::default()
     };
     let base_eval_json = serde_json::to_string(&base_eval_res).unwrap();
 
@@ -662,12 +647,7 @@ async fn test_rehearsal_drift_resolved_count_and_pass_at_1() {
             patch_stats: None,
             patch_error_log: None,
         }],
-        behavioral: maxwells_daemon::run::evaluate::BehavioralMetrics::default(),
-        breakdown: vec![],
-        cost_attribution: vec![],
-        model_mix_summary: vec![],
-        latency_summary: None,
-        provenance: None,
+        ..Default::default()
     };
     let cand_eval_json = serde_json::to_string(&cand_eval_res).unwrap();
 

--- a/tests/snapshots/bench_report__bench_report_basic.snap
+++ b/tests/snapshots/bench_report__bench_report_basic.snap
@@ -30,6 +30,7 @@ expression: content
 | Total cost USD | $0.3000 |
 | $/resolved instance | $0.1500 |
 | Mean lines changed (resolved) | _no evaluation data — run `bench evaluate` to populate_ |
+| test-only resolved | _no evaluation data — run `bench evaluate` to populate_ |
 
 ## Failure Mix
 


### PR DESCRIPTION
Resolves #292.

## Key Changes
- **Diff Classification**: Introduced a new `SubmissionClass` enum (`prod_only`, `mixed`, `test_only`, `empty`) inside `src/run/patch_stats.rs` to categorize hunks.
- **Rollup & Trust Signal**: Calculated `submission_class_rollup` and root-level `test_only_resolved_rate` during evaluation (`src/run/evaluate.rs`).
- **CI Gate Threshold**: Added `--max-test-only-resolved-rate` flag to `bench compare` that enforces limits and exits with a dedicated code `21` (`EvalGamingGateFailure`) upon breach (`src/cli/mod.rs` & `src/exit_code.rs`).
- **Visual & Inspection Metrics**: Added inline tooltip alerts & spec links in `bench report` output and rendered warnings under `bench inspect`.
- **Validation**: Comprehensive unit/integration tests added and verified 100% green.