### PR TITLE
⚡ Bolt: Remove intermediate vector allocations and use pre-allocation

### DIFF
--- a/src/run/reproduce.rs
+++ b/src/run/reproduce.rs
@@ -569,27 +569,26 @@ pub fn top_diverging_failure_categories(
     let mut counts: HashMap<String, usize> = HashMap::new();
 
     for entry in instances {
-        let diverging = match (entry.original_resolved, entry.replay_resolved) {
+        match (entry.original_resolved, entry.replay_resolved) {
             (true, false) => {
-                // flipped to unresolved — note the new failure category
-                entry.replay_failure_category.iter().collect::<Vec<_>>()
+                if let Some(cat) = &entry.replay_failure_category {
+                    *counts.entry(cat.clone()).or_insert(0) += 1;
+                }
             }
             (false, true) => {
-                // flipped to resolved — note what was failing before
-                entry.original_failure_category.iter().collect::<Vec<_>>()
+                if let Some(cat) = &entry.original_failure_category {
+                    *counts.entry(cat.clone()).or_insert(0) += 1;
+                }
             }
             (false, false) if entry.original_failure_category != entry.replay_failure_category => {
-                // same unresolved outcome but different category — note both
-                entry
-                    .original_failure_category
-                    .iter()
-                    .chain(entry.replay_failure_category.iter())
-                    .collect::<Vec<_>>()
+                if let Some(cat) = &entry.original_failure_category {
+                    *counts.entry(cat.clone()).or_insert(0) += 1;
+                }
+                if let Some(cat) = &entry.replay_failure_category {
+                    *counts.entry(cat.clone()).or_insert(0) += 1;
+                }
             }
-            _ => vec![],
-        };
-        for cat in diverging {
-            *counts.entry(cat.clone()).or_insert(0) += 1;
+            _ => {}
         }
     }
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -90,7 +90,7 @@ impl SkillRegistry {
         }
         skill_files.sort();
 
-        let mut manifests = Vec::new();
+        let mut manifests = Vec::with_capacity(skill_files.len());
         let mut seen_names = BTreeSet::new();
         for path in skill_files {
             let text = std::fs::read_to_string(&path)?;


### PR DESCRIPTION
💡 What: 
- Replaced a `.collect::<Vec<_>>()` chain in `src/run/reproduce.rs` inside `top_diverging_failure_categories` with direct iteration to update `counts` HashMap.
- Switched `Vec::new()` to `Vec::with_capacity(skill_files.len())` in `src/skills.rs` for the `manifests` vector in `scan_paths`.

🎯 Why:
- Intermediate heap allocations are unnecessary when all we do is iterate over them immediately after.
- Growing a vector repeatedly via `Vec::new()` requires multiple allocations and copies, which can be avoided since the required size is exactly known ahead of time.

📊 Impact:
- Removes temporary heap allocations in the reproduce pipeline.
- Reduces reallocation overhead in skill registry scanning.

🔬 Measurement:
- Run `cargo test --lib run::reproduce::tests` and `cargo bench` if applicable. All functionality stays logically identical while bypassing intermediate variables.

---
*PR created automatically by Jules for task [13931013717214140896](https://jules.google.com/task/13931013717214140896) started by @madmax983*