### PR TITLE
🌟 Nova: Trajectory JSON Exporter

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2494,7 +2494,10 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "json"
+    ) {
         return bench_inspect_export(i);
     }
 
@@ -2573,6 +2576,10 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "json" => {
+            use crate::trajectory::export::{JsonExporter, TrajectoryExporter};
+            JsonExporter::export(&traj)
+        }
         _ => unreachable!("dispatch guarded by caller"),
     };
 

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -53,7 +53,18 @@ pub struct MermaidExporter;
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
+/// Transforms a [`Trajectory`] into a JSON document.
+///
+/// Note: This exporter formats the full trajectory structure as minified or pretty JSON.
+pub struct JsonExporter;
+
 use std::fmt::Write;
+
+impl TrajectoryExporter for JsonExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        serde_json::to_string_pretty(trajectory).unwrap_or_else(|_| "{}".to_string())
+    }
+}
 
 #[cfg(feature = "csv-export")]
 impl TrajectoryExporter for CsvExporter {
@@ -247,6 +258,7 @@ impl TrajectoryExporter for MermaidExporter {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
     use crate::model::Message;
     use crate::trajectory::outcome;
@@ -339,5 +351,26 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+
+    #[test]
+    fn test_json_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent"));
+
+        let json_str = JsonExporter::export(&t);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(parsed["info"]["task"].as_str().unwrap(), "Add a feature");
+        assert_eq!(parsed["info"]["outcome"].as_str().unwrap(), "submitted");
+        assert_eq!(parsed["messages"][0]["role"].as_str().unwrap(), "system");
+        assert_eq!(
+            parsed["messages"][0]["content"].as_str().unwrap(),
+            "System prompt"
+        );
     }
 }


### PR DESCRIPTION
💡 **The Spark:** "We can export trajectories to Markdown, HTML, CSV, and Mermaid. Why not JSON format using the exact same structure as the existing exports? We already have `serde_json` and `.traj.json` files, but the CLI doesn't natively expose a simple JSON formatter using the `TrajectoryExporter` trait for standard output inspection workflows."

🚀 **The Feature:** "Implemented `JsonExporter` struct which implements the `TrajectoryExporter` trait using `serde_json::to_string_pretty`. Updated the CLI routing in `src/cli/mod.rs` to correctly match `--format json` in instance mode to output using the new `JsonExporter`."

🔮 **The Potential:** "Could be used for piping structured trajectory data seamlessly into external tooling like `jq`, custom dashboards, or automated reporting scripts without writing bespoke `.traj.json` parsers. It opens up pure JSON interop for any system consuming the CLI's standard output."

⚠️ **Risk:** "Low. Isolated in `src/trajectory/export.rs` and merely adds a match arm to the CLI's existing trajectory format dispatcher."

---
*PR created automatically by Jules for task [9541170519125668123](https://jules.google.com/task/9541170519125668123) started by @madmax983*