### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -8,7 +8,7 @@ macro_rules! string_id {
     ($name:ident) => {
         #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
         #[serde(transparent)]
-        pub struct $name(pub String);
+        pub struct $name(String);
 
         impl $name {
             pub fn new(s: impl Into<String>) -> Self {
@@ -44,7 +44,13 @@ string_id!(TaskId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct StepIdx(pub u32);
+pub struct StepIdx(u32);
+
+impl StepIdx {
+    pub const fn new(val: u32) -> Self {
+        Self(val)
+    }
+}
 
 impl StepIdx {
     pub const fn zero() -> Self {

--- a/tests/fuzz_step_idx.rs
+++ b/tests/fuzz_step_idx.rs
@@ -4,7 +4,7 @@ use proptest::prelude::*;
 proptest! {
     #[test]
     fn step_idx_next_never_panics(x in 0u32..=u32::MAX) {
-        let step = StepIdx(x);
+        let step = StepIdx::new(x);
         let _ = step.next();
     }
 }

--- a/tests/fuzz_step_idx_overflow.rs
+++ b/tests/fuzz_step_idx_overflow.rs
@@ -1,6 +1,6 @@
 #[test]
 fn step_idx_next_saturates_on_max() {
-    let mut step = maxwells_daemon::ids::StepIdx(u32::MAX);
+    let mut step = maxwells_daemon::ids::StepIdx::new(u32::MAX);
     step = step.next();
     assert_eq!(step.get(), u32::MAX);
 }


### PR DESCRIPTION
🕸️ Tangle: The structural problem is a leaky abstraction where `ContainerId`, `TaskId`, and `StepIdx` incorrectly expose their internal state (e.g. `pub String` and `pub u32`), making them behave like type aliases rather than strongly encapsulated domain boundaries.
📐 Blueprint: Remove the `pub` visibility modifier from the inner fields of the `string_id!` macro and `StepIdx` struct, and implement a `new` constructor for `StepIdx` to cleanly construct it without leaking representation.
🧱 Stability: Reduced coupling by encapsulating internal data representations, preventing external callers from relying on or modifying the underlying value directly.
🔭 Verification: Builds successfully (`cargo test` passes, strict isolation enforced).

---
*PR created automatically by Jules for task [6450942519909954876](https://jules.google.com/task/6450942519909954876) started by @madmax983*