### PR TITLE
🌟 Nova: JUnit Exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+junit-export = []
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1798,7 +1798,7 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`, and `junit`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2525,7 +2525,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         }
         if i.output.is_some() {
             return Err(Error::Config(crate::error::ConfigError::Invalid(
-                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid)".into(),
+                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/junit)".into(),
             )));
         }
         let format = parse_trajectory_diff_format(&i.format)?;
@@ -2540,13 +2540,16 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "junit"
+    ) {
         return bench_inspect_export(i);
     }
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/junit), not `{}`",
             i.format
         ))));
     }
@@ -2556,7 +2559,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         "json" => crate::run::inspect::InspectFormat::Json,
         other => {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, or `mermaid`)"
+                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, `mermaid`, or `junit`)"
             ))));
         }
     };
@@ -2598,7 +2601,8 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     })?;
     let instance_id = i.instance.as_deref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
-            "inspect: --instance is required for export formats (markdown/html/csv/mermaid)".into(),
+            "inspect: --instance is required for export formats (markdown/html/csv/mermaid/junit)"
+                .into(),
         ))
     })?;
     let traj_path =
@@ -2620,6 +2624,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "junit" => inspect_export_junit(&traj)?,
         _ => unreachable!("dispatch guarded by caller"),
     };
 
@@ -2689,6 +2694,22 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "format_unavailable: --format csv requires the `csv-export` Cargo feature; \
          rebuild with `--features csv-export`"
+            .into(),
+    )))
+}
+
+#[cfg(feature = "junit-export")]
+#[allow(clippy::unnecessary_wraps)]
+fn inspect_export_junit(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    use crate::trajectory::export::{JunitExporter, TrajectoryExporter};
+    Ok(JunitExporter::export(traj))
+}
+
+#[cfg(not(feature = "junit-export"))]
+fn inspect_export_junit(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "format_unavailable: --format junit requires the `junit-export` Cargo feature; \
+         rebuild with `--features junit-export`"
             .into(),
     )))
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -245,6 +245,32 @@ impl TrajectoryExporter for MermaidExporter {
     }
 }
 
+#[cfg(feature = "junit-export")]
+pub struct JunitExporter;
+
+#[cfg(feature = "junit-export")]
+impl TrajectoryExporter for JunitExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let mut xml = String::new();
+        xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        xml.push_str("<testsuites>\n");
+        xml.push_str("  <testsuite name=\"Trajectory\" tests=\"1\">\n");
+        let task = trajectory.info.task.as_deref().unwrap_or("unknown");
+        let safe_task = task
+            .replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+            .replace('"', "&quot;");
+        let _ = writeln!(xml, "    <testcase classname=\"AgentRun\" name=\"{safe_task}\">");
+        if trajectory.info.outcome.as_deref() != Some(crate::trajectory::outcome::SUBMITTED) {
+            xml.push_str("      <failure message=\"Agent did not submit successfully\" />\n");
+        }
+        xml.push_str("    </testcase>\n");
+        xml.push_str("  </testsuite>\n</testsuites>");
+        xml
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -339,5 +365,22 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+
+    #[cfg(feature = "junit-export")]
+    #[test]
+    fn test_junit_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::system("System prompt"));
+
+        let xml = JunitExporter::export(&t);
+
+        assert!(xml.starts_with("<?xml version=\"1.0\""));
+        assert!(xml.contains("<testsuites>"));
+        assert!(xml.contains("<testcase classname=\"AgentRun\" name=\"Add a feature\">"));
+        assert!(!xml.contains("<failure"));
     }
 }


### PR DESCRIPTION
💡 **The Spark:** "I noticed we export trajectories in many formats (CSV, HTML, Markdown, Mermaid) for humans, but lack a standard machine-readable format like JUnit for CI systems to easily parse agent runs as test cases."
🚀 **The Feature:** "Implemented `JunitExporter` behind the `junit-export` feature flag to export a `Trajectory` as a JUnit XML test suite."
🔮 **The Potential:** "This allows `bench inspect` to dump agent trajectories into a format natively understood by CI/CD providers (GitHub Actions, GitLab CI, Jenkins) for immediate, native failure tracking and test reporting."
⚠️ **Risk:** "Low. Isolated under the `junit-export` Cargo feature and confined to `src/trajectory/export.rs` and CLI dispatch."

---
*PR created automatically by Jules for task [10509706726483943938](https://jules.google.com/task/10509706726483943938) started by @madmax983*