### PR TITLE
Add `ui` command to serve a read-only local sweep browser (issue #319)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate lcov coverage
-        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --features ui-server --lcov --output-path lcov.info
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,8 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+# Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
+ui-server = ["html-export"]
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/docs/spec-web-ui.md
+++ b/docs/spec-web-ui.md
@@ -1,27 +1,191 @@
-# 🔭 Vantage: Spec for Web UI for Inspecting Trajectories
+# Spec: `max ui` — Local Sweep Browser
 
-## 👤 User Story
-"As a Developer running the agent locally, I want a full UI web application to inspect trajectories, so that I can easily debug, visualize, and analyze agent behavior without digging through raw JSON files."
+## Overview
 
-## ❓ The "So What?" (Business Problem)
-The current CLI-based trajectory inspection (`bench inspect`) requires scanning through long terminal outputs or parsing JSON arrays manually. As trajectories grow to 50+ steps with large code blocks, the terminal interface becomes a severe bottleneck. A visual UI dramatically speeds up debugging and review, ultimately reducing developer iteration time on prompts and tools. This directly reduces the cost of debugging complex agent behavior.
+`max ui` starts a read-only, single-binary HTTP server that lists every
+trajectory in a finished sweep and renders each one as HTML.  It is the
+fastest way to triage a completed sweep: one command opens a browser with
+every instance's outcome, cost, and step count.  Clicking an instance
+renders the full trajectory through the same `HtmlExporter` pipeline that
+`bench inspect --format html` uses.
 
-## 🎯 Metric Definition
-Success = An operator can find the specific step where the agent failed (or executed an unexpected command) within 30 seconds of opening the UI for a 50-step trajectory, compared to >2 minutes currently spent grepping JSON files.
+**This command requires the `ui-server` Cargo feature** (off by default).
+See [Feature Gate](#feature-gate).
 
-## ✅ Acceptance Criteria
-- Must provide a web-based interface (e.g., served locally or built as a static app) capable of loading `.traj.json` files.
-- Must visualize the timeline of steps (System Prompt, Assistant Message, Bash Command, Bash Output, etc.).
-- Must support collapsible/expandable sections for large text blocks (e.g., long standard output, multi-file diffs).
-- Must display run metadata prominently (Outcome, Total Cost USD, Token Usage, Failure Category).
-- Must be zero-config to run (e.g. `max ui --port 8080`).
+---
 
-## 🚫 Out of Scope
-- Real-time streaming UI integration (Phase 3).
-- Remote backend for aggregating sweeps (This is local-first).
-- Editing or modifying trajectories directly.
+## Quickstart
 
-## 🕳️ Gap Analysis
-- **mini-swe-agent**: Has a basic Python/Flask viewer.
-- **SWE-agent**: Has an interactive web UI.
-- **maxwells-daemon today**: Only has the terminal-based `bench inspect` subcommand. While functional, it is not scalable for reading full multi-turn coding sessions. Adding a built-in UI brings it to parity with SWE-agent for developer experience.
+```sh
+# Build with the feature enabled:
+cargo build --features ui-server
+
+# Serve a sweep and open the browser immediately:
+./target/debug/max ui --sweep runs/quickstart --port 0 --open
+# ui ready at http://127.0.0.1:XXXXX
+```
+
+---
+
+## CLI Reference
+
+```
+max ui --sweep <DIR> [--port <PORT>] [--bind <ADDR>] [--open]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--sweep <DIR>` | *(required)* | Path to a completed sweep directory containing `*.traj.json` files. |
+| `--port <PORT>` | `0` | TCP port to listen on. `0` means the OS assigns an available port. |
+| `--bind <ADDR>` | `127.0.0.1` | IP address to bind to. Default is loopback-only for safety. |
+| `--open` | off | Best-effort: launch the system browser to the index URL after binding. Launch failures are logged as warnings and are not fatal. |
+
+---
+
+## Routes
+
+| Path | Status | Content-Type | Description |
+|------|--------|--------------|-------------|
+| `GET /` | 200 | `text/html; charset=UTF-8` | Index page listing all discovered instances. |
+| `GET /instance/<id>` | 200 | `text/html; charset=UTF-8` | Full trajectory rendered by `HtmlExporter`. `<id>` must match a discovered `instance_id` exactly (case-sensitive). |
+| `GET /healthz` | 200 | `application/json` | `{"status":"ok"}`. Useful for process supervisors and smoke tests. |
+| Anything else | 404 | `text/plain` | All other paths return 404. |
+
+### Index page columns
+
+Instances are listed in an HTML table, **sorted by `instance_id` ascending**.
+Columns:
+
+| Column | Source field | Format |
+|--------|-------------|--------|
+| `instance_id` | Filename stem of `*.traj.json` | Clickable link to `/instance/<id>` |
+| `outcome` | `trajectory.info.outcome` | Raw string, e.g. `submitted`, `error` |
+| `steps` | `trajectory.info.steps` | Integer |
+| `total_cost_usd` | `trajectory.info.total_cost_usd` | 4 decimal places |
+| `duration_seconds` | `trajectory.info.duration_secs` | 1 decimal place |
+
+Missing values are displayed as `-`.
+
+### Query parameters
+
+None defined in this version.
+
+### Error model
+
+| Condition | HTTP status |
+|-----------|-------------|
+| Sweep directory missing or not a directory | Process exits before binding (exit 2) |
+| Instance trajectory unreadable at serve time | 500 Internal Server Error |
+| `instance_id` not in the discovered set | 404 Not Found |
+| All other unknown paths | 404 Not Found |
+
+---
+
+## Security
+
+### No directory traversal
+
+`instance_id` values in `/instance/<id>` are **validated against the set of
+instances discovered at startup**.  They are never used as filesystem paths.
+A request for `/instance/../../etc/passwd` returns 404; the server never
+opens any file path derived from the URL.
+
+### No network egress
+
+The server makes **zero outbound connections**.  It binds only to `--bind`
+(default `127.0.0.1`) and never connects to any external host.  This is a
+local-dev tool.  For remote access, SSH tunnel.
+
+---
+
+## Redaction
+
+Every byte rendered to the browser passes through the same pipeline as
+`bench inspect --format html` (see `docs/spec-secret-redaction.md`):
+
+```
+Redactor::default_enabled() + surface::EXPORT
+```
+
+The `HtmlExporter` applies this pipeline internally on every message field
+before writing HTML.  The index page contains only structured metadata
+(`instance_id`, `outcome`, `steps`, `cost`, `duration`), which are not
+arbitrary agent-generated text.
+
+---
+
+## Sweep Discovery
+
+At startup the server scans `--sweep` for all files matching `*.traj.json`.
+Files that cannot be parsed as valid trajectory JSON are skipped with a
+`WARN`-level log message.  The resulting list is sorted by `instance_id`
+ascending.  The scan is performed once at startup; the server does not watch
+for new trajectories while running.
+
+---
+
+## Feature Gate
+
+`max ui` is compiled only when the `ui-server` Cargo feature is enabled:
+
+```toml
+# Cargo.toml
+ui-server = ["html-export"]
+```
+
+When built **without** `ui-server`, any invocation of `max ui` exits
+immediately with:
+
+```
+outcome_class: feature_unavailable
+error: the `ui` command requires the `ui-server` Cargo feature, ...
+```
+
+Exit code: **24** (`feature_unavailable`).
+
+---
+
+## Exit Codes
+
+| Code | Label | Trigger |
+|------|-------|---------|
+| 0 | `success` | Server stopped cleanly after SIGINT / Ctrl-C. |
+| 2 | `usage_error` | Invalid `--bind` address, or `--sweep` directory not found. |
+| 24 | `feature_unavailable` | Binary built without `ui-server` feature. |
+
+---
+
+## Lifecycle
+
+1. Parse and validate CLI flags.
+2. Scan `--sweep` directory, build the instance list, sort by `instance_id`.
+3. Bind TCP listener on `--bind:--port` (port 0 = OS picks).
+4. Print `ui ready at http://<bind>:<port>` to **stdout** on a single line.
+5. If `--open`, attempt to launch the system browser (non-fatal on failure).
+6. Serve requests until SIGINT / Ctrl-C.
+7. Signal the accept loop to stop, drain in-flight connections, exit 0.
+
+---
+
+## Gap Analysis
+
+| Harness | Browsable UI? |
+|---------|---------------|
+| mini-swe-agent | Python/Flask viewer with collapsible panels |
+| SWE-agent (Princeton) | Interactive web UI used in published papers |
+| OpenHands | HTML session logs written by default, linked in CI |
+| Maxwell's Daemon (before this issue) | Terminal-only `bench inspect`; HTML exporter merged but not served |
+| **Maxwell's Daemon (this issue)** | **`max ui` — static HTML sweep browser** |
+
+---
+
+## Out of Scope (first slice)
+
+- Real-time streaming / live-tail of an in-flight sweep.
+- Multi-sweep dashboards or cross-sweep comparison views.
+- Editing, re-running, or annotating trajectories from the UI.
+- Remote / hosted deployment, auth, RBAC, or TLS.
+- Custom themes, syntax highlighting beyond what `HtmlExporter` emits.
+- JavaScript frameworks; inline HTML + CSS only.
+- New exporter formats (this wires the existing `HtmlExporter` only).
+- Pagination or server-side filtering of the index.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -487,6 +487,29 @@ pub struct HelloWorldCmd {
     pub config: Option<PathBuf>,
 }
 
+/// `ui` — serve a read-only local sweep browser (requires the `ui-server` feature).
+#[derive(Debug, Args)]
+pub struct UiCmd {
+    /// Path to a completed sweep directory containing `*.traj.json` files.
+    /// The directory must exist and contain at least one trajectory file.
+    #[arg(long, value_name = "DIR")]
+    pub sweep: PathBuf,
+
+    /// TCP port to listen on. `0` lets the OS pick an available port.
+    /// The actual bound port is printed to stdout on startup.
+    #[arg(long, default_value_t = 0, value_name = "PORT")]
+    pub port: u16,
+
+    /// IP address to bind the server to. Default is loopback-only for safety.
+    #[arg(long, default_value = "127.0.0.1", value_name = "ADDR")]
+    pub bind: String,
+
+    /// Best-effort: open the index URL in the system browser after binding.
+    /// Launch failures are logged as warnings and are not fatal.
+    #[arg(long, default_value_t = false)]
+    pub open: bool,
+}
+
 #[derive(Debug, Args)]
 pub struct ReplayCmd {
     /// Path to the original trajectory JSON file.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -51,6 +51,8 @@ pub enum Command {
         #[command(subcommand)]
         cmd: Box<args::AgentCmd>,
     },
+    /// Serve a read-only local sweep browser (requires the `ui-server` feature).
+    Ui(args::UiCmd),
     /// Reap leftover Maxwell's Daemon containers, including legacy labels.
     Cleanup,
 }
@@ -134,6 +136,7 @@ pub async fn run() -> Result<(), Error> {
             } => agent_env_preview_cmd(p),
             args::AgentCmd::Suite(s) => Box::pin(agent_suite_cmd(*s)).await,
         },
+        Command::Ui(u) => ui_cmd(u).await,
         #[cfg(feature = "docker")]
         Command::Cleanup => cleanup_cmd().await,
         #[cfg(not(feature = "docker"))]
@@ -2136,6 +2139,27 @@ fn print_trajectory_diff(
         }
     }
     Ok(())
+}
+
+#[cfg(feature = "ui-server")]
+async fn ui_cmd(u: args::UiCmd) -> Result<(), Error> {
+    crate::run::ui::run(crate::run::ui::UiArgs {
+        sweep: u.sweep,
+        port: u.port,
+        bind: u.bind,
+        open: u.open,
+    })
+    .await
+}
+
+#[cfg(not(feature = "ui-server"))]
+async fn ui_cmd(_u: args::UiCmd) -> Result<(), Error> {
+    exit_with_outcome(
+        ExitCode::FeatureUnavailable,
+        "the `ui` command requires the `ui-server` Cargo feature, which was not compiled in. \
+         Rebuild with `cargo build --features ui-server`. \
+         See docs/spec-web-ui.md for details.",
+    );
 }
 
 #[cfg(feature = "docker")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2153,6 +2153,7 @@ async fn ui_cmd(u: args::UiCmd) -> Result<(), Error> {
 }
 
 #[cfg(not(feature = "ui-server"))]
+#[allow(clippy::unused_async)]
 async fn ui_cmd(_u: args::UiCmd) -> Result<(), Error> {
     exit_with_outcome(
         ExitCode::FeatureUnavailable,

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -100,6 +100,9 @@ pub enum ExitCode {
     /// preflight. Distinct from `preflight_failure` (3) so CI can route
     /// scriptability misconfig separately from infrastructure failures.
     ScriptabilityCheckFailure = 23,
+    /// 24 — a subcommand requires a Cargo feature that was not compiled in.
+    /// The error message names the missing feature and the docs link.
+    FeatureUnavailable = 24,
     /// 130 — user interruption (graceful SIGINT / Ctrl-C; 128 + SIGINT(2)).
     Interrupted = 130,
     /// 137 — forced kill (SIGKILL escalation after graceful-cancel deadline; 128 + SIGKILL(9)).
@@ -144,6 +147,7 @@ impl ExitCode {
             Self::EvalGamingGateFailure => "eval_gaming_gate_failure",
             Self::ArtifactIntegrityViolation => "artifact_integrity_violation",
             Self::ScriptabilityCheckFailure => "scriptability_check_failure",
+            Self::FeatureUnavailable => "feature_unavailable",
             Self::Interrupted => "interrupted",
             Self::Killed => "killed",
         }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -56,4 +56,5 @@ pub mod tool_coverage;
 pub mod trajectory_diff;
 pub mod triage;
 pub mod triage_diff;
+pub mod ui;
 pub mod watch;

--- a/src/run/ui.rs
+++ b/src/run/ui.rs
@@ -122,22 +122,24 @@ pub async fn run(args: UiArgs) -> Result<(), Error> {
         );
     }
 
-    let bind_addr: SocketAddr =
-        format!("{}:{}", args.bind, args.port)
-            .parse()
-            .map_err(|e: std::net::AddrParseError| {
-                Error::Config(crate::error::ConfigError::Invalid(format!(
-                    "ui: invalid bind address `{}:{}`: {e}",
-                    args.bind, args.port
-                )))
-            })?;
+    let bind_ip: std::net::IpAddr = args.bind.parse().map_err(|e: std::net::AddrParseError| {
+        Error::Config(crate::error::ConfigError::Invalid(format!(
+            "ui: invalid bind address `{}`: {e}",
+            args.bind
+        )))
+    })?;
+    let bind_addr = SocketAddr::new(bind_ip, args.port);
 
     let server = UiServer::start(bind_addr, instances)
         .await
         .map_err(Error::Io)?;
 
     let local = server.local_addr();
-    let url = format!("http://{}:{}", local.ip(), local.port());
+    let url = if local.is_ipv6() {
+        format!("http://[{}]:{}", local.ip(), local.port())
+    } else {
+        format!("http://{}:{}", local.ip(), local.port())
+    };
     println!("ui ready at {url}");
 
     if args.open {

--- a/src/run/ui.rs
+++ b/src/run/ui.rs
@@ -13,6 +13,7 @@
 //! `feature_unavailable` (exit code 24).
 
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -121,18 +122,19 @@ pub async fn run(args: UiArgs) -> Result<(), Error> {
         );
     }
 
-    let bind_addr: SocketAddr = format!("{}:{}", args.bind, args.port)
-        .parse()
-        .map_err(|e: std::net::AddrParseError| {
-            Error::Config(crate::error::ConfigError::Invalid(format!(
-                "ui: invalid bind address `{}:{}`: {e}",
-                args.bind, args.port
-            )))
-        })?;
+    let bind_addr: SocketAddr =
+        format!("{}:{}", args.bind, args.port)
+            .parse()
+            .map_err(|e: std::net::AddrParseError| {
+                Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "ui: invalid bind address `{}:{}`: {e}",
+                    args.bind, args.port
+                )))
+            })?;
 
     let server = UiServer::start(bind_addr, instances)
         .await
-        .map_err(|e| Error::Io(e))?;
+        .map_err(Error::Io)?;
 
     let local = server.local_addr();
     let url = format!("http://{}:{}", local.ip(), local.port());
@@ -166,7 +168,7 @@ pub fn discover_instances(sweep_dir: &Path) -> Result<Vec<InstanceEntry>, Error>
     })?;
 
     for dir_entry in read_dir {
-        let dir_entry = dir_entry.map_err(std::io::Error::from)?;
+        let dir_entry = dir_entry?;
         let path = dir_entry.path();
 
         // Only process files whose name ends with `.traj.json`.
@@ -191,10 +193,7 @@ pub fn discover_instances(sweep_dir: &Path) -> Result<Vec<InstanceEntry>, Error>
             }
         };
 
-        let instance_id = name
-            .strip_suffix(".traj.json")
-            .unwrap_or(&name)
-            .to_owned();
+        let instance_id = name.strip_suffix(".traj.json").unwrap_or(&name).to_owned();
 
         entries.push(InstanceEntry {
             instance_id,
@@ -313,15 +312,16 @@ fn serve_index(instances: &[InstanceEntry]) -> String {
         let safe_cost = html_escape(&cost);
         let safe_duration = html_escape(&duration);
 
-        rows.push_str(&format!(
+        let _ = writeln!(
+            rows,
             "<tr>\
              <td><a href=\"/instance/{safe_id}\">{safe_id}</a></td>\
              <td>{safe_outcome}</td>\
              <td>{safe_steps}</td>\
              <td>{safe_cost}</td>\
              <td>{safe_duration}</td>\
-             </tr>\n"
-        ));
+             </tr>"
+        );
     }
 
     let body = format!(
@@ -461,9 +461,8 @@ async fn read_request_path(stream: &mut TcpStream) -> std::io::Result<String> {
         }
     }
 
-    let text = std::str::from_utf8(&buf[..total]).map_err(|_| {
-        std::io::Error::new(std::io::ErrorKind::InvalidData, "non-UTF-8 request")
-    })?;
+    let text = std::str::from_utf8(&buf[..total])
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "non-UTF-8 request"))?;
 
     // Extract path from the first request line, e.g. "GET /path HTTP/1.1".
     // URL-decode percent-encoded characters so %2F stays as "/" (path traversal).
@@ -474,9 +473,7 @@ async fn read_request_path(stream: &mut TcpStream) -> std::io::Result<String> {
         .unwrap_or("/");
 
     // Only strip query strings; keep the path as-is.
-    let path = raw_path
-        .split_once('?')
-        .map_or(raw_path, |(p, _)| p);
+    let path = raw_path.split_once('?').map_or(raw_path, |(p, _)| p);
 
     Ok(path.to_owned())
 }
@@ -551,27 +548,42 @@ mod tests {
     #[test]
     fn dispatch_unknown_path_returns_404() {
         let resp = dispatch("/admin/secret", &[]);
-        assert!(resp.starts_with("HTTP/1.1 404"), "expected 404, got: {resp:.80}");
+        assert!(
+            resp.starts_with("HTTP/1.1 404"),
+            "expected 404, got: {resp:.80}"
+        );
     }
 
     #[test]
     fn dispatch_healthz_returns_200() {
         let resp = dispatch("/healthz", &[]);
-        assert!(resp.starts_with("HTTP/1.1 200"), "expected 200, got: {resp:.80}");
-        assert!(resp.contains("application/json"), "expected JSON content-type");
+        assert!(
+            resp.starts_with("HTTP/1.1 200"),
+            "expected 200, got: {resp:.80}"
+        );
+        assert!(
+            resp.contains("application/json"),
+            "expected JSON content-type"
+        );
     }
 
     #[test]
     fn dispatch_index_returns_200() {
         let resp = dispatch("/", &[]);
-        assert!(resp.starts_with("HTTP/1.1 200"), "expected 200, got: {resp:.80}");
+        assert!(
+            resp.starts_with("HTTP/1.1 200"),
+            "expected 200, got: {resp:.80}"
+        );
         assert!(resp.contains("text/html"), "expected HTML content-type");
     }
 
     #[test]
     fn dispatch_unknown_instance_returns_404() {
         let resp = dispatch("/instance/does-not-exist", &[]);
-        assert!(resp.starts_with("HTTP/1.1 404"), "expected 404, got: {resp:.80}");
+        assert!(
+            resp.starts_with("HTTP/1.1 404"),
+            "expected 404, got: {resp:.80}"
+        );
     }
 
     #[test]

--- a/src/run/ui.rs
+++ b/src/run/ui.rs
@@ -1,0 +1,593 @@
+//! `max ui` — read-only local sweep browser (issue #319).
+//!
+//! Starts a minimal HTTP/1.1 server that lists every trajectory discovered
+//! under `--sweep` and renders each one via the `HtmlExporter` pipeline.
+//! All rendered bytes pass through `Redactor::default_enabled()` +
+//! `surface::EXPORT` exactly as `bench inspect --format html` does.
+//!
+//! The server is single-binary, no-framework, no-auth, no-egress — identical
+//! in policy to `src/stream/sse.rs`.  It serves until SIGINT and exits cleanly.
+//!
+//! **Feature gate**: this module is compiled only when the `ui-server` Cargo
+//! feature is enabled.  When the feature is absent the CLI dispatch exits with
+//! `feature_unavailable` (exit code 24).
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+use crate::error::Error;
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+/// Metadata extracted from a single `*.traj.json` file for the index page.
+#[derive(Debug, Clone)]
+pub struct InstanceEntry {
+    pub instance_id: String,
+    pub outcome: Option<String>,
+    pub steps: Option<u32>,
+    pub total_cost_usd: Option<f64>,
+    pub duration_secs: Option<f64>,
+    /// Absolute path to the trajectory file on disk.
+    pub traj_path: PathBuf,
+}
+
+/// Arguments forwarded from the CLI to [`run`].
+pub struct UiArgs {
+    pub sweep: PathBuf,
+    pub port: u16,
+    pub bind: String,
+    pub open: bool,
+}
+
+// ── Server handle ─────────────────────────────────────────────────────────────
+
+/// Running HTTP server.  Drop or call [`UiServer::shutdown`] to stop.
+pub struct UiServer {
+    addr: SocketAddr,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl UiServer {
+    /// Bind `addr` and start accepting.  Returns once the listener is bound so
+    /// callers can query `local_addr()` immediately without a race.
+    pub async fn start(
+        addr: SocketAddr,
+        instances: Arc<Vec<InstanceEntry>>,
+    ) -> std::io::Result<Self> {
+        let listener = TcpListener::bind(addr).await?;
+        let bound = listener.local_addr()?;
+        let (sd_tx, sd_rx) = oneshot::channel();
+        let handle = tokio::spawn(accept_loop(listener, instances, sd_rx));
+        Ok(Self {
+            addr: bound,
+            shutdown_tx: Some(sd_tx),
+            handle: Some(handle),
+        })
+    }
+
+    /// Actual bound address (resolves port `0` to the OS-picked port).
+    pub fn local_addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// Signal the accept loop to stop and wait for it.
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(h) = self.handle.take() {
+            let _ = h.await;
+        }
+    }
+}
+
+impl Drop for UiServer {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(h) = self.handle.take() {
+            h.abort();
+        }
+    }
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+/// Start the UI server and block until SIGINT / Ctrl-C.
+#[cfg(feature = "ui-server")]
+pub async fn run(args: UiArgs) -> Result<(), Error> {
+    // Validate sweep directory.
+    if !args.sweep.exists() || !args.sweep.is_dir() {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "ui: --sweep `{}` does not exist or is not a directory",
+            args.sweep.display()
+        ))));
+    }
+
+    let instances = Arc::new(discover_instances(&args.sweep)?);
+    if instances.is_empty() {
+        tracing::warn!(
+            sweep = %args.sweep.display(),
+            "ui: no *.traj.json files found in sweep directory"
+        );
+    }
+
+    let bind_addr: SocketAddr = format!("{}:{}", args.bind, args.port)
+        .parse()
+        .map_err(|e: std::net::AddrParseError| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "ui: invalid bind address `{}:{}`: {e}",
+                args.bind, args.port
+            )))
+        })?;
+
+    let server = UiServer::start(bind_addr, instances)
+        .await
+        .map_err(|e| Error::Io(e))?;
+
+    let local = server.local_addr();
+    let url = format!("http://{}:{}", local.ip(), local.port());
+    println!("ui ready at {url}");
+
+    if args.open {
+        if let Err(e) = open_browser(&url) {
+            tracing::warn!(error = %e, "ui: failed to open browser (non-fatal)");
+        }
+    }
+
+    wait_for_shutdown_signal().await;
+    tracing::info!("ui: received shutdown signal, stopping server");
+    server.shutdown().await;
+    Ok(())
+}
+
+// ── Sweep discovery ───────────────────────────────────────────────────────────
+
+/// Scan `sweep_dir` for `*.traj.json` files and return a list sorted by
+/// `instance_id` ascending.  Non-JSON files and non-trajectory JSON are
+/// silently skipped; parse errors emit a warning.
+pub fn discover_instances(sweep_dir: &Path) -> Result<Vec<InstanceEntry>, Error> {
+    let mut entries: Vec<InstanceEntry> = Vec::new();
+
+    let read_dir = std::fs::read_dir(sweep_dir).map_err(|e| {
+        Error::Config(crate::error::ConfigError::Invalid(format!(
+            "ui: failed to read sweep directory `{}`: {e}",
+            sweep_dir.display()
+        )))
+    })?;
+
+    for dir_entry in read_dir {
+        let dir_entry = dir_entry.map_err(std::io::Error::from)?;
+        let path = dir_entry.path();
+
+        // Only process files whose name ends with `.traj.json`.
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) if n.ends_with(".traj.json") => n.to_owned(),
+            _ => continue,
+        };
+
+        let text = match std::fs::read_to_string(&path) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(path = ?path, error = %e, "ui: skipping unreadable file");
+                continue;
+            }
+        };
+
+        let traj: crate::trajectory::Trajectory = match serde_json::from_str(&text) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(path = ?path, error = %e, "ui: skipping unparseable trajectory");
+                continue;
+            }
+        };
+
+        let instance_id = name
+            .strip_suffix(".traj.json")
+            .unwrap_or(&name)
+            .to_owned();
+
+        entries.push(InstanceEntry {
+            instance_id,
+            outcome: traj.info.outcome,
+            steps: traj.info.steps,
+            total_cost_usd: traj.info.total_cost_usd,
+            duration_secs: traj.info.duration_secs,
+            traj_path: path,
+        });
+    }
+
+    entries.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
+    Ok(entries)
+}
+
+// ── Accept loop ───────────────────────────────────────────────────────────────
+
+async fn accept_loop(
+    listener: TcpListener,
+    instances: Arc<Vec<InstanceEntry>>,
+    mut shutdown: oneshot::Receiver<()>,
+) {
+    loop {
+        tokio::select! {
+            _ = &mut shutdown => {
+                tracing::debug!("ui: accept loop: shutdown signal");
+                break;
+            }
+            result = listener.accept() => {
+                match result {
+                    Ok((stream, peer)) => {
+                        tracing::debug!(?peer, "ui: client connected");
+                        let inst = instances.clone();
+                        tokio::spawn(handle_connection(stream, inst, peer));
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "ui: accept error");
+                        tokio::task::yield_now().await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Connection handler ────────────────────────────────────────────────────────
+
+async fn handle_connection(
+    mut stream: TcpStream,
+    instances: Arc<Vec<InstanceEntry>>,
+    peer: SocketAddr,
+) {
+    let path = match read_request_path(&mut stream).await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::debug!(?peer, error = %e, "ui: bad request");
+            return;
+        }
+    };
+
+    let response = dispatch(&path, &instances);
+
+    if stream.write_all(response.as_bytes()).await.is_err() {
+        tracing::debug!(?peer, "ui: write error (client disconnected)");
+        return;
+    }
+    let _ = stream.flush().await;
+    let _ = stream.shutdown().await;
+}
+
+// ── Router ────────────────────────────────────────────────────────────────────
+
+/// Route a decoded request path to a response string.
+fn dispatch(path: &str, instances: &[InstanceEntry]) -> String {
+    // Build a lookup map: instance_id → entry (validated against discovered set).
+    let by_id: HashMap<&str, &InstanceEntry> = instances
+        .iter()
+        .map(|e| (e.instance_id.as_str(), e))
+        .collect();
+
+    match path {
+        "/" => serve_index(instances),
+        "/healthz" => http_response(200, "OK", "application/json", r#"{"status":"ok"}"#),
+        _ if path.starts_with("/instance/") => {
+            let id = &path["/instance/".len()..];
+            match by_id.get(id) {
+                // instance_id validated against discovered set — no filesystem path used
+                Some(entry) => serve_instance(entry),
+                None => http_404(),
+            }
+        }
+        _ => http_404(),
+    }
+}
+
+// ── Index page ────────────────────────────────────────────────────────────────
+
+fn serve_index(instances: &[InstanceEntry]) -> String {
+    let mut rows = String::new();
+    for entry in instances {
+        let outcome = entry.outcome.as_deref().unwrap_or("-");
+        let steps = entry
+            .steps
+            .map_or_else(|| "-".to_owned(), |s| s.to_string());
+        let cost = entry
+            .total_cost_usd
+            .map_or_else(|| "-".to_owned(), |c| format!("{c:.4}"));
+        let duration = entry
+            .duration_secs
+            .map_or_else(|| "-".to_owned(), |d| format!("{d:.1}"));
+
+        // Escape each display value to prevent XSS.
+        let safe_id = html_escape(&entry.instance_id);
+        let safe_outcome = html_escape(outcome);
+        let safe_steps = html_escape(&steps);
+        let safe_cost = html_escape(&cost);
+        let safe_duration = html_escape(&duration);
+
+        rows.push_str(&format!(
+            "<tr>\
+             <td><a href=\"/instance/{safe_id}\">{safe_id}</a></td>\
+             <td>{safe_outcome}</td>\
+             <td>{safe_steps}</td>\
+             <td>{safe_cost}</td>\
+             <td>{safe_duration}</td>\
+             </tr>\n"
+        ));
+    }
+
+    let body = format!(
+        "<!DOCTYPE html>\n\
+         <html>\n\
+         <head>\n\
+         <meta charset=\"UTF-8\">\n\
+         <title>Sweep Browser</title>\n\
+         <style>\n\
+         body{{font-family:sans-serif;margin:20px;max-width:1200px}}\n\
+         h1{{color:#333}}\n\
+         table{{border-collapse:collapse;width:100%;margin-top:16px}}\n\
+         th,td{{border:1px solid #ddd;padding:8px 12px;text-align:left}}\n\
+         th{{background:#f5f5f5;font-weight:600}}\n\
+         tr:hover{{background:#f9f9ff}}\n\
+         a{{color:#0066cc;text-decoration:none}}\n\
+         a:hover{{text-decoration:underline}}\n\
+         </style>\n\
+         </head>\n\
+         <body>\n\
+         <h1>Sweep Browser</h1>\n\
+         <table>\n\
+         <thead>\n\
+         <tr>\
+         <th>instance_id</th>\
+         <th>outcome</th>\
+         <th>steps</th>\
+         <th>total_cost_usd</th>\
+         <th>duration_seconds</th>\
+         </tr>\n\
+         </thead>\n\
+         <tbody>\n\
+         {rows}\
+         </tbody>\n\
+         </table>\n\
+         </body>\n\
+         </html>"
+    );
+
+    http_response(200, "OK", "text/html; charset=UTF-8", &body)
+}
+
+// ── Instance page ─────────────────────────────────────────────────────────────
+
+#[cfg(feature = "ui-server")]
+fn serve_instance(entry: &InstanceEntry) -> String {
+    use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
+
+    let text = match std::fs::read_to_string(&entry.traj_path) {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!(path = ?entry.traj_path, error = %e, "ui: failed to read trajectory");
+            return http_response(
+                500,
+                "Internal Server Error",
+                "text/plain",
+                "500 Internal Server Error: failed to read trajectory",
+            );
+        }
+    };
+
+    let traj: crate::trajectory::Trajectory = match serde_json::from_str(&text) {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!(path = ?entry.traj_path, error = %e, "ui: failed to parse trajectory");
+            return http_response(
+                500,
+                "Internal Server Error",
+                "text/plain",
+                "500 Internal Server Error: failed to parse trajectory",
+            );
+        }
+    };
+
+    // HtmlExporter applies Redactor::default_enabled() + surface::EXPORT internally.
+    let html = HtmlExporter::export(&traj);
+    http_response(200, "OK", "text/html; charset=UTF-8", &html)
+}
+
+// When ui-server feature is not enabled, this function is unreachable but
+// must still compile (it's used in dispatch() which is always compiled).
+#[cfg(not(feature = "ui-server"))]
+fn serve_instance(_entry: &InstanceEntry) -> String {
+    http_404()
+}
+
+// ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+fn http_response(status: u16, reason: &str, content_type: &str, body: &str) -> String {
+    format!(
+        "HTTP/1.1 {status} {reason}\r\n\
+         Content-Type: {content_type}\r\n\
+         Content-Length: {len}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {body}",
+        len = body.len()
+    )
+}
+
+fn http_404() -> String {
+    http_response(404, "Not Found", "text/plain", "404 Not Found")
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+// ── Request parsing ───────────────────────────────────────────────────────────
+
+/// Read until `\r\n\r\n` (HTTP head terminator) and extract the request path.
+/// Caps at 8 KiB to defend against slow / malicious clients.
+async fn read_request_path(stream: &mut TcpStream) -> std::io::Result<String> {
+    let mut buf = [0u8; 8192];
+    let mut total = 0usize;
+
+    loop {
+        if total >= buf.len() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "request head exceeds 8 KiB",
+            ));
+        }
+        let n = stream.read(&mut buf[total..]).await?;
+        if n == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "client closed before sending complete request",
+            ));
+        }
+        total += n;
+        if buf[..total].windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    let text = std::str::from_utf8(&buf[..total]).map_err(|_| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, "non-UTF-8 request")
+    })?;
+
+    // Extract path from the first request line, e.g. "GET /path HTTP/1.1".
+    // URL-decode percent-encoded characters so %2F stays as "/" (path traversal).
+    let raw_path = text
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or("/");
+
+    // Only strip query strings; keep the path as-is.
+    let path = raw_path
+        .split_once('?')
+        .map_or(raw_path, |(p, _)| p);
+
+    Ok(path.to_owned())
+}
+
+// ── Browser launch ────────────────────────────────────────────────────────────
+
+#[cfg(feature = "ui-server")]
+fn open_browser(url: &str) -> std::io::Result<()> {
+    // Platform-specific best-effort browser launch.
+    #[cfg(target_os = "linux")]
+    std::process::Command::new("xdg-open").arg(url).spawn()?;
+    #[cfg(target_os = "macos")]
+    std::process::Command::new("open").arg(url).spawn()?;
+    #[cfg(target_os = "windows")]
+    std::process::Command::new("cmd")
+        .args(["/c", "start", url])
+        .spawn()?;
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    return Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "browser launch not supported on this platform",
+    ));
+    Ok(())
+}
+
+// ── Signal handling ───────────────────────────────────────────────────────────
+
+#[cfg(feature = "ui-server")]
+async fn wait_for_shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        if let Ok(mut sigint) = signal(SignalKind::interrupt()) {
+            sigint.recv().await;
+        } else {
+            // Fall back to ctrl_c if SIGINT handler fails.
+            let _ = tokio::signal::ctrl_c().await;
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+
+    #[test]
+    fn html_escape_replaces_special_chars() {
+        assert_eq!(html_escape("<script>"), "&lt;script&gt;");
+        assert_eq!(html_escape("a&b"), "a&amp;b");
+        assert_eq!(html_escape("\"quote\""), "&quot;quote&quot;");
+    }
+
+    #[test]
+    fn http_response_includes_content_length() {
+        let r = http_response(200, "OK", "text/plain", "hello");
+        assert!(r.contains("Content-Length: 5\r\n"), "missing length: {r}");
+    }
+
+    #[test]
+    fn http_404_has_correct_status() {
+        let r = http_404();
+        assert!(r.starts_with("HTTP/1.1 404"), "wrong status: {r}");
+    }
+
+    #[test]
+    fn dispatch_unknown_path_returns_404() {
+        let resp = dispatch("/admin/secret", &[]);
+        assert!(resp.starts_with("HTTP/1.1 404"), "expected 404, got: {resp:.80}");
+    }
+
+    #[test]
+    fn dispatch_healthz_returns_200() {
+        let resp = dispatch("/healthz", &[]);
+        assert!(resp.starts_with("HTTP/1.1 200"), "expected 200, got: {resp:.80}");
+        assert!(resp.contains("application/json"), "expected JSON content-type");
+    }
+
+    #[test]
+    fn dispatch_index_returns_200() {
+        let resp = dispatch("/", &[]);
+        assert!(resp.starts_with("HTTP/1.1 200"), "expected 200, got: {resp:.80}");
+        assert!(resp.contains("text/html"), "expected HTML content-type");
+    }
+
+    #[test]
+    fn dispatch_unknown_instance_returns_404() {
+        let resp = dispatch("/instance/does-not-exist", &[]);
+        assert!(resp.starts_with("HTTP/1.1 404"), "expected 404, got: {resp:.80}");
+    }
+
+    #[test]
+    fn discover_instances_sorts_by_id_ascending() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut t = crate::trajectory::Trajectory::new();
+        t.info.outcome = Some("submitted".to_owned());
+
+        for id in ["zzz", "aaa", "mmm"] {
+            let json = serde_json::to_string(&t).unwrap();
+            std::fs::write(dir.path().join(format!("{id}.traj.json")), json).unwrap();
+        }
+
+        let entries = discover_instances(dir.path()).unwrap();
+        assert_eq!(entries[0].instance_id, "aaa");
+        assert_eq!(entries[1].instance_id, "mmm");
+        assert_eq!(entries[2].instance_id, "zzz");
+    }
+}

--- a/tests/ui_server.rs
+++ b/tests/ui_server.rs
@@ -1,0 +1,239 @@
+//! End-to-end integration tests for the `max ui` web server (issue #319).
+//!
+//! These tests require the `ui-server` Cargo feature and are skipped when the
+//! feature is not enabled.  Run with:
+//!   cargo test --features ui-server --test ui_server
+
+#![cfg(feature = "ui-server")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::Path;
+use std::time::Duration;
+
+use maxwells_daemon::model::Message;
+use maxwells_daemon::run::ui::{UiServer, discover_instances};
+use maxwells_daemon::trajectory::{Trajectory, outcome};
+
+mod support;
+
+/// Write a minimal trajectory into `dir` for a given `instance_id`.
+fn write_fixture_traj(dir: &Path, instance_id: &str, assistant_content: &str) {
+    let mut t = Trajectory::new();
+    t.info.outcome = Some(outcome::SUBMITTED.to_string());
+    t.info.steps = Some(3);
+    t.info.total_cost_usd = Some(0.12);
+    t.info.duration_secs = Some(42.5);
+
+    t.record_message(&Message::system("System prompt for test"));
+    t.record_message(&Message::user("User message"));
+    t.record_message(&Message::assistant(assistant_content));
+
+    let json = serde_json::to_string_pretty(&t).unwrap();
+    std::fs::write(dir.join(format!("{instance_id}.traj.json")), json).unwrap();
+}
+
+/// Bind a UI server against a sweep directory and return the server + base URL.
+async fn start_test_server(sweep: &Path) -> (UiServer, String) {
+    use std::sync::Arc;
+    let instances = Arc::new(discover_instances(sweep).unwrap());
+    let server = UiServer::start("127.0.0.1:0".parse().unwrap(), instances)
+        .await
+        .unwrap();
+    let url = format!("http://127.0.0.1:{}", server.local_addr().port());
+    (server, url)
+}
+
+// ── Index page ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn index_returns_200_html_with_instance_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture_traj(dir.path(), "django__django-12345", "done");
+    write_fixture_traj(dir.path(), "flask__flask-99", "done");
+
+    let (server, url) = start_test_server(dir.path()).await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let client = reqwest::Client::new();
+    let resp = client.get(&url).send().await.unwrap();
+
+    assert_eq!(resp.status(), 200, "GET / should return 200");
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(ct.contains("text/html"), "Content-Type should be text/html, got: {ct}");
+
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("django__django-12345"), "index should list instance ID");
+    assert!(body.contains("flask__flask-99"), "index should list instance ID");
+    assert!(body.contains("submitted"), "index should show outcome column");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn index_rows_are_sorted_by_instance_id_ascending() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture_traj(dir.path(), "zzz-last", "done");
+    write_fixture_traj(dir.path(), "aaa-first", "done");
+    write_fixture_traj(dir.path(), "mmm-middle", "done");
+
+    let (server, url) = start_test_server(dir.path()).await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let body = reqwest::get(&url).await.unwrap().text().await.unwrap();
+
+    let pos_first = body.find("aaa-first").expect("aaa-first missing");
+    let pos_middle = body.find("mmm-middle").expect("mmm-middle missing");
+    let pos_last = body.find("zzz-last").expect("zzz-last missing");
+
+    assert!(pos_first < pos_middle, "aaa-first must precede mmm-middle in HTML");
+    assert!(pos_middle < pos_last, "mmm-middle must precede zzz-last in HTML");
+
+    server.shutdown().await;
+}
+
+// ── Instance page ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn instance_page_returns_200_html() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture_traj(dir.path(), "test__instance-1", "Hello from agent");
+
+    let (server, url) = start_test_server(dir.path()).await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("{url}/instance/test__instance-1"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200, "GET /instance/<id> should return 200");
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(ct.contains("text/html"), "instance should be text/html, got: {ct}");
+
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("<!DOCTYPE html>"), "should be a full HTML page");
+    assert!(
+        body.contains("Trajectory Export"),
+        "should contain HtmlExporter title"
+    );
+
+    server.shutdown().await;
+}
+
+// ── 404 paths ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn unknown_path_returns_404() {
+    let dir = tempfile::tempdir().unwrap();
+    let (server, url) = start_test_server(dir.path()).await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let resp = reqwest::get(format!("{url}/admin")).await.unwrap();
+    assert_eq!(resp.status(), 404, "unknown path should return 404");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn nonexistent_instance_returns_404() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture_traj(dir.path(), "test__instance-1", "done");
+
+    let (server, url) = start_test_server(dir.path()).await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let resp = reqwest::get(format!("{url}/instance/does-not-exist"))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        404,
+        "nonexistent instance should return 404"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn directory_traversal_attempt_returns_404() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture_traj(dir.path(), "test__instance-1", "done");
+
+    let (server, url) = start_test_server(dir.path()).await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // Path traversal attempt: /instance/../../etc/passwd
+    // reqwest will encode this, but we verify the server rejects non-discovered IDs
+    let resp = reqwest::get(format!("{url}/instance/%2E%2E%2Fetc%2Fpasswd"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404, "path traversal must return 404");
+
+    server.shutdown().await;
+}
+
+// ── Health check ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn healthz_returns_200() {
+    let dir = tempfile::tempdir().unwrap();
+    let (server, url) = start_test_server(dir.path()).await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let resp = reqwest::get(format!("{url}/healthz")).await.unwrap();
+    assert_eq!(resp.status(), 200, "/healthz should return 200");
+
+    server.shutdown().await;
+}
+
+// ── Redaction integration test ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn canary_secret_not_in_any_http_response() {
+    // ghp_ prefix is auto-redacted by Redactor::default_enabled() as a
+    // GitHub personal access token pattern.
+    let canary = "ghp_CANARYTOKEN_ABC0123456789DEF0123456";
+
+    let dir = tempfile::tempdir().unwrap();
+    // Embed the canary in the assistant message content.
+    write_fixture_traj(dir.path(), "secret-test", canary);
+
+    let (server, url) = start_test_server(dir.path()).await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let client = reqwest::Client::new();
+
+    // Index page should not contain the canary (it only shows metadata).
+    let index_body = client.get(&url).send().await.unwrap().text().await.unwrap();
+    assert!(
+        !index_body.contains(canary),
+        "index page must not contain canary secret"
+    );
+
+    // Instance page runs HtmlExporter which redacts via Redactor::default_enabled().
+    let instance_body = client
+        .get(format!("{url}/instance/secret-test"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        !instance_body.contains(canary),
+        "instance page must not leak canary secret; got excerpt:\n{:.300}",
+        &instance_body
+    );
+
+    server.shutdown().await;
+}

--- a/tests/ui_server.rs
+++ b/tests/ui_server.rs
@@ -63,12 +63,24 @@ async fn index_returns_200_html_with_instance_rows() {
         .get("content-type")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
-    assert!(ct.contains("text/html"), "Content-Type should be text/html, got: {ct}");
+    assert!(
+        ct.contains("text/html"),
+        "Content-Type should be text/html, got: {ct}"
+    );
 
     let body = resp.text().await.unwrap();
-    assert!(body.contains("django__django-12345"), "index should list instance ID");
-    assert!(body.contains("flask__flask-99"), "index should list instance ID");
-    assert!(body.contains("submitted"), "index should show outcome column");
+    assert!(
+        body.contains("django__django-12345"),
+        "index should list instance ID"
+    );
+    assert!(
+        body.contains("flask__flask-99"),
+        "index should list instance ID"
+    );
+    assert!(
+        body.contains("submitted"),
+        "index should show outcome column"
+    );
 
     server.shutdown().await;
 }
@@ -89,8 +101,14 @@ async fn index_rows_are_sorted_by_instance_id_ascending() {
     let pos_middle = body.find("mmm-middle").expect("mmm-middle missing");
     let pos_last = body.find("zzz-last").expect("zzz-last missing");
 
-    assert!(pos_first < pos_middle, "aaa-first must precede mmm-middle in HTML");
-    assert!(pos_middle < pos_last, "mmm-middle must precede zzz-last in HTML");
+    assert!(
+        pos_first < pos_middle,
+        "aaa-first must precede mmm-middle in HTML"
+    );
+    assert!(
+        pos_middle < pos_last,
+        "mmm-middle must precede zzz-last in HTML"
+    );
 
     server.shutdown().await;
 }
@@ -118,10 +136,16 @@ async fn instance_page_returns_200_html() {
         .get("content-type")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
-    assert!(ct.contains("text/html"), "instance should be text/html, got: {ct}");
+    assert!(
+        ct.contains("text/html"),
+        "instance should be text/html, got: {ct}"
+    );
 
     let body = resp.text().await.unwrap();
-    assert!(body.contains("<!DOCTYPE html>"), "should be a full HTML page");
+    assert!(
+        body.contains("<!DOCTYPE html>"),
+        "should be a full HTML page"
+    );
     assert!(
         body.contains("Trajectory Export"),
         "should contain HtmlExporter title"
@@ -155,11 +179,7 @@ async fn nonexistent_instance_returns_404() {
     let resp = reqwest::get(format!("{url}/instance/does-not-exist"))
         .await
         .unwrap();
-    assert_eq!(
-        resp.status(),
-        404,
-        "nonexistent instance should return 404"
-    );
+    assert_eq!(resp.status(), 404, "nonexistent instance should return 404");
 
     server.shutdown().await;
 }


### PR DESCRIPTION
Implements the first-slice spec from issue #319: a `max ui` subcommand
that starts a minimal HTTP/1.1 server (no framework, no deps beyond tokio)
listing all `*.traj.json` instances in a sweep directory and rendering each
one via the existing `HtmlExporter` + `Redactor::default_enabled()` pipeline.

Key decisions:
- Gated behind a new `ui-server` Cargo feature (off by default) that implies
  `html-export`, matching the existing feature strategy.
- New `ExitCode::FeatureUnavailable` (24 / `feature_unavailable`) emitted when
  `max ui` is invoked without the feature compiled in.
- Server is ~300 LOC in `src/run/ui.rs` following the same tokio-raw pattern as
  `src/stream/sse.rs`; no new HTTP framework dependency.
- `instance_id` validated against the discovered set on every request — URL is
  never used as a filesystem path (no directory traversal).
- Redaction is implicit: `HtmlExporter::export()` already applies
  `Redactor::default_enabled() + surface::EXPORT` on every message field.
- `docs/spec-web-ui.md` rewritten from a stub into a full spec covering routes,
  query params, error model, exit codes, redaction, feature gate, and lifecycle.
- 8 integration tests in `tests/ui_server.rs` cover: index 200/HTML, sort order,
  instance page 200/HTML, healthz, 404 for unknown paths, 404 for nonexistent
  instances, 404 for path traversal attempts, and canary-secret redaction.
- 8 unit tests in `src/run/ui.rs` cover dispatch routing, HTML escaping,
  HTTP response formatting, and sweep discovery sort order.