### PR TITLE
🎨 Mosaic: UI Polish for `bench grep`

### DIFF
--- a/src/run/grep.rs
+++ b/src/run/grep.rs
@@ -138,16 +138,27 @@ pub fn run(args: &GrepArgs) -> Result<GrepReport, Error> {
     })
 }
 
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+
 pub fn render_text(report: &GrepReport) -> String {
-    let mut out = String::new();
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec!["Instance ID", "Turn", "Role", "Snippet"]);
+
     for m in &report.matches {
         let snippet = m.snippet.replace(['\n', '\r', '\t'], " ");
-        let _ = writeln!(
-            out,
-            "{}\t{}\t{}\t{}",
-            m.instance_id, m.turn_index, m.role, snippet
-        );
+        table.add_row(vec![
+            m.instance_id.clone(),
+            m.turn_index.to_string(),
+            m.role.clone(),
+            snippet,
+        ]);
     }
+
+    let mut out = String::new();
+    let _ = writeln!(out, "{table}");
     out
 }
 


### PR DESCRIPTION
🖌️ **Before:** `bench grep` output was a raw, unformatted tab-separated text block, making it difficult to read and failing the "Mosaic" visual hierarchy standard.

✨ **After:** Formatted `bench grep` output into a clean, human-readable table using `comfy-table`.

🖼️ **Visuals:** Implemented a Z-Pattern scanning layout using UTF-8 table borders and clear column headers (Instance ID, Turn, Role, Snippet), aligning the CLI output with the rest of the ecosystem's dashboard-like tools.

---
*PR created automatically by Jules for task [8612136435901569015](https://jules.google.com/task/8612136435901569015) started by @madmax983*