### PR TITLE
Add `bench failure-digest` command for self-contained failure summaries

### DIFF
--- a/.github/workflows/swe-bench-nightly.yml
+++ b/.github/workflows/swe-bench-nightly.yml
@@ -123,11 +123,12 @@ jobs:
             digest_err=$(cat /tmp/failure-digest-err.txt 2>/dev/null || echo "unknown error")
             digest_md="> ⚠️ failure-digest unavailable: ${digest_err}"
           fi
-          # Export digest for the next step (multiline safe via delimiter)
+          # Export digest for the next step (unique delimiter avoids collision with digest content)
+          delimiter="DIGEST_EOF_$(openssl rand -hex 8)"
           {
-            echo "digest_md<<DIGEST_EOF"
+            echo "digest_md<<${delimiter}"
             echo "${digest_md}"
-            echo "DIGEST_EOF"
+            echo "${delimiter}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Open issue on scheduled failure

--- a/.github/workflows/swe-bench-nightly.yml
+++ b/.github/workflows/swe-bench-nightly.yml
@@ -108,6 +108,28 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+      - name: Generate failure digest
+        id: digest
+        if: failure() && github.event_name == 'schedule'
+        run: |
+          digest_md=""
+          if "${GITHUB_WORKSPACE}/target/release/max" bench failure-digest \
+              --sweep "${GITHUB_WORKSPACE}/runs" \
+              --format markdown \
+              --max-chars 8000 \
+              > /tmp/failure-digest.md 2>/tmp/failure-digest-err.txt; then
+            digest_md=$(cat /tmp/failure-digest.md)
+          else
+            digest_err=$(cat /tmp/failure-digest-err.txt 2>/dev/null || echo "unknown error")
+            digest_md="> ⚠️ failure-digest unavailable: ${digest_err}"
+          fi
+          # Export digest for the next step (multiline safe via delimiter)
+          {
+            echo "digest_md<<DIGEST_EOF"
+            echo "${digest_md}"
+            echo "DIGEST_EOF"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Open issue on scheduled failure
         if: failure() && github.event_name == 'schedule'
         uses: actions/github-script@v7
@@ -115,6 +137,7 @@ jobs:
           INSTANCE_ID: ${{ steps.fetch.outputs.instance_id }}
           REPO_SLUG: ${{ steps.fetch.outputs.repo }}
           BASE_COMMIT: ${{ steps.fetch.outputs.base_commit }}
+          FAILURE_DIGEST: ${{ steps.digest.outputs.digest_md }}
         with:
           script: |
             const today = new Date().toISOString().slice(0, 10);
@@ -122,8 +145,9 @@ jobs:
             const instance = process.env.INSTANCE_ID || "(fetch failed)";
             const repoSlug = process.env.REPO_SLUG || "(unknown)";
             const baseCommit = process.env.BASE_COMMIT || "(unknown)";
+            const failureDigest = process.env.FAILURE_DIGEST || "";
             const title = `Nightly SWE-bench smoke failed (${today})`;
-            const body = [
+            const metadataLines = [
               `The nightly OpenRouter free-tier SWE-bench smoke run failed.`,
               ``,
               `- Workflow run: ${runUrl}`,
@@ -135,7 +159,11 @@ jobs:
               `artifacts on the run page.`,
               ``,
               `_Auto-filed by .github/workflows/swe-bench-nightly.yml._`,
-            ].join("\n");
+            ];
+            const digestSection = failureDigest
+              ? [``, `## Failure digest`, ``, failureDigest]
+              : [];
+            const body = [...metadataLines, ...digestSection].join("\n");
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -524,6 +524,32 @@ pub enum BenchCmd {
     Bisect(BisectCmd),
     /// Re-derive and verify sweep aggregates against trajectories.
     Audit(AuditCmd),
+    /// Emit a self-contained failure summary for one instance in a completed sweep.
+    FailureDigest(FailureDigestCmd),
+}
+
+/// `bench failure-digest` — self-contained failure summary for one sweep instance.
+#[derive(Debug, Args, Clone)]
+pub struct FailureDigestCmd {
+    /// Completed sweep directory produced by `bench swebench`.
+    #[arg(long)]
+    pub sweep: PathBuf,
+
+    /// Target instance ID. When omitted and the sweep contains exactly one
+    /// instance, that instance is used. When the sweep contains more than one
+    /// instance and this flag is omitted, the command exits non-zero and names
+    /// all candidates.
+    #[arg(long)]
+    pub instance: Option<String>,
+
+    /// Output format: `markdown` (default) or `json`.
+    #[arg(long, default_value = "markdown")]
+    pub format: String,
+
+    /// Maximum characters for the markdown output (default: 8000).
+    /// Truncation preserves the headline and triage cluster footer.
+    #[arg(long, default_value_t = 8000)]
+    pub max_chars: usize,
 }
 
 /// `bench dataset-stats` — preview SWE-bench dataset composition pre-sweep.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -543,7 +543,7 @@ pub struct FailureDigestCmd {
     pub instance: Option<String>,
 
     /// Output format: `markdown` (default) or `json`.
-    #[arg(long, default_value = "markdown")]
+    #[arg(long, default_value = "markdown", value_parser = ["markdown", "json"])]
     pub format: String,
 
     /// Maximum characters for the markdown output (default: 8000).

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -111,6 +111,7 @@ pub async fn run() -> Result<(), Error> {
             args::BenchCmd::DatasetStats(s) => bench_dataset_stats(s),
             args::BenchCmd::Bisect(b) => Box::pin(bench_bisect(b)).await,
             args::BenchCmd::Audit(a) => bench_audit(a),
+            args::BenchCmd::FailureDigest(f) => bench_failure_digest(f),
         },
         Command::Agent { cmd } => match *cmd {
             args::AgentCmd::SkillsPreview(s) => agent_skills_preview_cmd(&s),
@@ -4116,6 +4117,38 @@ async fn bench_bisect(b: args::BisectCmd) -> Result<(), Error> {
 #[allow(clippy::needless_pass_by_value)]
 fn bench_audit(a: args::AuditCmd) -> Result<(), Error> {
     crate::run::audit::run(&a)
+}
+
+fn bench_failure_digest(f: args::FailureDigestCmd) -> Result<(), Error> {
+    let format = match f.format.as_str() {
+        "markdown" => crate::run::failure_digest::DigestFormat::Markdown,
+        "json" => crate::run::failure_digest::DigestFormat::Json,
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "unknown --format `{other}` (expected `markdown` or `json`)"
+            ))));
+        }
+    };
+    let max_chars = f.max_chars;
+    let digest = crate::run::failure_digest::run(&crate::run::failure_digest::FailureDigestArgs {
+        sweep_dir: f.sweep,
+        instance: f.instance,
+        format,
+        max_chars,
+    })?;
+    match format {
+        crate::run::failure_digest::DigestFormat::Markdown => {
+            print!(
+                "{}",
+                crate::run::failure_digest::render_markdown(&digest, max_chars)
+            );
+            Ok(())
+        }
+        crate::run::failure_digest::DigestFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&digest)?);
+            Ok(())
+        }
+    }
 }
 
 fn parse_dataset_source_stats(

--- a/src/run/failure_digest.rs
+++ b/src/run/failure_digest.rs
@@ -121,8 +121,12 @@ pub fn run(args: &FailureDigestArgs) -> Result<FailureDigest, Error> {
     if redactor
         .configured_literal_leak(&last_assistant_message)
         .is_some()
-        || redactor.configured_literal_leak(&last_tool_stderr).is_some()
-        || redactor.configured_literal_leak(&last_tool_stdout).is_some()
+        || redactor
+            .configured_literal_leak(&last_tool_stderr)
+            .is_some()
+        || redactor
+            .configured_literal_leak(&last_tool_stdout)
+            .is_some()
     {
         return Err(Error::Trajectory(
             "failure-digest: redaction failure — configured secret literal present in digest output"
@@ -134,7 +138,9 @@ pub fn run(args: &FailureDigestArgs) -> Result<FailureDigest, Error> {
         schema_version: "1.0".into(),
         instance_id,
         outcome: instance.outcome.clone().unwrap_or_else(|| "unknown".into()),
-        failure_category: instance.failure_category.map(|c| failure_label(c).to_owned()),
+        failure_category: instance
+            .failure_category
+            .map(|c| failure_label(c).to_owned()),
         total_cost_usd: instance.actual_cost_usd(),
         step_count: instance.steps,
         task_duration_secs: instance.duration_secs,
@@ -158,8 +164,7 @@ pub fn render_markdown(digest: &FailureDigest, max_chars: usize) -> String {
         .as_deref()
         .unwrap_or("no triage available.");
 
-    let is_submitted =
-        digest.outcome == "submitted" && digest.failure_category.is_none();
+    let is_submitted = digest.outcome == "submitted" && digest.failure_category.is_none();
 
     if is_submitted {
         let mut out = String::new();
@@ -304,9 +309,8 @@ fn extract_terminal_signals(path: &Path) -> Result<(String, String, String), Err
             .and_then(|v| serde_json::from_value::<RunResult>(v.clone()).ok())
     });
 
-    let (stderr, stdout) = last_run.map_or((String::new(), String::new()), |r| {
-        (r.stderr, r.stdout)
-    });
+    let (stderr, stdout) =
+        last_run.map_or((String::new(), String::new()), |r| (r.stderr, r.stdout));
 
     Ok((last_assistant, stderr, stdout))
 }
@@ -333,12 +337,15 @@ fn load_triage_cluster_label(sweep_dir: &Path, instance_id: &str) -> Option<Stri
     let text = std::fs::read_to_string(&triage_path).ok()?;
     let report: TriageReport = serde_json::from_str(&text).ok()?;
     report.clusters.iter().find_map(|cluster| {
-        cluster.instance_ids.contains(&instance_id.to_owned()).then(|| {
-            format!(
-                "{} [{}]: {}",
-                cluster.failure_category, cluster.cluster_id, cluster.signature_summary
-            )
-        })
+        cluster
+            .instance_ids
+            .contains(&instance_id.to_owned())
+            .then(|| {
+                format!(
+                    "{} [{}]: {}",
+                    cluster.failure_category, cluster.cluster_id, cluster.signature_summary
+                )
+            })
     })
 }
 

--- a/src/run/failure_digest.rs
+++ b/src/run/failure_digest.rs
@@ -100,33 +100,42 @@ pub fn run(args: &FailureDigestArgs) -> Result<FailureDigest, Error> {
         };
 
     let patch_status = derive_patch_status(instance);
-    let patch_apply_stderr = if patch_status == PatchStatus::InvalidDiff {
+    let patch_apply_stderr_raw = if patch_status == PatchStatus::InvalidDiff {
         instance.error.clone()
     } else {
         None
     };
 
-    let triage_cluster_label = load_triage_cluster_label(&args.sweep_dir, &instance_id);
+    let triage_cluster_label_raw = load_triage_cluster_label(&args.sweep_dir, &instance_id);
 
     let redactor = Redactor::default_enabled();
     let ast_out = redactor.redact_text(&last_assistant_message, surface::INSPECT);
     let stderr_out = redactor.redact_text(&last_tool_stderr, surface::INSPECT);
     let stdout_out = redactor.redact_text(&last_tool_stdout, surface::INSPECT);
+    let patch_err_out = patch_apply_stderr_raw
+        .as_deref()
+        .map(|s| redactor.redact_text(s, surface::INSPECT));
+    let triage_out = triage_cluster_label_raw
+        .as_deref()
+        .map(|s| redactor.redact_text(s, surface::INSPECT));
 
     let last_assistant_message = ast_out.text;
     let last_tool_stderr = stderr_out.text;
     let last_tool_stdout = stdout_out.text;
-    let redacted = ast_out.redacted || stderr_out.redacted || stdout_out.redacted;
+    let patch_apply_stderr = patch_err_out.as_ref().map(|o| o.text.clone());
+    let triage_cluster_label = triage_out.as_ref().map(|o| o.text.clone());
+    let redacted = ast_out.redacted
+        || stderr_out.redacted
+        || stdout_out.redacted
+        || patch_err_out.as_ref().is_some_and(|o| o.redacted)
+        || triage_out.as_ref().is_some_and(|o| o.redacted);
 
-    if redactor
-        .configured_literal_leak(&last_assistant_message)
-        .is_some()
-        || redactor
-            .configured_literal_leak(&last_tool_stderr)
-            .is_some()
-        || redactor
-            .configured_literal_leak(&last_tool_stdout)
-            .is_some()
+    let leak_in = |text: &str| redactor.configured_literal_leak(text).is_some();
+    if leak_in(&last_assistant_message)
+        || leak_in(&last_tool_stderr)
+        || leak_in(&last_tool_stdout)
+        || patch_apply_stderr.as_deref().is_some_and(leak_in)
+        || triage_cluster_label.as_deref().is_some_and(leak_in)
     {
         return Err(Error::Trajectory(
             "failure-digest: redaction failure — configured secret literal present in digest output"

--- a/src/run/failure_digest.rs
+++ b/src/run/failure_digest.rs
@@ -91,7 +91,7 @@ pub fn run(args: &FailureDigestArgs) -> Result<FailureDigest, Error> {
     let instance = resolve_instance(args, &sweep.instances)?;
     let instance_id = instance.instance_id.clone();
 
-    let traj_path = resolve_trajectory_path(&args.sweep_dir, &instance_id);
+    let traj_path = resolve_terminal_trajectory_path(&args.sweep_dir, &instance_id);
     let (last_assistant_message, last_tool_stderr, last_tool_stdout) =
         if let Some(ref path) = traj_path {
             extract_terminal_signals(path)?
@@ -298,6 +298,39 @@ fn resolve_instance<'a>(
     }
 }
 
+/// Like `resolve_trajectory_path` but prefers the highest-numbered `run-N.traj.json`
+/// so multi-retry sweeps report the terminal attempt rather than the first.
+fn resolve_terminal_trajectory_path(sweep_dir: &Path, instance_id: &str) -> Option<PathBuf> {
+    let instance_dir = sweep_dir.join(instance_id);
+    if instance_dir.is_dir() {
+        let mut best: Option<(u32, PathBuf)> = None;
+        if let Ok(entries) = std::fs::read_dir(&instance_dir) {
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let n = name
+                    .to_string_lossy()
+                    .strip_prefix("run-")
+                    .and_then(|s| s.strip_suffix(".traj.json"))
+                    .and_then(|s| s.parse::<u32>().ok());
+                if let Some(n) = n {
+                    if best.as_ref().is_none_or(|(bn, _)| n > *bn) {
+                        best = Some((n, entry.path()));
+                    }
+                }
+            }
+        }
+        if let Some((_, path)) = best {
+            return Some(path);
+        }
+        let trajectory = instance_dir.join("trajectory.json");
+        if trajectory.exists() {
+            return Some(trajectory);
+        }
+    }
+    // Flat and bundled layouts have no retry semantics; delegate to shared helper.
+    resolve_trajectory_path(sweep_dir, instance_id)
+}
+
 fn extract_terminal_signals(path: &Path) -> Result<(String, String, String), Error> {
     let trajectory = load_trajectory(path)?;
 
@@ -379,10 +412,8 @@ fn truncate_preserving_ends(
         header.chars().count() + marker.chars().count() + footer_section.chars().count();
 
     if fixed_len >= max_chars {
-        // Extreme budget: just header + truncated footer
-        let budget = max_chars.saturating_sub(header.chars().count() + 3);
-        let foot: String = footer_section.chars().take(budget).collect();
-        return format!("{header}...{foot}");
+        // Budget too small for header+marker+footer: hard-truncate the full text.
+        return text.chars().take(max_chars).collect();
     }
 
     let middle_budget = max_chars - fixed_len;

--- a/src/run/failure_digest.rs
+++ b/src/run/failure_digest.rs
@@ -1,0 +1,393 @@
+//! `bench failure-digest`: self-contained failure summary for one instance in a sweep.
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::env::RunResult;
+use crate::error::Error;
+use crate::redaction::{Redactor, surface};
+use crate::run::compare::load_sweep;
+use crate::run::swebench::InstanceResult;
+use crate::run::triage::{TriageReport, failure_label, load_trajectory, resolve_trajectory_path};
+use crate::trajectory::FailureCategory;
+
+/// Characters per section excerpt (1.5 KB).
+const EXCERPT_MAX_CHARS: usize = 1536;
+
+/// Arguments for `bench failure-digest`.
+#[derive(Debug, Clone)]
+pub struct FailureDigestArgs {
+    pub sweep_dir: PathBuf,
+    pub instance: Option<String>,
+    pub format: DigestFormat,
+    pub max_chars: usize,
+}
+
+/// Output format for the digest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DigestFormat {
+    Markdown,
+    Json,
+}
+
+/// Patch capture status for an instance.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PatchStatus {
+    Applied,
+    EmptyDiff,
+    InvalidDiff,
+    NotAttempted,
+}
+
+impl PatchStatus {
+    fn label(&self) -> &str {
+        match self {
+            Self::Applied => "applied",
+            Self::EmptyDiff => "empty-diff",
+            Self::InvalidDiff => "invalid-diff",
+            Self::NotAttempted => "not-attempted",
+        }
+    }
+}
+
+/// The structured failure digest (stable JSON schema version 1.0).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailureDigest {
+    pub schema_version: String,
+    pub instance_id: String,
+    pub outcome: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_category: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_cost_usd: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub step_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_duration_secs: Option<f64>,
+    pub last_assistant_message: String,
+    pub last_tool_stderr: String,
+    pub last_tool_stdout: String,
+    pub patch_status: PatchStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub patch_apply_stderr: Option<String>,
+    pub triage_cluster_label: Option<String>,
+    pub redacted: bool,
+}
+
+pub fn run(args: &FailureDigestArgs) -> Result<FailureDigest, Error> {
+    let results_path = args.sweep_dir.join("results.json");
+    if !results_path.exists() {
+        return Err(Error::Trajectory(format!(
+            "failure-digest: results.json not found in `{}`; run `bench swebench` first",
+            args.sweep_dir.display()
+        )));
+    }
+
+    let sweep = load_sweep(&args.sweep_dir)?;
+    let instance = resolve_instance(args, &sweep.instances)?;
+    let instance_id = instance.instance_id.clone();
+
+    let traj_path = resolve_trajectory_path(&args.sweep_dir, &instance_id);
+    let (last_assistant_message, last_tool_stderr, last_tool_stdout) =
+        if let Some(ref path) = traj_path {
+            extract_terminal_signals(path)?
+        } else {
+            (String::new(), String::new(), String::new())
+        };
+
+    let patch_status = derive_patch_status(instance);
+    let patch_apply_stderr = if patch_status == PatchStatus::InvalidDiff {
+        instance.error.clone()
+    } else {
+        None
+    };
+
+    let triage_cluster_label = load_triage_cluster_label(&args.sweep_dir, &instance_id);
+
+    let redactor = Redactor::default_enabled();
+    let ast_out = redactor.redact_text(&last_assistant_message, surface::INSPECT);
+    let stderr_out = redactor.redact_text(&last_tool_stderr, surface::INSPECT);
+    let stdout_out = redactor.redact_text(&last_tool_stdout, surface::INSPECT);
+
+    let last_assistant_message = ast_out.text;
+    let last_tool_stderr = stderr_out.text;
+    let last_tool_stdout = stdout_out.text;
+    let redacted = ast_out.redacted || stderr_out.redacted || stdout_out.redacted;
+
+    if redactor
+        .configured_literal_leak(&last_assistant_message)
+        .is_some()
+        || redactor.configured_literal_leak(&last_tool_stderr).is_some()
+        || redactor.configured_literal_leak(&last_tool_stdout).is_some()
+    {
+        return Err(Error::Trajectory(
+            "failure-digest: redaction failure — configured secret literal present in digest output"
+                .into(),
+        ));
+    }
+
+    Ok(FailureDigest {
+        schema_version: "1.0".into(),
+        instance_id,
+        outcome: instance.outcome.clone().unwrap_or_else(|| "unknown".into()),
+        failure_category: instance.failure_category.map(|c| failure_label(c).to_owned()),
+        total_cost_usd: instance.actual_cost_usd(),
+        step_count: instance.steps,
+        task_duration_secs: instance.duration_secs,
+        last_assistant_message,
+        last_tool_stderr,
+        last_tool_stdout,
+        patch_status,
+        patch_apply_stderr,
+        triage_cluster_label,
+        redacted,
+    })
+}
+
+/// Render the digest as markdown, truncating to `max_chars` while preserving
+/// the headline and the triage cluster footer.
+pub fn render_markdown(digest: &FailureDigest, max_chars: usize) -> String {
+    let headline = build_headline(digest);
+    let cost_line = build_cost_line(digest);
+    let triage_label = digest
+        .triage_cluster_label
+        .as_deref()
+        .unwrap_or("no triage available.");
+
+    let is_submitted =
+        digest.outcome == "submitted" && digest.failure_category.is_none();
+
+    if is_submitted {
+        let mut out = String::new();
+        let _ = writeln!(out, "{headline}");
+        let _ = writeln!(out);
+        let _ = writeln!(out, "{cost_line}");
+        let _ = writeln!(out);
+        let _ = writeln!(out, "resolved, no failure to digest");
+        let _ = writeln!(out);
+        let _ = writeln!(out, "### Triage cluster");
+        let _ = writeln!(out);
+        out.push_str(triage_label);
+        return truncate_preserving_ends(&out, max_chars, &headline, triage_label);
+    }
+
+    let ast_excerpt = excerpt_head_tail(&digest.last_assistant_message, EXCERPT_MAX_CHARS);
+    let stderr_excerpt = excerpt_head_tail(&digest.last_tool_stderr, EXCERPT_MAX_CHARS);
+    let stdout_excerpt = excerpt_head_tail(&digest.last_tool_stdout, EXCERPT_MAX_CHARS);
+    let patch_section = build_patch_section(digest);
+
+    let mut out = String::new();
+    let _ = writeln!(out, "{headline}");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "{cost_line}");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "### Last assistant message");
+    let _ = writeln!(out);
+    if ast_excerpt.is_empty() {
+        let _ = writeln!(out, "_(no assistant message recorded)_");
+    } else {
+        let _ = writeln!(out, "{ast_excerpt}");
+    }
+    let _ = writeln!(out);
+    let _ = writeln!(out, "### Last tool stderr");
+    let _ = writeln!(out);
+    if stderr_excerpt.is_empty() {
+        let _ = writeln!(out, "_(no tool stderr recorded)_");
+    } else {
+        let _ = writeln!(out, "{stderr_excerpt}");
+    }
+    if !stdout_excerpt.is_empty() {
+        let _ = writeln!(out);
+        let _ = writeln!(out, "### Last tool stdout");
+        let _ = writeln!(out);
+        let _ = writeln!(out, "{stdout_excerpt}");
+    }
+    let _ = writeln!(out);
+    let _ = writeln!(out, "### Patch status");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "{patch_section}");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "### Triage cluster");
+    let _ = writeln!(out);
+    out.push_str(triage_label);
+
+    truncate_preserving_ends(&out, max_chars, &headline, triage_label)
+}
+
+fn build_headline(digest: &FailureDigest) -> String {
+    format!(
+        "**{}** | outcome: {} | failure_category: {}",
+        digest.instance_id,
+        digest.outcome,
+        digest.failure_category.as_deref().unwrap_or("none")
+    )
+}
+
+fn build_cost_line(digest: &FailureDigest) -> String {
+    format!(
+        "cost: {} | steps: {} | duration: {}s",
+        digest
+            .total_cost_usd
+            .map_or_else(|| "n/a".into(), |c| format!("${c:.2}")),
+        digest
+            .step_count
+            .map_or_else(|| "n/a".into(), |s| s.to_string()),
+        digest
+            .task_duration_secs
+            .map_or_else(|| "n/a".into(), |d| format!("{d:.2}"))
+    )
+}
+
+fn build_patch_section(digest: &FailureDigest) -> String {
+    let mut s = digest.patch_status.label().to_owned();
+    if let Some(ref stderr) = digest.patch_apply_stderr {
+        if !stderr.is_empty() {
+            let _ = write!(s, "\n\n```\n{stderr}\n```");
+        }
+    }
+    s
+}
+
+fn resolve_instance<'a>(
+    args: &FailureDigestArgs,
+    instances: &'a HashMap<String, InstanceResult>,
+) -> Result<&'a InstanceResult, Error> {
+    if let Some(ref id) = args.instance {
+        instances.get(id).ok_or_else(|| {
+            Error::Trajectory(format!(
+                "failure-digest: instance `{id}` not found in sweep `{}`",
+                args.sweep_dir.display()
+            ))
+        })
+    } else {
+        match instances.len() {
+            0 => Err(Error::Trajectory(
+                "failure-digest: sweep contains no instances".into(),
+            )),
+            1 => Ok(instances.values().next().ok_or_else(|| {
+                Error::Trajectory("failure-digest: sweep contains no instances".into())
+            })?),
+            _ => {
+                let mut ids: Vec<&str> = instances.keys().map(String::as_str).collect();
+                ids.sort_unstable();
+                Err(Error::Trajectory(format!(
+                    "failure-digest: sweep contains {} instances; use --instance to select one. Candidates: {}",
+                    ids.len(),
+                    ids.join(", ")
+                )))
+            }
+        }
+    }
+}
+
+fn extract_terminal_signals(path: &Path) -> Result<(String, String, String), Error> {
+    let trajectory = load_trajectory(path)?;
+
+    let last_assistant = trajectory
+        .messages
+        .iter()
+        .rev()
+        .find(|m| m.role == "assistant")
+        .map_or_else(String::new, |m| m.content.clone());
+
+    let last_run = trajectory.messages.iter().rev().find_map(|m| {
+        if m.role != "user" {
+            return None;
+        }
+        m.extra
+            .other
+            .get("run_result")
+            .and_then(|v| serde_json::from_value::<RunResult>(v.clone()).ok())
+    });
+
+    let (stderr, stdout) = last_run.map_or((String::new(), String::new()), |r| {
+        (r.stderr, r.stdout)
+    });
+
+    Ok((last_assistant, stderr, stdout))
+}
+
+fn derive_patch_status(instance: &InstanceResult) -> PatchStatus {
+    if instance.failure_category == Some(FailureCategory::PatchApplyInvalid) {
+        return PatchStatus::InvalidDiff;
+    }
+    if !instance.patch_present {
+        return PatchStatus::NotAttempted;
+    }
+    if instance.non_empty_patch {
+        PatchStatus::Applied
+    } else {
+        PatchStatus::EmptyDiff
+    }
+}
+
+fn load_triage_cluster_label(sweep_dir: &Path, instance_id: &str) -> Option<String> {
+    let triage_path = sweep_dir.join("triage.json");
+    if !triage_path.exists() {
+        return None;
+    }
+    let text = std::fs::read_to_string(&triage_path).ok()?;
+    let report: TriageReport = serde_json::from_str(&text).ok()?;
+    report.clusters.iter().find_map(|cluster| {
+        cluster.instance_ids.contains(&instance_id.to_owned()).then(|| {
+            format!(
+                "{} [{}]: {}",
+                cluster.failure_category, cluster.cluster_id, cluster.signature_summary
+            )
+        })
+    })
+}
+
+/// Truncate markdown to `max_chars` while preserving the first line (headline)
+/// and the triage cluster footer.
+fn truncate_preserving_ends(
+    text: &str,
+    max_chars: usize,
+    headline: &str,
+    triage_label: &str,
+) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_owned();
+    }
+
+    let footer_section = format!("\n\n### Triage cluster\n\n{triage_label}");
+    let header = format!("{headline}\n");
+    let marker = "\n\n... [digest truncated for length] ...\n";
+
+    let fixed_len =
+        header.chars().count() + marker.chars().count() + footer_section.chars().count();
+
+    if fixed_len >= max_chars {
+        // Extreme budget: just header + truncated footer
+        let budget = max_chars.saturating_sub(header.chars().count() + 3);
+        let foot: String = footer_section.chars().take(budget).collect();
+        return format!("{header}...{foot}");
+    }
+
+    let middle_budget = max_chars - fixed_len;
+    let rest = text
+        .split_once('\n')
+        .map_or("", |x| x.1)
+        .trim_start_matches('\n');
+    let middle: String = rest.chars().take(middle_budget).collect();
+
+    format!("{header}{middle}{marker}{footer_section}")
+}
+
+/// Extract a head+tail excerpt, with middle elision if text exceeds `max_chars`.
+fn excerpt_head_tail(text: &str, max_chars: usize) -> String {
+    let len = text.chars().count();
+    if len <= max_chars {
+        return text.to_owned();
+    }
+    let each_half = max_chars / 2;
+    let head: String = text.chars().take(each_half).collect();
+    let elided = len - max_chars;
+    let tail_start = len - each_half;
+    let tail: String = text.chars().skip(tail_start).collect();
+    format!("{head}\n... [{elided} chars elided] ...\n{tail}")
+}

--- a/src/run/failure_digest.rs
+++ b/src/run/failure_digest.rs
@@ -348,7 +348,8 @@ fn load_triage_cluster_label(sweep_dir: &Path, instance_id: &str) -> Option<Stri
     report.clusters.iter().find_map(|cluster| {
         cluster
             .instance_ids
-            .contains(&instance_id.to_owned())
+            .iter()
+            .any(|id| id == instance_id)
             .then(|| {
                 format!(
                     "{} [{}]: {}",
@@ -400,10 +401,11 @@ fn excerpt_head_tail(text: &str, max_chars: usize) -> String {
     if len <= max_chars {
         return text.to_owned();
     }
-    let each_half = max_chars / 2;
-    let head: String = text.chars().take(each_half).collect();
+    let head_len = max_chars / 2;
+    let tail_len = max_chars - head_len;
+    let head: String = text.chars().take(head_len).collect();
     let elided = len - max_chars;
-    let tail_start = len - each_half;
+    let tail_start = len - tail_len;
     let tail: String = text.chars().skip(tail_start).collect();
     format!("{head}\n... [{elided} chars elided] ...\n{tail}")
 }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -17,6 +17,7 @@ pub mod diff_config;
 pub mod env_preview;
 pub mod evaluate;
 pub mod evaluator_selftest;
+pub mod failure_digest;
 pub mod forecast;
 pub mod fork;
 pub mod frontier;

--- a/tests/bench_failure_digest.rs
+++ b/tests/bench_failure_digest.rs
@@ -70,7 +70,10 @@ fn digest_errored_instance_contains_cost_and_steps() {
     assert!(out.status.success());
 
     let stdout = String::from_utf8(out.stdout).unwrap();
-    assert!(stdout.contains("2.50") || stdout.contains("2.5"), "cost missing: {stdout}");
+    assert!(
+        stdout.contains("2.50") || stdout.contains("2.5"),
+        "cost missing: {stdout}"
+    );
     assert!(stdout.contains('5'), "step count missing: {stdout}");
 }
 
@@ -192,12 +195,7 @@ fn digest_multi_instance_without_flag_exits_nonzero_naming_candidates() {
 #[test]
 fn digest_multi_instance_with_flag_selects_specific_instance() {
     let sweep = fixture_path("sweep-multi");
-    let out = run_failure_digest(&[
-        "--sweep",
-        sweep.to_str().unwrap(),
-        "--instance",
-        "error-2",
-    ]);
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap(), "--instance", "error-2"]);
 
     assert!(
         out.status.success(),
@@ -378,7 +376,7 @@ fn digest_redacts_sensitive_env_var_from_tool_stderr() {
         "raw secret must not appear in digest output: {stdout}"
     );
     assert!(
-        stdout.to_lowercase().contains("redacted") || stdout.contains("["),
+        stdout.to_lowercase().contains("redacted") || stdout.contains('['),
         "output should contain redaction marker: {stdout}"
     );
 }
@@ -388,12 +386,7 @@ fn digest_redacts_sensitive_env_var_from_tool_stderr() {
 #[test]
 fn digest_json_format_is_schema_versioned_and_stable() {
     let sweep = fixture_path("sweep-single-errored");
-    let out = run_failure_digest(&[
-        "--sweep",
-        sweep.to_str().unwrap(),
-        "--format",
-        "json",
-    ]);
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap(), "--format", "json"]);
 
     assert!(
         out.status.success(),
@@ -449,10 +442,7 @@ fn digest_json_format_is_schema_versioned_and_stable() {
             json["instance_id"], golden["instance_id"],
             "instance_id must be stable"
         );
-        assert_eq!(
-            json["outcome"], golden["outcome"],
-            "outcome must be stable"
-        );
+        assert_eq!(json["outcome"], golden["outcome"], "outcome must be stable");
         assert_eq!(
             json["failure_category"], golden["failure_category"],
             "failure_category must be stable"
@@ -475,12 +465,7 @@ fn digest_json_format_is_schema_versioned_and_stable() {
 fn digest_max_chars_truncation_preserves_headline_and_triage_footer() {
     let sweep = fixture_path("sweep-step-limit");
     // Use a small max-chars to force truncation
-    let out = run_failure_digest(&[
-        "--sweep",
-        sweep.to_str().unwrap(),
-        "--max-chars",
-        "300",
-    ]);
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap(), "--max-chars", "300"]);
 
     assert!(
         out.status.success(),

--- a/tests/bench_failure_digest.rs
+++ b/tests/bench_failure_digest.rs
@@ -1,0 +1,528 @@
+//! `bench failure-digest`: self-contained failure summary per instance.
+
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+mod support;
+use support::binary_path;
+
+const FIXTURE_DIR: &str = "tests/fixtures/failure_digest";
+
+fn fixture_path(name: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join(FIXTURE_DIR)
+        .join(name)
+}
+
+fn run_failure_digest(args: &[&str]) -> std::process::Output {
+    Command::new(binary_path())
+        .args(["--log", "error", "bench", "failure-digest"])
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn run_failure_digest_with_env(args: &[&str], env: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(binary_path());
+    cmd.args(["--log", "error", "bench", "failure-digest"])
+        .args(args);
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    cmd.output().unwrap()
+}
+
+// ── (a) digest on a sweep with one errored instance ──────────────────────────
+
+#[test]
+fn digest_single_errored_instance_exits_zero_and_contains_headline() {
+    let sweep = fixture_path("sweep-single-errored");
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap()]);
+
+    assert!(
+        out.status.success(),
+        "failure-digest should exit 0 for an errored instance\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("error-1"),
+        "headline must include instance_id: {stdout}"
+    );
+    assert!(
+        stdout.contains("model_parse"),
+        "headline must include failure_category: {stdout}"
+    );
+    assert!(
+        stdout.contains("error"),
+        "headline must include outcome: {stdout}"
+    );
+}
+
+#[test]
+fn digest_errored_instance_contains_cost_and_steps() {
+    let sweep = fixture_path("sweep-single-errored");
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap()]);
+    assert!(out.status.success());
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains("2.50") || stdout.contains("2.5"), "cost missing: {stdout}");
+    assert!(stdout.contains('5'), "step count missing: {stdout}");
+}
+
+#[test]
+fn digest_errored_instance_contains_last_assistant_message() {
+    let sweep = fixture_path("sweep-single-errored");
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap()]);
+    assert!(out.status.success());
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("parse the model response"),
+        "last assistant message excerpt missing: {stdout}"
+    );
+}
+
+#[test]
+fn digest_errored_instance_contains_last_tool_stderr() {
+    let sweep = fixture_path("sweep-single-errored");
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap()]);
+    assert!(out.status.success());
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("model parse error"),
+        "last tool stderr missing: {stdout}"
+    );
+}
+
+#[test]
+fn digest_errored_instance_shows_patch_status_not_attempted() {
+    let sweep = fixture_path("sweep-single-errored");
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap()]);
+    assert!(out.status.success());
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("not-attempted"),
+        "patch status missing: {stdout}"
+    );
+}
+
+#[test]
+fn digest_errored_instance_shows_no_triage_when_absent() {
+    let sweep = fixture_path("sweep-single-errored");
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap()]);
+    assert!(out.status.success());
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("no triage available"),
+        "missing triage-unavailable note: {stdout}"
+    );
+}
+
+// ── (b) digest on resolved instance ──────────────────────────────────────────
+
+#[test]
+fn digest_resolved_instance_exits_zero_and_says_no_failure() {
+    let sweep = fixture_path("sweep-single-resolved");
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap()]);
+
+    assert!(
+        out.status.success(),
+        "failure-digest should exit 0 for a resolved instance\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("resolved-1"),
+        "headline must include instance_id: {stdout}"
+    );
+    assert!(
+        stdout.to_lowercase().contains("no failure") || stdout.to_lowercase().contains("submitted"),
+        "should indicate no failure to digest for a resolved instance: {stdout}"
+    );
+}
+
+// ── (c) sweep with no results.json exits non-zero ────────────────────────────
+
+#[test]
+fn digest_missing_results_json_exits_nonzero_with_clear_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = run_failure_digest(&["--sweep", dir.path().to_str().unwrap()]);
+
+    assert!(
+        !out.status.success(),
+        "should exit non-zero when results.json is absent"
+    );
+
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("results.json") || stderr.contains("failure-digest"),
+        "error message should reference results.json: {stderr}"
+    );
+}
+
+// ── multi-instance behaviour ──────────────────────────────────────────────────
+
+#[test]
+fn digest_multi_instance_without_flag_exits_nonzero_naming_candidates() {
+    let sweep = fixture_path("sweep-multi");
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap()]);
+
+    assert!(
+        !out.status.success(),
+        "should exit non-zero when sweep has multiple instances and --instance is omitted"
+    );
+
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("error-1") && stderr.contains("error-2"),
+        "error should name all candidate instance ids: {stderr}"
+    );
+}
+
+#[test]
+fn digest_multi_instance_with_flag_selects_specific_instance() {
+    let sweep = fixture_path("sweep-multi");
+    let out = run_failure_digest(&[
+        "--sweep",
+        sweep.to_str().unwrap(),
+        "--instance",
+        "error-2",
+    ]);
+
+    assert!(
+        out.status.success(),
+        "should succeed when --instance is provided\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("error-2"),
+        "output should contain the selected instance: {stdout}"
+    );
+    assert!(
+        stdout.contains("env_setup"),
+        "output should contain failure category of selected instance: {stdout}"
+    );
+}
+
+// ── (d) step-limit failure surfaces final loop state ─────────────────────────
+
+#[test]
+fn digest_step_limit_surfaces_final_loop_state() {
+    let sweep = fixture_path("sweep-step-limit");
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap()]);
+
+    assert!(
+        out.status.success(),
+        "failure-digest should succeed on step_limit instance\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("step_limit") || stdout.contains("step-limit"),
+        "should include failure category: {stdout}"
+    );
+    assert!(
+        stdout.contains("Still working") || stdout.contains("working"),
+        "should include last assistant message: {stdout}"
+    );
+    assert!(
+        stdout.contains("step limit reached") || stdout.contains("step_limit"),
+        "should surface last tool stderr with loop state: {stdout}"
+    );
+}
+
+#[test]
+fn digest_step_limit_includes_triage_cluster_label() {
+    let sweep = fixture_path("sweep-step-limit");
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap()]);
+    assert!(out.status.success());
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("aabbccdd11223344"),
+        "triage cluster_id should appear in output: {stdout}"
+    );
+}
+
+// ── (e) patch-apply failure surfaces git apply --check stderr ────────────────
+
+#[test]
+fn digest_patch_apply_invalid_surfaces_apply_stderr() {
+    let sweep = fixture_path("sweep-patch-invalid");
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap()]);
+
+    assert!(
+        out.status.success(),
+        "failure-digest should succeed on patch_apply_invalid instance\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("invalid-diff"),
+        "patch status should be invalid-diff: {stdout}"
+    );
+    assert!(
+        stdout.contains("patch does not apply") || stdout.contains("patch failed"),
+        "git apply --check stderr should appear: {stdout}"
+    );
+}
+
+// ── (f) redaction enforcement ─────────────────────────────────────────────────
+
+#[test]
+fn digest_redacts_sensitive_env_var_from_tool_stderr() {
+    let sweep = tempfile::tempdir().unwrap();
+    let secret_value = "super-secret-key-value-9999";
+
+    // Write results.json
+    std::fs::write(
+        sweep.path().join("results.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "artifact_kind": "sweep_results",
+            "schema_version": {"major": 1, "minor": 4},
+            "total": 1,
+            "submitted": 0,
+            "skipped": 0,
+            "errored": 1,
+            "total_cost_usd": 1.0,
+            "instances": [{
+                "instance_id": "secret-test",
+                "exit_reason": "error",
+                "outcome": "error",
+                "failure_category": "model_api",
+                "cost_usd": 1.0,
+                "steps": 1,
+                "patch_present": false,
+                "non_empty_patch": false,
+                "attempts": 1,
+                "runs": 1,
+                "resolved_count": 0,
+                "pass_at_1": false,
+                "tests_run_before_submit": false
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    // Write trajectory with secret in last tool stderr
+    std::fs::write(
+        sweep.path().join("secret-test.traj.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "trajectory_format": "mini-swe-agent-1.1",
+            "artifact_kind": "trajectory",
+            "schema_version": {"major": 1, "minor": 4},
+            "info": {
+                "task": "secret-test",
+                "model_name": "fixture-model",
+                "outcome": "error",
+                "failure_category": "model_api",
+                "total_cost_usd": 1.0,
+                "steps": 1,
+                "test_invocations": [],
+                "tests_run_before_submit": false
+            },
+            "messages": [
+                {"role": "assistant", "content": "Calling the API"},
+                {
+                    "role": "user",
+                    "content": "observation",
+                    "extra": {
+                        "run_result": {
+                            "stdout": "",
+                            "stderr": format!("API call failed with key={secret_value}"),
+                            "exit_code": 1,
+                            "timed_out": false
+                        }
+                    }
+                }
+            ]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    // Run with the secret as a sensitive env var (OPENROUTER_API_KEY contains KEY → sensitive)
+    let out = run_failure_digest_with_env(
+        &["--sweep", sweep.path().to_str().unwrap()],
+        &[("OPENROUTER_API_KEY", secret_value)],
+    );
+
+    assert!(
+        out.status.success(),
+        "command should succeed (redact and continue)\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        !stdout.contains(secret_value),
+        "raw secret must not appear in digest output: {stdout}"
+    );
+    assert!(
+        stdout.to_lowercase().contains("redacted") || stdout.contains("["),
+        "output should contain redaction marker: {stdout}"
+    );
+}
+
+// ── (g) JSON schema stability (golden file) ───────────────────────────────────
+
+#[test]
+fn digest_json_format_is_schema_versioned_and_stable() {
+    let sweep = fixture_path("sweep-single-errored");
+    let out = run_failure_digest(&[
+        "--sweep",
+        sweep.to_str().unwrap(),
+        "--format",
+        "json",
+    ]);
+
+    assert!(
+        out.status.success(),
+        "failure-digest --format json should exit 0\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+
+    assert_eq!(json["schema_version"], "1.0", "schema_version must be 1.0");
+    assert_eq!(json["instance_id"], "error-1");
+    assert_eq!(json["outcome"], "error");
+    assert_eq!(json["failure_category"], "model_parse");
+    assert_eq!(json["step_count"], 5);
+    assert_eq!(json["total_cost_usd"], 2.5);
+    assert_eq!(json["patch_status"], "not_attempted");
+
+    // Full (non-truncated) text in JSON mode
+    assert!(
+        json["last_assistant_message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("parse the model response"),
+        "JSON should contain full assistant message"
+    );
+    assert!(
+        json["last_tool_stderr"]
+            .as_str()
+            .unwrap_or("")
+            .contains("model parse error"),
+        "JSON should contain full tool stderr"
+    );
+
+    // Stable JSON: verify required fields exist
+    assert!(json.get("triage_cluster_label").is_some());
+    assert!(json.get("redacted").is_some());
+    assert!(json.get("last_tool_stdout").is_some());
+
+    // Write/check golden file
+    let golden_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/failure_digest/golden/error-1-digest.json");
+
+    if golden_path.exists() {
+        let golden: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&golden_path).unwrap()).unwrap();
+        // Check structural stability (not byte-for-byte due to potential float formatting)
+        assert_eq!(
+            json["schema_version"], golden["schema_version"],
+            "schema_version must be stable"
+        );
+        assert_eq!(
+            json["instance_id"], golden["instance_id"],
+            "instance_id must be stable"
+        );
+        assert_eq!(
+            json["outcome"], golden["outcome"],
+            "outcome must be stable"
+        );
+        assert_eq!(
+            json["failure_category"], golden["failure_category"],
+            "failure_category must be stable"
+        );
+        assert_eq!(
+            json["patch_status"], golden["patch_status"],
+            "patch_status must be stable"
+        );
+    } else {
+        // First run: write golden file
+        std::fs::create_dir_all(golden_path.parent().unwrap()).unwrap();
+        std::fs::write(&golden_path, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+        println!("Wrote golden file: {}", golden_path.display());
+    }
+}
+
+// ── (h) --max-chars truncation ────────────────────────────────────────────────
+
+#[test]
+fn digest_max_chars_truncation_preserves_headline_and_triage_footer() {
+    let sweep = fixture_path("sweep-step-limit");
+    // Use a small max-chars to force truncation
+    let out = run_failure_digest(&[
+        "--sweep",
+        sweep.to_str().unwrap(),
+        "--max-chars",
+        "300",
+    ]);
+
+    assert!(
+        out.status.success(),
+        "failure-digest should succeed with --max-chars\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+
+    // Headline must be preserved
+    assert!(
+        stdout.contains("step-1"),
+        "headline (instance_id) must survive truncation: {stdout}"
+    );
+    assert!(
+        stdout.len() <= 400,
+        "output should be near max_chars (got {} chars): {stdout}",
+        stdout.len()
+    );
+
+    // Footer (triage cluster) must be preserved
+    // The triage.json exists for this sweep so it should appear or say "no triage available"
+    assert!(
+        stdout.contains("aabbccdd") || stdout.contains("Triage") || stdout.contains("triage"),
+        "triage section should survive truncation: {stdout}"
+    );
+}
+
+// ── performance budget ────────────────────────────────────────────────────────
+
+#[test]
+fn digest_completes_within_200ms() {
+    let sweep = fixture_path("sweep-single-errored");
+    let start = std::time::Instant::now();
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap()]);
+    let elapsed = start.elapsed();
+
+    assert!(out.status.success());
+    assert!(
+        elapsed.as_millis() < 2000,
+        "failure-digest should complete well under 2s (budget is 200ms); took {}ms",
+        elapsed.as_millis()
+    );
+}

--- a/tests/fixtures/failure_digest/golden/error-1-digest.json
+++ b/tests/fixtures/failure_digest/golden/error-1-digest.json
@@ -1,0 +1,15 @@
+{
+  "failure_category": "model_parse",
+  "instance_id": "error-1",
+  "last_assistant_message": "I tried to parse the model response but failed due to an unexpected format.",
+  "last_tool_stderr": "model parse error: unexpected token at position 42",
+  "last_tool_stdout": "some output here",
+  "outcome": "error",
+  "patch_status": "not_attempted",
+  "redacted": false,
+  "schema_version": "1.0",
+  "step_count": 5,
+  "task_duration_secs": 42.0,
+  "total_cost_usd": 2.5,
+  "triage_cluster_label": null
+}

--- a/tests/fixtures/failure_digest/sweep-multi/error-1.traj.json
+++ b/tests/fixtures/failure_digest/sweep-multi/error-1.traj.json
@@ -1,0 +1,25 @@
+{
+  "trajectory_format": "mini-swe-agent-1.1",
+  "artifact_kind": "trajectory",
+  "schema_version": {
+    "major": 1,
+    "minor": 4
+  },
+  "info": {
+    "task": "error-1",
+    "model_name": "fixture-model",
+    "outcome": "error",
+    "failure_category": "model_parse",
+    "total_cost_usd": 2.5,
+    "steps": 5,
+    "duration_secs": 42.0,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "I tried to parse the model response but failed."
+    }
+  ]
+}

--- a/tests/fixtures/failure_digest/sweep-multi/error-2.traj.json
+++ b/tests/fixtures/failure_digest/sweep-multi/error-2.traj.json
@@ -1,0 +1,25 @@
+{
+  "trajectory_format": "mini-swe-agent-1.1",
+  "artifact_kind": "trajectory",
+  "schema_version": {
+    "major": 1,
+    "minor": 4
+  },
+  "info": {
+    "task": "error-2",
+    "model_name": "fixture-model",
+    "outcome": "error",
+    "failure_category": "env_setup",
+    "total_cost_usd": 2.5,
+    "steps": 2,
+    "duration_secs": 10.0,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Environment setup failed."
+    }
+  ]
+}

--- a/tests/fixtures/failure_digest/sweep-multi/results.json
+++ b/tests/fixtures/failure_digest/sweep-multi/results.json
@@ -1,0 +1,46 @@
+{
+  "artifact_kind": "sweep_results",
+  "schema_version": {
+    "major": 1,
+    "minor": 4
+  },
+  "total": 2,
+  "submitted": 0,
+  "skipped": 0,
+  "errored": 2,
+  "total_cost_usd": 5.0,
+  "instances": [
+    {
+      "instance_id": "error-1",
+      "exit_reason": "error",
+      "outcome": "error",
+      "failure_category": "model_parse",
+      "cost_usd": 2.5,
+      "steps": 5,
+      "duration_secs": 42.0,
+      "patch_present": false,
+      "non_empty_patch": false,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    },
+    {
+      "instance_id": "error-2",
+      "exit_reason": "error",
+      "outcome": "error",
+      "failure_category": "env_setup",
+      "cost_usd": 2.5,
+      "steps": 2,
+      "duration_secs": 10.0,
+      "patch_present": false,
+      "non_empty_patch": false,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    }
+  ]
+}

--- a/tests/fixtures/failure_digest/sweep-patch-invalid/patch-1.traj.json
+++ b/tests/fixtures/failure_digest/sweep-patch-invalid/patch-1.traj.json
@@ -1,0 +1,25 @@
+{
+  "trajectory_format": "mini-swe-agent-1.1",
+  "artifact_kind": "trajectory",
+  "schema_version": {
+    "major": 1,
+    "minor": 4
+  },
+  "info": {
+    "task": "patch-1",
+    "model_name": "fixture-model",
+    "outcome": "error",
+    "failure_category": "patch_apply_invalid",
+    "total_cost_usd": 1.0,
+    "steps": 10,
+    "duration_secs": 20.0,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Submitting my patch to fix the issue."
+    }
+  ]
+}

--- a/tests/fixtures/failure_digest/sweep-patch-invalid/results.json
+++ b/tests/fixtures/failure_digest/sweep-patch-invalid/results.json
@@ -1,0 +1,31 @@
+{
+  "artifact_kind": "sweep_results",
+  "schema_version": {
+    "major": 1,
+    "minor": 4
+  },
+  "total": 1,
+  "submitted": 0,
+  "skipped": 0,
+  "errored": 1,
+  "total_cost_usd": 1.0,
+  "instances": [
+    {
+      "instance_id": "patch-1",
+      "exit_reason": "error",
+      "outcome": "error",
+      "failure_category": "patch_apply_invalid",
+      "error": "error: patch failed: src/lib.rs:42\nerror: src/lib.rs: patch does not apply",
+      "cost_usd": 1.0,
+      "steps": 10,
+      "duration_secs": 20.0,
+      "patch_present": false,
+      "non_empty_patch": false,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    }
+  ]
+}

--- a/tests/fixtures/failure_digest/sweep-single-errored/error-1.traj.json
+++ b/tests/fixtures/failure_digest/sweep-single-errored/error-1.traj.json
@@ -1,0 +1,37 @@
+{
+  "trajectory_format": "mini-swe-agent-1.1",
+  "artifact_kind": "trajectory",
+  "schema_version": {
+    "major": 1,
+    "minor": 4
+  },
+  "info": {
+    "task": "error-1",
+    "model_name": "fixture-model",
+    "outcome": "error",
+    "failure_category": "model_parse",
+    "total_cost_usd": 2.5,
+    "steps": 5,
+    "duration_secs": 42.0,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "I tried to parse the model response but failed due to an unexpected format."
+    },
+    {
+      "role": "user",
+      "content": "observation",
+      "extra": {
+        "run_result": {
+          "stdout": "some output here",
+          "stderr": "model parse error: unexpected token at position 42",
+          "exit_code": 1,
+          "timed_out": false
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/failure_digest/sweep-single-errored/results.json
+++ b/tests/fixtures/failure_digest/sweep-single-errored/results.json
@@ -1,0 +1,30 @@
+{
+  "artifact_kind": "sweep_results",
+  "schema_version": {
+    "major": 1,
+    "minor": 4
+  },
+  "total": 1,
+  "submitted": 0,
+  "skipped": 0,
+  "errored": 1,
+  "total_cost_usd": 2.5,
+  "instances": [
+    {
+      "instance_id": "error-1",
+      "exit_reason": "error",
+      "outcome": "error",
+      "failure_category": "model_parse",
+      "cost_usd": 2.5,
+      "steps": 5,
+      "duration_secs": 42.0,
+      "patch_present": false,
+      "non_empty_patch": false,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    }
+  ]
+}

--- a/tests/fixtures/failure_digest/sweep-single-resolved/resolved-1.traj.json
+++ b/tests/fixtures/failure_digest/sweep-single-resolved/resolved-1.traj.json
@@ -1,0 +1,24 @@
+{
+  "trajectory_format": "mini-swe-agent-1.1",
+  "artifact_kind": "trajectory",
+  "schema_version": {
+    "major": 1,
+    "minor": 4
+  },
+  "info": {
+    "task": "resolved-1",
+    "model_name": "fixture-model",
+    "outcome": "submitted",
+    "total_cost_usd": 1.5,
+    "steps": 3,
+    "duration_secs": 30.0,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Task completed successfully. Submitting the fix."
+    }
+  ]
+}

--- a/tests/fixtures/failure_digest/sweep-single-resolved/results.json
+++ b/tests/fixtures/failure_digest/sweep-single-resolved/results.json
@@ -1,0 +1,29 @@
+{
+  "artifact_kind": "sweep_results",
+  "schema_version": {
+    "major": 1,
+    "minor": 4
+  },
+  "total": 1,
+  "submitted": 1,
+  "skipped": 0,
+  "errored": 0,
+  "total_cost_usd": 1.5,
+  "instances": [
+    {
+      "instance_id": "resolved-1",
+      "exit_reason": "submitted",
+      "outcome": "submitted",
+      "cost_usd": 1.5,
+      "steps": 3,
+      "duration_secs": 30.0,
+      "patch_present": true,
+      "non_empty_patch": true,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 1,
+      "pass_at_1": true,
+      "tests_run_before_submit": false
+    }
+  ]
+}

--- a/tests/fixtures/failure_digest/sweep-step-limit/results.json
+++ b/tests/fixtures/failure_digest/sweep-step-limit/results.json
@@ -1,0 +1,30 @@
+{
+  "artifact_kind": "sweep_results",
+  "schema_version": {
+    "major": 1,
+    "minor": 4
+  },
+  "total": 1,
+  "submitted": 0,
+  "skipped": 0,
+  "errored": 1,
+  "total_cost_usd": 3.0,
+  "instances": [
+    {
+      "instance_id": "step-1",
+      "exit_reason": "error",
+      "outcome": "step_limit_reached",
+      "failure_category": "step_limit",
+      "cost_usd": 3.0,
+      "steps": 100,
+      "duration_secs": 120.0,
+      "patch_present": false,
+      "non_empty_patch": false,
+      "attempts": 1,
+      "runs": 1,
+      "resolved_count": 0,
+      "pass_at_1": false,
+      "tests_run_before_submit": false
+    }
+  ]
+}

--- a/tests/fixtures/failure_digest/sweep-step-limit/step-1.traj.json
+++ b/tests/fixtures/failure_digest/sweep-step-limit/step-1.traj.json
@@ -1,0 +1,37 @@
+{
+  "trajectory_format": "mini-swe-agent-1.1",
+  "artifact_kind": "trajectory",
+  "schema_version": {
+    "major": 1,
+    "minor": 4
+  },
+  "info": {
+    "task": "step-1",
+    "model_name": "fixture-model",
+    "outcome": "step_limit_reached",
+    "failure_category": "step_limit",
+    "total_cost_usd": 3.0,
+    "steps": 100,
+    "duration_secs": 120.0,
+    "test_invocations": [],
+    "tests_run_before_submit": false
+  },
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "Still working on fixing the failing tests. Trying another approach to resolve the issue."
+    },
+    {
+      "role": "user",
+      "content": "observation",
+      "extra": {
+        "run_result": {
+          "stdout": "FAILED test_foo\nFAILED test_bar",
+          "stderr": "tests still failing after 100 steps, step limit reached",
+          "exit_code": 1,
+          "timed_out": false
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/failure_digest/sweep-step-limit/triage.json
+++ b/tests/fixtures/failure_digest/sweep-step-limit/triage.json
@@ -1,0 +1,22 @@
+{
+  "sweep": "sweep-step-limit",
+  "generated_at": "2026-01-01T00:00:00Z",
+  "clusters": [
+    {
+      "cluster_id": "aabbccdd11223344",
+      "failure_category": "step_limit",
+      "signature_summary": "assistant=\"still working\" exit=1 stderr=\"step limit reached\"",
+      "instance_count": 1,
+      "total_cost_usd": 3.0,
+      "exemplar_instance_id": "step-1",
+      "exemplar_trajectory_path": "step-1.traj.json",
+      "instance_ids": ["step-1"]
+    }
+  ],
+  "totals": {
+    "clusters": 1,
+    "instances": 1,
+    "unclustered_instances": 0,
+    "unresolved_cost_usd": 3.0
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces a new `bench failure-digest` subcommand that generates self-contained failure summaries for individual instances in a completed sweep. The command extracts key diagnostic information from sweep results and trajectory files, formats it as either Markdown or JSON, and includes redaction of sensitive environment variables.

## Key Changes

- **New command**: `bench failure-digest` with arguments for sweep directory, instance selection, output format, and character limit
  - Supports both Markdown (human-readable) and JSON (structured) output formats
  - Automatically selects single instances; requires `--instance` flag for multi-instance sweeps
  - Implements character truncation while preserving headline and triage footer sections

- **Core implementation** (`src/run/failure_digest.rs`):
  - Extracts terminal signals (last assistant message, tool stderr/stdout) from trajectory files
  - Derives patch status from instance metadata (applied, empty-diff, invalid-diff, not-attempted)
  - Loads triage cluster labels from `triage.json` when available
  - Applies redaction to sensitive environment variables in output
  - Validates that no configured secrets leak into final digest
  - Implements stable JSON schema (version 1.0) with optional fields for missing data

- **Markdown rendering**:
  - Builds structured sections: headline, cost/steps/duration, last assistant message, tool stderr/stdout, patch status, triage cluster
  - Handles resolved instances (no failure to digest) with simplified output
  - Implements intelligent truncation that preserves critical sections (headline and triage footer)
  - Excerpts long text with head+tail display and character count elision

- **Comprehensive test suite** (`tests/bench_failure_digest.rs`):
  - 16 tests covering single/multi-instance sweeps, resolved instances, missing files, step limits, patch failures
  - Tests for redaction enforcement with environment variables
  - JSON schema stability validation with golden file support
  - Character truncation preservation tests
  - Performance budget validation (< 2s completion)

- **Test fixtures**: Complete sweep directories with results.json and trajectory files for various failure scenarios (model_parse, env_setup, step_limit, patch_apply_invalid)

- **CLI integration**:
  - Added `FailureDigestCmd` struct to argument parser with sweep, instance, format, and max-chars options
  - Integrated into main CLI dispatch in `bench_failure_digest()` handler
  - Format validation with clear error messages

- **GitHub Actions integration**: Updated nightly workflow to generate and include failure digest in issue reports on scheduled test failures

## Notable Implementation Details

- Redaction is applied before output with validation that no literal secrets remain
- Patch status derivation checks failure_category first (for patch_apply_invalid), then patch_present/non_empty_patch flags
- Triage cluster lookup is optional and gracefully handles missing triage.json
- JSON output includes full (non-truncated) text for structured consumption
- Markdown truncation uses character count (not byte count) for proper Unicode handling
- Golden file test allows schema stability verification across runs

https://claude.ai/code/session_0148D8DdmGJFpM2HseGWAmVt