### PR TITLE
⚡ Bolt: pre-allocate vectors in skill resolution

### DIFF
--- a/src/skills.rs
+++ b/src/skills.rs
@@ -128,7 +128,7 @@ impl SkillRegistry {
         &self,
         request: SkillResolveRequest<'_>,
     ) -> Vec<(SkillActivationReason, &SkillManifest)> {
-        let mut candidates = Vec::new();
+        let mut candidates = Vec::with_capacity(self.manifests.len());
         let mut seen = BTreeSet::new();
         let normalized_task = normalize_search_text(request.task);
         let task_tokens = tokenize(&normalized_task)
@@ -166,7 +166,7 @@ impl SkillRegistry {
             return Ok(ActiveSkillSet::default());
         }
 
-        let mut selected = Vec::new();
+        let mut selected = Vec::with_capacity(request.max_active);
         let mut seen = BTreeSet::new();
         let normalized_task = normalize_search_text(request.task);
         let task_tokens = tokenize(&normalized_task)


### PR DESCRIPTION
⚡ Bolt: pre-allocate vectors in skill resolution

💡 What: Replaced `Vec::new()` with `Vec::with_capacity()` in `src/skills.rs` for `resolve_candidates` and `resolve` where the target collection size is bounded and known.
🎯 Why: Iteratively appending to dynamically-sized vectors forces multiple heap reallocations when scaling up skill manifests. Pre-allocating to known bounds prevents these allocations.
📊 Impact: Eliminates O(log N) potential intermediate heap allocations when scanning user-defined skills, giving a small latency/memory efficiency boost inside the hot loops.
🔬 Measurement: Verify zero compilation warnings and pass all skill unit tests with `cargo test --lib skills`.

---
*PR created automatically by Jules for task [11208320385160525600](https://jules.google.com/task/11208320385160525600) started by @madmax983*