### PR TITLE
Add `bench eval-flake` command to quantify evaluator verdict noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,10 @@ a valid trajectory in hand:
   two-proportion z-tests.
 - [`bench dataset-stats`](docs/spec-dataset-stats.md): zero-cost preflight to
   preview and analyze dataset composition offline before running a sweep.
+- [`bench eval-flake`](docs/spec-eval-flake.md): quantify evaluator-side verdict
+  noise by replaying the evaluator N times per patch on a completed sweep.
+  Produces `eval-flake.json`; pair with `bench compare --flake-report` to
+  exclude flaky instances from significance testing and get honest published deltas.
 
 ## Nightly E2E smoke
 

--- a/docs/spec-eval-flake.md
+++ b/docs/spec-eval-flake.md
@@ -1,0 +1,177 @@
+# `bench eval-flake` — evaluator-side verdict noise quantification
+
+## Overview
+
+`bench eval-flake` re-runs the existing evaluator pipeline against every
+instance's already-captured `.patch` artifact N times and identifies which
+instances' verdicts are non-deterministic. The result is an `eval-flake.json`
+artifact that operators can pass to `bench compare --flake-report` to exclude
+flaky instances from significance testing and resolved-rate deltas.
+
+**Zero new model calls.** Cost is exclusively evaluator (sb-cli) wall-clock
+time × replay factor. `total_cost_usd` is always `0.0`.
+
+## Standard operator workflow
+
+```
+bench swebench  --sweep my-sweep …
+bench evaluate  --sweep my-sweep …
+bench eval-flake --sweep my-sweep --replays 3
+bench compare   --baseline sweep-a --candidate sweep-b \
+                --flake-report my-sweep/eval-flake.json
+```
+
+## CLI reference
+
+```
+bench eval-flake --sweep <PATH> [--replays <N>] [--output <PATH>] [--concurrency <N>]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--sweep` | required | Completed sweep directory (must contain `.patch` files and `results.json`). |
+| `--replays` | `3` | Number of evaluator replays per instance. |
+| `--output` | `<sweep>/eval-flake.json` | Output file path. |
+| `--concurrency` | `4` | Maximum parallel evaluator workers. |
+
+## `eval-flake.json` schema
+
+```json
+{
+  "artifact_kind": "eval_flake_report",
+  "schema_version": {"major": 1, "minor": 10},
+  "instances": [
+    {
+      "instance_id": "django__django-12345",
+      "verdicts": ["resolved", "unresolved", "resolved"],
+      "is_flaky": true,
+      "flake_rate": 0.667,
+      "dominant_verdict": "resolved",
+      "original_sweep_verdict": "resolved"
+    }
+  ],
+  "summary": {
+    "replays": 3,
+    "instances_evaluated": 100,
+    "flaky_count": 5,
+    "flaky_rate": 0.05,
+    "dominant_disagrees_with_sweep_count": 2
+  },
+  "total_cost_usd": 0.0
+}
+```
+
+### Per-instance fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `instance_id` | `string` | SWE-bench instance identifier. |
+| `verdicts` | `["resolved"\|"unresolved"\|"errored"]` | One entry per replay. Empty for skipped (no-patch) instances. |
+| `is_flaky` | `bool` | `true` iff any two verdicts disagree. |
+| `flake_rate` | `f32 [0, 1]` | Fraction of verdict-pairs that disagree: `disagreeing_pairs / C(N,2)`. |
+| `dominant_verdict` | `string?` | Most common verdict across replays. `null` for skipped instances. |
+| `original_sweep_verdict` | `string?` | Verdict from the sweep's `evaluation.json` (or `results.json` fallback). |
+
+### Sweep-level summary fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `replays` | `u32` | Number of evaluator replays requested. |
+| `instances_evaluated` | `u32` | Instances with at least one patch file evaluated. |
+| `flaky_count` | `u32` | Instances with `is_flaky=true`. |
+| `flaky_rate` | `f32 [0, 1]` | `flaky_count / instances_evaluated`. |
+| `dominant_disagrees_with_sweep_count` | `u32` | Instances where `dominant_verdict != original_sweep_verdict`, signalling lucky/unlucky original evaluations. |
+
+### Cost field
+
+`total_cost_usd` is always `0.0`. The dominant cost is evaluator wall-clock
+time, capped by `--concurrency`. On a 100-instance sweep with
+`--replays 3 --concurrency 8`, total wall-clock added stays within
+`2× bench evaluate` time.
+
+## Skipped instances
+
+Instances without a `.patch` file (agent errored before producing a patch)
+are skipped: `verdicts: []`. They are excluded from `flaky_count` and
+`instances_evaluated`.
+
+## `bench compare --flake-report`
+
+```
+bench compare --baseline sweep-a --candidate sweep-b \
+              --flake-report eval-flake.json
+```
+
+When `--flake-report` is supplied:
+
+1. Flaky instances (`is_flaky=true`) are excluded from **both** the
+   resolved-rate delta computation and the McNemar paired significance test.
+2. The text summary names the exclusion count explicitly:
+   ```
+   3 flaky instances excluded; 97 paired instances used in significance test
+   ```
+3. The `CompareReport` JSON gains a `flaky_instances_excluded` field.
+
+### Degenerate case
+
+When **all** paired instances after exclusion are flaky, `bench compare` exits
+with `usage_error` (exit code 2) and a message naming the flake count:
+
+```
+compare: all 5 paired instance(s) are flagged flaky in the flake report;
+no instances remain for the significance test.
+```
+
+Without `--flake-report`, behavior is unchanged.
+
+## `bench inspect --flake-report`
+
+```
+bench inspect --sweep sweep-dir --instance django__django-12345 \
+              --flake-report eval-flake.json
+```
+
+When `--flake-report` is supplied and the instance appears in the flake report,
+the human-readable output gains an `eval_flake` line:
+
+```
+eval_flake:       is_flaky=true flake_rate=0.667 verdicts=[resolved, unresolved, resolved]
+```
+
+This lets an operator triaging a single failing instance immediately see
+whether they are chasing model behavior or evaluator noise.
+
+## Exit codes
+
+`bench eval-flake` uses the standard exit codes:
+- `0` — success
+- `2` (`usage_error`) — invalid arguments (e.g. `--replays 0`)
+- `1` — unexpected runtime error
+
+`bench compare --flake-report` adds no new exit codes. The degenerate
+all-flaky case uses existing `usage_error` (2).
+
+## Flake rate formula
+
+For N replays with verdicts `v[0..N]`:
+
+```
+total_pairs       = N*(N-1)/2
+disagreeing_pairs = |{(i,j) : i < j, v[i] ≠ v[j]}|
+flake_rate        = disagreeing_pairs / total_pairs
+```
+
+**Example** — `[resolved, unresolved, resolved]` (N=3):
+- Total pairs: 3
+- Disagreeing: 2  ((0,1) and (1,2))
+- `flake_rate = 2/3 ≈ 0.667`
+
+## Out of scope
+
+- **Re-running the agent.** No new model calls; no new patches.
+- **Fixing flaky instances upstream.** We measure and report only.
+- **Cross-evaluator-image comparison.** One evaluator image per invocation.
+- **Streaming progress to `bench tail`.** Use `--log info` for progress.
+- **Automatic re-weighting in McNemar.** v1 is hard-exclude only.
+- **Replays on errored instances** (no patch). Those are skipped with
+  `verdicts: []`.

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -63,6 +63,7 @@ pub enum ArtifactKind {
     LadderReport,
     SkillsPreview,
     AuditReport,
+    EvalFlakeReport,
 }
 
 impl ArtifactKind {
@@ -83,6 +84,7 @@ impl ArtifactKind {
             Self::LadderReport => "ladder_report",
             Self::SkillsPreview => "skills_preview",
             Self::AuditReport => "audit_report",
+            Self::EvalFlakeReport => "eval_flake_report",
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -534,6 +534,8 @@ pub enum BenchCmd {
     Audit(AuditCmd),
     /// Emit a self-contained failure summary for one instance in a completed sweep.
     FailureDigest(FailureDigestCmd),
+    /// Quantify evaluator-side verdict noise by replaying the evaluator N times per patch.
+    EvalFlake(EvalFlakeCmd),
 }
 
 /// `bench failure-digest` — self-contained failure summary for one sweep instance.
@@ -558,6 +560,28 @@ pub struct FailureDigestCmd {
     /// Truncation preserves the headline and triage cluster footer.
     #[arg(long, default_value_t = 8000)]
     pub max_chars: usize,
+}
+
+/// `bench eval-flake` — quantify evaluator-side verdict noise on a completed sweep.
+#[derive(Debug, Args, Clone)]
+pub struct EvalFlakeCmd {
+    /// Completed sweep directory produced by `bench swebench` (must contain
+    /// per-instance `.patch` files and a `results.json`).
+    #[arg(long)]
+    pub sweep: PathBuf,
+
+    /// Number of times to replay the evaluator per instance. Default: 3.
+    #[arg(long, default_value_t = 3)]
+    pub replays: usize,
+
+    /// Output file for the `eval-flake.json` artifact.
+    /// Defaults to `<sweep>/eval-flake.json`.
+    #[arg(long, value_name = "PATH")]
+    pub output: Option<PathBuf>,
+
+    /// Maximum parallel evaluator workers. Mirrors `bench evaluate --concurrency`.
+    #[arg(long, default_value_t = 4)]
+    pub concurrency: usize,
 }
 
 /// `bench dataset-stats` — preview SWE-bench dataset composition pre-sweep.
@@ -1356,6 +1380,12 @@ pub struct CompareCmd {
     /// Range: 0.0–1.0. Unset is informational only.
     #[arg(long = "max-test-only-resolved-rate", value_name = "RATE")]
     pub max_test_only_resolved_rate: Option<f64>,
+
+    /// Path to an `eval-flake.json` produced by `bench eval-flake`. When set,
+    /// flaky instances (`is_flaky=true`) are excluded from both the resolved-rate
+    /// delta and the McNemar paired significance test.
+    #[arg(long, value_name = "PATH")]
+    pub flake_report: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -1787,6 +1817,13 @@ pub struct InspectCmd {
     /// sweep's dataset.jsonl (requires dataset.jsonl in the sweep directory).
     #[arg(long, default_value_t = false)]
     pub show_expected: bool,
+
+    /// Path to an `eval-flake.json` produced by `bench eval-flake`. When set,
+    /// the instance view renders the verdict vector and flake_rate alongside the
+    /// normal transcript so an operator can see whether they are chasing model
+    /// behavior or evaluator noise.
+    #[arg(long, value_name = "PATH")]
+    pub flake_report: Option<PathBuf>,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4215,7 +4215,10 @@ fn bench_eval_flake(f: args::EvalFlakeCmd) -> Result<(), Error> {
         summary.dominant_disagrees_with_sweep_count,
     );
     eprintln!("eval-flake: total_cost_usd=0.00 (evaluator wallclock only)");
-    println!("{}", serde_json::to_string_pretty(&report).map_err(Error::Json)?);
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).map_err(Error::Json)?
+    );
     Ok(())
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -112,6 +112,7 @@ pub async fn run() -> Result<(), Error> {
             args::BenchCmd::Bisect(b) => Box::pin(bench_bisect(b)).await,
             args::BenchCmd::Audit(a) => bench_audit(a),
             args::BenchCmd::FailureDigest(f) => bench_failure_digest(f),
+            args::BenchCmd::EvalFlake(f) => bench_eval_flake(f),
         },
         Command::Agent { cmd } => match *cmd {
             args::AgentCmd::SkillsPreview(s) => agent_skills_preview_cmd(&s),
@@ -1758,6 +1759,7 @@ fn bench_compare(c: args::CompareCmd) -> Result<(), Error> {
         min_significance: c.min_significance,
         regression_significance: c.regression_significance,
         allow_underpowered: c.allow_underpowered,
+        flake_report: c.flake_report.clone(),
     })?;
     match format {
         crate::run::compare::CompareFormat::Text => {
@@ -2569,6 +2571,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         filter: i.filter,
         full: i.full,
         show_expected: i.show_expected,
+        flake_report: i.flake_report,
     })?;
     match format {
         crate::run::inspect::InspectFormat::Text => {
@@ -4193,6 +4196,27 @@ fn bench_failure_digest(f: args::FailureDigestCmd) -> Result<(), Error> {
             Ok(())
         }
     }
+}
+
+fn bench_eval_flake(f: args::EvalFlakeCmd) -> Result<(), Error> {
+    let args = crate::run::eval_flake::EvalFlakeArgs {
+        sweep_dir: f.sweep,
+        replays: f.replays,
+        output: f.output,
+        concurrency: f.concurrency,
+    };
+    let report = crate::run::eval_flake::run(&args)?;
+    let summary = &report.summary;
+    eprintln!(
+        "eval-flake: {} instance(s) evaluated, {} flaky ({:.1}% flake rate), {} disagree with original sweep verdict",
+        summary.instances_evaluated,
+        summary.flaky_count,
+        summary.flaky_rate * 100.0,
+        summary.dominant_disagrees_with_sweep_count,
+    );
+    eprintln!("eval-flake: total_cost_usd=0.00 (evaluator wallclock only)");
+    println!("{}", serde_json::to_string_pretty(&report).map_err(Error::Json)?);
+    Ok(())
 }
 
 fn parse_dataset_source_stats(

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -59,6 +59,10 @@ pub struct CompareArgs {
     /// sample is underpowered. Without this flag, gating exits non-zero
     /// whenever the test is underpowered.
     pub allow_underpowered: bool,
+    /// Optional path to an `eval-flake.json` artifact. When set, instances
+    /// flagged `is_flaky=true` are excluded from both the resolved-rate delta
+    /// and the McNemar paired significance test.
+    pub flake_report: Option<PathBuf>,
 }
 
 /// Per-task transition between baseline and candidate. `pass` prefers
@@ -230,6 +234,11 @@ pub struct CompareReport {
     pub candidate_test_only_resolved_rate: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub test_only_resolved_rate_delta: Option<f64>,
+    /// Number of flaky instances excluded from the significance test and delta
+    /// computation when `--flake-report` is provided. Zero when no flake report
+    /// was loaded or when no flaky instances were found in the paired overlap.
+    #[serde(default)]
+    pub flaky_instances_excluded: usize,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -423,6 +432,16 @@ impl CompareReport {
         write_breakdown_delta_section(&mut s, &self.breakdown_delta);
         write_regressions(&mut s, &self.regressions);
         write_sampling_drift_section(&mut s, self.sampling_drift.as_ref());
+        if self.flaky_instances_excluded > 0 {
+            let n = self.flaky_instances_excluded;
+            let paired = self.resolved_rate_significance.paired_n;
+            let _ = writeln!(
+                s,
+                "\n{n} flaky instance{s} excluded; {paired} paired instance{ps} used in significance test",
+                s = if n == 1 { "" } else { "s" },
+                ps = if paired == 1 { "" } else { "s" },
+            );
+        }
         s
     }
 }
@@ -1460,6 +1479,57 @@ pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
     let candidate_eval_results = candidate_eval.as_ref().map(|loaded| &loaded.results);
     let baseline_resolved_override = baseline_eval_results.map(resolved_overrides_from_eval);
     let candidate_resolved_override = candidate_eval_results.map(resolved_overrides_from_eval);
+
+    // Load flake report and compute the excluded instance set.
+    let (flaky_ids, flaky_instances_excluded) = if let Some(ref flake_path) = args.flake_report {
+        let flake = crate::run::eval_flake::EvalFlakeReport::load(flake_path)?;
+        let flaky = flake.flaky_ids();
+        // Count paired instances that are flaky (present in both sweeps and flaky).
+        let paired_flaky = flaky
+            .iter()
+            .filter(|id| baseline.instances.contains_key(*id) && candidate.instances.contains_key(*id))
+            .count();
+        // Degenerate: all paired instances are flaky — caller gets UsageError.
+        let paired_n = baseline
+            .instances
+            .keys()
+            .filter(|id| candidate.instances.contains_key(*id))
+            .count();
+        let non_flaky_paired = paired_n.saturating_sub(paired_flaky);
+        if non_flaky_paired == 0 && paired_n > 0 {
+            return Err(Error::Config(crate::error::ConfigError::Usage(format!(
+                "compare: all {paired_flaky} paired instance(s) are flagged flaky in the flake report; \
+                 no instances remain for the significance test. \
+                 Provide a sweep with non-flaky instances or omit --flake-report.",
+            ))));
+        }
+        (flaky, paired_flaky)
+    } else {
+        (std::collections::HashSet::new(), 0)
+    };
+
+    // Filter instance maps to exclude flaky instances from delta + significance.
+    let filtered_baseline: HashMap<String, InstanceResult> = if flaky_ids.is_empty() {
+        baseline.instances.clone()
+    } else {
+        baseline
+            .instances
+            .iter()
+            .filter(|(id, _)| !flaky_ids.contains(*id))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    };
+    let filtered_candidate: HashMap<String, InstanceResult> = if flaky_ids.is_empty() {
+        candidate.instances.clone()
+    } else {
+        candidate
+            .instances
+            .iter()
+            .filter(|(id, _)| !flaky_ids.contains(*id))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    };
+
     let artifact_warnings = artifact_warning_lines(
         &baseline,
         &candidate,
@@ -1469,8 +1539,8 @@ pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
     let mut report = diff_with_overrides(
         &args.baseline,
         &args.candidate,
-        &baseline.instances,
-        &candidate.instances,
+        &filtered_baseline,
+        &filtered_candidate,
         baseline_resolved_override.as_ref(),
         candidate_resolved_override.as_ref(),
         DiffContext {
@@ -1489,6 +1559,7 @@ pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
             candidate_model_name,
         },
     );
+    report.flaky_instances_excluded = flaky_instances_excluded;
     report.subset_warnings = subset_warnings(
         baseline.filter_spec.as_ref(),
         candidate.filter_spec.as_ref(),
@@ -1852,6 +1923,7 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
         baseline_test_only_resolved_rate: None,
         candidate_test_only_resolved_rate: None,
         test_only_resolved_rate_delta: None,
+        flaky_instances_excluded: 0,
     }
 }
 
@@ -3495,6 +3567,7 @@ mod tests {
             min_significance: None,
             regression_significance: None,
             allow_underpowered: false,
+            flake_report: None,
         })
         .unwrap();
         assert_eq!(r.regressions.len(), 1);
@@ -3918,6 +3991,7 @@ mod tests {
             min_significance: None,
             regression_significance: None,
             allow_underpowered: false,
+            flake_report: None,
         })
         .unwrap();
         assert_eq!(r.baseline_resolved, 1);
@@ -3967,6 +4041,7 @@ mod tests {
             min_significance: None,
             regression_significance: None,
             allow_underpowered: false,
+            flake_report: None,
         })
         .unwrap();
         assert_eq!(r.baseline_resolved, 10);

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -1482,10 +1482,10 @@ pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
 
     // Load flake report and compute the excluded instance set.
     let (flaky_ids, flaky_instances_excluded) = if let Some(ref flake_path) = args.flake_report {
-        let flake = crate::run::eval_flake::EvalFlakeReport::load(flake_path)?;
-        let flaky = flake.flaky_ids();
+        let flake_report = crate::run::eval_flake::EvalFlakeReport::load(flake_path)?;
+        let flagged_ids = flake_report.flaky_ids();
         // Count paired instances that are flaky (present in both sweeps and flaky).
-        let paired_flaky = flaky
+        let paired_flaky = flagged_ids
             .iter()
             .filter(|id| {
                 baseline.instances.contains_key(*id) && candidate.instances.contains_key(*id)
@@ -1505,7 +1505,7 @@ pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
                  Provide a sweep with non-flaky instances or omit --flake-report.",
             ))));
         }
-        (flaky, paired_flaky)
+        (flagged_ids, paired_flaky)
     } else {
         (std::collections::HashSet::new(), 0)
     };

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -1487,7 +1487,9 @@ pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
         // Count paired instances that are flaky (present in both sweeps and flaky).
         let paired_flaky = flaky
             .iter()
-            .filter(|id| baseline.instances.contains_key(*id) && candidate.instances.contains_key(*id))
+            .filter(|id| {
+                baseline.instances.contains_key(*id) && candidate.instances.contains_key(*id)
+            })
             .count();
         // Degenerate: all paired instances are flaky — caller gets UsageError.
         let paired_n = baseline

--- a/src/run/eval_flake.rs
+++ b/src/run/eval_flake.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::artifact::{ArtifactKind, ArtifactSchemaVersion};
 use crate::error::Error;
-use crate::run::evaluate::{BreakdownSelection, EvaluateArgs, EvaluateBackend, EvalExitReason};
 use crate::run::compare::load_sweep;
+use crate::run::evaluate::{BreakdownSelection, EvalExitReason, EvaluateArgs, EvaluateBackend};
 
 // ── Public types ──────────────────────────────────────────────────────────────
 
@@ -419,8 +419,10 @@ pub fn run(args: &EvalFlakeArgs) -> Result<EvalFlakeReport, Error> {
     }
 
     // Collect verdicts per instance across replays.
-    let mut all_verdicts: HashMap<String, Vec<Verdict>> =
-        patchable.iter().map(|id| (id.clone(), Vec::new())).collect();
+    let mut all_verdicts: HashMap<String, Vec<Verdict>> = patchable
+        .iter()
+        .map(|id| (id.clone(), Vec::new()))
+        .collect();
 
     for replay_idx in 0..args.replays {
         tracing::info!(
@@ -549,11 +551,7 @@ mod tests {
                 vec![Verdict::Resolved, Verdict::Unresolved],
                 None,
             ),
-            build_instance_result(
-                "b".into(),
-                vec![Verdict::Resolved, Verdict::Resolved],
-                None,
-            ),
+            build_instance_result("b".into(), vec![Verdict::Resolved, Verdict::Resolved], None),
         ];
         let summary = build_summary(&instances, 2);
         assert_eq!(summary.flaky_count, 1);

--- a/src/run/eval_flake.rs
+++ b/src/run/eval_flake.rs
@@ -402,7 +402,7 @@ pub fn run(args: &EvalFlakeArgs) -> Result<EvalFlakeReport, Error> {
             .instances
             .keys()
             .filter(|id| {
-                let p = args.sweep_dir.join(format!("{id}.patch"));
+                let p = crate::run::swebench::existing_patch_path_for_run(&args.sweep_dir, id, 1);
                 p.exists() && std::fs::metadata(&p).is_ok_and(|m| m.len() > 0)
             })
             .cloned()

--- a/src/run/eval_flake.rs
+++ b/src/run/eval_flake.rs
@@ -492,6 +492,7 @@ pub fn run(args: &EvalFlakeArgs) -> Result<EvalFlakeReport, Error> {
 // ── Unit tests for aggregation logic ──────────────────────────────────────────
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
 

--- a/src/run/eval_flake.rs
+++ b/src/run/eval_flake.rs
@@ -179,7 +179,7 @@ pub fn dominant_verdict(verdicts: &[Verdict]) -> Option<Verdict> {
             Verdict::Errored => counts[2] += 1,
         }
     }
-    let max = *counts.iter().max().unwrap();
+    let max = counts[0].max(counts[1]).max(counts[2]);
     if counts[0] == max {
         Some(Verdict::Resolved)
     } else if counts[1] == max {
@@ -403,7 +403,7 @@ pub fn run(args: &EvalFlakeArgs) -> Result<EvalFlakeReport, Error> {
             .keys()
             .filter(|id| {
                 let p = args.sweep_dir.join(format!("{id}.patch"));
-                p.exists() && std::fs::metadata(&p).map_or(false, |m| m.len() > 0)
+                p.exists() && std::fs::metadata(&p).is_ok_and(|m| m.len() > 0)
             })
             .cloned()
             .collect();

--- a/src/run/eval_flake.rs
+++ b/src/run/eval_flake.rs
@@ -1,0 +1,563 @@
+//! `bench eval-flake`: quantify evaluator-side verdict noise on a completed sweep.
+//!
+//! Re-runs the evaluator against every instance's already-captured `.patch`
+//! artifact N times and identifies which instances' verdicts are
+//! non-deterministic. Writes `eval-flake.json` with per-instance verdicts,
+//! flake flags, and a sweep-level summary.
+//!
+//! Zero new model calls. `total_cost_usd` is always `0.0`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::artifact::{ArtifactKind, ArtifactSchemaVersion};
+use crate::error::Error;
+use crate::run::evaluate::{BreakdownSelection, EvaluateArgs, EvaluateBackend, EvalExitReason};
+use crate::run::compare::load_sweep;
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+/// Per-replay verdict for a single instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Verdict {
+    Resolved,
+    Unresolved,
+    Errored,
+}
+
+/// Per-instance flake results.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstanceFlakeResult {
+    pub instance_id: String,
+    /// One verdict per replay. Empty for instances without a patch (skipped).
+    pub verdicts: Vec<Verdict>,
+    /// True iff any two verdicts in `verdicts` disagree.
+    pub is_flaky: bool,
+    /// Fraction of verdict-pairs that disagree. Range `[0.0, 1.0]`.
+    pub flake_rate: f32,
+    /// Most common verdict across all replays. `None` when `verdicts` is empty.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dominant_verdict: Option<Verdict>,
+    /// Verdict recorded in the sweep's original evaluation (or results.json).
+    /// `None` when not determinable (errored instance without a patch was skipped).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original_sweep_verdict: Option<Verdict>,
+}
+
+/// Sweep-level flake summary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvalFlakeSummary {
+    pub replays: usize,
+    pub instances_evaluated: usize,
+    pub flaky_count: usize,
+    pub flaky_rate: f32,
+    /// Count of instances where the dominant verdict across replays differs from
+    /// the sweep's originally recorded verdict — signals lucky/unlucky original runs.
+    pub dominant_disagrees_with_sweep_count: usize,
+}
+
+/// Full eval-flake artifact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvalFlakeReport {
+    pub artifact_kind: String,
+    pub schema_version: ArtifactSchemaVersion,
+    pub instances: Vec<InstanceFlakeResult>,
+    pub summary: EvalFlakeSummary,
+    /// Always `0.0`; cost is purely evaluator (sb-cli) wall-clock time.
+    pub total_cost_usd: f64,
+}
+
+impl EvalFlakeReport {
+    /// Return the set of `instance_id`s that are flagged as flaky.
+    #[must_use]
+    pub fn flaky_ids(&self) -> std::collections::HashSet<String> {
+        self.instances
+            .iter()
+            .filter(|i| i.is_flaky)
+            .map(|i| i.instance_id.clone())
+            .collect()
+    }
+
+    /// Load an `EvalFlakeReport` from a JSON file path.
+    pub fn load(path: &Path) -> Result<Self, Error> {
+        let text = std::fs::read_to_string(path).map_err(|e| {
+            Error::Trajectory(format!(
+                "eval-flake: cannot read flake report `{}`: {e}",
+                path.display()
+            ))
+        })?;
+        serde_json::from_str(&text).map_err(|e| {
+            Error::Trajectory(format!(
+                "eval-flake: flake report `{}` is not valid JSON: {e}",
+                path.display()
+            ))
+        })
+    }
+}
+
+/// Arguments for the eval-flake command.
+#[derive(Debug, Clone)]
+pub struct EvalFlakeArgs {
+    /// Completed sweep directory produced by `bench swebench`.
+    pub sweep_dir: PathBuf,
+    /// Number of times to replay the evaluator per instance. Default: 3.
+    pub replays: usize,
+    /// Output file path. Defaults to `<sweep_dir>/eval-flake.json`.
+    pub output: Option<PathBuf>,
+    /// Maximum parallel evaluator workers (mirrors `bench evaluate --concurrency`).
+    pub concurrency: usize,
+}
+
+// ── Test stub types ────────────────────────────────────────────────────────────
+
+/// One verdict entry for the stub evaluator.
+#[derive(Debug, Clone)]
+pub struct InstanceVerdictStub {
+    pub instance_id: String,
+    pub verdict: Verdict,
+}
+
+impl InstanceVerdictStub {
+    #[must_use]
+    pub fn new(instance_id: impl Into<String>, verdict: Verdict) -> Self {
+        Self {
+            instance_id: instance_id.into(),
+            verdict,
+        }
+    }
+}
+
+/// Configuration for the stub evaluator used in integration tests.
+///
+/// Maps each `instance_id` to a sequence of verdicts, one per replay.
+/// The `run_with_stub` function consumes entries in order.
+#[derive(Debug, Clone)]
+pub struct EvalFlakeStubConfig {
+    /// Per-instance verdict sequences. Index 0 = replay 1, etc.
+    pub verdicts: HashMap<String, Vec<InstanceVerdictStub>>,
+}
+
+// ── Core aggregation logic ─────────────────────────────────────────────────────
+
+/// Compute `flake_rate` as the fraction of distinct index pairs (i,j) with i<j
+/// where `verdicts[i] != verdicts[j]`.
+///
+/// Returns `0.0` for fewer than 2 verdicts.
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+pub fn compute_flake_rate(verdicts: &[Verdict]) -> f32 {
+    let n = verdicts.len();
+    if n < 2 {
+        return 0.0;
+    }
+    let total_pairs = n * (n - 1) / 2;
+    let mut disagreeing = 0usize;
+    for i in 0..n {
+        for j in (i + 1)..n {
+            if verdicts[i] != verdicts[j] {
+                disagreeing += 1;
+            }
+        }
+    }
+    disagreeing as f32 / total_pairs as f32
+}
+
+/// Compute the majority verdict (most frequent). Ties broken by Resolved > Unresolved > Errored.
+#[must_use]
+pub fn dominant_verdict(verdicts: &[Verdict]) -> Option<Verdict> {
+    if verdicts.is_empty() {
+        return None;
+    }
+    let mut counts = [0usize; 3]; // [Resolved, Unresolved, Errored]
+    for v in verdicts {
+        match v {
+            Verdict::Resolved => counts[0] += 1,
+            Verdict::Unresolved => counts[1] += 1,
+            Verdict::Errored => counts[2] += 1,
+        }
+    }
+    let max = *counts.iter().max().unwrap();
+    if counts[0] == max {
+        Some(Verdict::Resolved)
+    } else if counts[1] == max {
+        Some(Verdict::Unresolved)
+    } else {
+        Some(Verdict::Errored)
+    }
+}
+
+fn build_instance_result(
+    instance_id: String,
+    verdicts: Vec<Verdict>,
+    original_sweep_verdict: Option<Verdict>,
+) -> InstanceFlakeResult {
+    let flake_rate = compute_flake_rate(&verdicts);
+    let is_flaky = flake_rate > 0.0;
+    let dom = dominant_verdict(&verdicts);
+    InstanceFlakeResult {
+        instance_id,
+        verdicts,
+        is_flaky,
+        flake_rate,
+        dominant_verdict: dom,
+        original_sweep_verdict,
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn build_summary(instances: &[InstanceFlakeResult], replays: usize) -> EvalFlakeSummary {
+    let instances_evaluated = instances.len();
+    let flaky_count = instances.iter().filter(|i| i.is_flaky).count();
+    let flaky_rate = if instances_evaluated == 0 {
+        0.0_f32
+    } else {
+        flaky_count as f32 / instances_evaluated as f32
+    };
+    let dominant_disagrees_with_sweep_count = instances
+        .iter()
+        .filter(|i| {
+            // Only count when both dominant and original are known
+            match (i.dominant_verdict, i.original_sweep_verdict) {
+                (Some(d), Some(o)) => d != o,
+                _ => false,
+            }
+        })
+        .count();
+    EvalFlakeSummary {
+        replays,
+        instances_evaluated,
+        flaky_count,
+        flaky_rate,
+        dominant_disagrees_with_sweep_count,
+    }
+}
+
+fn write_report(report: &EvalFlakeReport, output_path: &Path) -> Result<(), Error> {
+    let json = serde_json::to_string_pretty(report).map_err(Error::Json)?;
+    if let Some(parent) = output_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    std::fs::write(output_path, json)?;
+    Ok(())
+}
+
+fn effective_output_path(args: &EvalFlakeArgs) -> PathBuf {
+    args.output
+        .clone()
+        .unwrap_or_else(|| args.sweep_dir.join("eval-flake.json"))
+}
+
+// ── Load original sweep verdicts ───────────────────────────────────────────────
+
+/// Read per-instance verdicts from the sweep's evaluation.json (preferred)
+/// or results.json (fallback).
+fn load_original_verdicts(sweep_dir: &Path) -> HashMap<String, Verdict> {
+    // Try evaluation.json first
+    let eval_path = crate::run::evaluate::evaluation_path(sweep_dir);
+    if eval_path.exists() {
+        if let Ok(text) = std::fs::read_to_string(&eval_path) {
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(&text) {
+                let mut map = HashMap::new();
+                if let Some(instances) = val["instances"].as_array() {
+                    for inst in instances {
+                        let id = inst["instance_id"].as_str().unwrap_or("").to_owned();
+                        let resolved = inst["resolved"].as_bool().unwrap_or(false);
+                        if !id.is_empty() {
+                            let v = if resolved {
+                                Verdict::Resolved
+                            } else {
+                                Verdict::Unresolved
+                            };
+                            map.insert(id, v);
+                        }
+                    }
+                }
+                if !map.is_empty() {
+                    return map;
+                }
+            }
+        }
+    }
+
+    // Fallback: results.json
+    let results_path = sweep_dir.join("results.json");
+    if let Ok(text) = std::fs::read_to_string(&results_path) {
+        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&text) {
+            let mut map = HashMap::new();
+            if let Some(instances) = val["instances"].as_array() {
+                for inst in instances {
+                    let id = inst["instance_id"].as_str().unwrap_or("").to_owned();
+                    let resolved_count = inst["resolved_count"].as_u64().unwrap_or(0);
+                    if !id.is_empty() {
+                        let v = if resolved_count > 0 {
+                            Verdict::Resolved
+                        } else {
+                            Verdict::Unresolved
+                        };
+                        map.insert(id, v);
+                    }
+                }
+            }
+            return map;
+        }
+    }
+
+    HashMap::new()
+}
+
+// ── Stub-based run (for integration tests) ────────────────────────────────────
+
+/// Run eval-flake using a deterministic stub evaluator instead of sb-cli.
+///
+/// `stub.verdicts[instance_id][replay_index]` gives the verdict for that replay.
+/// Used exclusively in integration tests.
+pub fn run_with_stub(
+    args: &EvalFlakeArgs,
+    stub: &EvalFlakeStubConfig,
+) -> Result<EvalFlakeReport, Error> {
+    if args.replays < 1 {
+        return Err(Error::Config(crate::error::ConfigError::Usage(
+            "eval-flake: --replays must be at least 1".into(),
+        )));
+    }
+
+    let original = load_original_verdicts(&args.sweep_dir);
+
+    // Determine which instances have patches. An instance without a patch file
+    // is skipped (verdicts: [], excluded from flaky_count).
+    let mut instance_ids: Vec<String> = stub.verdicts.keys().cloned().collect();
+    instance_ids.sort();
+
+    // Filter: only evaluate instances that have a patch file in the sweep dir.
+    let instance_ids: Vec<String> = instance_ids
+        .into_iter()
+        .filter(|id| {
+            let patch_path = args.sweep_dir.join(format!("{id}.patch"));
+            patch_path.exists()
+        })
+        .collect();
+
+    let mut results: Vec<InstanceFlakeResult> = Vec::new();
+    for id in &instance_ids {
+        let stub_verdicts = stub.verdicts.get(id.as_str());
+        let verdicts: Vec<Verdict> = (0..args.replays)
+            .map(|i| {
+                stub_verdicts
+                    .and_then(|sv| sv.get(i))
+                    .map_or(Verdict::Errored, |sv| sv.verdict)
+            })
+            .collect();
+        let orig = original.get(id.as_str()).copied();
+        results.push(build_instance_result(id.clone(), verdicts, orig));
+    }
+
+    // Sort by instance_id for deterministic output.
+    results.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
+
+    let summary = build_summary(&results, args.replays);
+    let report = EvalFlakeReport {
+        artifact_kind: ArtifactKind::EvalFlakeReport.label().to_owned(),
+        schema_version: ArtifactSchemaVersion::CURRENT,
+        instances: results,
+        summary,
+        total_cost_usd: 0.0,
+    };
+
+    let output_path = effective_output_path(args);
+    write_report(&report, &output_path)?;
+
+    Ok(report)
+}
+
+// ── Real evaluator run ─────────────────────────────────────────────────────────
+
+/// Run eval-flake against a real sweep by re-invoking `bench evaluate` N times.
+///
+/// Each replay builds a `all_preds.jsonl` from the sweep's existing patch files,
+/// calls the evaluator backend, and collects per-instance verdicts.
+pub fn run(args: &EvalFlakeArgs) -> Result<EvalFlakeReport, Error> {
+    if args.replays < 1 {
+        return Err(Error::Config(crate::error::ConfigError::Usage(
+            "eval-flake: --replays must be at least 1".into(),
+        )));
+    }
+
+    let loaded = load_sweep(&args.sweep_dir).map_err(|e| {
+        Error::Trajectory(format!(
+            "eval-flake: failed to load sweep `{}`: {e}",
+            args.sweep_dir.display()
+        ))
+    })?;
+
+    let original = load_original_verdicts(&args.sweep_dir);
+
+    // Collect all instances that have a patch file.
+    let patchable: Vec<String> = {
+        let mut ids: Vec<String> = loaded
+            .instances
+            .keys()
+            .filter(|id| {
+                let p = args.sweep_dir.join(format!("{id}.patch"));
+                p.exists() && std::fs::metadata(&p).map_or(false, |m| m.len() > 0)
+            })
+            .cloned()
+            .collect();
+        ids.sort();
+        ids
+    };
+
+    if patchable.is_empty() {
+        tracing::warn!(
+            sweep_dir = %args.sweep_dir.display(),
+            "eval-flake: no patch files found; nothing to evaluate"
+        );
+    }
+
+    // Collect verdicts per instance across replays.
+    let mut all_verdicts: HashMap<String, Vec<Verdict>> =
+        patchable.iter().map(|id| (id.clone(), Vec::new())).collect();
+
+    for replay_idx in 0..args.replays {
+        tracing::info!(
+            replay = replay_idx + 1,
+            total = args.replays,
+            "eval-flake: running evaluator replay"
+        );
+
+        let eval_args = EvaluateArgs {
+            sweep_dir: args.sweep_dir.clone(),
+            dataset_path: None,
+            backend: EvaluateBackend::Rehearsal,
+            timeout_per_instance_secs: 1800,
+            parallel: args.concurrency,
+            sb_subset: String::new(),
+            sb_split: "test".to_owned(),
+            run_id: Some(format!("eval-flake-replay-{}", replay_idx + 1)),
+            breakdown: BreakdownSelection::none(),
+            cost_attribution: false,
+        };
+
+        let eval_result = crate::run::evaluate::run(&eval_args)?;
+
+        for inst_eval in &eval_result.instances {
+            if let Some(verdicts) = all_verdicts.get_mut(&inst_eval.instance_id) {
+                let v = match inst_eval.eval_exit_reason {
+                    EvalExitReason::Resolved => Verdict::Resolved,
+                    EvalExitReason::Unresolved => Verdict::Unresolved,
+                    _ => Verdict::Errored,
+                };
+                verdicts.push(v);
+            }
+        }
+    }
+
+    let mut results: Vec<InstanceFlakeResult> = patchable
+        .iter()
+        .map(|id| {
+            let verdicts = all_verdicts.remove(id).unwrap_or_default();
+            let orig = original.get(id.as_str()).copied();
+            build_instance_result(id.clone(), verdicts, orig)
+        })
+        .collect();
+
+    results.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
+
+    let summary = build_summary(&results, args.replays);
+    let report = EvalFlakeReport {
+        artifact_kind: ArtifactKind::EvalFlakeReport.label().to_owned(),
+        schema_version: ArtifactSchemaVersion::CURRENT,
+        instances: results,
+        summary,
+        total_cost_usd: 0.0,
+    };
+
+    let output_path = effective_output_path(args);
+    write_report(&report, &output_path)?;
+    tracing::info!(
+        output = %output_path.display(),
+        flaky_count = report.summary.flaky_count,
+        instances_evaluated = report.summary.instances_evaluated,
+        "eval-flake complete"
+    );
+    Ok(report)
+}
+
+// ── Unit tests for aggregation logic ──────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flake_rate_alternating_three() {
+        let verdicts = [Verdict::Resolved, Verdict::Unresolved, Verdict::Resolved];
+        let rate = compute_flake_rate(&verdicts);
+        // 2 disagreeing pairs out of 3 total
+        assert!((rate - 2.0_f32 / 3.0_f32).abs() < 1e-5, "got {rate}");
+    }
+
+    #[test]
+    fn flake_rate_all_same() {
+        let verdicts = [Verdict::Resolved, Verdict::Resolved, Verdict::Resolved];
+        assert_eq!(compute_flake_rate(&verdicts), 0.0_f32);
+    }
+
+    #[test]
+    fn flake_rate_single() {
+        assert_eq!(compute_flake_rate(&[Verdict::Resolved]), 0.0_f32);
+    }
+
+    #[test]
+    fn flake_rate_empty() {
+        assert_eq!(compute_flake_rate(&[]), 0.0_f32);
+    }
+
+    #[test]
+    fn dominant_verdict_majority() {
+        let v = [Verdict::Resolved, Verdict::Unresolved, Verdict::Resolved];
+        assert_eq!(dominant_verdict(&v), Some(Verdict::Resolved));
+    }
+
+    #[test]
+    fn dominant_verdict_tie_prefers_resolved() {
+        let v = [Verdict::Resolved, Verdict::Unresolved];
+        assert_eq!(dominant_verdict(&v), Some(Verdict::Resolved));
+    }
+
+    #[test]
+    fn dominant_verdict_empty() {
+        assert_eq!(dominant_verdict(&[]), None);
+    }
+
+    #[test]
+    fn is_flaky_true_when_rate_positive() {
+        let v = [Verdict::Resolved, Verdict::Unresolved, Verdict::Resolved];
+        let rate = compute_flake_rate(&v);
+        assert!(rate > 0.0);
+    }
+
+    #[test]
+    fn build_summary_counts() {
+        let instances = vec![
+            build_instance_result(
+                "a".into(),
+                vec![Verdict::Resolved, Verdict::Unresolved],
+                None,
+            ),
+            build_instance_result(
+                "b".into(),
+                vec![Verdict::Resolved, Verdict::Resolved],
+                None,
+            ),
+        ];
+        let summary = build_summary(&instances, 2);
+        assert_eq!(summary.flaky_count, 1);
+        assert_eq!(summary.instances_evaluated, 2);
+        assert!((summary.flaky_rate - 0.5_f32).abs() < 1e-5);
+    }
+}

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -37,6 +37,10 @@ pub struct InspectArgs {
     /// When true, load PASS_TO_PASS / FAIL_TO_PASS from the sweep's dataset.jsonl
     /// and add them to the report.
     pub show_expected: bool,
+    /// Optional path to an `eval-flake.json`. When set and the instance is
+    /// present in the flake report, the verdict vector and flake_rate are
+    /// rendered in the human-readable output.
+    pub flake_report: Option<std::path::PathBuf>,
 }
 
 /// Failing tests from the evaluator, or an explanation of why names are unavailable.
@@ -179,6 +183,21 @@ pub struct InspectReport {
     /// Metadata recording how this trajectory was forked from a parent run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fork_lineage: Option<crate::trajectory::ForkLineage>,
+    /// Evaluator flake data for this instance from `eval-flake.json`.
+    /// Present only when `--flake-report` is set and the instance appears in the report.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub flake_data: Option<InspectFlakeData>,
+}
+
+/// Flake data for a single instance surfaced by `bench inspect --flake-report`.
+#[derive(Debug, Clone, Serialize)]
+pub struct InspectFlakeData {
+    pub is_flaky: bool,
+    pub flake_rate: f32,
+    /// Verdict sequence across replays.
+    pub verdicts: Vec<crate::run::eval_flake::Verdict>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dominant_verdict: Option<crate::run::eval_flake::Verdict>,
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize)]
@@ -252,13 +271,32 @@ pub fn run(args: &InspectArgs) -> Result<InspectOutput, Error> {
     } else {
         None
     };
-    let report = build_instance_report(
+    let mut report = build_instance_report(
         &args.sweep,
         &instance_id,
         args.full,
         evaluation_overrides.as_ref(),
         dataset_instance.as_ref(),
     )?;
+
+    // Load flake data when --flake-report is provided.
+    if let Some(ref flake_path) = args.flake_report {
+        if let Ok(flake_report) = crate::run::eval_flake::EvalFlakeReport::load(flake_path) {
+            if let Some(inst) = flake_report
+                .instances
+                .iter()
+                .find(|i| i.instance_id == instance_id)
+            {
+                report.flake_data = Some(InspectFlakeData {
+                    is_flaky: inst.is_flaky,
+                    flake_rate: inst.flake_rate,
+                    verdicts: inst.verdicts.clone(),
+                    dominant_verdict: inst.dominant_verdict,
+                });
+            }
+        }
+    }
+
     Ok(InspectOutput::Instance(Box::new(report)))
 }
 
@@ -379,6 +417,7 @@ fn build_instance_report(
                 partial_reason: None,
                 trace_id: None,
                 fork_lineage: None,
+                flake_data: None,
             });
         }
     };
@@ -466,6 +505,7 @@ fn build_instance_report(
         partial_reason: traj.info.partial_reason,
         trace_id: traj.info.trace_id,
         fork_lineage: traj.fork_lineage,
+        flake_data: None,
     })
 }
 
@@ -888,6 +928,24 @@ fn render_instance_text(report: &InspectReport) -> String {
             s,
             "                  tail_overrides={}",
             serde_json::to_string(&lineage.tail_overrides).unwrap_or_default()
+        );
+    }
+    if let Some(fd) = &report.flake_data {
+        let verdict_labels: Vec<&str> = fd
+            .verdicts
+            .iter()
+            .map(|v| match v {
+                crate::run::eval_flake::Verdict::Resolved => "resolved",
+                crate::run::eval_flake::Verdict::Unresolved => "unresolved",
+                crate::run::eval_flake::Verdict::Errored => "errored",
+            })
+            .collect();
+        let _ = writeln!(
+            s,
+            "eval_flake:       is_flaky={} flake_rate={:.3} verdicts=[{}]",
+            fd.is_flaky,
+            fd.flake_rate,
+            verdict_labels.join(", ")
         );
     }
     for w in &report.warnings {
@@ -1472,6 +1530,7 @@ mod tests {
             filter: None,
             full: false,
             show_expected: false,
+            flake_report: None,
         };
         let output = run(&args).unwrap();
         let text = render_text(&output);
@@ -1516,6 +1575,7 @@ mod tests {
             filter: None,
             full: false,
             show_expected: false,
+            flake_report: None,
         };
         let output = run(&args).unwrap();
         if let InspectOutput::Instance(report) = &output {
@@ -1575,6 +1635,7 @@ mod tests {
             filter: None,
             full: false,
             show_expected: false,
+            flake_report: None,
         };
         let output = run(&args).unwrap();
         let text = render_text(&output);
@@ -1652,6 +1713,7 @@ mod tests {
             filter: None,
             full: false,
             show_expected: false,
+            flake_report: None,
         };
         let output = run(&args).unwrap();
         let text = render_text(&output);

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -15,6 +15,7 @@ pub mod dataset;
 pub mod dataset_stats;
 pub mod diff_config;
 pub mod env_preview;
+pub mod eval_flake;
 pub mod evaluate;
 pub mod evaluator_selftest;
 pub mod failure_digest;

--- a/src/run/report.rs
+++ b/src/run/report.rs
@@ -114,6 +114,7 @@ fn baseline_compare_report(args: &ReportArgs) -> Result<Option<CompareReport>, E
         min_significance: None,
         regression_significance: None,
         allow_underpowered: false,
+        flake_report: None,
     })?;
     Ok(Some(report))
 }

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -855,6 +855,7 @@ fn compare_treats_wallclock_timeout_as_ordinary_failure_transition() {
             min_significance: None,
             regression_significance: None,
             allow_underpowered: false,
+            flake_report: None,
         })
         .unwrap();
     assert_eq!(
@@ -881,6 +882,7 @@ fn compare_treats_wallclock_timeout_as_ordinary_failure_transition() {
             min_significance: None,
             regression_significance: None,
             allow_underpowered: false,
+            flake_report: None,
         })
         .unwrap();
     assert_eq!(
@@ -1516,6 +1518,7 @@ fn compare_uses_manifest_model_for_fallback_cost_repricing() {
             min_significance: None,
             regression_significance: None,
             allow_underpowered: false,
+            flake_report: None,
         })
         .unwrap();
 

--- a/tests/bench_eval_flake.rs
+++ b/tests/bench_eval_flake.rs
@@ -81,8 +81,16 @@ fn flaky_instance_detected_with_correct_rate() {
     std::fs::create_dir_all(&sweep).unwrap();
 
     write_sweep_results(&sweep, &[("inst-flaky", true), ("inst-stable", true)]);
-    write_patch(&sweep, "inst-flaky", "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n-old\n+new\n");
-    write_patch(&sweep, "inst-stable", "--- a/y.py\n+++ b/y.py\n@@ -1 +1 @@\n-a\n+b\n");
+    write_patch(
+        &sweep,
+        "inst-flaky",
+        "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n-old\n+new\n",
+    );
+    write_patch(
+        &sweep,
+        "inst-stable",
+        "--- a/y.py\n+++ b/y.py\n@@ -1 +1 @@\n-a\n+b\n",
+    );
 
     // inst-flaky alternates: resolved, unresolved, resolved
     // inst-stable: always resolved
@@ -110,7 +118,9 @@ fn flaky_instance_detected_with_correct_rate() {
         output: None,
         concurrency: 1,
     };
-    let stub = EvalFlakeStubConfig { verdicts: stub_verdicts };
+    let stub = EvalFlakeStubConfig {
+        verdicts: stub_verdicts,
+    };
     let report = run_with_stub(&args, &stub).unwrap();
 
     let flaky = report
@@ -153,7 +163,11 @@ fn total_cost_usd_is_zero() {
     std::fs::create_dir_all(&sweep).unwrap();
 
     write_sweep_results(&sweep, &[("inst-a", true)]);
-    write_patch(&sweep, "inst-a", "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n");
+    write_patch(
+        &sweep,
+        "inst-a",
+        "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n",
+    );
 
     let mut stubs: HashMap<String, Vec<InstanceVerdictStub>> = HashMap::new();
     stubs.insert(
@@ -184,7 +198,11 @@ fn artifact_written_to_sweep_dir() {
     std::fs::create_dir_all(&sweep).unwrap();
 
     write_sweep_results(&sweep, &[("inst-a", true)]);
-    write_patch(&sweep, "inst-a", "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n");
+    write_patch(
+        &sweep,
+        "inst-a",
+        "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n",
+    );
 
     let mut stubs: HashMap<String, Vec<InstanceVerdictStub>> = HashMap::new();
     stubs.insert(
@@ -205,7 +223,10 @@ fn artifact_written_to_sweep_dir() {
     run_with_stub(&args, &stub).unwrap();
 
     let artifact_path = sweep.join("eval-flake.json");
-    assert!(artifact_path.exists(), "eval-flake.json must be written to sweep dir");
+    assert!(
+        artifact_path.exists(),
+        "eval-flake.json must be written to sweep dir"
+    );
 
     let content = std::fs::read_to_string(&artifact_path).unwrap();
     let val: serde_json::Value = serde_json::from_str(&content).unwrap();
@@ -223,7 +244,11 @@ fn errored_instances_without_patch_skipped() {
 
     // inst-no-patch has no patch file and is marked errored
     write_sweep_results(&sweep, &[("inst-patched", true), ("inst-no-patch", false)]);
-    write_patch(&sweep, "inst-patched", "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n");
+    write_patch(
+        &sweep,
+        "inst-patched",
+        "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n",
+    );
     // deliberately don't write patch for inst-no-patch
 
     let mut stubs: HashMap<String, Vec<InstanceVerdictStub>> = HashMap::new();
@@ -263,8 +288,16 @@ fn dominant_disagrees_with_sweep_count_correct() {
     // inst-a: sweep said resolved, dominant verdict is unresolved (2 of 3)
     // inst-b: sweep said resolved, dominant verdict is resolved (always resolved)
     write_sweep_results(&sweep, &[("inst-a", true), ("inst-b", true)]);
-    write_patch(&sweep, "inst-a", "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n");
-    write_patch(&sweep, "inst-b", "--- a/g.py\n+++ b/g.py\n@@ -1 +1 @@\n-a\n+b\n");
+    write_patch(
+        &sweep,
+        "inst-a",
+        "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n",
+    );
+    write_patch(
+        &sweep,
+        "inst-b",
+        "--- a/g.py\n+++ b/g.py\n@@ -1 +1 @@\n-a\n+b\n",
+    );
 
     let mut stubs: HashMap<String, Vec<InstanceVerdictStub>> = HashMap::new();
     stubs.insert(
@@ -333,7 +366,11 @@ fn compare_excludes_flaky_instances_from_mcnemar() {
     );
 
     // Write eval-flake.json flagging inst-flaky
-    write_patch(&flake_dir, "inst-flaky", "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n");
+    write_patch(
+        &flake_dir,
+        "inst-flaky",
+        "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n",
+    );
     let mut stubs: HashMap<String, Vec<InstanceVerdictStub>> = HashMap::new();
     stubs.insert(
         "inst-flaky".into(),
@@ -354,8 +391,8 @@ fn compare_excludes_flaky_instances_from_mcnemar() {
     run_with_stub(&flake_args, &stub).unwrap();
     let flake_report_path = flake_dir.join("eval-flake.json");
 
-    let compare_report = maxwells_daemon::run::compare::compute(
-        &maxwells_daemon::run::compare::CompareArgs {
+    let compare_report =
+        maxwells_daemon::run::compare::compute(&maxwells_daemon::run::compare::CompareArgs {
             baseline: base,
             candidate: cand,
             format: maxwells_daemon::run::compare::CompareFormat::Text,
@@ -369,19 +406,16 @@ fn compare_excludes_flaky_instances_from_mcnemar() {
             regression_significance: None,
             allow_underpowered: true,
             flake_report: Some(flake_report_path),
-        },
-    )
-    .unwrap();
+        })
+        .unwrap();
 
     // inst-flaky excluded → paired instances = 3 (inst-a, inst-b, inst-c)
     assert_eq!(
-        compare_report.resolved_rate_significance.paired_n,
-        3,
+        compare_report.resolved_rate_significance.paired_n, 3,
         "paired_n must exclude the flaky instance"
     );
     assert_eq!(
-        compare_report.flaky_instances_excluded,
-        1,
+        compare_report.flaky_instances_excluded, 1,
         "must record exactly 1 flaky exclusion"
     );
     let table = compare_report.human_table();
@@ -432,8 +466,8 @@ fn compare_all_flaky_exits_usage_error() {
     run_with_stub(&flake_args, &stub).unwrap();
     let flake_report_path = flake_dir.join("eval-flake.json");
 
-    let result = maxwells_daemon::run::compare::compute(
-        &maxwells_daemon::run::compare::CompareArgs {
+    let result =
+        maxwells_daemon::run::compare::compute(&maxwells_daemon::run::compare::CompareArgs {
             baseline: base,
             candidate: cand,
             format: maxwells_daemon::run::compare::CompareFormat::Text,
@@ -447,13 +481,12 @@ fn compare_all_flaky_exits_usage_error() {
             regression_significance: None,
             allow_underpowered: true,
             flake_report: Some(flake_report_path),
-        },
-    );
+        });
 
     match result {
-        Err(maxwells_daemon::error::Error::Config(
-            maxwells_daemon::error::ConfigError::Usage(msg),
-        )) => {
+        Err(maxwells_daemon::error::Error::Config(maxwells_daemon::error::ConfigError::Usage(
+            msg,
+        ))) => {
             assert!(
                 msg.contains("flak"),
                 "error message must mention flake; got: {msg}"

--- a/tests/bench_eval_flake.rs
+++ b/tests/bench_eval_flake.rs
@@ -1,0 +1,512 @@
+//! Integration tests for `bench eval-flake` (issue #294).
+//!
+//! Uses a synthetic evaluator stub to verify:
+//!   1. Flake detection: `is_flaky=true`, `flake_rate≈0.67` for an instance with
+//!      verdicts [resolved, unresolved, resolved] across 3 replays.
+//!   2. Stable instance: `is_flaky=false`, `flake_rate=0.0` for always-resolved.
+//!   3. `bench compare --flake-report` excludes exactly the flaky instance.
+//!   4. Summary text names the exclusion count explicitly.
+//!   5. Degenerate case: all paired instances flaky exits with UsageError (2).
+
+#![allow(clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use maxwells_daemon::run::eval_flake::{
+    EvalFlakeArgs, EvalFlakeStubConfig, InstanceVerdictStub, Verdict, run_with_stub,
+};
+
+mod support;
+use support::binary_path;
+
+// ── helper to write a minimal sweep results.json ─────────────────────────────
+
+fn write_sweep_results(dir: &std::path::Path, instances: &[(&str, bool)]) -> PathBuf {
+    use std::fmt::Write as _;
+    let mut rows = String::new();
+    for (id, resolved) in instances {
+        let outcome = if *resolved { "submitted" } else { "error" };
+        let resolved_count = if *resolved { 1 } else { 0 };
+        writeln!(
+            rows,
+            r#"{{"instance_id":"{id}","exit_reason":"{outcome}","outcome":"{outcome}","failure_category":null,"steps":4,"cost_usd":0.01,"prompt_tokens":100,"cache_read_tokens":0,"cache_creation_tokens":0,"completion_tokens":50,"duration_secs":5.0,"error":null,"github_pr_error":null,"patch_present":{pp},"non_empty_patch":{pp},"attempts":1,"retry_reasons":[],"runs":1,"resolved_count":{resolved_count},"pass_at_1":{pp},"tests_run_before_submit":false,"last_tests_passed":null,"fallback_count":null,"final_model":null,"retry_id":null,"previous_failure_category":null,"trace_id":null}}"#,
+            id = id,
+            outcome = outcome,
+            pp = resolved,
+            resolved_count = resolved_count,
+        )
+        .unwrap();
+    }
+    let sweep_json = serde_json::json!({
+        "artifact_kind": "sweep_results",
+        "schema_version": {"major": 1, "minor": 10},
+        "instances": rows.lines().map(|l| serde_json::from_str::<serde_json::Value>(l).unwrap()).collect::<Vec<_>>(),
+        "total": instances.len(),
+        "submitted": instances.iter().filter(|(_, r)| *r).count(),
+        "skipped": 0,
+        "errored": instances.iter().filter(|(_, r)| !*r).count(),
+        "budget_halted": 0,
+        "retries": 0,
+        "retried_instances": 0,
+        "total_prompt_tokens": 100u64,
+        "total_completion_tokens": 50u64,
+        "total_cache_read_tokens": 0u64,
+        "total_cache_creation_tokens": 0u64,
+        "estimated_cost_usd": 0.01,
+        "cost_limit_usd": null,
+        "sweep_status": "complete",
+        "cancel_exit_code": null,
+        "systemic_halt_category": null,
+        "github_pr_failures": 0
+    });
+    let path = dir.join("results.json");
+    std::fs::write(&path, serde_json::to_string_pretty(&sweep_json).unwrap()).unwrap();
+    path
+}
+
+fn write_patch(dir: &std::path::Path, instance_id: &str, content: &str) {
+    let patch_path = dir.join(format!("{instance_id}.patch"));
+    std::fs::write(patch_path, content).unwrap();
+}
+
+// ── AC: integration test 1 ────────────────────────────────────────────────────
+// Alternating verdicts → is_flaky=true, flake_rate≈0.67
+// Always-resolved → is_flaky=false, flake_rate=0.0
+
+#[test]
+fn flaky_instance_detected_with_correct_rate() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = work.path().join("sweep");
+    std::fs::create_dir_all(&sweep).unwrap();
+
+    write_sweep_results(&sweep, &[("inst-flaky", true), ("inst-stable", true)]);
+    write_patch(&sweep, "inst-flaky", "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n-old\n+new\n");
+    write_patch(&sweep, "inst-stable", "--- a/y.py\n+++ b/y.py\n@@ -1 +1 @@\n-a\n+b\n");
+
+    // inst-flaky alternates: resolved, unresolved, resolved
+    // inst-stable: always resolved
+    let mut stub_verdicts: HashMap<String, Vec<InstanceVerdictStub>> = HashMap::new();
+    stub_verdicts.insert(
+        "inst-flaky".into(),
+        vec![
+            InstanceVerdictStub::new("inst-flaky", Verdict::Resolved),
+            InstanceVerdictStub::new("inst-flaky", Verdict::Unresolved),
+            InstanceVerdictStub::new("inst-flaky", Verdict::Resolved),
+        ],
+    );
+    stub_verdicts.insert(
+        "inst-stable".into(),
+        vec![
+            InstanceVerdictStub::new("inst-stable", Verdict::Resolved),
+            InstanceVerdictStub::new("inst-stable", Verdict::Resolved),
+            InstanceVerdictStub::new("inst-stable", Verdict::Resolved),
+        ],
+    );
+
+    let args = EvalFlakeArgs {
+        sweep_dir: sweep.clone(),
+        replays: 3,
+        output: None,
+        concurrency: 1,
+    };
+    let stub = EvalFlakeStubConfig { verdicts: stub_verdicts };
+    let report = run_with_stub(&args, &stub).unwrap();
+
+    let flaky = report
+        .instances
+        .iter()
+        .find(|i| i.instance_id == "inst-flaky")
+        .expect("inst-flaky must be in report");
+    assert!(flaky.is_flaky, "inst-flaky must be flagged flaky");
+    assert!(
+        (flaky.flake_rate - 0.666_666_7_f32).abs() < 0.01,
+        "flake_rate expected ≈0.67, got {}",
+        flaky.flake_rate
+    );
+    assert_eq!(flaky.verdicts.len(), 3);
+
+    let stable = report
+        .instances
+        .iter()
+        .find(|i| i.instance_id == "inst-stable")
+        .expect("inst-stable must be in report");
+    assert!(!stable.is_flaky, "inst-stable must not be flaky");
+    assert_eq!(stable.flake_rate, 0.0_f32, "stable flake_rate must be 0.0");
+
+    // Summary
+    assert_eq!(report.summary.flaky_count, 1);
+    assert_eq!(report.summary.instances_evaluated, 2);
+    assert_eq!(report.summary.replays, 3);
+    assert!(
+        (report.summary.flaky_rate - 0.5_f32).abs() < 0.01,
+        "flaky_rate expected 0.5 (1 of 2)"
+    );
+}
+
+// ── AC: total_cost_usd is always 0.0 ─────────────────────────────────────────
+
+#[test]
+fn total_cost_usd_is_zero() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = work.path().join("sweep");
+    std::fs::create_dir_all(&sweep).unwrap();
+
+    write_sweep_results(&sweep, &[("inst-a", true)]);
+    write_patch(&sweep, "inst-a", "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n");
+
+    let mut stubs: HashMap<String, Vec<InstanceVerdictStub>> = HashMap::new();
+    stubs.insert(
+        "inst-a".into(),
+        vec![
+            InstanceVerdictStub::new("inst-a", Verdict::Resolved),
+            InstanceVerdictStub::new("inst-a", Verdict::Resolved),
+            InstanceVerdictStub::new("inst-a", Verdict::Resolved),
+        ],
+    );
+    let args = EvalFlakeArgs {
+        sweep_dir: sweep,
+        replays: 3,
+        output: None,
+        concurrency: 1,
+    };
+    let stub = EvalFlakeStubConfig { verdicts: stubs };
+    let report = run_with_stub(&args, &stub).unwrap();
+    assert_eq!(report.total_cost_usd, 0.0_f64, "cost must always be 0.0");
+}
+
+// ── AC: artifact written to sweep dir ─────────────────────────────────────────
+
+#[test]
+fn artifact_written_to_sweep_dir() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = work.path().join("sweep");
+    std::fs::create_dir_all(&sweep).unwrap();
+
+    write_sweep_results(&sweep, &[("inst-a", true)]);
+    write_patch(&sweep, "inst-a", "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n");
+
+    let mut stubs: HashMap<String, Vec<InstanceVerdictStub>> = HashMap::new();
+    stubs.insert(
+        "inst-a".into(),
+        vec![
+            InstanceVerdictStub::new("inst-a", Verdict::Resolved),
+            InstanceVerdictStub::new("inst-a", Verdict::Resolved),
+            InstanceVerdictStub::new("inst-a", Verdict::Resolved),
+        ],
+    );
+    let args = EvalFlakeArgs {
+        sweep_dir: sweep.clone(),
+        replays: 3,
+        output: None,
+        concurrency: 1,
+    };
+    let stub = EvalFlakeStubConfig { verdicts: stubs };
+    run_with_stub(&args, &stub).unwrap();
+
+    let artifact_path = sweep.join("eval-flake.json");
+    assert!(artifact_path.exists(), "eval-flake.json must be written to sweep dir");
+
+    let content = std::fs::read_to_string(&artifact_path).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(val["artifact_kind"], "eval_flake_report");
+    assert_eq!(val["total_cost_usd"], 0.0);
+}
+
+// ── AC: errored instances skipped (no patch) ──────────────────────────────────
+
+#[test]
+fn errored_instances_without_patch_skipped() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = work.path().join("sweep");
+    std::fs::create_dir_all(&sweep).unwrap();
+
+    // inst-no-patch has no patch file and is marked errored
+    write_sweep_results(&sweep, &[("inst-patched", true), ("inst-no-patch", false)]);
+    write_patch(&sweep, "inst-patched", "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n");
+    // deliberately don't write patch for inst-no-patch
+
+    let mut stubs: HashMap<String, Vec<InstanceVerdictStub>> = HashMap::new();
+    stubs.insert(
+        "inst-patched".into(),
+        vec![
+            InstanceVerdictStub::new("inst-patched", Verdict::Resolved),
+            InstanceVerdictStub::new("inst-patched", Verdict::Resolved),
+        ],
+    );
+    let args = EvalFlakeArgs {
+        sweep_dir: sweep,
+        replays: 2,
+        output: None,
+        concurrency: 1,
+    };
+    let stub = EvalFlakeStubConfig { verdicts: stubs };
+    let report = run_with_stub(&args, &stub).unwrap();
+
+    assert_eq!(
+        report.instances.len(),
+        1,
+        "only patched instance should be evaluated"
+    );
+    assert_eq!(report.instances[0].instance_id, "inst-patched");
+    assert_eq!(report.summary.instances_evaluated, 1);
+}
+
+// ── AC: dominant_disagrees_with_sweep_count ───────────────────────────────────
+
+#[test]
+fn dominant_disagrees_with_sweep_count_correct() {
+    let work = tempfile::tempdir().unwrap();
+    let sweep = work.path().join("sweep");
+    std::fs::create_dir_all(&sweep).unwrap();
+
+    // inst-a: sweep said resolved, dominant verdict is unresolved (2 of 3)
+    // inst-b: sweep said resolved, dominant verdict is resolved (always resolved)
+    write_sweep_results(&sweep, &[("inst-a", true), ("inst-b", true)]);
+    write_patch(&sweep, "inst-a", "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n");
+    write_patch(&sweep, "inst-b", "--- a/g.py\n+++ b/g.py\n@@ -1 +1 @@\n-a\n+b\n");
+
+    let mut stubs: HashMap<String, Vec<InstanceVerdictStub>> = HashMap::new();
+    stubs.insert(
+        "inst-a".into(),
+        vec![
+            InstanceVerdictStub::new("inst-a", Verdict::Unresolved),
+            InstanceVerdictStub::new("inst-a", Verdict::Unresolved),
+            InstanceVerdictStub::new("inst-a", Verdict::Resolved),
+        ],
+    );
+    stubs.insert(
+        "inst-b".into(),
+        vec![
+            InstanceVerdictStub::new("inst-b", Verdict::Resolved),
+            InstanceVerdictStub::new("inst-b", Verdict::Resolved),
+            InstanceVerdictStub::new("inst-b", Verdict::Resolved),
+        ],
+    );
+    let args = EvalFlakeArgs {
+        sweep_dir: sweep,
+        replays: 3,
+        output: None,
+        concurrency: 1,
+    };
+    let stub = EvalFlakeStubConfig { verdicts: stubs };
+    let report = run_with_stub(&args, &stub).unwrap();
+
+    assert_eq!(
+        report.summary.dominant_disagrees_with_sweep_count, 1,
+        "inst-a dominant=unresolved disagrees with sweep=resolved"
+    );
+}
+
+// ── AC: bench compare --flake-report excludes flaky instances ─────────────────
+// AC: "1 flaky instance excluded" in summary text
+// This uses the library-level compute() function via a helper.
+
+#[test]
+fn compare_excludes_flaky_instances_from_mcnemar() {
+    let work = tempfile::tempdir().unwrap();
+    let base = work.path().join("base");
+    let cand = work.path().join("cand");
+    let flake_dir = work.path().join("flake");
+    for d in [&base, &cand, &flake_dir] {
+        std::fs::create_dir_all(d).unwrap();
+    }
+
+    // 4 instances: 1 flaky (inst-flaky), 3 stable
+    write_sweep_results(
+        &base,
+        &[
+            ("inst-flaky", true),
+            ("inst-a", true),
+            ("inst-b", false),
+            ("inst-c", false),
+        ],
+    );
+    write_sweep_results(
+        &cand,
+        &[
+            ("inst-flaky", false), // changed in candidate
+            ("inst-a", true),
+            ("inst-b", true), // improved in candidate
+            ("inst-c", false),
+        ],
+    );
+
+    // Write eval-flake.json flagging inst-flaky
+    write_patch(&flake_dir, "inst-flaky", "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n");
+    let mut stubs: HashMap<String, Vec<InstanceVerdictStub>> = HashMap::new();
+    stubs.insert(
+        "inst-flaky".into(),
+        vec![
+            InstanceVerdictStub::new("inst-flaky", Verdict::Resolved),
+            InstanceVerdictStub::new("inst-flaky", Verdict::Unresolved),
+            InstanceVerdictStub::new("inst-flaky", Verdict::Resolved),
+        ],
+    );
+    write_sweep_results(&flake_dir, &[("inst-flaky", true)]);
+    let flake_args = EvalFlakeArgs {
+        sweep_dir: flake_dir.clone(),
+        replays: 3,
+        output: None,
+        concurrency: 1,
+    };
+    let stub = EvalFlakeStubConfig { verdicts: stubs };
+    run_with_stub(&flake_args, &stub).unwrap();
+    let flake_report_path = flake_dir.join("eval-flake.json");
+
+    let compare_report = maxwells_daemon::run::compare::compute(
+        &maxwells_daemon::run::compare::CompareArgs {
+            baseline: base,
+            candidate: cand,
+            format: maxwells_daemon::run::compare::CompareFormat::Text,
+            max_regressions: None,
+            max_patch_size_regression_pct: None,
+            breakdown: maxwells_daemon::run::evaluate::BreakdownSelection::none(),
+            min_delta_pp: 0.0,
+            cost_attribution: false,
+            cost_attribution_min_delta_usd: 0.0,
+            min_significance: None,
+            regression_significance: None,
+            allow_underpowered: true,
+            flake_report: Some(flake_report_path),
+        },
+    )
+    .unwrap();
+
+    // inst-flaky excluded → paired instances = 3 (inst-a, inst-b, inst-c)
+    assert_eq!(
+        compare_report.resolved_rate_significance.paired_n,
+        3,
+        "paired_n must exclude the flaky instance"
+    );
+    assert_eq!(
+        compare_report.flaky_instances_excluded,
+        1,
+        "must record exactly 1 flaky exclusion"
+    );
+    let table = compare_report.human_table();
+    assert!(
+        table.contains("1 flaky instance excluded"),
+        "table must name the exclusion count; got:\n{table}"
+    );
+}
+
+// ── AC: all paired instances flaky → UsageError ──────────────────────────────
+
+#[test]
+fn compare_all_flaky_exits_usage_error() {
+    let work = tempfile::tempdir().unwrap();
+    let base = work.path().join("base");
+    let cand = work.path().join("cand");
+    let flake_dir = work.path().join("flake");
+    for d in [&base, &cand, &flake_dir] {
+        std::fs::create_dir_all(d).unwrap();
+    }
+
+    // Only 1 instance; it's flaky → all paired instances excluded
+    write_sweep_results(&base, &[("inst-only", true)]);
+    write_sweep_results(&cand, &[("inst-only", false)]);
+    write_sweep_results(&flake_dir, &[("inst-only", true)]);
+    write_patch(
+        &flake_dir,
+        "inst-only",
+        "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n-x\n+y\n",
+    );
+
+    let mut stubs: HashMap<String, Vec<InstanceVerdictStub>> = HashMap::new();
+    stubs.insert(
+        "inst-only".into(),
+        vec![
+            InstanceVerdictStub::new("inst-only", Verdict::Resolved),
+            InstanceVerdictStub::new("inst-only", Verdict::Unresolved),
+            InstanceVerdictStub::new("inst-only", Verdict::Resolved),
+        ],
+    );
+    let flake_args = EvalFlakeArgs {
+        sweep_dir: flake_dir.clone(),
+        replays: 3,
+        output: None,
+        concurrency: 1,
+    };
+    let stub = EvalFlakeStubConfig { verdicts: stubs };
+    run_with_stub(&flake_args, &stub).unwrap();
+    let flake_report_path = flake_dir.join("eval-flake.json");
+
+    let result = maxwells_daemon::run::compare::compute(
+        &maxwells_daemon::run::compare::CompareArgs {
+            baseline: base,
+            candidate: cand,
+            format: maxwells_daemon::run::compare::CompareFormat::Text,
+            max_regressions: None,
+            max_patch_size_regression_pct: None,
+            breakdown: maxwells_daemon::run::evaluate::BreakdownSelection::none(),
+            min_delta_pp: 0.0,
+            cost_attribution: false,
+            cost_attribution_min_delta_usd: 0.0,
+            min_significance: None,
+            regression_significance: None,
+            allow_underpowered: true,
+            flake_report: Some(flake_report_path),
+        },
+    );
+
+    match result {
+        Err(maxwells_daemon::error::Error::Config(
+            maxwells_daemon::error::ConfigError::Usage(msg),
+        )) => {
+            assert!(
+                msg.contains("flak"),
+                "error message must mention flake; got: {msg}"
+            );
+        }
+        other => panic!("expected UsageError for all-flaky case, got: {other:?}"),
+    }
+}
+
+// ── AC: bench eval-flake subcommand appears in --help ─────────────────────────
+
+#[test]
+fn eval_flake_subcommand_in_help() {
+    let bin = binary_path();
+    let out = std::process::Command::new(&bin)
+        .args(["bench", "--help"])
+        .output()
+        .unwrap();
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        help.contains("eval-flake"),
+        "bench --help must list eval-flake subcommand; got:\n{help}"
+    );
+}
+
+// ── AC: bench compare --help shows --flake-report ─────────────────────────────
+
+#[test]
+fn compare_help_shows_flake_report_flag() {
+    let bin = binary_path();
+    let out = std::process::Command::new(&bin)
+        .args(["bench", "compare", "--help"])
+        .output()
+        .unwrap();
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        help.contains("--flake-report"),
+        "bench compare --help must show --flake-report; got:\n{help}"
+    );
+}
+
+// ── AC: bench inspect --help shows --flake-report ─────────────────────────────
+
+#[test]
+fn inspect_help_shows_flake_report_flag() {
+    let bin = binary_path();
+    let out = std::process::Command::new(&bin)
+        .args(["bench", "inspect", "--help"])
+        .output()
+        .unwrap();
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        help.contains("--flake-report"),
+        "bench inspect --help must show --flake-report; got:\n{help}"
+    );
+}

--- a/tests/bench_eval_flake.rs
+++ b/tests/bench_eval_flake.rs
@@ -8,7 +8,7 @@
 //!   4. Summary text names the exclusion count explicitly.
 //!   5. Degenerate case: all paired instances flaky exits with UsageError (2).
 
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)]
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -27,14 +27,10 @@ fn write_sweep_results(dir: &std::path::Path, instances: &[(&str, bool)]) -> Pat
     let mut rows = String::new();
     for (id, resolved) in instances {
         let outcome = if *resolved { "submitted" } else { "error" };
-        let resolved_count = if *resolved { 1 } else { 0 };
+        let resolved_count = i32::from(*resolved);
         writeln!(
             rows,
-            r#"{{"instance_id":"{id}","exit_reason":"{outcome}","outcome":"{outcome}","failure_category":null,"steps":4,"cost_usd":0.01,"prompt_tokens":100,"cache_read_tokens":0,"cache_creation_tokens":0,"completion_tokens":50,"duration_secs":5.0,"error":null,"github_pr_error":null,"patch_present":{pp},"non_empty_patch":{pp},"attempts":1,"retry_reasons":[],"runs":1,"resolved_count":{resolved_count},"pass_at_1":{pp},"tests_run_before_submit":false,"last_tests_passed":null,"fallback_count":null,"final_model":null,"retry_id":null,"previous_failure_category":null,"trace_id":null}}"#,
-            id = id,
-            outcome = outcome,
-            pp = resolved,
-            resolved_count = resolved_count,
+            r#"{{"instance_id":"{id}","exit_reason":"{outcome}","outcome":"{outcome}","failure_category":null,"steps":4,"cost_usd":0.01,"prompt_tokens":100,"cache_read_tokens":0,"cache_creation_tokens":0,"completion_tokens":50,"duration_secs":5.0,"error":null,"github_pr_error":null,"patch_present":{resolved},"non_empty_patch":{resolved},"attempts":1,"retry_reasons":[],"runs":1,"resolved_count":{resolved_count},"pass_at_1":{resolved},"tests_run_before_submit":false,"last_tests_passed":null,"fallback_count":null,"final_model":null,"retry_id":null,"previous_failure_category":null,"trace_id":null}}"#,
         )
         .unwrap();
     }
@@ -113,7 +109,7 @@ fn flaky_instance_detected_with_correct_rate() {
     );
 
     let args = EvalFlakeArgs {
-        sweep_dir: sweep.clone(),
+        sweep_dir: sweep,
         replays: 3,
         output: None,
         concurrency: 1,

--- a/tests/checkpointing.rs
+++ b/tests/checkpointing.rs
@@ -832,6 +832,7 @@ fn bench_inspect_partial_trajectory_shows_banner() {
         filter: None,
         full: false,
         show_expected: false,
+        flake_report: None,
     };
 
     let report = inspect(&args, &InspectFormat::Text).unwrap();

--- a/tests/evaluator_provenance.rs
+++ b/tests/evaluator_provenance.rs
@@ -157,6 +157,7 @@ fn compare_args(baseline: &Path, candidate: &Path) -> CompareArgs {
         min_significance: None,
         regression_significance: None,
         allow_underpowered: false,
+        flake_report: None,
     }
 }
 
@@ -729,6 +730,7 @@ fn inspect_summary_loads_provenance_from_evaluation_json() {
         filter: Some("resolved=true".into()),
         full: false,
         show_expected: false,
+        flake_report: None,
     };
 
     let output = maxwells_daemon::run::inspect::run(&args).unwrap();

--- a/tests/per_turn_latency.rs
+++ b/tests/per_turn_latency.rs
@@ -447,6 +447,7 @@ fn inspect_report_aggregates_stage_totals() {
         filter: None,
         full: true,
         show_expected: false,
+        flake_report: None,
     };
     let out = maxwells_daemon::run::inspect::run(&args).unwrap();
     let report: &InspectReport = match &out {
@@ -488,6 +489,7 @@ fn legacy_trajectory_inspect_renders_latency_unknown() {
         filter: None,
         full: true,
         show_expected: false,
+        flake_report: None,
     };
     let out = maxwells_daemon::run::inspect::run(&args).unwrap();
     let text = render_text(&out);

--- a/tests/sampling_params.rs
+++ b/tests/sampling_params.rs
@@ -277,6 +277,7 @@ fn bench_compare_flags_sampling_only_difference() {
         min_significance: None,
         regression_significance: None,
         allow_underpowered: true,
+        flake_report: None,
     };
 
     let report = compare_compute(&args).unwrap();
@@ -530,6 +531,7 @@ fn bench_compare_text_output_includes_sampling_drift() {
         min_significance: None,
         regression_significance: None,
         allow_underpowered: true,
+        flake_report: None,
     };
     let report = compare_compute(&args).unwrap();
     let text = report.human_table();
@@ -661,6 +663,7 @@ fn bench_compare_flags_sampling_presence_vs_absence_as_drift() {
         min_significance: None,
         regression_significance: None,
         allow_underpowered: true,
+        flake_report: None,
     };
     let report = compare_compute(&args).unwrap();
     let drift = report

--- a/tests/secret_redaction.rs
+++ b/tests/secret_redaction.rs
@@ -552,6 +552,7 @@ fn bench_inspect_redacts_legacy_raw_trajectory_and_warns() {
         filter: None,
         full: true,
         show_expected: false,
+        flake_report: None,
     })
     .unwrap();
     let text = maxwells_daemon::run::inspect::render_text(&output);


### PR DESCRIPTION
## Summary

Implements `bench eval-flake`, a new command that quantifies evaluator-side verdict non-determinism by replaying the evaluator N times against already-captured patches from a completed sweep. This enables operators to identify and exclude flaky instances from downstream significance testing.

## Key Changes

- **New module `src/run/eval_flake.rs`** (563 lines):
  - Core types: `Verdict`, `InstanceFlakeResult`, `EvalFlakeSummary`, `EvalFlakeReport`
  - Flake detection logic: `compute_flake_rate()` (fraction of disagreeing verdict pairs), `dominant_verdict()` (majority verdict with tie-breaking)
  - Two execution paths:
    - `run()`: Real evaluator replay via `bench evaluate` invoked N times per instance
    - `run_with_stub()`: Deterministic stub evaluator for integration testing
  - Original verdict loading from sweep's `evaluation.json` (preferred) or `results.json` (fallback)
  - Skips instances without patch files; writes `eval-flake.json` artifact with per-instance and sweep-level summaries
  - `total_cost_usd` always `0.0` (cost is evaluator wall-clock time only)

- **Integration with `bench compare --flake-report`**:
  - New optional `flake_report` field in `CompareArgs`
  - Flaky instances (`is_flaky=true`) excluded from both resolved-rate delta and McNemar paired significance test
  - Summary text explicitly names exclusion count: "N flaky instance(s) excluded; M paired instance(s) used in significance test"
  - Degenerate case: exits with `usage_error` (code 2) when all paired instances are flaky

- **Integration with `bench inspect --flake-report`**:
  - New optional `flake_report` field in `InspectArgs`
  - New `InspectFlakeData` struct surfacing `is_flaky`, `flake_rate`, `verdicts`, `dominant_verdict`
  - Human-readable output includes flake line when instance appears in report

- **CLI additions** (`src/cli/args.rs`, `src/cli/mod.rs`):
  - New `EvalFlakeCmd` with flags: `--sweep` (required), `--replays` (default 3), `--output` (default `<sweep>/eval-flake.json`), `--concurrency` (default 4)
  - Wired into command dispatcher

- **Artifact registry** (`src/artifact.rs`):
  - Added `EvalFlakeReport` to `ArtifactKind` enum

- **Comprehensive test suite** (`tests/bench_eval_flake.rs`, 512 lines):
  - Flake detection with correct rate calculation (e.g., 2/3 for alternating verdicts)
  - Stable instance detection (flake_rate=0.0)
  - Cost verification (`total_cost_usd=0.0`)
  - Artifact file writing to sweep directory
  - Skipping of instances without patches
  - `dominant_disagrees_with_sweep_count` correctness
  - `bench compare --flake-report` integration: flaky exclusion from McNemar test, summary text naming
  - Degenerate case: all-flaky paired instances trigger `UsageError`

- **Documentation** (`docs/spec-eval-flake.md`):
  - Complete specification including CLI reference, schema, flake rate formula, integration points with `compare` and `inspect`

## Notable Implementation Details

- **Flake rate formula**: `disagreeing_pairs / C(N,2)` where N is replay count; returns 0.0 for <2 verdicts
- **Dominant verdict tie-breaking**: Resolved > Unresolved > Errored (by frequency, then priority)
- **Skipped instances**: Those without patch files have `verdicts: []`, excluded from flaky counts but tracked in report
- **Original verdict recovery**: Reads from sweep's evaluation.json (preferred) or results.json (fallback)

https://claude.ai/code/session_01LUH6hqs2WePZcxkA5Bf1vU