### PR TITLE
🗺️ Atlas: [architectural change] Enforce strict boundaries on ID newtypes

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -8,7 +8,7 @@ macro_rules! string_id {
     ($name:ident) => {
         #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
         #[serde(transparent)]
-        pub struct $name(pub String);
+        pub struct $name(String);
 
         impl $name {
             pub fn new(s: impl Into<String>) -> Self {
@@ -44,9 +44,12 @@ string_id!(TaskId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct StepIdx(pub u32);
+pub struct StepIdx(u32);
 
 impl StepIdx {
+    pub const fn new(val: u32) -> Self {
+        Self(val)
+    }
     pub const fn zero() -> Self {
         Self(0)
     }

--- a/tests/fuzz_step_idx.rs
+++ b/tests/fuzz_step_idx.rs
@@ -4,7 +4,7 @@ use proptest::prelude::*;
 proptest! {
     #[test]
     fn step_idx_next_never_panics(x in 0u32..=u32::MAX) {
-        let step = StepIdx(x);
+        let step = StepIdx::new(x);
         let _ = step.next();
     }
 }

--- a/tests/fuzz_step_idx_overflow.rs
+++ b/tests/fuzz_step_idx_overflow.rs
@@ -1,6 +1,6 @@
 #[test]
 fn step_idx_next_saturates_on_max() {
-    let mut step = maxwells_daemon::ids::StepIdx(u32::MAX);
+    let mut step = maxwells_daemon::ids::StepIdx::new(u32::MAX);
     step = step.next();
     assert_eq!(step.get(), u32::MAX);
 }


### PR DESCRIPTION
🕸️ Tangle: The "New Types" for `ContainerId`, `TaskId`, and `StepIdx` were exposing their inner fields (`pub String`, `pub u32`) publicly. This created a "leaky abstraction" where external modules could bypass the types' public APIs to access or construct them via tuple struct literal syntax.

📐 Blueprint: Removed `pub` from the inner fields across the `string_id!` macro and `StepIdx` definition to truly enforce the "New Type" pattern boundary. Added a public `new` constructor for `StepIdx` since it can no longer be instantiated directly via literal syntax by external callers, and updated the fuzz tests to use the new constructor.

🧱 Stability: Enforces stricter boundaries and high cohesion. Prevents external code from relying on the internal representation of the IDs, making future refactors easier and safer without breaking downstream consumers.

🔬 Verification: `cargo clippy --all-targets --all-features -- -D warnings`, `cargo check`, and `cargo test` pass successfully. Tests that relied on public internal fields have been updated to utilize the new public APIs.

---
*PR created automatically by Jules for task [4276731891840298159](https://jules.google.com/task/4276731891840298159) started by @madmax983*