### PR TITLE
🌟 Nova: [Jupyter Notebook Exporter]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+jupyter-export = []
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/add_feature.py
+++ b/add_feature.py
@@ -1,0 +1,6 @@
+import re
+with open("Cargo.toml", "r") as f:
+    content = f.read()
+content = re.sub(r'mermaid-export = \[\]', 'mermaid-export = []\njupyter-export = []', content)
+with open("Cargo.toml", "w") as f:
+    f.write(content)

--- a/scaffold_jupyter.py
+++ b/scaffold_jupyter.py
@@ -1,0 +1,43 @@
+import re
+with open("src/trajectory/export.rs", "r") as f:
+    content = f.read()
+
+struct_def = """
+#[cfg(feature = "jupyter-export")]
+pub struct JupyterExporter;
+
+#[cfg(feature = "jupyter-export")]
+impl TrajectoryExporter for JupyterExporter {
+    fn export(_trajectory: &Trajectory) -> String {
+        String::new()
+    }
+}
+"""
+test_def = """
+    #[cfg(feature = "jupyter-export")]
+    #[test]
+    fn test_jupyter_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some("submitted".to_string());
+
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::user("Hello user"));
+
+        let jupyter = JupyterExporter::export(&t);
+
+        assert!(jupyter.starts_with("{"));
+        assert!(jupyter.contains("\\"cells\\""));
+        assert!(jupyter.contains("Add a feature"));
+        assert!(jupyter.contains("submitted"));
+        assert!(jupyter.contains("Hello agent"));
+        assert!(jupyter.contains("Hello user"));
+    }
+}
+"""
+# Ensure we only replace once by compiling regex and using count=1
+content = re.sub(r'pub struct HtmlExporter;', 'pub struct HtmlExporter;\n' + struct_def, content, count=1)
+# Replace the very end
+content = re.sub(r'\}\s*$', '', content) + test_def
+with open("src/trajectory/export.rs", "w") as f:
+    f.write(content)

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -53,6 +53,77 @@ pub struct MermaidExporter;
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
+#[cfg(feature = "jupyter-export")]
+pub struct JupyterExporter;
+
+#[cfg(feature = "jupyter-export")]
+impl TrajectoryExporter for JupyterExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut cells = Vec::new();
+
+        let mut header = String::from(
+            "# Trajectory Export
+
+",
+        );
+        if let Some(task) = &trajectory.info.task {
+            let task = redactor.redact_text(task, surface::EXPORT).text;
+            header.push_str(&format!(
+                "**Task:** {task}
+
+"
+            ));
+        }
+        if let Some(outcome) = &trajectory.info.outcome {
+            let outcome = redactor.redact_text(outcome, surface::EXPORT).text;
+            header.push_str(&format!(
+                "**Outcome:** {outcome}
+
+"
+            ));
+        }
+
+        cells.push(serde_json::json!({
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [header]
+        }));
+
+        for msg in &trajectory.messages {
+            let role_title = match msg.role.as_str() {
+                "system" => "System",
+                "user" => "User",
+                "assistant" => "Assistant",
+                "tool" => "Tool",
+                other => other,
+            };
+
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            let cell_source = format!(
+                "### {role_title}
+
+{content}"
+            );
+
+            cells.push(serde_json::json!({
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": [cell_source]
+            }));
+        }
+
+        let notebook = serde_json::json!({
+            "cells": cells,
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5
+        });
+
+        serde_json::to_string_pretty(&notebook).unwrap_or_default()
+    }
+}
+
 use std::fmt::Write;
 
 #[cfg(feature = "csv-export")]
@@ -339,5 +410,25 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+
+    #[cfg(feature = "jupyter-export")]
+    #[test]
+    fn test_jupyter_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some("submitted".to_string());
+
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::user("Hello user"));
+
+        let jupyter = JupyterExporter::export(&t);
+
+        assert!(jupyter.starts_with('{'));
+        assert!(jupyter.contains("\"cells\""));
+        assert!(jupyter.contains("Add a feature"));
+        assert!(jupyter.contains("submitted"));
+        assert!(jupyter.contains("Hello agent"));
+        assert!(jupyter.contains("Hello user"));
     }
 }


### PR DESCRIPTION
💡 **The Spark:** "We can inspect trajectories as markdown, csv, mermaid, and html. But what if data scientists want to analyze or render trajectories directly in Jupyter Notebooks?"
🚀 **The Feature:** "Implemented `JupyterExporter` behind a `jupyter-export` feature flag."
🔮 **The Potential:** "Allows direct integration of SWE-agent trajectories into data science workflows, enabling custom analysis or interactive visualization of the agent's behavior step-by-step."
⚠️ **Risk:** "Low. The feature is completely isolated behind the `jupyter-export` Cargo feature and does not affect the core agent loop or default build."

---
*PR created automatically by Jules for task [976829928483053257](https://jules.google.com/task/976829928483053257) started by @madmax983*