### PR TITLE
Add `bench near-miss` subcommand to rank unresolved instances by gold proximity

### DIFF
--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -67,6 +67,7 @@ pub enum ArtifactKind {
     StagnationReport,
     SuiteResults,
     ScriptabilityCheck,
+    NearMissReport,
 }
 
 impl ArtifactKind {
@@ -91,6 +92,7 @@ impl ArtifactKind {
             Self::StagnationReport => "stagnation_report",
             Self::SuiteResults => "suite_results",
             Self::ScriptabilityCheck => "scriptability_check",
+            Self::NearMissReport => "near_miss_report",
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -639,6 +639,8 @@ pub enum BenchCmd {
     ContaminationCheck(ContaminationCheckCmd),
     /// Probe every configured MCP server and dry-run every configured hook before any model call.
     ScriptabilityCheck(ScriptabilityCheckCmd),
+    /// Rank unresolved sweep instances by gold-patch proximity (zero-cost: reads only evaluation.json).
+    NearMiss(NearMissCmd),
 }
 
 /// `bench failure-digest` — self-contained failure summary for one sweep instance.
@@ -2679,6 +2681,24 @@ pub struct ScriptabilityCheckCmd {
     /// Write the JSON artifact to `<output>/scriptability_check.json`.
     #[arg(long)]
     pub output: Option<PathBuf>,
+
+    /// Output format: `text` (default) or `json`.
+    #[arg(long, default_value = "text", value_parser = ["text", "json"])]
+    pub format: String,
+}
+
+/// `bench near-miss` — rank unresolved sweep instances by gold-patch proximity.
+#[derive(Debug, Args, Clone)]
+pub struct NearMissCmd {
+    /// Completed sweep directory produced by `bench swebench` (must contain
+    /// `evaluation.json`). The command reads only that file; it does not invoke
+    /// the evaluator, model, or agent.
+    #[arg(long)]
+    pub sweep: PathBuf,
+
+    /// Show at most N eligible instances in the ranked table. Default: 20.
+    #[arg(long, default_value_t = 20)]
+    pub top: usize,
 
     /// Output format: `text` (default) or `json`.
     #[arg(long, default_value = "text", value_parser = ["text", "json"])]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3546,25 +3546,19 @@ fn bench_near_miss(n: args::NearMissCmd) -> Result<(), Error> {
         format,
     };
 
-    let report = run(&args).map_err(|e| {
-        // Trajectory error = missing evaluation.json → exit 2 (usage error).
-        match &e {
-            Error::Trajectory(_) => {
-                exit_with_outcome(
-                    ExitCode::UsageError,
-                    &format!("bench near-miss: {e}"),
-                );
-            }
-            _ => {}
-        }
-        e
-    })?;
+    let report = run(&args).unwrap_or_else(|e| {
+        // Missing evaluation.json → usage error (exit 2); parse failure → internal error (exit 1).
+        let code = if matches!(e, Error::Trajectory(_)) {
+            ExitCode::UsageError
+        } else {
+            ExitCode::InternalError
+        };
+        exit_with_outcome(code, &format!("bench near-miss: {e}"));
+    });
 
     match format {
         NearMissFormat::Text => print!("{}", render_text(&report)),
-        NearMissFormat::Json => {
-            println!("{}", render_json(&report)?);
-        }
+        NearMissFormat::Json => println!("{}", render_json(&report)?),
     }
 
     Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -126,6 +126,7 @@ pub async fn run() -> Result<(), Error> {
             args::BenchCmd::ExportCi(c) => bench_export_ci(c),
             args::BenchCmd::ContaminationCheck(c) => bench_contamination_check(c),
             args::BenchCmd::ScriptabilityCheck(s) => Box::pin(bench_scriptability_check(s)).await,
+            args::BenchCmd::NearMiss(n) => bench_near_miss(n),
         },
         Command::Agent { cmd } => match *cmd {
             args::AgentCmd::SkillsPreview(s) => agent_skills_preview_cmd(&s),
@@ -3525,6 +3526,45 @@ async fn bench_scriptability_check(cmd: args::ScriptabilityCheckCmd) -> Result<(
                  {failed_hooks} hook(s) had failures"
             ),
         );
+    }
+
+    Ok(())
+}
+
+fn bench_near_miss(n: args::NearMissCmd) -> Result<(), Error> {
+    use crate::run::near_miss::{NearMissArgs, NearMissFormat, render_json, render_text, run};
+
+    let format: NearMissFormat = n.format.parse().map_err(|e| {
+        Error::Config(crate::error::ConfigError::Invalid(format!(
+            "bench near-miss: {e}"
+        )))
+    })?;
+
+    let args = NearMissArgs {
+        sweep: n.sweep,
+        top: n.top,
+        format,
+    };
+
+    let report = run(&args).map_err(|e| {
+        // Trajectory error = missing evaluation.json → exit 2 (usage error).
+        match &e {
+            Error::Trajectory(_) => {
+                exit_with_outcome(
+                    ExitCode::UsageError,
+                    &format!("bench near-miss: {e}"),
+                );
+            }
+            _ => {}
+        }
+        e
+    })?;
+
+    match format {
+        NearMissFormat::Text => print!("{}", render_text(&report)),
+        NearMissFormat::Json => {
+            println!("{}", render_json(&report)?);
+        }
     }
 
     Ok(())

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -431,6 +431,11 @@ impl CompareReport {
         write_subset_warnings(&mut s, &subset_warnings);
         write_breakdown_delta_section(&mut s, &self.breakdown_delta);
         write_regressions(&mut s, &self.regressions);
+        let _ = writeln!(
+            s,
+            "Run 'bench near-miss --sweep {}' to rank failed instances by gold-patch proximity.",
+            self.candidate_dir.display()
+        );
         write_sampling_drift_section(&mut s, self.sampling_drift.as_ref());
         if self.flaky_instances_excluded > 0 {
             let n = self.flaky_instances_excluded;

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -34,6 +34,7 @@ pub mod instance_history;
 pub mod ladder;
 pub mod matrix;
 pub mod mini;
+pub mod near_miss;
 pub mod patch_stats;
 pub mod policy_impact;
 pub mod power;

--- a/src/run/near_miss.rs
+++ b/src/run/near_miss.rs
@@ -105,13 +105,12 @@ fn eval_exit_reason_label(reason: &crate::run::evaluate::EvalExitReason) -> &'st
 /// - `Error::Trajectory` when `evaluation.json` is missing (caller maps to exit 2).
 /// - `Error::Json` on parse failures (caller maps to exit 1).
 pub fn run(args: &NearMissArgs) -> Result<NearMissReport, Error> {
-    let eval = load_evaluation_results(&args.sweep)?
-        .ok_or_else(|| {
-            Error::Trajectory(format!(
-                "near-miss: {} does not contain evaluation.json",
-                args.sweep.display()
-            ))
-        })?;
+    let eval = load_evaluation_results(&args.sweep)?.ok_or_else(|| {
+        Error::Trajectory(format!(
+            "near-miss: {} does not contain evaluation.json",
+            args.sweep.display()
+        ))
+    })?;
 
     let mut eligible: Vec<NearMissRow> = Vec::new();
     let mut no_gold: usize = 0;
@@ -130,7 +129,11 @@ pub fn run(args: &NearMissArgs) -> Result<NearMissReport, Error> {
             empty_patch += 1;
             continue;
         }
-        match (stats.gold_files_iou, stats.gold_lines_overlap, stats.gold_size_ratio) {
+        match (
+            stats.gold_files_iou,
+            stats.gold_lines_overlap,
+            stats.gold_size_ratio,
+        ) {
             (Some(iou), Some(overlap), Some(size_ratio)) => {
                 eligible.push(NearMissRow {
                     rank: 0, // assigned after sort
@@ -241,8 +244,13 @@ pub fn render_text(report: &NearMissReport) -> String {
     let _ = writeln!(
         s,
         "{:<6} {:<40} {:>10} {:>14} {:>12} {:>20} {:>14}",
-        "rank", "instance_id", "files_iou", "lines_overlap", "size_ratio",
-        "failure_category", "lines_changed"
+        "rank",
+        "instance_id",
+        "files_iou",
+        "lines_overlap",
+        "size_ratio",
+        "failure_category",
+        "lines_changed"
     );
     let _ = writeln!(s, "{}", "-".repeat(120));
     for row in &report.ranked {
@@ -266,20 +274,26 @@ pub fn render_text(report: &NearMissReport) -> String {
 
 /// Render the report as a versioned JSON artifact.
 pub fn render_json(report: &NearMissReport) -> Result<String, Error> {
-    crate::artifact::to_string_pretty(ArtifactKind::NearMissReport, report)
-        .map_err(Error::Json)
+    crate::artifact::to_string_pretty(ArtifactKind::NearMissReport, report).map_err(Error::Json)
 }
 
 // ── unit tests ────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
 
     #[test]
     fn format_parse_round_trips() {
-        assert_eq!("text".parse::<NearMissFormat>().unwrap(), NearMissFormat::Text);
-        assert_eq!("json".parse::<NearMissFormat>().unwrap(), NearMissFormat::Json);
+        assert_eq!(
+            "text".parse::<NearMissFormat>().unwrap(),
+            NearMissFormat::Text
+        );
+        assert_eq!(
+            "json".parse::<NearMissFormat>().unwrap(),
+            NearMissFormat::Json
+        );
         assert!("bad".parse::<NearMissFormat>().is_err());
     }
 

--- a/src/run/near_miss.rs
+++ b/src/run/near_miss.rs
@@ -15,8 +15,6 @@
 //!   3. `(gold_size_ratio - 1.0).abs()` asc  (tertiary — penalise shotgun/bloated)
 //!   4. `instance_id` asc  (tiebreak for determinism)
 
-#![allow(clippy::cast_precision_loss)]
-
 use std::fmt::Write as _;
 use std::path::PathBuf;
 

--- a/src/run/near_miss.rs
+++ b/src/run/near_miss.rs
@@ -198,8 +198,7 @@ fn now_utc_iso8601() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let secs = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_secs());
     let sec = secs % 60;
     let min = (secs / 60) % 60;
     let hour = (secs / 3600) % 24;

--- a/src/run/near_miss.rs
+++ b/src/run/near_miss.rs
@@ -1,0 +1,294 @@
+//! `bench near-miss`: rank unresolved sweep instances by gold-patch proximity.
+//!
+//! Zero-cost: reads only `evaluation.json` from the sweep dir. No model calls,
+//! no network, no evaluator invocation.
+//!
+//! Unresolved instances are split into four buckets:
+//! - **eligible**:    non-empty patch AND gold proximity fields present.
+//! - **no_gold**:     non-empty patch but `gold_files_iou` is absent (dataset has no gold).
+//! - **empty_patch**: `patch_stats.is_empty == true` (agent submitted nothing).
+//! - **no_stats**:    `patch_stats` field is missing or null entirely.
+//!
+//! Eligible instances are ranked by:
+//!   1. `gold_files_iou` desc  (primary)
+//!   2. `gold_lines_overlap` desc  (secondary)
+//!   3. `(gold_size_ratio - 1.0).abs()` asc  (tertiary — penalise shotgun/bloated)
+//!   4. `instance_id` asc  (tiebreak for determinism)
+
+#![allow(clippy::cast_precision_loss)]
+
+use std::fmt::Write as _;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::artifact::ArtifactKind;
+use crate::error::Error;
+use crate::run::compare::load_evaluation_results;
+
+// ── format ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NearMissFormat {
+    Text,
+    Json,
+}
+
+impl std::str::FromStr for NearMissFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "text" => Ok(Self::Text),
+            "json" => Ok(Self::Json),
+            other => Err(format!("unknown format `{other}` (expected text|json)")),
+        }
+    }
+}
+
+// ── args ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct NearMissArgs {
+    pub sweep: PathBuf,
+    pub top: usize,
+    pub format: NearMissFormat,
+}
+
+// ── data model ───────────────────────────────────────────────────────────────
+
+/// Bucket counts for the four categories of unresolved instances.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NearMissBuckets {
+    pub eligible: usize,
+    pub no_gold: usize,
+    pub empty_patch: usize,
+    pub no_stats: usize,
+}
+
+/// One ranked row in the eligible bucket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NearMissRow {
+    pub rank: usize,
+    pub instance_id: String,
+    pub files_iou: f32,
+    pub lines_overlap: f32,
+    pub size_ratio: f32,
+    pub failure_category: Option<String>,
+    pub lines_changed: u32,
+}
+
+/// The complete near-miss report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NearMissReport {
+    pub buckets: NearMissBuckets,
+    /// Top-N eligible instances ranked by gold proximity.
+    pub ranked: Vec<NearMissRow>,
+    pub sweep_path: String,
+    pub generated_at: String,
+}
+
+// ── core logic ───────────────────────────────────────────────────────────────
+
+fn eval_exit_reason_label(reason: &crate::run::evaluate::EvalExitReason) -> &'static str {
+    use crate::run::evaluate::EvalExitReason;
+    match reason {
+        EvalExitReason::Resolved => "resolved",
+        EvalExitReason::Unresolved => "unresolved",
+        EvalExitReason::PatchApplyFailed => "patch_apply_failed",
+        EvalExitReason::EvalError => "eval_error",
+        EvalExitReason::SkippedNoPatch => "skipped_no_patch",
+    }
+}
+
+/// Run the near-miss analysis over a completed sweep directory.
+///
+/// Errors:
+/// - `Error::Trajectory` when `evaluation.json` is missing (caller maps to exit 2).
+/// - `Error::Json` on parse failures (caller maps to exit 1).
+pub fn run(args: &NearMissArgs) -> Result<NearMissReport, Error> {
+    let eval = load_evaluation_results(&args.sweep)?
+        .ok_or_else(|| {
+            Error::Trajectory(format!(
+                "near-miss: {} does not contain evaluation.json",
+                args.sweep.display()
+            ))
+        })?;
+
+    let mut eligible: Vec<NearMissRow> = Vec::new();
+    let mut no_gold: usize = 0;
+    let mut empty_patch: usize = 0;
+    let mut no_stats: usize = 0;
+
+    for inst in &eval.instances {
+        if inst.resolved {
+            continue;
+        }
+        let Some(stats) = &inst.patch_stats else {
+            no_stats += 1;
+            continue;
+        };
+        if stats.is_empty {
+            empty_patch += 1;
+            continue;
+        }
+        match (stats.gold_files_iou, stats.gold_lines_overlap, stats.gold_size_ratio) {
+            (Some(iou), Some(overlap), Some(size_ratio)) => {
+                eligible.push(NearMissRow {
+                    rank: 0, // assigned after sort
+                    instance_id: inst.instance_id.clone(),
+                    files_iou: iou,
+                    lines_overlap: overlap,
+                    size_ratio,
+                    failure_category: Some(
+                        eval_exit_reason_label(&inst.eval_exit_reason).to_owned(),
+                    ),
+                    lines_changed: stats.lines_changed(),
+                });
+            }
+            _ => {
+                no_gold += 1;
+            }
+        }
+    }
+
+    // Sort: primary gold_files_iou desc, secondary gold_lines_overlap desc,
+    // tertiary (size_ratio - 1.0).abs() asc, then instance_id asc.
+    eligible.sort_by(|a, b| {
+        b.files_iou
+            .partial_cmp(&a.files_iou)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                b.lines_overlap
+                    .partial_cmp(&a.lines_overlap)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| {
+                let da = (a.size_ratio - 1.0_f32).abs();
+                let db = (b.size_ratio - 1.0_f32).abs();
+                da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| a.instance_id.cmp(&b.instance_id))
+    });
+
+    let total_eligible = eligible.len();
+
+    // Assign ranks and truncate to --top N.
+    let mut ranked: Vec<NearMissRow> = eligible.into_iter().take(args.top).collect();
+    for (i, row) in ranked.iter_mut().enumerate() {
+        row.rank = i + 1;
+    }
+
+    Ok(NearMissReport {
+        buckets: NearMissBuckets {
+            eligible: total_eligible,
+            no_gold,
+            empty_patch,
+            no_stats,
+        },
+        ranked,
+        sweep_path: args.sweep.display().to_string(),
+        generated_at: now_utc_iso8601(),
+    })
+}
+
+fn now_utc_iso8601() -> String {
+    // Integer UTC timestamp via std::time — no external crate needed.
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let sec = secs % 60;
+    let min = (secs / 60) % 60;
+    let hour = (secs / 3600) % 24;
+    let days = secs / 86400;
+    // Civil calendar from days-since-epoch (Howarth 2001 / Howard Hinnant algorithm).
+    let z = days + 719_468;
+    let era = z / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{y:04}-{m:02}-{d:02}T{hour:02}:{min:02}:{sec:02}Z")
+}
+
+// ── text rendering ────────────────────────────────────────────────────────────
+
+/// Render the report as a human-readable text table.
+pub fn render_text(report: &NearMissReport) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "\n=== bench near-miss ===");
+    let _ = writeln!(s, "Sweep:              {}", report.sweep_path);
+    let b = &report.buckets;
+    let _ = writeln!(
+        s,
+        "Buckets:            eligible: {}  no_gold: {}  empty_patch: {}  no_stats: {}",
+        b.eligible, b.no_gold, b.empty_patch, b.no_stats
+    );
+    if report.ranked.is_empty() {
+        let _ = writeln!(s, "\nNo eligible unresolved instances found.");
+        return s;
+    }
+    let showing = report.ranked.len();
+    let _ = writeln!(
+        s,
+        "\nTop {} of {} eligible (ranked by gold proximity):",
+        showing, b.eligible
+    );
+    let _ = writeln!(
+        s,
+        "{:<6} {:<40} {:>10} {:>14} {:>12} {:>20} {:>14}",
+        "rank", "instance_id", "files_iou", "lines_overlap", "size_ratio",
+        "failure_category", "lines_changed"
+    );
+    let _ = writeln!(s, "{}", "-".repeat(120));
+    for row in &report.ranked {
+        let cat = row.failure_category.as_deref().unwrap_or("-");
+        let _ = writeln!(
+            s,
+            "{:<6} {:<40} {:>10.4} {:>14.4} {:>12.4} {:>20} {:>14}",
+            row.rank,
+            row.instance_id,
+            row.files_iou,
+            row.lines_overlap,
+            row.size_ratio,
+            cat,
+            row.lines_changed
+        );
+    }
+    s
+}
+
+// ── JSON rendering ────────────────────────────────────────────────────────────
+
+/// Render the report as a versioned JSON artifact.
+pub fn render_json(report: &NearMissReport) -> Result<String, Error> {
+    crate::artifact::to_string_pretty(ArtifactKind::NearMissReport, report)
+        .map_err(Error::Json)
+}
+
+// ── unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_parse_round_trips() {
+        assert_eq!("text".parse::<NearMissFormat>().unwrap(), NearMissFormat::Text);
+        assert_eq!("json".parse::<NearMissFormat>().unwrap(), NearMissFormat::Json);
+        assert!("bad".parse::<NearMissFormat>().is_err());
+    }
+
+    #[test]
+    fn now_utc_iso8601_looks_valid() {
+        let ts = now_utc_iso8601();
+        assert!(ts.ends_with('Z'), "should end with Z: {ts}");
+        assert_eq!(ts.len(), 20, "should be 20 chars: {ts}");
+    }
+}

--- a/tests/bench_near_miss.rs
+++ b/tests/bench_near_miss.rs
@@ -1,0 +1,679 @@
+//! `bench near-miss`: integration tests for issue #307.
+//!
+//! TDD red → green → refactor. Tests drive the full CLI binary via `Command`.
+//! All test sweep directories are synthetic — no model calls, no network.
+
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+mod support;
+use support::binary_path;
+
+// ── fixture helpers ───────────────────────────────────────────────────────────
+
+/// Write a minimal `results.json` so `load_sweep` doesn't complain.
+fn write_results_json(dir: &Path) {
+    let payload = serde_json::json!({
+        "artifact_kind": "sweep_results",
+        "schema_version": {"major": 1, "minor": 10},
+        "total": 5,
+        "sweep_status": "completed",
+        "submitted": 5,
+        "submitted_with_tests": 0,
+        "skipped": 0,
+        "errored": 0,
+        "failures_by_category": {},
+        "budget_halted": 0,
+        "with_patch": 4,
+        "patch_empty": 1,
+        "patch_apply_invalid": 0,
+        "github_pr_failures": 0,
+        "total_prompt_tokens": 0,
+        "total_cache_read_tokens": 0,
+        "total_cache_creation_tokens": 0,
+        "total_completion_tokens": 0,
+        "estimated_cost_usd": 0.0,
+        "cache_hit_rate": 0.0,
+        "retries": 0,
+        "retried_instances": 0,
+        "pass_at_k": 0.0,
+        "filter_spec": {},
+        "instances": [
+            {
+                "instance_id": "iou_1",
+                "exit_reason": "submitted",
+                "outcome": "submitted",
+                "patch_present": true,
+                "non_empty_patch": true,
+                "attempts": 1,
+                "retry_reasons": [],
+                "runs": 1,
+                "resolved_count": 0,
+                "pass_at_1": false
+            },
+            {
+                "instance_id": "iou_0_5",
+                "exit_reason": "submitted",
+                "outcome": "submitted",
+                "patch_present": true,
+                "non_empty_patch": true,
+                "attempts": 1,
+                "retry_reasons": [],
+                "runs": 1,
+                "resolved_count": 0,
+                "pass_at_1": false
+            },
+            {
+                "instance_id": "iou_0_1",
+                "exit_reason": "submitted",
+                "outcome": "submitted",
+                "patch_present": true,
+                "non_empty_patch": true,
+                "attempts": 1,
+                "retry_reasons": [],
+                "runs": 1,
+                "resolved_count": 0,
+                "pass_at_1": false
+            },
+            {
+                "instance_id": "iou_0_0",
+                "exit_reason": "submitted",
+                "outcome": "submitted",
+                "patch_present": true,
+                "non_empty_patch": true,
+                "attempts": 1,
+                "retry_reasons": [],
+                "runs": 1,
+                "resolved_count": 0,
+                "pass_at_1": false
+            },
+            {
+                "instance_id": "empty_patch",
+                "exit_reason": "submitted",
+                "outcome": "submitted",
+                "patch_present": false,
+                "non_empty_patch": false,
+                "attempts": 1,
+                "retry_reasons": [],
+                "runs": 1,
+                "resolved_count": 0,
+                "pass_at_1": false
+            }
+        ],
+        "total_fallbacks": 0,
+        "model_mix": {},
+        "retry_history": [],
+        "partial": 0,
+        "span_export_dropped": 0
+    });
+    std::fs::write(
+        dir.join("results.json"),
+        serde_json::to_string_pretty(&payload).unwrap(),
+    )
+    .unwrap();
+}
+
+/// Write a synthetic `evaluation.json` with five unresolved instances:
+/// - `iou_1`:      gold_files_iou=1.0, gold_lines_overlap=0.9, gold_size_ratio=1.1 (top)
+/// - `iou_0_5`:    gold_files_iou=0.5, gold_lines_overlap=0.5, gold_size_ratio=1.2 (second)
+/// - `iou_0_1`:    gold_files_iou=0.1, gold_lines_overlap=0.1, gold_size_ratio=2.0 (third)
+/// - `iou_0_0`:    gold_files_iou=0.0, gold_lines_overlap=0.0, gold_size_ratio=0.0 (fourth / no_gold path via null gold)
+/// - `no_gold`:    gold_files_iou=null (missing gold)  → `no_gold` bucket
+/// - `empty_patch`: patch_stats.is_empty=true          → `empty_patch` bucket
+/// - `no_stats`:   patch_stats=null                    → `no_stats` bucket
+fn write_evaluation_json_full(dir: &Path) {
+    let payload = serde_json::json!({
+        "artifact_kind": "evaluation_results",
+        "schema_version": {"major": 1, "minor": 10},
+        "instances": [
+            {
+                "instance_id": "iou_1",
+                "resolved": false,
+                "eval_exit_reason": "unresolved",
+                "patch_stats": {
+                    "files_changed": 2,
+                    "hunks": 2,
+                    "lines_added": 5,
+                    "lines_removed": 3,
+                    "is_empty": false,
+                    "touches_test_files": false,
+                    "touches_lock_or_generated": false,
+                    "gold_files_iou": 1.0,
+                    "gold_lines_overlap": 0.9,
+                    "gold_size_ratio": 1.1
+                }
+            },
+            {
+                "instance_id": "iou_0_5",
+                "resolved": false,
+                "eval_exit_reason": "unresolved",
+                "patch_stats": {
+                    "files_changed": 1,
+                    "hunks": 1,
+                    "lines_added": 3,
+                    "lines_removed": 1,
+                    "is_empty": false,
+                    "touches_test_files": false,
+                    "touches_lock_or_generated": false,
+                    "gold_files_iou": 0.5,
+                    "gold_lines_overlap": 0.5,
+                    "gold_size_ratio": 1.2
+                }
+            },
+            {
+                "instance_id": "iou_0_1",
+                "resolved": false,
+                "eval_exit_reason": "unresolved",
+                "patch_stats": {
+                    "files_changed": 1,
+                    "hunks": 1,
+                    "lines_added": 2,
+                    "lines_removed": 0,
+                    "is_empty": false,
+                    "touches_test_files": false,
+                    "touches_lock_or_generated": false,
+                    "gold_files_iou": 0.1,
+                    "gold_lines_overlap": 0.1,
+                    "gold_size_ratio": 2.0
+                }
+            },
+            {
+                "instance_id": "iou_0_0",
+                "resolved": false,
+                "eval_exit_reason": "unresolved",
+                "patch_stats": {
+                    "files_changed": 1,
+                    "hunks": 1,
+                    "lines_added": 1,
+                    "lines_removed": 0,
+                    "is_empty": false,
+                    "touches_test_files": false,
+                    "touches_lock_or_generated": false,
+                    "gold_files_iou": 0.0,
+                    "gold_lines_overlap": 0.0,
+                    "gold_size_ratio": 0.5
+                }
+            },
+            {
+                "instance_id": "no_gold",
+                "resolved": false,
+                "eval_exit_reason": "unresolved",
+                "patch_stats": {
+                    "files_changed": 1,
+                    "hunks": 1,
+                    "lines_added": 1,
+                    "lines_removed": 0,
+                    "is_empty": false,
+                    "touches_test_files": false,
+                    "touches_lock_or_generated": false
+                }
+            },
+            {
+                "instance_id": "empty_patch",
+                "resolved": false,
+                "eval_exit_reason": "skipped_no_patch",
+                "patch_stats": {
+                    "files_changed": 0,
+                    "hunks": 0,
+                    "lines_added": 0,
+                    "lines_removed": 0,
+                    "is_empty": true,
+                    "touches_test_files": false,
+                    "touches_lock_or_generated": false
+                }
+            },
+            {
+                "instance_id": "no_stats",
+                "resolved": false,
+                "eval_exit_reason": "unresolved"
+            }
+        ],
+    });
+    std::fs::write(
+        dir.join("evaluation.json"),
+        serde_json::to_string_pretty(&payload).unwrap(),
+    )
+    .unwrap();
+}
+
+// ── AC: subcommand exists in --help ──────────────────────────────────────────
+
+#[test]
+fn near_miss_appears_in_bench_help() {
+    let out = Command::new(binary_path())
+        .args(["bench", "--help"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("near-miss"),
+        "bench --help should list near-miss subcommand; got:\n{stdout}"
+    );
+}
+
+// ── AC: exit code 2 when evaluation.json is missing ──────────────────────────
+
+#[test]
+fn near_miss_exits_2_when_no_evaluation_json() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results_json(dir.path());
+
+    let out = Command::new(binary_path())
+        .args(["bench", "near-miss", "--sweep", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected exit code 2 when evaluation.json is missing; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ── AC: exit code 0 on success ────────────────────────────────────────────────
+
+#[test]
+fn near_miss_exits_0_on_success() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results_json(dir.path());
+    write_evaluation_json_full(dir.path());
+
+    let out = Command::new(binary_path())
+        .args(["bench", "near-miss", "--sweep", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "expected exit code 0; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ── AC: deterministic ranking ────────────────────────────────────────────────
+
+#[test]
+fn near_miss_ranking_is_deterministic_and_correct() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results_json(dir.path());
+    write_evaluation_json_full(dir.path());
+
+    let out = Command::new(binary_path())
+        .args(["bench", "near-miss", "--sweep", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // iou_1 must be ranked first (gold_files_iou=1.0)
+    let pos_iou1 = stdout.find("iou_1").unwrap_or(usize::MAX);
+    let pos_iou05 = stdout.find("iou_0_5").unwrap_or(usize::MAX);
+    let pos_iou01 = stdout.find("iou_0_1").unwrap_or(usize::MAX);
+    let pos_iou00 = stdout.find("iou_0_0").unwrap_or(usize::MAX);
+
+    assert!(
+        pos_iou1 < pos_iou05,
+        "iou_1 (IoU=1.0) should appear before iou_0_5 (IoU=0.5); stdout:\n{stdout}"
+    );
+    assert!(
+        pos_iou05 < pos_iou01,
+        "iou_0_5 (IoU=0.5) should appear before iou_0_1 (IoU=0.1); stdout:\n{stdout}"
+    );
+    assert!(
+        pos_iou01 < pos_iou00,
+        "iou_0_1 (IoU=0.1) should appear before iou_0_0 (IoU=0.0); stdout:\n{stdout}"
+    );
+}
+
+// ── AC: correct bucket assignment ────────────────────────────────────────────
+
+#[test]
+fn near_miss_buckets_are_correct_in_text_output() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results_json(dir.path());
+    write_evaluation_json_full(dir.path());
+
+    let out = Command::new(binary_path())
+        .args(["bench", "near-miss", "--sweep", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // Eligible: iou_1, iou_0_5, iou_0_1, iou_0_0 (4 instances)
+    assert!(
+        stdout.contains("eligible: 4"),
+        "should show eligible: 4; got:\n{stdout}"
+    );
+    // no_gold: 1
+    assert!(
+        stdout.contains("no_gold: 1"),
+        "should show no_gold: 1; got:\n{stdout}"
+    );
+    // empty_patch: 1
+    assert!(
+        stdout.contains("empty_patch: 1"),
+        "should show empty_patch: 1; got:\n{stdout}"
+    );
+    // no_stats: 1
+    assert!(
+        stdout.contains("no_stats: 1"),
+        "should show no_stats: 1; got:\n{stdout}"
+    );
+}
+
+// ── AC: --top N limits the output ────────────────────────────────────────────
+
+#[test]
+fn near_miss_top_2_limits_eligible_output() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results_json(dir.path());
+    write_evaluation_json_full(dir.path());
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "near-miss",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+            "--top",
+            "2",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // Should show iou_1 and iou_0_5 but NOT iou_0_1 or iou_0_0 in the table
+    assert!(
+        stdout.contains("iou_1"),
+        "--top 2 should include iou_1; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("iou_0_5"),
+        "--top 2 should include iou_0_5; got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("iou_0_1"),
+        "--top 2 should NOT include iou_0_1; got:\n{stdout}"
+    );
+}
+
+// ── AC: JSON output has versioned artifact ────────────────────────────────────
+
+#[test]
+fn near_miss_json_output_is_versioned_artifact() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results_json(dir.path());
+    write_evaluation_json_full(dir.path());
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "near-miss",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("JSON output should be valid; err={e}; got:\n{stdout}"));
+
+    assert_eq!(
+        json["artifact_kind"].as_str(),
+        Some("near_miss_report"),
+        "artifact_kind should be near_miss_report; got:\n{json}"
+    );
+    assert_eq!(
+        json["schema_version"]["major"].as_u64(),
+        Some(1),
+        "schema_version.major should be 1; got:\n{json}"
+    );
+    assert!(
+        json["ranked"].is_array(),
+        "JSON should have ranked array; got:\n{json}"
+    );
+    assert!(
+        json["buckets"].is_object(),
+        "JSON should have buckets object; got:\n{json}"
+    );
+    assert!(
+        json["sweep_path"].is_string(),
+        "JSON should have sweep_path; got:\n{json}"
+    );
+    assert!(
+        json["generated_at"].is_string(),
+        "JSON should have generated_at timestamp; got:\n{json}"
+    );
+}
+
+// ── AC: JSON ranking is correct ───────────────────────────────────────────────
+
+#[test]
+fn near_miss_json_ranking_order_is_correct() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results_json(dir.path());
+    write_evaluation_json_full(dir.path());
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "near-miss",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    let ranked = json["ranked"].as_array().unwrap();
+    assert!(
+        ranked.len() >= 4,
+        "should have 4 eligible ranked entries; got: {}",
+        ranked.len()
+    );
+
+    assert_eq!(ranked[0]["instance_id"].as_str(), Some("iou_1"));
+    assert_eq!(ranked[1]["instance_id"].as_str(), Some("iou_0_5"));
+    assert_eq!(ranked[2]["instance_id"].as_str(), Some("iou_0_1"));
+    assert_eq!(ranked[3]["instance_id"].as_str(), Some("iou_0_0"));
+
+    // Verify bucket counts
+    assert_eq!(json["buckets"]["eligible"].as_u64(), Some(4));
+    assert_eq!(json["buckets"]["no_gold"].as_u64(), Some(1));
+    assert_eq!(json["buckets"]["empty_patch"].as_u64(), Some(1));
+    assert_eq!(json["buckets"]["no_stats"].as_u64(), Some(1));
+}
+
+// ── AC: no patch text in default output (redaction-safe) ─────────────────────
+
+#[test]
+fn near_miss_output_contains_no_patch_text() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results_json(dir.path());
+    write_evaluation_json_full(dir.path());
+
+    let out = Command::new(binary_path())
+        .args(["bench", "near-miss", "--sweep", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // Should not contain diff markers
+    assert!(
+        !stdout.contains("diff --git"),
+        "output should not contain patch text; got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("@@"),
+        "output should not contain diff hunks; got:\n{stdout}"
+    );
+}
+
+// ── AC: bench compare text output has near-miss referral line ─────────────────
+
+#[test]
+fn bench_compare_text_output_has_near_miss_referral() {
+    // Construct a sweep with one regression (pass->fail) to trigger the
+    // regressions section, and verify the referral line is present.
+    let baseline = tempfile::tempdir().unwrap();
+    let candidate = tempfile::tempdir().unwrap();
+
+    // baseline: instance "a" resolved
+    let baseline_payload = serde_json::json!({
+        "artifact_kind": "sweep_results",
+        "schema_version": {"major": 1, "minor": 10},
+        "total": 1,
+        "sweep_status": "completed",
+        "submitted": 1,
+        "submitted_with_tests": 0,
+        "skipped": 0,
+        "errored": 0,
+        "failures_by_category": {},
+        "budget_halted": 0,
+        "with_patch": 1,
+        "patch_empty": 0,
+        "patch_apply_invalid": 0,
+        "github_pr_failures": 0,
+        "total_prompt_tokens": 0,
+        "total_cache_read_tokens": 0,
+        "total_cache_creation_tokens": 0,
+        "total_completion_tokens": 0,
+        "estimated_cost_usd": 0.0,
+        "cache_hit_rate": 0.0,
+        "retries": 0,
+        "retried_instances": 0,
+        "pass_at_k": 1.0,
+        "filter_spec": {},
+        "instances": [{
+            "instance_id": "a",
+            "exit_reason": "submitted",
+            "outcome": "submitted",
+            "patch_present": true,
+            "non_empty_patch": true,
+            "attempts": 1,
+            "retry_reasons": [],
+            "runs": 1,
+            "resolved_count": 1,
+            "pass_at_1": true
+        }],
+        "total_fallbacks": 0,
+        "model_mix": {},
+        "retry_history": [],
+        "partial": 0,
+        "span_export_dropped": 0
+    });
+    std::fs::write(
+        baseline.path().join("results.json"),
+        serde_json::to_string_pretty(&baseline_payload).unwrap(),
+    )
+    .unwrap();
+    let baseline_eval = serde_json::json!({
+        "artifact_kind": "evaluation_results",
+        "schema_version": {"major": 1, "minor": 10},
+        "instances": [{"instance_id": "a", "resolved": true, "eval_exit_reason": "resolved"}]
+    });
+    std::fs::write(
+        baseline.path().join("evaluation.json"),
+        serde_json::to_string_pretty(&baseline_eval).unwrap(),
+    )
+    .unwrap();
+
+    // candidate: instance "a" fails (regression)
+    let candidate_payload = serde_json::json!({
+        "artifact_kind": "sweep_results",
+        "schema_version": {"major": 1, "minor": 10},
+        "total": 1,
+        "sweep_status": "completed",
+        "submitted": 0,
+        "submitted_with_tests": 0,
+        "skipped": 0,
+        "errored": 1,
+        "failures_by_category": {"step_limit": 1},
+        "budget_halted": 0,
+        "with_patch": 0,
+        "patch_empty": 0,
+        "patch_apply_invalid": 0,
+        "github_pr_failures": 0,
+        "total_prompt_tokens": 0,
+        "total_cache_read_tokens": 0,
+        "total_cache_creation_tokens": 0,
+        "total_completion_tokens": 0,
+        "estimated_cost_usd": 0.0,
+        "cache_hit_rate": 0.0,
+        "retries": 0,
+        "retried_instances": 0,
+        "pass_at_k": 0.0,
+        "filter_spec": {},
+        "instances": [{
+            "instance_id": "a",
+            "exit_reason": "step_limit",
+            "outcome": "error",
+            "failure_category": "step_limit",
+            "patch_present": false,
+            "non_empty_patch": false,
+            "attempts": 1,
+            "retry_reasons": [],
+            "runs": 1,
+            "resolved_count": 0,
+            "pass_at_1": false
+        }],
+        "total_fallbacks": 0,
+        "model_mix": {},
+        "retry_history": [],
+        "partial": 0,
+        "span_export_dropped": 0
+    });
+    std::fs::write(
+        candidate.path().join("results.json"),
+        serde_json::to_string_pretty(&candidate_payload).unwrap(),
+    )
+    .unwrap();
+    let candidate_eval = serde_json::json!({
+        "artifact_kind": "evaluation_results",
+        "schema_version": {"major": 1, "minor": 10},
+        "instances": [{"instance_id": "a", "resolved": false, "eval_exit_reason": "unresolved"}]
+    });
+    std::fs::write(
+        candidate.path().join("evaluation.json"),
+        serde_json::to_string_pretty(&candidate_eval).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "compare",
+            "--baseline",
+            baseline.path().to_str().unwrap(),
+            "--candidate",
+            candidate.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("bench near-miss"),
+        "bench compare text output should contain 'bench near-miss' referral; got:\n{stdout}"
+    );
+}

--- a/tests/bench_near_miss.rs
+++ b/tests/bench_near_miss.rs
@@ -123,6 +123,7 @@ fn write_results_json(dir: &Path) {
 /// - `no_gold`:    gold_files_iou=null (missing gold)  → `no_gold` bucket
 /// - `empty_patch`: patch_stats.is_empty=true          → `empty_patch` bucket
 /// - `no_stats`:   patch_stats=null                    → `no_stats` bucket
+#[allow(clippy::too_many_lines)]
 fn write_evaluation_json_full(dir: &Path) {
     let payload = serde_json::json!({
         "artifact_kind": "evaluation_results",
@@ -261,7 +262,12 @@ fn near_miss_exits_2_when_no_evaluation_json() {
     write_results_json(dir.path());
 
     let out = Command::new(binary_path())
-        .args(["bench", "near-miss", "--sweep", dir.path().to_str().unwrap()])
+        .args([
+            "bench",
+            "near-miss",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+        ])
         .output()
         .unwrap();
 
@@ -282,7 +288,12 @@ fn near_miss_exits_0_on_success() {
     write_evaluation_json_full(dir.path());
 
     let out = Command::new(binary_path())
-        .args(["bench", "near-miss", "--sweep", dir.path().to_str().unwrap()])
+        .args([
+            "bench",
+            "near-miss",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+        ])
         .output()
         .unwrap();
 
@@ -303,7 +314,12 @@ fn near_miss_ranking_is_deterministic_and_correct() {
     write_evaluation_json_full(dir.path());
 
     let out = Command::new(binary_path())
-        .args(["bench", "near-miss", "--sweep", dir.path().to_str().unwrap()])
+        .args([
+            "bench",
+            "near-miss",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+        ])
         .output()
         .unwrap();
 
@@ -311,21 +327,21 @@ fn near_miss_ranking_is_deterministic_and_correct() {
     let stdout = String::from_utf8_lossy(&out.stdout);
 
     // iou_1 must be ranked first (gold_files_iou=1.0)
-    let pos_iou1 = stdout.find("iou_1").unwrap_or(usize::MAX);
-    let pos_iou05 = stdout.find("iou_0_5").unwrap_or(usize::MAX);
-    let pos_iou01 = stdout.find("iou_0_1").unwrap_or(usize::MAX);
-    let pos_iou00 = stdout.find("iou_0_0").unwrap_or(usize::MAX);
+    let rank_iou_full = stdout.find("iou_1").unwrap_or(usize::MAX);
+    let rank_iou_half = stdout.find("iou_0_5").unwrap_or(usize::MAX);
+    let rank_iou_tenth = stdout.find("iou_0_1").unwrap_or(usize::MAX);
+    let rank_iou_zero = stdout.find("iou_0_0").unwrap_or(usize::MAX);
 
     assert!(
-        pos_iou1 < pos_iou05,
+        rank_iou_full < rank_iou_half,
         "iou_1 (IoU=1.0) should appear before iou_0_5 (IoU=0.5); stdout:\n{stdout}"
     );
     assert!(
-        pos_iou05 < pos_iou01,
+        rank_iou_half < rank_iou_tenth,
         "iou_0_5 (IoU=0.5) should appear before iou_0_1 (IoU=0.1); stdout:\n{stdout}"
     );
     assert!(
-        pos_iou01 < pos_iou00,
+        rank_iou_tenth < rank_iou_zero,
         "iou_0_1 (IoU=0.1) should appear before iou_0_0 (IoU=0.0); stdout:\n{stdout}"
     );
 }
@@ -339,7 +355,12 @@ fn near_miss_buckets_are_correct_in_text_output() {
     write_evaluation_json_full(dir.path());
 
     let out = Command::new(binary_path())
-        .args(["bench", "near-miss", "--sweep", dir.path().to_str().unwrap()])
+        .args([
+            "bench",
+            "near-miss",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+        ])
         .output()
         .unwrap();
 
@@ -511,7 +532,12 @@ fn near_miss_output_contains_no_patch_text() {
     write_evaluation_json_full(dir.path());
 
     let out = Command::new(binary_path())
-        .args(["bench", "near-miss", "--sweep", dir.path().to_str().unwrap()])
+        .args([
+            "bench",
+            "near-miss",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+        ])
         .output()
         .unwrap();
 
@@ -531,6 +557,7 @@ fn near_miss_output_contains_no_patch_text() {
 
 // ── AC: bench compare text output has near-miss referral line ─────────────────
 
+#[allow(clippy::too_many_lines)]
 #[test]
 fn bench_compare_text_output_has_near_miss_referral() {
     // Construct a sweep with one regression (pass->fail) to trigger the


### PR DESCRIPTION
## Summary

Implements the `bench near-miss` subcommand (issue #307) to rank unresolved sweep instances by their proximity to gold patches. This is a zero-cost analysis tool that reads only `evaluation.json` from a completed sweep directory, requiring no model calls, network access, or evaluator invocation.

## Key Changes

- **New module `src/run/near_miss.rs`**: Core logic for analyzing unresolved instances and ranking them by gold-patch proximity metrics
  - Splits unresolved instances into four buckets: `eligible` (non-empty patch with gold metrics), `no_gold` (missing gold data), `empty_patch` (no patch submitted), and `no_stats` (missing patch_stats)
  - Ranks eligible instances by: (1) `gold_files_iou` descending, (2) `gold_lines_overlap` descending, (3) `(gold_size_ratio - 1.0).abs()` ascending, (4) `instance_id` ascending for determinism
  - Supports both text and JSON output formats with `--top N` limiting
  - Includes ISO8601 timestamp generation without external dependencies

- **CLI integration**:
  - Added `NearMissCmd` struct in `src/cli/args.rs` with `--sweep`, `--top`, and `--format` options
  - Integrated handler in `src/cli/mod.rs` with proper error handling (exit code 2 for missing evaluation.json, exit code 1 for parse errors)

- **Artifact versioning**: Added `NearMissReport` to `ArtifactKind` enum in `src/artifact.rs` for versioned JSON output

- **Integration with `bench compare`**: Added referral line in comparison text output directing users to `bench near-miss` for regression analysis

- **Comprehensive test suite** (`tests/bench_near_miss.rs`): 679 lines of integration tests covering:
  - Subcommand presence in help text
  - Exit codes (0 on success, 2 when evaluation.json missing)
  - Deterministic ranking correctness
  - Bucket assignment accuracy
  - `--top N` limiting behavior
  - JSON output structure and versioning
  - Redaction safety (no patch text in output)
  - Integration with `bench compare` workflow

## Implementation Details

- Uses existing `load_evaluation_results` from `src/run/compare.rs` for consistency
- Implements custom ISO8601 timestamp generation using only `std::time` (no external crate)
- Sorting uses Rust's `partial_cmp` with proper handling of floating-point comparisons
- Text output uses fixed-width table formatting for readability
- JSON output follows the versioned artifact pattern with `artifact_kind` and `schema_version`

https://claude.ai/code/session_016mtoTiZYs2fzDJ3a4DK1W9