### PR TITLE
Add `bench self-check` command for agent verdict calibration

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -540,6 +540,8 @@ pub enum BenchCmd {
     Annotate(AnnotateCmd),
     /// Surface looped-action signatures across a sweep (zero-cost: reads only on-disk artifacts).
     StagnationReport(StagnationReportCmd),
+    /// Score agent self-verdict (last_tests_passed) against the evaluator (zero-cost: reads only on-disk artifacts).
+    SelfCheck(SelfCheckCmd),
 }
 
 /// `bench failure-digest` — self-contained failure summary for one sweep instance.
@@ -980,6 +982,31 @@ pub struct StagnationReportCmd {
     /// JSON emits a stable, schema-versioned artifact suitable for CI snapshot diffing.
     #[arg(long, default_value = "text", value_name = "FMT")]
     pub format: String,
+}
+
+/// `bench self-check` — score agent self-verdict (last_tests_passed) against the evaluator.
+///
+/// Reads existing sweep artifacts (`*.traj.json` + `evaluation.json`) and computes
+/// a 3×2 confusion matrix, precision/recall, Brier score, and calibration delta.
+/// Zero-cost: no model calls, no container calls.
+#[derive(Debug, Args)]
+pub struct SelfCheckCmd {
+    /// Completed sweep directory containing `*.traj.json` files and `evaluation.json`.
+    #[arg(long)]
+    pub sweep: PathBuf,
+
+    /// Output format: `text` (default) or `json`.
+    #[arg(long, default_value = "text")]
+    pub format: String,
+
+    /// Show this many false-positive and false-negative instance IDs in text output.
+    /// Set to `0` to suppress those lists.
+    #[arg(long, default_value_t = 10)]
+    pub list: usize,
+
+    /// Show per-repository breakdown in addition to the overall report.
+    #[arg(long, default_value_t = false)]
+    pub by_repo: bool,
 }
 
 /// `bench instance-history` — longitudinal view of instance resolution across sweeps.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -115,6 +115,7 @@ pub async fn run() -> Result<(), Error> {
             args::BenchCmd::EvalFlake(f) => bench_eval_flake(f),
             args::BenchCmd::Annotate(a) => bench_annotate(a),
             args::BenchCmd::StagnationReport(s) => bench_stagnation_report(s),
+            args::BenchCmd::SelfCheck(s) => bench_self_check(s),
         },
         Command::Agent { cmd } => match *cmd {
             args::AgentCmd::SkillsPreview(s) => agent_skills_preview_cmd(&s),
@@ -3242,6 +3243,36 @@ fn bench_stagnation_report(s: args::StagnationReportCmd) -> Result<(), Error> {
         crate::run::stagnation_report::StagnationReportFormat::Json => {
             let json = crate::run::stagnation_report::render_json(&report)?;
             println!("{json}");
+        }
+    }
+    Ok(())
+}
+
+fn bench_self_check(s: args::SelfCheckCmd) -> Result<(), Error> {
+    let args = crate::run::self_check::SelfCheckArgs {
+        sweep_dir: s.sweep,
+        format: s.format.clone(),
+        list: s.list,
+        by_repo: s.by_repo,
+    };
+    let report = crate::run::self_check::run(&args)?;
+    match s.format.as_str() {
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report).map_err(Error::Json)?
+            );
+        }
+        "text" => {
+            print!(
+                "{}",
+                crate::run::self_check::render_text(&report, s.list)
+            );
+        }
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "bench self-check: --format '{other}' is not valid; use 'text' or 'json'"
+            ))));
         }
     }
     Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3264,10 +3264,7 @@ fn bench_self_check(s: args::SelfCheckCmd) -> Result<(), Error> {
             );
         }
         "text" => {
-            print!(
-                "{}",
-                crate::run::self_check::render_text(&report, s.list)
-            );
+            print!("{}", crate::run::self_check::render_text(&report, s.list));
         }
         other => {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -40,6 +40,7 @@ pub mod replay;
 pub mod report;
 pub mod reproduce;
 pub mod retry;
+pub mod self_check;
 pub mod skills_preview;
 pub mod stagnation_report;
 pub mod swebench;

--- a/src/run/self_check.rs
+++ b/src/run/self_check.rs
@@ -1,0 +1,496 @@
+//! `bench self-check` — score the agent's own test verdict against the evaluator.
+//!
+//! Reads existing sweep artifacts (`*.traj.json` + `evaluation.json`) and computes
+//! a 3×2 confusion matrix, precision/recall, Brier score, and calibration delta.
+//! Zero-cost: no model calls, no container calls.
+//!
+//! # Exit codes
+//! * 0 — success
+//! * 2 — `evaluation.json` missing (`Error::Config` → `UsageError`)
+//! * 3 — trajectory predates the `tests_run_before_submit` field added in #46
+//!        (`Error::Preflight` → `PreflightFailure`)
+//! * 1 — internal I/O or JSON parse error
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{ConfigError, Error};
+
+// ── public arg struct ─────────────────────────────────────────────────────────
+
+/// Arguments for `bench self-check`.
+#[derive(Debug, Clone)]
+pub struct SelfCheckArgs {
+    /// Completed sweep directory containing `*.traj.json` files and
+    /// `evaluation.json`.
+    pub sweep_dir: PathBuf,
+    /// Output format: `"text"` (default) or `"json"`.
+    pub format: String,
+    /// Show this many false-positive / false-negative IDs in text output.
+    /// `0` suppresses the lists. The `SelfCheckReport` always stores all IDs.
+    pub list: usize,
+    /// When `true`, populate `by_repo` with per-repository `ConfusionCounts`.
+    pub by_repo: bool,
+}
+
+// ── report structs ────────────────────────────────────────────────────────────
+
+/// 3×2 confusion matrix.
+///
+/// Rows represent the agent's self-verdict (`last_tests_passed`), columns
+/// represent the external evaluator verdict (`resolved`).
+///
+/// ```text
+///                      | resolved=true | resolved=false
+/// tests_passed = true  |  passed_resolved (TP) | passed_unresolved (FP)
+/// tests_passed = false |  failed_resolved (FN) | failed_unresolved (TN)
+/// tests_passed = None  |  none_resolved        | none_unresolved
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct ConfusionCounts {
+    /// True positives: agent said "passed", evaluator said "resolved".
+    pub passed_resolved: u32,
+    /// False positives: agent said "passed", evaluator said "not resolved".
+    pub passed_unresolved: u32,
+    /// False negatives: agent said "failed", evaluator said "resolved".
+    pub failed_resolved: u32,
+    /// True negatives: agent said "failed", evaluator said "not resolved".
+    pub failed_unresolved: u32,
+    /// Agent reported no test result; evaluator said "resolved".
+    pub none_resolved: u32,
+    /// Agent reported no test result; evaluator said "not resolved".
+    pub none_unresolved: u32,
+}
+
+/// Calibration metrics derived from the confusion matrix.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SelfCheckMetrics {
+    /// Fraction of "passed" calls that were actually resolved.
+    /// `None` when the denominator (TP + FP) is zero.
+    pub precision: Option<f64>,
+    /// Fraction of resolved instances that were called "passed".
+    /// `None` when the denominator (TP + FN) is zero.
+    pub recall: Option<f64>,
+    /// Mean-squared-error treating `last_tests_passed` as a probability
+    /// (`true=1.0`, `false=0.0`, `None=0.5`) compared to `resolved`.
+    /// Rounded to 3 decimal places.
+    pub brier_score: f64,
+}
+
+/// Top-level self-check report — the return value of [`run`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SelfCheckReport {
+    /// Schema identifier for machine-readable consumers.
+    pub schema: String,
+    /// 3×2 confusion matrix across all instances.
+    pub confusion: ConfusionCounts,
+    /// Derived calibration metrics.
+    pub metrics: SelfCheckMetrics,
+    /// Instance IDs where `last_tests_passed=true` but `resolved=false`
+    /// (false positives), sorted lexicographically.
+    pub false_positives: Vec<String>,
+    /// Instance IDs where `last_tests_passed=false` but `resolved=true`
+    /// (false negatives), sorted lexicographically.
+    pub false_negatives: Vec<String>,
+    /// Overall resolved rate across all instances
+    /// (`total_resolved / total_instances`).
+    pub base_rate: f64,
+    /// Number of instances excluded from precision/recall because
+    /// `last_tests_passed` was `None`.
+    pub n_excluded_none: u32,
+    /// `precision − base_rate`. Positive means the agent's "passed" signal
+    /// is more reliable than a random baseline.
+    /// `None` when precision is undefined.
+    pub calibration_delta: Option<f64>,
+    /// Per-repository breakdown (only populated when `args.by_repo = true`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub by_repo: Option<BTreeMap<String, ConfusionCounts>>,
+}
+
+// ── main entry point ──────────────────────────────────────────────────────────
+
+/// Run the self-check and return a [`SelfCheckReport`].
+///
+/// # Errors
+/// * `Error::Config` (exit 2) — `evaluation.json` is absent or malformed.
+/// * `Error::Preflight` (exit 3) — a trajectory predates the `tests_run_before_submit`
+///   field introduced in harness issue #46.
+/// * `Error::Io` / `Error::Json` (exit 1) — unexpected I/O or parse failure.
+pub fn run(args: &SelfCheckArgs) -> Result<SelfCheckReport, Error> {
+    // ── 1. Load evaluation.json ───────────────────────────────────────────────
+    let eval_path = args.sweep_dir.join("evaluation.json");
+    if !eval_path.exists() {
+        return Err(Error::Config(ConfigError::Invalid(format!(
+            "evaluation.json not found in {}; run `bench evaluate` first to produce it",
+            args.sweep_dir.display()
+        ))));
+    }
+
+    let eval_text = std::fs::read_to_string(&eval_path)?;
+    let eval_json: serde_json::Value = serde_json::from_str(&eval_text)?;
+
+    let instances = eval_json["instances"].as_array().ok_or_else(|| {
+        Error::Config(ConfigError::Invalid(
+            "evaluation.json is missing the 'instances' array".into(),
+        ))
+    })?;
+
+    // ── 2. Iterate instances ──────────────────────────────────────────────────
+    let mut confusion = ConfusionCounts::default();
+    let mut false_positives: Vec<String> = Vec::new();
+    let mut false_negatives: Vec<String> = Vec::new();
+    let mut brier_sum = 0.0_f64;
+    let total = instances.len();
+    let mut total_resolved = 0_u32;
+    let mut by_repo_map: BTreeMap<String, ConfusionCounts> = BTreeMap::new();
+
+    for inst in instances {
+        let instance_id = inst["instance_id"].as_str().ok_or_else(|| {
+            Error::Config(ConfigError::Invalid(
+                "an instance in evaluation.json is missing 'instance_id'".into(),
+            ))
+        })?;
+
+        let resolved = inst["resolved"].as_bool().ok_or_else(|| {
+            Error::Config(ConfigError::Invalid(format!(
+                "instance '{instance_id}' in evaluation.json is missing 'resolved'"
+            )))
+        })?;
+
+        if resolved {
+            total_resolved += 1;
+        }
+
+        // ── 3. Load trajectory and check schema ───────────────────────────────
+        let traj_path = find_trajectory_path(&args.sweep_dir, instance_id)?;
+        let (tests_run_field_present, last_tests_passed) = load_trajectory_info(&traj_path)?;
+
+        if !tests_run_field_present {
+            return Err(Error::Preflight(format!(
+                "trajectory for '{instance_id}' predates #46: the 'tests_run_before_submit' \
+                 field is absent; self-check requires sweeps run with harness ≥ #46"
+            )));
+        }
+
+        // ── 4. Brier score contribution ───────────────────────────────────────
+        // f_i = agent's implied probability that the patch was correct:
+        //   tests_passed=true  → 1.0
+        //   tests_passed=false → 0.0
+        //   tests_passed=None  → 0.5 (maximum-uncertainty prior)
+        let f_i: f64 = match last_tests_passed {
+            Some(true) => 1.0,
+            Some(false) => 0.0,
+            None => 0.5,
+        };
+        let y_i: f64 = if resolved { 1.0 } else { 0.0 };
+        brier_sum += (f_i - y_i).powi(2);
+
+        // ── 5. Confusion matrix cell ──────────────────────────────────────────
+        let repo_key = parse_repo_from_instance_id(instance_id);
+
+        match last_tests_passed {
+            Some(true) => {
+                if resolved {
+                    confusion.passed_resolved += 1;
+                } else {
+                    confusion.passed_unresolved += 1;
+                    false_positives.push(instance_id.to_owned());
+                }
+            }
+            Some(false) => {
+                if resolved {
+                    confusion.failed_resolved += 1;
+                    false_negatives.push(instance_id.to_owned());
+                } else {
+                    confusion.failed_unresolved += 1;
+                }
+            }
+            None => {
+                if resolved {
+                    confusion.none_resolved += 1;
+                } else {
+                    confusion.none_unresolved += 1;
+                }
+            }
+        }
+
+        // ── 6. Per-repo cell (optional) ───────────────────────────────────────
+        if args.by_repo {
+            if let Some(repo) = repo_key {
+                let entry = by_repo_map.entry(repo).or_default();
+                match last_tests_passed {
+                    Some(true) => {
+                        if resolved {
+                            entry.passed_resolved += 1;
+                        } else {
+                            entry.passed_unresolved += 1;
+                        }
+                    }
+                    Some(false) => {
+                        if resolved {
+                            entry.failed_resolved += 1;
+                        } else {
+                            entry.failed_unresolved += 1;
+                        }
+                    }
+                    None => {
+                        if resolved {
+                            entry.none_resolved += 1;
+                        } else {
+                            entry.none_unresolved += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ── 7. Derive aggregate metrics ───────────────────────────────────────────
+    false_positives.sort();
+    false_negatives.sort();
+
+    let tp = f64::from(confusion.passed_resolved);
+    let fp = f64::from(confusion.passed_unresolved);
+    let fn_ = f64::from(confusion.failed_resolved);
+
+    let precision = if tp + fp > 0.0 {
+        Some(tp / (tp + fp))
+    } else {
+        None
+    };
+    let recall = if tp + fn_ > 0.0 {
+        Some(tp / (tp + fn_))
+    } else {
+        None
+    };
+
+    #[allow(clippy::cast_precision_loss)]
+    let brier_score = if total > 0 {
+        round3(brier_sum / total as f64)
+    } else {
+        0.0
+    };
+
+    #[allow(clippy::cast_precision_loss)]
+    let base_rate = if total > 0 {
+        f64::from(total_resolved) / total as f64
+    } else {
+        0.0
+    };
+
+    let calibration_delta = precision.map(|p| p - base_rate);
+    let n_excluded_none = confusion.none_resolved + confusion.none_unresolved;
+
+    let by_repo = if args.by_repo {
+        Some(by_repo_map)
+    } else {
+        None
+    };
+
+    Ok(SelfCheckReport {
+        schema: "bench-self-check/1".to_owned(),
+        confusion,
+        metrics: SelfCheckMetrics {
+            precision,
+            recall,
+            brier_score,
+        },
+        false_positives,
+        false_negatives,
+        base_rate,
+        n_excluded_none,
+        calibration_delta,
+        by_repo,
+    })
+}
+
+// ── text renderer ─────────────────────────────────────────────────────────────
+
+/// Render a [`SelfCheckReport`] as human-readable text.
+///
+/// `list_n` controls how many false-positive / false-negative instance IDs to
+/// show. Pass `0` to suppress those sections entirely.
+#[must_use]
+pub fn render_text(report: &SelfCheckReport, list_n: usize) -> String {
+    let mut out = String::new();
+
+    out.push_str("=== Bench Self-Check: Agent Verdict vs. Evaluator ===\n\n");
+
+    // ── Confusion matrix ──────────────────────────────────────────────────────
+    out.push_str("Confusion Matrix (rows: last_tests_passed, cols: resolved)\n");
+    out.push_str(
+        "                    Resolved  Unresolved\n",
+    );
+    out.push_str(&format!(
+        "  tests passed=true  {:>8}  {:>10}\n",
+        report.confusion.passed_resolved, report.confusion.passed_unresolved
+    ));
+    out.push_str(&format!(
+        "  tests passed=false {:>8}  {:>10}\n",
+        report.confusion.failed_resolved, report.confusion.failed_unresolved
+    ));
+    out.push_str(&format!(
+        "  tests passed=None  {:>8}  {:>10}\n",
+        report.confusion.none_resolved, report.confusion.none_unresolved
+    ));
+    out.push('\n');
+
+    // ── Metrics ───────────────────────────────────────────────────────────────
+    out.push_str("Metrics:\n");
+    match report.metrics.precision {
+        Some(p) => out.push_str(&format!("  Precision:          {p:.3}\n")),
+        None => out.push_str("  Precision:          N/A (no passed rows)\n"),
+    }
+    match report.metrics.recall {
+        Some(r) => out.push_str(&format!("  Recall:             {r:.3}\n")),
+        None => out.push_str("  Recall:             N/A (no resolved rows)\n"),
+    }
+    out.push_str(&format!(
+        "  Brier score:        {:.3}\n",
+        report.metrics.brier_score
+    ));
+    out.push_str(&format!(
+        "  Base rate:          {:.3}\n",
+        report.base_rate
+    ));
+    match report.calibration_delta {
+        Some(d) => out.push_str(&format!("  Calibration delta:  {d:+.3}\n")),
+        None => out.push_str("  Calibration delta:  N/A\n"),
+    }
+    out.push_str(&format!(
+        "  Excluded (None):    {}\n",
+        report.n_excluded_none
+    ));
+    out.push('\n');
+
+    // ── False positives ───────────────────────────────────────────────────────
+    if list_n > 0 && !report.false_positives.is_empty() {
+        let shown = report.false_positives.len().min(list_n);
+        out.push_str(&format!(
+            "False positives (tests_passed=true, resolved=false) — first {shown}:\n"
+        ));
+        for id in report.false_positives.iter().take(list_n) {
+            out.push_str(&format!("  {id}\n"));
+        }
+        out.push('\n');
+    }
+
+    // ── False negatives ───────────────────────────────────────────────────────
+    if list_n > 0 && !report.false_negatives.is_empty() {
+        let shown = report.false_negatives.len().min(list_n);
+        out.push_str(&format!(
+            "False negatives (tests_passed=false, resolved=true) — first {shown}:\n"
+        ));
+        for id in report.false_negatives.iter().take(list_n) {
+            out.push_str(&format!("  {id}\n"));
+        }
+        out.push('\n');
+    }
+
+    // ── Per-repository breakdown ──────────────────────────────────────────────
+    if let Some(by_repo) = &report.by_repo {
+        out.push_str("Per-repository breakdown:\n");
+        for (repo, c) in by_repo {
+            out.push_str(&format!(
+                "  {repo}: TP={} FP={} FN={} TN={} None+R={} None+U={}\n",
+                c.passed_resolved,
+                c.passed_unresolved,
+                c.failed_resolved,
+                c.failed_unresolved,
+                c.none_resolved,
+                c.none_unresolved
+            ));
+        }
+    }
+
+    out
+}
+
+// ── private helpers ───────────────────────────────────────────────────────────
+
+/// Round `v` to 3 decimal places.
+fn round3(v: f64) -> f64 {
+    (v * 1000.0).round() / 1000.0
+}
+
+/// Locate the trajectory file for `instance_id` inside `sweep_dir`.
+///
+/// Tries the canonical path pattern `{sweep_dir}/{instance_id}.traj.json`.
+fn find_trajectory_path(sweep_dir: &Path, instance_id: &str) -> Result<PathBuf, Error> {
+    let candidate = sweep_dir.join(format!("{instance_id}.traj.json"));
+    if candidate.exists() {
+        return Ok(candidate);
+    }
+    Err(Error::Config(ConfigError::Invalid(format!(
+        "trajectory file not found for instance '{instance_id}' in {}; \
+         expected '{instance_id}.traj.json'",
+        sweep_dir.display()
+    ))))
+}
+
+/// Load the two fields we need from a trajectory JSON file.
+///
+/// Returns `(tests_run_field_present, last_tests_passed)`.
+///
+/// `tests_run_field_present` is `true` when `info.tests_run_before_submit` key
+/// exists in the raw JSON (even if its value is `false`). A missing key signals a
+/// pre-#46 trajectory.
+fn load_trajectory_info(path: &Path) -> Result<(bool, Option<bool>), Error> {
+    let text = std::fs::read_to_string(path)?;
+    let raw: serde_json::Value = serde_json::from_str(&text)?;
+
+    let info = &raw["info"];
+    let tests_run_field_present = info.get("tests_run_before_submit").is_some();
+
+    // `last_tests_passed` is absent from JSON when None (skip_serializing_if),
+    // and present as a bool otherwise.
+    let last_tests_passed = info
+        .get("last_tests_passed")
+        .and_then(serde_json::Value::as_bool);
+
+    Ok((tests_run_field_present, last_tests_passed))
+}
+
+/// Parse a SWE-bench `owner__repo-NNNNN` instance ID into `"owner/repo"`.
+///
+/// Returns `None` when the ID does not match the expected format.
+fn parse_repo_from_instance_id(instance_id: &str) -> Option<String> {
+    let (owner, rest) = instance_id.split_once("__")?;
+    let (repo, _suffix) = rest.rsplit_once('-')?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_repo_round_trips() {
+        assert_eq!(
+            parse_repo_from_instance_id("django__django-12345"),
+            Some("django/django".to_owned())
+        );
+        assert_eq!(
+            parse_repo_from_instance_id("sympy__sympy-99999"),
+            Some("sympy/sympy".to_owned())
+        );
+    }
+
+    #[test]
+    fn parse_repo_rejects_bad_format() {
+        assert!(parse_repo_from_instance_id("no-double-underscore").is_none());
+        assert!(parse_repo_from_instance_id("__-missing-owner").is_none());
+    }
+
+    #[test]
+    fn round3_rounds_correctly() {
+        assert_eq!(round3(0.0), 0.0);
+        assert_eq!(round3(0.25), 0.25);
+        assert!((round3(3.75 / 13.0) - 0.288).abs() < 1e-9);
+    }
+}

--- a/src/run/self_check.rs
+++ b/src/run/self_check.rs
@@ -506,8 +506,8 @@ mod tests {
 
     #[test]
     fn round3_rounds_correctly() {
-        assert_eq!(round3(0.0), 0.0);
-        assert_eq!(round3(0.25), 0.25);
+        assert!((round3(0.0) - 0.0).abs() < 1e-9);
+        assert!((round3(0.25) - 0.25).abs() < 1e-9);
         assert!((round3(3.75 / 13.0) - 0.288).abs() < 1e-9);
     }
 }

--- a/src/run/self_check.rs
+++ b/src/run/self_check.rs
@@ -8,10 +8,11 @@
 //! * 0 — success
 //! * 2 — `evaluation.json` missing (`Error::Config` → `UsageError`)
 //! * 3 — trajectory predates the `tests_run_before_submit` field added in #46
-//!        (`Error::Preflight` → `PreflightFailure`)
+//!   (`Error::Preflight` → `PreflightFailure`)
 //! * 1 — internal I/O or JSON parse error
 
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -48,7 +49,7 @@ pub struct SelfCheckArgs {
 /// tests_passed = false |  failed_resolved (FN) | failed_unresolved (TN)
 /// tests_passed = None  |  none_resolved        | none_unresolved
 /// ```
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ConfusionCounts {
     /// True positives: agent said "passed", evaluator said "resolved".
     pub passed_resolved: u32,
@@ -119,191 +120,202 @@ pub struct SelfCheckReport {
 ///   field introduced in harness issue #46.
 /// * `Error::Io` / `Error::Json` (exit 1) — unexpected I/O or parse failure.
 pub fn run(args: &SelfCheckArgs) -> Result<SelfCheckReport, Error> {
-    // ── 1. Load evaluation.json ───────────────────────────────────────────────
-    let eval_path = args.sweep_dir.join("evaluation.json");
-    if !eval_path.exists() {
-        return Err(Error::Config(ConfigError::Invalid(format!(
-            "evaluation.json not found in {}; run `bench evaluate` first to produce it",
-            args.sweep_dir.display()
-        ))));
-    }
-
-    let eval_text = std::fs::read_to_string(&eval_path)?;
-    let eval_json: serde_json::Value = serde_json::from_str(&eval_text)?;
-
-    let instances = eval_json["instances"].as_array().ok_or_else(|| {
-        Error::Config(ConfigError::Invalid(
-            "evaluation.json is missing the 'instances' array".into(),
-        ))
-    })?;
-
-    // ── 2. Iterate instances ──────────────────────────────────────────────────
-    let mut confusion = ConfusionCounts::default();
-    let mut false_positives: Vec<String> = Vec::new();
-    let mut false_negatives: Vec<String> = Vec::new();
-    let mut brier_sum = 0.0_f64;
+    let instances = load_eval_instances(&args.sweep_dir)?;
     let total = instances.len();
-    let mut total_resolved = 0_u32;
-    let mut by_repo_map: BTreeMap<String, ConfusionCounts> = BTreeMap::new();
+    let mut acc = InstanceAccumulator::default();
 
-    for inst in instances {
+    for inst in &instances {
         let instance_id = inst["instance_id"].as_str().ok_or_else(|| {
             Error::Config(ConfigError::Invalid(
                 "an instance in evaluation.json is missing 'instance_id'".into(),
             ))
         })?;
-
         let resolved = inst["resolved"].as_bool().ok_or_else(|| {
             Error::Config(ConfigError::Invalid(format!(
                 "instance '{instance_id}' in evaluation.json is missing 'resolved'"
             )))
         })?;
 
-        if resolved {
-            total_resolved += 1;
-        }
-
-        // ── 3. Load trajectory and check schema ───────────────────────────────
         let traj_path = find_trajectory_path(&args.sweep_dir, instance_id)?;
-        let (tests_run_field_present, last_tests_passed) = load_trajectory_info(&traj_path)?;
-
-        if !tests_run_field_present {
+        let (schema_ok, last_tests_passed) = load_trajectory_info(&traj_path)?;
+        if !schema_ok {
             return Err(Error::Preflight(format!(
                 "trajectory for '{instance_id}' predates #46: the 'tests_run_before_submit' \
                  field is absent; self-check requires sweeps run with harness ≥ #46"
             )));
         }
 
-        // ── 4. Brier score contribution ───────────────────────────────────────
-        // f_i = agent's implied probability that the patch was correct:
-        //   tests_passed=true  → 1.0
-        //   tests_passed=false → 0.0
-        //   tests_passed=None  → 0.5 (maximum-uncertainty prior)
+        acc.tally(instance_id, resolved, last_tests_passed, args.by_repo);
+    }
+
+    Ok(acc.into_report(total))
+}
+
+/// Load and parse the `instances` array from `<sweep>/evaluation.json`.
+fn load_eval_instances(sweep_dir: &Path) -> Result<Vec<serde_json::Value>, Error> {
+    let eval_path = sweep_dir.join("evaluation.json");
+    if !eval_path.exists() {
+        return Err(Error::Config(ConfigError::Invalid(format!(
+            "evaluation.json not found in {}; run `bench evaluate` first to produce it",
+            sweep_dir.display()
+        ))));
+    }
+    let text = std::fs::read_to_string(&eval_path)?;
+    let json: serde_json::Value = serde_json::from_str(&text)?;
+    let arr = json["instances"]
+        .as_array()
+        .ok_or_else(|| {
+            Error::Config(ConfigError::Invalid(
+                "evaluation.json is missing the 'instances' array".into(),
+            ))
+        })?
+        .clone();
+    Ok(arr)
+}
+
+/// Mutable accumulator for the per-instance loop in [`run`].
+#[derive(Default)]
+struct InstanceAccumulator {
+    confusion: ConfusionCounts,
+    false_positives: Vec<String>,
+    false_negatives: Vec<String>,
+    brier_sum: f64,
+    total_resolved: u32,
+    by_repo_map: BTreeMap<String, ConfusionCounts>,
+}
+
+impl InstanceAccumulator {
+    /// Record one instance into the accumulator.
+    fn tally(
+        &mut self,
+        instance_id: &str,
+        resolved: bool,
+        last_tests_passed: Option<bool>,
+        track_by_repo: bool,
+    ) {
+        if resolved {
+            self.total_resolved += 1;
+        }
+
+        // Brier: f_i = implied P(correct): true→1, false→0, None→0.5
         let f_i: f64 = match last_tests_passed {
             Some(true) => 1.0,
             Some(false) => 0.0,
             None => 0.5,
         };
-        let y_i: f64 = if resolved { 1.0 } else { 0.0 };
-        brier_sum += (f_i - y_i).powi(2);
+        self.brier_sum += (f_i - if resolved { 1.0 } else { 0.0 }).powi(2);
 
-        // ── 5. Confusion matrix cell ──────────────────────────────────────────
-        let repo_key = parse_repo_from_instance_id(instance_id);
+        // Confusion matrix + FP/FN lists
+        tally_confusion(
+            &mut self.confusion,
+            &mut self.false_positives,
+            &mut self.false_negatives,
+            instance_id,
+            resolved,
+            last_tests_passed,
+        );
 
-        match last_tests_passed {
-            Some(true) => {
-                if resolved {
-                    confusion.passed_resolved += 1;
-                } else {
-                    confusion.passed_unresolved += 1;
-                    false_positives.push(instance_id.to_owned());
-                }
-            }
-            Some(false) => {
-                if resolved {
-                    confusion.failed_resolved += 1;
-                    false_negatives.push(instance_id.to_owned());
-                } else {
-                    confusion.failed_unresolved += 1;
-                }
-            }
-            None => {
-                if resolved {
-                    confusion.none_resolved += 1;
-                } else {
-                    confusion.none_unresolved += 1;
-                }
-            }
-        }
-
-        // ── 6. Per-repo cell (optional) ───────────────────────────────────────
-        if args.by_repo {
-            if let Some(repo) = repo_key {
-                let entry = by_repo_map.entry(repo).or_default();
-                match last_tests_passed {
-                    Some(true) => {
-                        if resolved {
-                            entry.passed_resolved += 1;
-                        } else {
-                            entry.passed_unresolved += 1;
-                        }
-                    }
-                    Some(false) => {
-                        if resolved {
-                            entry.failed_resolved += 1;
-                        } else {
-                            entry.failed_unresolved += 1;
-                        }
-                    }
-                    None => {
-                        if resolved {
-                            entry.none_resolved += 1;
-                        } else {
-                            entry.none_unresolved += 1;
-                        }
-                    }
-                }
+        // Optional per-repo breakdown (counts only — no FP/FN list needed here)
+        if track_by_repo {
+            if let Some(repo) = parse_repo_from_instance_id(instance_id) {
+                tally_confusion_counts(
+                    self.by_repo_map.entry(repo).or_default(),
+                    resolved,
+                    last_tests_passed,
+                );
             }
         }
     }
 
-    // ── 7. Derive aggregate metrics ───────────────────────────────────────────
-    false_positives.sort();
-    false_negatives.sort();
-
-    let tp = f64::from(confusion.passed_resolved);
-    let fp = f64::from(confusion.passed_unresolved);
-    let fn_ = f64::from(confusion.failed_resolved);
-
-    let precision = if tp + fp > 0.0 {
-        Some(tp / (tp + fp))
-    } else {
-        None
-    };
-    let recall = if tp + fn_ > 0.0 {
-        Some(tp / (tp + fn_))
-    } else {
-        None
-    };
-
+    /// Consume the accumulator and produce the final [`SelfCheckReport`].
     #[allow(clippy::cast_precision_loss)]
-    let brier_score = if total > 0 {
-        round3(brier_sum / total as f64)
-    } else {
-        0.0
-    };
+    fn into_report(mut self, total: usize) -> SelfCheckReport {
+        self.false_positives.sort();
+        self.false_negatives.sort();
 
-    #[allow(clippy::cast_precision_loss)]
-    let base_rate = if total > 0 {
-        f64::from(total_resolved) / total as f64
-    } else {
-        0.0
-    };
+        let tp = f64::from(self.confusion.passed_resolved);
+        let fp = f64::from(self.confusion.passed_unresolved);
+        let fn_ = f64::from(self.confusion.failed_resolved);
+        let precision = (tp + fp > 0.0).then(|| tp / (tp + fp));
+        let recall = (tp + fn_ > 0.0).then(|| tp / (tp + fn_));
 
-    let calibration_delta = precision.map(|p| p - base_rate);
-    let n_excluded_none = confusion.none_resolved + confusion.none_unresolved;
+        let brier_score = if total > 0 {
+            round3(self.brier_sum / total as f64)
+        } else {
+            0.0
+        };
+        let base_rate = if total > 0 {
+            f64::from(self.total_resolved) / total as f64
+        } else {
+            0.0
+        };
+        let calibration_delta = precision.map(|p| p - base_rate);
+        let n_excluded_none = self.confusion.none_resolved + self.confusion.none_unresolved;
 
-    let by_repo = if args.by_repo {
-        Some(by_repo_map)
-    } else {
-        None
-    };
+        SelfCheckReport {
+            schema: "bench-self-check/1".to_owned(),
+            confusion: self.confusion,
+            metrics: SelfCheckMetrics {
+                precision,
+                recall,
+                brier_score,
+            },
+            false_positives: self.false_positives,
+            false_negatives: self.false_negatives,
+            base_rate,
+            n_excluded_none,
+            calibration_delta,
+            by_repo: (!self.by_repo_map.is_empty()).then_some(self.by_repo_map),
+        }
+    }
+}
 
-    Ok(SelfCheckReport {
-        schema: "bench-self-check/1".to_owned(),
-        confusion,
-        metrics: SelfCheckMetrics {
-            precision,
-            recall,
-            brier_score,
-        },
-        false_positives,
-        false_negatives,
-        base_rate,
-        n_excluded_none,
-        calibration_delta,
-        by_repo,
-    })
+/// Update a `ConfusionCounts` cell and the FP/FN lists for one instance.
+fn tally_confusion(
+    confusion: &mut ConfusionCounts,
+    false_positives: &mut Vec<String>,
+    false_negatives: &mut Vec<String>,
+    instance_id: &str,
+    resolved: bool,
+    last_tests_passed: Option<bool>,
+) {
+    tally_confusion_counts(confusion, resolved, last_tests_passed);
+    match last_tests_passed {
+        Some(true) if !resolved => false_positives.push(instance_id.to_owned()),
+        Some(false) if resolved => false_negatives.push(instance_id.to_owned()),
+        _ => {}
+    }
+}
+
+/// Update only the `ConfusionCounts` cell (no FP/FN list tracking).
+fn tally_confusion_counts(
+    confusion: &mut ConfusionCounts,
+    resolved: bool,
+    last_tests_passed: Option<bool>,
+) {
+    match last_tests_passed {
+        Some(true) => {
+            if resolved {
+                confusion.passed_resolved += 1;
+            } else {
+                confusion.passed_unresolved += 1;
+            }
+        }
+        Some(false) => {
+            if resolved {
+                confusion.failed_resolved += 1;
+            } else {
+                confusion.failed_unresolved += 1;
+            }
+        }
+        None => {
+            if resolved {
+                confusion.none_resolved += 1;
+            } else {
+                confusion.none_unresolved += 1;
+            }
+        }
+    }
 }
 
 // ── text renderer ─────────────────────────────────────────────────────────────
@@ -320,59 +332,62 @@ pub fn render_text(report: &SelfCheckReport, list_n: usize) -> String {
 
     // ── Confusion matrix ──────────────────────────────────────────────────────
     out.push_str("Confusion Matrix (rows: last_tests_passed, cols: resolved)\n");
-    out.push_str(
-        "                    Resolved  Unresolved\n",
-    );
-    out.push_str(&format!(
-        "  tests passed=true  {:>8}  {:>10}\n",
+    out.push_str("                    Resolved  Unresolved\n");
+    let _ = writeln!(
+        out,
+        "  tests passed=true  {:>8}  {:>10}",
         report.confusion.passed_resolved, report.confusion.passed_unresolved
-    ));
-    out.push_str(&format!(
-        "  tests passed=false {:>8}  {:>10}\n",
+    );
+    let _ = writeln!(
+        out,
+        "  tests passed=false {:>8}  {:>10}",
         report.confusion.failed_resolved, report.confusion.failed_unresolved
-    ));
-    out.push_str(&format!(
-        "  tests passed=None  {:>8}  {:>10}\n",
+    );
+    let _ = writeln!(
+        out,
+        "  tests passed=None  {:>8}  {:>10}",
         report.confusion.none_resolved, report.confusion.none_unresolved
-    ));
+    );
     out.push('\n');
 
     // ── Metrics ───────────────────────────────────────────────────────────────
     out.push_str("Metrics:\n");
     match report.metrics.precision {
-        Some(p) => out.push_str(&format!("  Precision:          {p:.3}\n")),
+        Some(p) => {
+            let _ = writeln!(out, "  Precision:          {p:.3}");
+        }
         None => out.push_str("  Precision:          N/A (no passed rows)\n"),
     }
     match report.metrics.recall {
-        Some(r) => out.push_str(&format!("  Recall:             {r:.3}\n")),
+        Some(r) => {
+            let _ = writeln!(out, "  Recall:             {r:.3}");
+        }
         None => out.push_str("  Recall:             N/A (no resolved rows)\n"),
     }
-    out.push_str(&format!(
-        "  Brier score:        {:.3}\n",
+    let _ = writeln!(
+        out,
+        "  Brier score:        {:.3}",
         report.metrics.brier_score
-    ));
-    out.push_str(&format!(
-        "  Base rate:          {:.3}\n",
-        report.base_rate
-    ));
+    );
+    let _ = writeln!(out, "  Base rate:          {:.3}", report.base_rate);
     match report.calibration_delta {
-        Some(d) => out.push_str(&format!("  Calibration delta:  {d:+.3}\n")),
+        Some(d) => {
+            let _ = writeln!(out, "  Calibration delta:  {d:+.3}");
+        }
         None => out.push_str("  Calibration delta:  N/A\n"),
     }
-    out.push_str(&format!(
-        "  Excluded (None):    {}\n",
-        report.n_excluded_none
-    ));
+    let _ = writeln!(out, "  Excluded (None):    {}", report.n_excluded_none);
     out.push('\n');
 
     // ── False positives ───────────────────────────────────────────────────────
     if list_n > 0 && !report.false_positives.is_empty() {
         let shown = report.false_positives.len().min(list_n);
-        out.push_str(&format!(
-            "False positives (tests_passed=true, resolved=false) — first {shown}:\n"
-        ));
+        let _ = writeln!(
+            out,
+            "False positives (tests_passed=true, resolved=false) — first {shown}:"
+        );
         for id in report.false_positives.iter().take(list_n) {
-            out.push_str(&format!("  {id}\n"));
+            let _ = writeln!(out, "  {id}");
         }
         out.push('\n');
     }
@@ -380,11 +395,12 @@ pub fn render_text(report: &SelfCheckReport, list_n: usize) -> String {
     // ── False negatives ───────────────────────────────────────────────────────
     if list_n > 0 && !report.false_negatives.is_empty() {
         let shown = report.false_negatives.len().min(list_n);
-        out.push_str(&format!(
-            "False negatives (tests_passed=false, resolved=true) — first {shown}:\n"
-        ));
+        let _ = writeln!(
+            out,
+            "False negatives (tests_passed=false, resolved=true) — first {shown}:"
+        );
         for id in report.false_negatives.iter().take(list_n) {
-            out.push_str(&format!("  {id}\n"));
+            let _ = writeln!(out, "  {id}");
         }
         out.push('\n');
     }
@@ -393,15 +409,16 @@ pub fn render_text(report: &SelfCheckReport, list_n: usize) -> String {
     if let Some(by_repo) = &report.by_repo {
         out.push_str("Per-repository breakdown:\n");
         for (repo, c) in by_repo {
-            out.push_str(&format!(
-                "  {repo}: TP={} FP={} FN={} TN={} None+R={} None+U={}\n",
+            let _ = writeln!(
+                out,
+                "  {repo}: TP={} FP={} FN={} TN={} None+R={} None+U={}",
                 c.passed_resolved,
                 c.passed_unresolved,
                 c.failed_resolved,
                 c.failed_unresolved,
                 c.none_resolved,
                 c.none_unresolved
-            ));
+            );
         }
     }
 

--- a/tests/bench_self_check.rs
+++ b/tests/bench_self_check.rs
@@ -1,0 +1,683 @@
+//! Tests for `bench self-check` — agent self-verdict calibration (issue #300).
+//!
+//! Red → Green → Refactor TDD cycle.
+//!
+//! AC items covered:
+//! (a) all-resolved with all `last_tests_passed = true` → precision 1.0, recall 1.0, Brier 0.0
+//! (b) all-resolved with all `None` → n_excluded_none = N, Brier = 0.25
+//! (c) mixed sweep with deliberate counts → exact precision/recall/Brier values to 3 decimals
+//! (d) `--by-repo` produces one block per repository present
+//! (e) missing `evaluation.json` → exit 2 with helpful message
+//! (f) trajectory predates #46 field → exit 3 with which-field-missing pointer
+//! (g) `--format json` output round-trips through `serde_json::from_str::<SelfCheckReport>`
+//! (perf) 300-instance sweep completes in < 2 seconds
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::too_many_lines,
+    clippy::cast_precision_loss
+)]
+
+use std::path::Path;
+use std::time::Instant;
+
+use maxwells_daemon::run::self_check::{SelfCheckArgs, SelfCheckReport, run as run_self_check};
+
+// ── fixture writers ───────────────────────────────────────────────────────────
+
+/// Write a minimal trajectory JSON with `tests_run_before_submit` present (#46 field).
+fn write_trajectory(
+    dir: &Path,
+    instance_id: &str,
+    last_tests_passed: Option<bool>,
+) {
+    let ltp = match last_tests_passed {
+        Some(true) => "true",
+        Some(false) => "false",
+        None => "null",
+    };
+    let content = format!(
+        r#"{{
+  "trajectory_format": "mini-swe-agent-1.3",
+  "info": {{
+    "tests_run_before_submit": {},
+    "last_tests_passed": {}
+  }},
+  "messages": []
+}}"#,
+        last_tests_passed.unwrap_or(false),
+        ltp
+    );
+    std::fs::write(dir.join(format!("{instance_id}.traj.json")), content).unwrap();
+}
+
+/// Write a trajectory that LACKS `tests_run_before_submit` (predates #46).
+fn write_legacy_trajectory(dir: &Path, instance_id: &str) {
+    let content = r#"{
+  "trajectory_format": "mini-swe-agent-1.2",
+  "info": {
+    "outcome": "submitted"
+  },
+  "messages": []
+}"#;
+    std::fs::write(dir.join(format!("{instance_id}.traj.json")), content).unwrap();
+}
+
+/// Write an `evaluation.json` with the given instance verdicts.
+fn write_evaluation_json(dir: &Path, verdicts: &[(&str, bool)]) {
+    let instances: Vec<String> = verdicts
+        .iter()
+        .map(|(id, resolved)| {
+            format!(
+                r#"  {{"instance_id": "{id}", "resolved": {resolved}, "eval_exit_reason": "ok"}}"#
+            )
+        })
+        .collect();
+    let content = format!(
+        r#"{{
+  "artifact_kind": "evaluation_results",
+  "schema_version": 1,
+  "instances": [
+{}
+  ],
+  "behavioral": {{
+    "tests_run_before_submit_rate": 0.5,
+    "resolved_rate_when_tests_run": 0.6,
+    "resolved_rate_when_tests_skipped": 0.4
+  }}
+}}"#,
+        instances.join(",\n")
+    );
+    std::fs::write(dir.join("evaluation.json"), content).unwrap();
+}
+
+// ── test (a): all-resolved, all tests passed ──────────────────────────────────
+
+/// AC (a): all-resolved sweep with all `last_tests_passed = true`
+/// → precision 1.0, recall 1.0, Brier 0.0
+#[test]
+fn all_resolved_all_tests_passed_precision_recall_brier() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    // 5 instances: all resolved, all tests passed
+    let instances = ["inst-a", "inst-b", "inst-c", "inst-d", "inst-e"];
+    for id in &instances {
+        write_trajectory(dir, id, Some(true));
+    }
+    write_evaluation_json(dir, &instances.iter().map(|id| (*id, true)).collect::<Vec<_>>());
+
+    let report = run_self_check(&SelfCheckArgs {
+        sweep_dir: dir.to_path_buf(),
+        format: "text".into(),
+        list: 10,
+        by_repo: false,
+    })
+    .expect("should succeed");
+
+    // All 5 are TP
+    assert_eq!(report.confusion.passed_resolved, 5, "all should be TP");
+    assert_eq!(report.confusion.passed_unresolved, 0);
+    assert_eq!(report.confusion.failed_resolved, 0);
+    assert_eq!(report.confusion.failed_unresolved, 0);
+    assert_eq!(report.confusion.none_resolved, 0);
+    assert_eq!(report.confusion.none_unresolved, 0);
+
+    assert_eq!(report.metrics.precision, Some(1.0), "precision must be 1.0");
+    assert_eq!(report.metrics.recall, Some(1.0), "recall must be 1.0");
+    assert_eq!(report.metrics.brier_score, 0.0, "brier score must be 0.0");
+
+    assert!(report.false_positives.is_empty(), "no false positives");
+    assert!(report.false_negatives.is_empty(), "no false negatives");
+    assert_eq!(report.n_excluded_none, 0);
+}
+
+// ── test (b): all-resolved, all `last_tests_passed = None` ───────────────────
+
+/// AC (b): all-resolved sweep with all `None`
+/// → n_excluded_none = N, Brier ≈ 0.25 (documented non-zero)
+#[test]
+fn all_resolved_all_none_brier_and_excluded_count() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    let instances = ["inst-1", "inst-2", "inst-3", "inst-4"];
+    for id in &instances {
+        write_trajectory(dir, id, None);
+    }
+    write_evaluation_json(dir, &instances.iter().map(|id| (*id, true)).collect::<Vec<_>>());
+
+    let report = run_self_check(&SelfCheckArgs {
+        sweep_dir: dir.to_path_buf(),
+        format: "text".into(),
+        list: 10,
+        by_repo: false,
+    })
+    .expect("should succeed");
+
+    assert_eq!(
+        report.n_excluded_none,
+        4,
+        "all 4 should be excluded from precision/recall (n_excluded_none)"
+    );
+    assert_eq!(
+        report.confusion.none_resolved,
+        4,
+        "all 4 none+resolved"
+    );
+
+    // Precision/recall undefined when no passed/failed rows
+    assert_eq!(
+        report.metrics.precision, None,
+        "precision undefined with all-none"
+    );
+    assert_eq!(
+        report.metrics.recall, None,
+        "recall undefined with all-none"
+    );
+
+    // Brier: all f_i = 0.5, all y_i = 1.0 → (0.5 - 1.0)^2 = 0.25 per instance
+    assert!(
+        (report.metrics.brier_score - 0.25).abs() < 1e-6,
+        "Brier score should be 0.25 for all-none all-resolved, got {}",
+        report.metrics.brier_score
+    );
+}
+
+// ── test (c): mixed sweep, exact metric values ────────────────────────────────
+
+/// AC (c): mixed sweep — verify exact precision/recall/Brier to 3 decimals.
+///
+/// Setup:
+///   3 TP (tests_passed=true, resolved=true)
+///   2 FP (tests_passed=true, resolved=false)
+///   1 FN (tests_passed=false, resolved=true)
+///   4 TN (tests_passed=false, resolved=false)
+///   2 None+resolved, 1 None+unresolved
+///
+/// precision = 3/(3+2) = 0.6
+/// recall    = 3/(3+1) = 0.75
+/// Brier = (3*0 + 2*1 + 1*1 + 4*0 + 2*0.25 + 1*0.25) / 13
+///       = (0 + 2 + 1 + 0 + 0.5 + 0.25) / 13
+///       = 3.75 / 13 ≈ 0.28846… → rounded to 3 decimals = 0.288
+#[test]
+fn mixed_sweep_exact_metrics() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    // TP x3
+    write_trajectory(dir, "tp-1", Some(true));
+    write_trajectory(dir, "tp-2", Some(true));
+    write_trajectory(dir, "tp-3", Some(true));
+    // FP x2
+    write_trajectory(dir, "fp-1", Some(true));
+    write_trajectory(dir, "fp-2", Some(true));
+    // FN x1
+    write_trajectory(dir, "fn-1", Some(false));
+    // TN x4
+    write_trajectory(dir, "tn-1", Some(false));
+    write_trajectory(dir, "tn-2", Some(false));
+    write_trajectory(dir, "tn-3", Some(false));
+    write_trajectory(dir, "tn-4", Some(false));
+    // None+resolved x2
+    write_trajectory(dir, "none-r-1", None);
+    write_trajectory(dir, "none-r-2", None);
+    // None+unresolved x1
+    write_trajectory(dir, "none-u-1", None);
+
+    write_evaluation_json(
+        dir,
+        &[
+            ("tp-1", true),
+            ("tp-2", true),
+            ("tp-3", true),
+            ("fp-1", false),
+            ("fp-2", false),
+            ("fn-1", true),
+            ("tn-1", false),
+            ("tn-2", false),
+            ("tn-3", false),
+            ("tn-4", false),
+            ("none-r-1", true),
+            ("none-r-2", true),
+            ("none-u-1", false),
+        ],
+    );
+
+    let report = run_self_check(&SelfCheckArgs {
+        sweep_dir: dir.to_path_buf(),
+        format: "text".into(),
+        list: 10,
+        by_repo: false,
+    })
+    .expect("should succeed");
+
+    assert_eq!(report.confusion.passed_resolved, 3, "TP");
+    assert_eq!(report.confusion.passed_unresolved, 2, "FP");
+    assert_eq!(report.confusion.failed_resolved, 1, "FN");
+    assert_eq!(report.confusion.failed_unresolved, 4, "TN");
+    assert_eq!(report.confusion.none_resolved, 2, "None+resolved");
+    assert_eq!(report.confusion.none_unresolved, 1, "None+unresolved");
+
+    // precision = 3/5 = 0.600
+    let prec = report.metrics.precision.expect("precision defined");
+    assert!(
+        (prec - 0.6).abs() < 0.001,
+        "precision expected 0.600, got {prec:.3}"
+    );
+
+    // recall = 3/4 = 0.750
+    let rec = report.metrics.recall.expect("recall defined");
+    assert!(
+        (rec - 0.75).abs() < 0.001,
+        "recall expected 0.750, got {rec:.3}"
+    );
+
+    // Brier = (2 + 1 + 0.5 + 0.25) / 13 = 3.75/13 ≈ 0.2885 → 0.288 at 3dp
+    let expected_brier: f64 = 3.75 / 13.0;
+    assert!(
+        (report.metrics.brier_score - (expected_brier * 1000.0).round() / 1000.0).abs() < 1e-9,
+        "brier expected ≈{:.3}, got {:.3}",
+        expected_brier,
+        report.metrics.brier_score
+    );
+
+    // False positives: fp-1, fp-2 (sorted)
+    assert_eq!(report.false_positives, vec!["fp-1", "fp-2"]);
+    // False negatives: fn-1
+    assert_eq!(report.false_negatives, vec!["fn-1"]);
+
+    // n_excluded_none = 2 + 1 = 3
+    assert_eq!(report.n_excluded_none, 3);
+
+    // base_rate = (3+1+2) / 13 = 6/13 ≈ 0.462
+    let expected_base_rate = 6.0 / 13.0;
+    assert!(
+        (report.base_rate - expected_base_rate).abs() < 1e-9,
+        "base_rate expected {expected_base_rate:.4}, got {:.4}",
+        report.base_rate
+    );
+
+    // calibration_delta = precision - base_rate = 0.6 - 6/13 ≈ 0.138
+    let cal = report.calibration_delta.expect("calibration_delta defined");
+    let expected_cal = prec - expected_base_rate;
+    assert!(
+        (cal - expected_cal).abs() < 1e-3,
+        "calibration_delta expected {expected_cal:.4}, got {cal:.4}"
+    );
+}
+
+// ── test (d): --by-repo flag ──────────────────────────────────────────────────
+
+/// AC (d): `--by-repo` produces one block per repository present.
+///
+/// Instance IDs follow SWE-bench format: `owner__repo-NNNNN`.
+#[test]
+fn by_repo_flag_produces_per_repo_breakdown() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    // django__django repo (2 instances)
+    write_trajectory(dir, "django__django-10087", Some(true));
+    write_trajectory(dir, "django__django-10243", Some(false));
+
+    // sympy__sympy repo (1 instance)
+    write_trajectory(dir, "sympy__sympy-12345", Some(true));
+
+    write_evaluation_json(
+        dir,
+        &[
+            ("django__django-10087", true),
+            ("django__django-10243", true),
+            ("sympy__sympy-12345", false),
+        ],
+    );
+
+    let report = run_self_check(&SelfCheckArgs {
+        sweep_dir: dir.to_path_buf(),
+        format: "text".into(),
+        list: 10,
+        by_repo: true,
+    })
+    .expect("should succeed");
+
+    let by_repo = report.by_repo.expect("by_repo must be present");
+    assert_eq!(by_repo.len(), 2, "should have 2 repos");
+    assert!(by_repo.contains_key("django/django"), "should have django/django");
+    assert!(by_repo.contains_key("sympy/sympy"), "should have sympy/sympy");
+
+    let django = &by_repo["django/django"];
+    // django__django-10087: passed=true, resolved=true → TP
+    // django__django-10243: passed=false, resolved=true → FN
+    assert_eq!(django.passed_resolved, 1, "django TP");
+    assert_eq!(django.failed_resolved, 1, "django FN");
+
+    let sympy = &by_repo["sympy/sympy"];
+    // sympy__sympy-12345: passed=true, resolved=false → FP
+    assert_eq!(sympy.passed_unresolved, 1, "sympy FP");
+}
+
+// ── test (e): missing evaluation.json → exit 2 ───────────────────────────────
+
+/// AC (e): missing `evaluation.json` → error, and exit code maps to 2.
+#[test]
+fn missing_evaluation_json_returns_config_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    // Write some trajectories, but no evaluation.json
+    write_trajectory(dir, "some-instance-1", Some(true));
+
+    let result = run_self_check(&SelfCheckArgs {
+        sweep_dir: dir.to_path_buf(),
+        format: "text".into(),
+        list: 10,
+        by_repo: false,
+    });
+
+    assert!(result.is_err(), "should fail when evaluation.json is missing");
+    let err = result.unwrap_err();
+    let err_str = err.to_string();
+    assert!(
+        err_str.contains("evaluation.json") || err_str.contains("evaluation"),
+        "error message should mention evaluation.json, got: {err_str}"
+    );
+
+    // Verify exit code maps to 2 (UsageError)
+    let code = maxwells_daemon::exit_code::ExitCode::from_error(&err);
+    assert_eq!(
+        code.as_i32(),
+        2,
+        "missing evaluation.json should produce exit code 2, got {}",
+        code.as_i32()
+    );
+}
+
+// ── test (f): pre-#46 trajectory → exit 3 ────────────────────────────────────
+
+/// AC (f): trajectory predates #46 field → exit 3 with which-field-missing pointer.
+#[test]
+fn legacy_trajectory_missing_test_field_returns_preflight_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    // One modern trajectory and one legacy
+    write_trajectory(dir, "modern-inst", Some(true));
+    write_legacy_trajectory(dir, "legacy-inst");
+
+    write_evaluation_json(
+        dir,
+        &[("modern-inst", true), ("legacy-inst", false)],
+    );
+
+    let result = run_self_check(&SelfCheckArgs {
+        sweep_dir: dir.to_path_buf(),
+        format: "text".into(),
+        list: 10,
+        by_repo: false,
+    });
+
+    assert!(result.is_err(), "should fail for legacy trajectory");
+    let err = result.unwrap_err();
+    let err_str = err.to_string();
+    assert!(
+        err_str.contains("tests_run_before_submit") || err_str.contains("#46"),
+        "error should mention which field is missing: {err_str}"
+    );
+
+    // Verify exit code maps to 3 (PreflightFailure / schema mismatch)
+    let code = maxwells_daemon::exit_code::ExitCode::from_error(&err);
+    assert_eq!(
+        code.as_i32(),
+        3,
+        "legacy trajectory should produce exit code 3, got {}",
+        code.as_i32()
+    );
+}
+
+// ── test (g): JSON round-trip ─────────────────────────────────────────────────
+
+/// AC (g): `--format json` output round-trips through `serde_json::from_str::<SelfCheckReport>`.
+#[test]
+fn json_output_round_trips_cleanly() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    write_trajectory(dir, "inst-a", Some(true));
+    write_trajectory(dir, "inst-b", Some(false));
+    write_trajectory(dir, "inst-c", None);
+    write_evaluation_json(dir, &[("inst-a", true), ("inst-b", false), ("inst-c", true)]);
+
+    let report = run_self_check(&SelfCheckArgs {
+        sweep_dir: dir.to_path_buf(),
+        format: "json".into(),
+        list: 10,
+        by_repo: false,
+    })
+    .expect("should succeed");
+
+    let json = serde_json::to_string_pretty(&report).expect("serialization must succeed");
+    let roundtripped: SelfCheckReport =
+        serde_json::from_str(&json).expect("round-trip deserialization must succeed");
+
+    assert_eq!(
+        roundtripped.schema, "bench-self-check/1",
+        "schema field must survive round-trip"
+    );
+    assert_eq!(
+        roundtripped.confusion.passed_resolved,
+        report.confusion.passed_resolved
+    );
+    assert_eq!(roundtripped.base_rate, report.base_rate);
+    assert_eq!(roundtripped.n_excluded_none, report.n_excluded_none);
+}
+
+// ── test: confusion matrix totals are correct ─────────────────────────────────
+
+#[test]
+fn confusion_matrix_totals_are_consistent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    write_trajectory(dir, "i1", Some(true));
+    write_trajectory(dir, "i2", Some(true));
+    write_trajectory(dir, "i3", Some(false));
+    write_trajectory(dir, "i4", None);
+    write_evaluation_json(dir, &[("i1", true), ("i2", false), ("i3", false), ("i4", true)]);
+
+    let report = run_self_check(&SelfCheckArgs {
+        sweep_dir: dir.to_path_buf(),
+        format: "text".into(),
+        list: 10,
+        by_repo: false,
+    })
+    .unwrap();
+
+    let c = &report.confusion;
+    let total = c.passed_resolved
+        + c.passed_unresolved
+        + c.failed_resolved
+        + c.failed_unresolved
+        + c.none_resolved
+        + c.none_unresolved;
+    assert_eq!(total, 4, "total should match instance count");
+}
+
+// ── test: --list 0 suppresses false positive/negative lists ──────────────────
+
+#[test]
+fn list_zero_suppresses_false_positives_negatives() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    write_trajectory(dir, "fp-inst", Some(true));
+    write_trajectory(dir, "tp-inst", Some(true));
+    write_evaluation_json(dir, &[("fp-inst", false), ("tp-inst", true)]);
+
+    let report = run_self_check(&SelfCheckArgs {
+        sweep_dir: dir.to_path_buf(),
+        format: "text".into(),
+        list: 0,
+        by_repo: false,
+    })
+    .unwrap();
+
+    // The report always stores all IDs internally; list=0 only affects rendering.
+    // The run() function returns all FPs; the render limits.
+    // Actually the spec says `--list 0` to suppress rendering, not the data.
+    // Let's verify the internal list has the fp-inst:
+    assert!(
+        report.false_positives.contains(&"fp-inst".to_owned()),
+        "false_positives must be populated regardless of --list"
+    );
+}
+
+// ── test: text format contains expected sections ──────────────────────────────
+
+#[test]
+fn text_format_contains_required_sections() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    write_trajectory(dir, "tp", Some(true));
+    write_trajectory(dir, "fp", Some(true));
+    write_trajectory(dir, "fn_", Some(false));
+    write_trajectory(dir, "tn", Some(false));
+    write_evaluation_json(
+        dir,
+        &[("tp", true), ("fp", false), ("fn_", true), ("tn", false)],
+    );
+
+    let report = run_self_check(&SelfCheckArgs {
+        sweep_dir: dir.to_path_buf(),
+        format: "text".into(),
+        list: 10,
+        by_repo: false,
+    })
+    .unwrap();
+
+    let text = maxwells_daemon::run::self_check::render_text(&report, 10);
+
+    assert!(
+        text.contains("precision") || text.contains("Precision"),
+        "text must mention precision"
+    );
+    assert!(
+        text.contains("recall") || text.contains("Recall"),
+        "text must mention recall"
+    );
+    assert!(
+        text.contains("brier") || text.contains("Brier"),
+        "text must mention Brier score"
+    );
+    assert!(
+        text.contains("calibration") || text.contains("Calibration"),
+        "text must show calibration delta"
+    );
+}
+
+// ── test: calibration_delta positive when precision > base_rate ──────────────
+
+#[test]
+fn calibration_delta_is_positive_when_precision_exceeds_base_rate() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    // 9 TP, 1 FP, 0 FN, 10 TN
+    // precision = 9/10 = 0.9
+    // base_rate = 9/20 = 0.45
+    // calibration_delta = 0.9 - 0.45 = 0.45 (positive)
+    for i in 0..9 {
+        write_trajectory(dir, &format!("tp-{i}"), Some(true));
+    }
+    write_trajectory(dir, "fp-0", Some(true));
+    for i in 0..10 {
+        write_trajectory(dir, &format!("tn-{i}"), Some(false));
+    }
+
+    let verdicts: Vec<(&str, bool)> = Vec::new();
+    // We need stable string refs; build them first
+    let tp_ids: Vec<String> = (0..9).map(|i| format!("tp-{i}")).collect();
+    let tn_ids: Vec<String> = (0..10).map(|i| format!("tn-{i}")).collect();
+
+    let mut pairs: Vec<(String, bool)> = Vec::new();
+    for id in &tp_ids {
+        pairs.push((id.clone(), true));
+    }
+    pairs.push(("fp-0".to_owned(), false));
+    for id in &tn_ids {
+        pairs.push((id.clone(), false));
+    }
+
+    let verdict_refs: Vec<(&str, bool)> = pairs.iter().map(|(id, b)| (id.as_str(), *b)).collect();
+    write_evaluation_json(dir, &verdict_refs);
+    drop(verdicts);
+
+    let report = run_self_check(&SelfCheckArgs {
+        sweep_dir: dir.to_path_buf(),
+        format: "text".into(),
+        list: 10,
+        by_repo: false,
+    })
+    .unwrap();
+
+    let delta = report.calibration_delta.expect("calibration_delta defined");
+    assert!(
+        delta > 0.0,
+        "calibration_delta should be positive when precision > base_rate, got {delta}"
+    );
+}
+
+// ── perf test: 300 instances < 2s ────────────────────────────────────────────
+
+/// Performance regression test: 300-instance sweep must complete in < 2 seconds.
+#[test]
+fn perf_300_instances_under_2_seconds() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    let n = 300usize;
+    let mut verdicts: Vec<(String, bool)> = Vec::with_capacity(n);
+
+    for i in 0..n {
+        let id = format!("django__django-{i:05}");
+        let ltp = match i % 3 {
+            0 => Some(true),
+            1 => Some(false),
+            _ => None,
+        };
+        write_trajectory(dir, &id, ltp);
+        verdicts.push((id, i % 2 == 0));
+    }
+
+    let verdict_refs: Vec<(&str, bool)> = verdicts
+        .iter()
+        .map(|(id, b)| (id.as_str(), *b))
+        .collect();
+    write_evaluation_json(dir, &verdict_refs);
+
+    let start = Instant::now();
+    let report = run_self_check(&SelfCheckArgs {
+        sweep_dir: dir.to_path_buf(),
+        format: "text".into(),
+        list: 10,
+        by_repo: false,
+    })
+    .expect("should succeed");
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed.as_secs() < 2,
+        "300-instance sweep should complete in < 2s, took {:?}",
+        elapsed
+    );
+
+    let total = report.confusion.passed_resolved
+        + report.confusion.passed_unresolved
+        + report.confusion.failed_resolved
+        + report.confusion.failed_unresolved
+        + report.confusion.none_resolved
+        + report.confusion.none_unresolved;
+    assert_eq!(total, 300, "all 300 instances accounted for");
+}

--- a/tests/bench_self_check.rs
+++ b/tests/bench_self_check.rs
@@ -125,7 +125,10 @@ fn all_resolved_all_tests_passed_precision_recall_brier() {
 
     assert_eq!(report.metrics.precision, Some(1.0), "precision must be 1.0");
     assert_eq!(report.metrics.recall, Some(1.0), "recall must be 1.0");
-    assert_eq!(report.metrics.brier_score, 0.0, "brier score must be 0.0");
+    assert!(
+        (report.metrics.brier_score - 0.0).abs() < 1e-9,
+        "brier score must be 0.0"
+    );
 
     assert!(report.false_positives.is_empty(), "no false positives");
     assert!(report.false_negatives.is_empty(), "no false negatives");
@@ -475,7 +478,7 @@ fn json_output_round_trips_cleanly() {
         roundtripped.confusion.passed_resolved,
         report.confusion.passed_resolved
     );
-    assert_eq!(roundtripped.base_rate, report.base_rate);
+    assert!((roundtripped.base_rate - report.base_rate).abs() < 1e-9);
     assert_eq!(roundtripped.n_excluded_none, report.n_excluded_none);
 }
 
@@ -605,23 +608,21 @@ fn calibration_delta_is_positive_when_precision_exceeds_base_rate() {
         write_trajectory(dir, &format!("tn-{i}"), Some(false));
     }
 
-    let verdicts: Vec<(&str, bool)> = Vec::new();
     // We need stable string refs; build them first
-    let tp_ids: Vec<String> = (0..9).map(|i| format!("tp-{i}")).collect();
-    let tn_ids: Vec<String> = (0..10).map(|i| format!("tn-{i}")).collect();
+    let positive_ids: Vec<String> = (0..9).map(|i| format!("tp-{i}")).collect();
+    let negative_ids: Vec<String> = (0..10).map(|i| format!("tn-{i}")).collect();
 
     let mut pairs: Vec<(String, bool)> = Vec::new();
-    for id in &tp_ids {
+    for id in &positive_ids {
         pairs.push((id.clone(), true));
     }
     pairs.push(("fp-0".to_owned(), false));
-    for id in &tn_ids {
+    for id in &negative_ids {
         pairs.push((id.clone(), false));
     }
 
     let verdict_refs: Vec<(&str, bool)> = pairs.iter().map(|(id, b)| (id.as_str(), *b)).collect();
     write_evaluation_json(dir, &verdict_refs);
-    drop(verdicts);
 
     let report = run_self_check(&SelfCheckArgs {
         sweep_dir: dir.to_path_buf(),
@@ -676,8 +677,7 @@ fn perf_300_instances_under_2_seconds() {
 
     assert!(
         elapsed.as_secs() < 2,
-        "300-instance sweep should complete in < 2s, took {:?}",
-        elapsed
+        "300-instance sweep should complete in < 2s, took {elapsed:?}"
     );
 
     let total = report.confusion.passed_resolved

--- a/tests/bench_self_check.rs
+++ b/tests/bench_self_check.rs
@@ -27,11 +27,7 @@ use maxwells_daemon::run::self_check::{SelfCheckArgs, SelfCheckReport, run as ru
 // ── fixture writers ───────────────────────────────────────────────────────────
 
 /// Write a minimal trajectory JSON with `tests_run_before_submit` present (#46 field).
-fn write_trajectory(
-    dir: &Path,
-    instance_id: &str,
-    last_tests_passed: Option<bool>,
-) {
+fn write_trajectory(dir: &Path, instance_id: &str, last_tests_passed: Option<bool>) {
     let ltp = match last_tests_passed {
         Some(true) => "true",
         Some(false) => "false",
@@ -106,7 +102,10 @@ fn all_resolved_all_tests_passed_precision_recall_brier() {
     for id in &instances {
         write_trajectory(dir, id, Some(true));
     }
-    write_evaluation_json(dir, &instances.iter().map(|id| (*id, true)).collect::<Vec<_>>());
+    write_evaluation_json(
+        dir,
+        &instances.iter().map(|id| (*id, true)).collect::<Vec<_>>(),
+    );
 
     let report = run_self_check(&SelfCheckArgs {
         sweep_dir: dir.to_path_buf(),
@@ -146,7 +145,10 @@ fn all_resolved_all_none_brier_and_excluded_count() {
     for id in &instances {
         write_trajectory(dir, id, None);
     }
-    write_evaluation_json(dir, &instances.iter().map(|id| (*id, true)).collect::<Vec<_>>());
+    write_evaluation_json(
+        dir,
+        &instances.iter().map(|id| (*id, true)).collect::<Vec<_>>(),
+    );
 
     let report = run_self_check(&SelfCheckArgs {
         sweep_dir: dir.to_path_buf(),
@@ -157,15 +159,10 @@ fn all_resolved_all_none_brier_and_excluded_count() {
     .expect("should succeed");
 
     assert_eq!(
-        report.n_excluded_none,
-        4,
+        report.n_excluded_none, 4,
         "all 4 should be excluded from precision/recall (n_excluded_none)"
     );
-    assert_eq!(
-        report.confusion.none_resolved,
-        4,
-        "all 4 none+resolved"
-    );
+    assert_eq!(report.confusion.none_resolved, 4, "all 4 none+resolved");
 
     // Precision/recall undefined when no passed/failed rows
     assert_eq!(
@@ -344,8 +341,14 @@ fn by_repo_flag_produces_per_repo_breakdown() {
 
     let by_repo = report.by_repo.expect("by_repo must be present");
     assert_eq!(by_repo.len(), 2, "should have 2 repos");
-    assert!(by_repo.contains_key("django/django"), "should have django/django");
-    assert!(by_repo.contains_key("sympy/sympy"), "should have sympy/sympy");
+    assert!(
+        by_repo.contains_key("django/django"),
+        "should have django/django"
+    );
+    assert!(
+        by_repo.contains_key("sympy/sympy"),
+        "should have sympy/sympy"
+    );
 
     let django = &by_repo["django/django"];
     // django__django-10087: passed=true, resolved=true → TP
@@ -376,7 +379,10 @@ fn missing_evaluation_json_returns_config_error() {
         by_repo: false,
     });
 
-    assert!(result.is_err(), "should fail when evaluation.json is missing");
+    assert!(
+        result.is_err(),
+        "should fail when evaluation.json is missing"
+    );
     let err = result.unwrap_err();
     let err_str = err.to_string();
     assert!(
@@ -406,10 +412,7 @@ fn legacy_trajectory_missing_test_field_returns_preflight_error() {
     write_trajectory(dir, "modern-inst", Some(true));
     write_legacy_trajectory(dir, "legacy-inst");
 
-    write_evaluation_json(
-        dir,
-        &[("modern-inst", true), ("legacy-inst", false)],
-    );
+    write_evaluation_json(dir, &[("modern-inst", true), ("legacy-inst", false)]);
 
     let result = run_self_check(&SelfCheckArgs {
         sweep_dir: dir.to_path_buf(),
@@ -447,7 +450,10 @@ fn json_output_round_trips_cleanly() {
     write_trajectory(dir, "inst-a", Some(true));
     write_trajectory(dir, "inst-b", Some(false));
     write_trajectory(dir, "inst-c", None);
-    write_evaluation_json(dir, &[("inst-a", true), ("inst-b", false), ("inst-c", true)]);
+    write_evaluation_json(
+        dir,
+        &[("inst-a", true), ("inst-b", false), ("inst-c", true)],
+    );
 
     let report = run_self_check(&SelfCheckArgs {
         sweep_dir: dir.to_path_buf(),
@@ -484,7 +490,10 @@ fn confusion_matrix_totals_are_consistent() {
     write_trajectory(dir, "i2", Some(true));
     write_trajectory(dir, "i3", Some(false));
     write_trajectory(dir, "i4", None);
-    write_evaluation_json(dir, &[("i1", true), ("i2", false), ("i3", false), ("i4", true)]);
+    write_evaluation_json(
+        dir,
+        &[("i1", true), ("i2", false), ("i3", false), ("i4", true)],
+    );
 
     let report = run_self_check(&SelfCheckArgs {
         sweep_dir: dir.to_path_buf(),
@@ -651,10 +660,8 @@ fn perf_300_instances_under_2_seconds() {
         verdicts.push((id, i % 2 == 0));
     }
 
-    let verdict_refs: Vec<(&str, bool)> = verdicts
-        .iter()
-        .map(|(id, b)| (id.as_str(), *b))
-        .collect();
+    let verdict_refs: Vec<(&str, bool)> =
+        verdicts.iter().map(|(id, b)| (id.as_str(), *b)).collect();
     write_evaluation_json(dir, &verdict_refs);
 
     let start = Instant::now();


### PR DESCRIPTION
## Summary
Implements the `bench self-check` command (issue #300) to score the agent's self-reported test verdicts (`last_tests_passed`) against the external evaluator's ground truth (`resolved`). This is a zero-cost analysis tool that reads existing sweep artifacts and computes calibration metrics without any model or container invocations.

## Key Changes

- **New module `src/run/self_check.rs`**: Core implementation that:
  - Loads `evaluation.json` and trajectory files (`*.traj.json`) from a completed sweep
  - Builds a 3×2 confusion matrix (agent verdict × evaluator verdict)
  - Computes precision, recall, Brier score, and calibration delta
  - Supports per-repository breakdown via `--by-repo` flag
  - Validates that trajectories include the `tests_run_before_submit` field (added in harness #46)
  - Renders output in both human-readable text and JSON formats

- **CLI integration** (`src/cli/args.rs` and `src/cli/mod.rs`):
  - Added `SelfCheckCmd` struct with options for sweep directory, output format, false-positive/negative listing limit, and per-repo breakdown
  - Wired command into the `bench` subcommand dispatcher
  - Handles both text and JSON output rendering

- **Comprehensive test suite** (`tests/bench_self_check.rs`):
  - 683 lines of integration tests covering all acceptance criteria:
    - Perfect precision/recall/Brier when all tests pass and resolve
    - Correct handling of `None` verdicts (excluded from precision/recall, contribute 0.25 to Brier)
    - Mixed confusion matrix with exact metric validation to 3 decimal places
    - Per-repository breakdown functionality
    - Error handling for missing `evaluation.json` (exit code 2)
    - Error handling for pre-#46 trajectories (exit code 3)
    - JSON round-trip serialization
    - Performance regression test (300 instances in <2 seconds)

## Implementation Details

- **Confusion matrix**: 3 rows (tests_passed: true/false/None) × 2 columns (resolved: true/false)
- **Brier score**: Treats agent verdicts as probabilities (true=1.0, false=0.0, None=0.5) and computes MSE against ground truth, rounded to 3 decimals
- **Calibration delta**: `precision − base_rate`, indicating whether the agent's "passed" signal is more reliable than random
- **Repository parsing**: Extracts `owner/repo` from SWE-bench instance IDs (`owner__repo-NNNNN`)
- **Error codes**: 0 (success), 2 (missing evaluation.json), 3 (pre-#46 trajectory), 1 (I/O/parse errors)

https://claude.ai/code/session_01UQjSiJQ76xLJEGV82JqdoV