### PR TITLE
⚒️ Forge: Fix clippy warnings

### DIFF
--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -7987,6 +7987,7 @@ instance = "inst"
     /// every payload carries the schema-version envelope (AC #8 from #315).
     #[cfg(feature = "webhook")]
     #[tokio::test]
+    #[allow(clippy::too_many_lines)]
     async fn notify_webhook_posts_events_in_order_with_schema_envelope() {
         use std::sync::{Arc, Mutex};
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -8005,11 +8006,7 @@ instance = "inst"
                 };
                 let mut buf = Vec::new();
                 let mut chunk = [0u8; 8192];
-                loop {
-                    let n = match socket.read(&mut chunk).await {
-                        Ok(n) => n,
-                        Err(_) => break,
-                    };
+                while let Ok(n) = socket.read(&mut chunk).await {
                     if n == 0 {
                         break;
                     }
@@ -8107,6 +8104,7 @@ instance = "inst"
             notify_webhook_headers: vec![],
         };
 
+        #[allow(clippy::expect_used)]
         let results = tokio::time::timeout(std::time::Duration::from_secs(15), run(args))
             .await
             .expect("sweep timed out")

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -626,7 +626,7 @@ mod tests {
         match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((s, _))) => s,
             Ok(Err(e)) => panic!("accept error: {e}"),
-            Err(_) => panic!("accept timed out"),
+            Err(e) => panic!("accept timed out: {e}"),
         }
     }
 
@@ -637,7 +637,7 @@ mod tests {
             let n = match tokio::time::timeout(TEST_IO_TIMEOUT, socket.read(&mut chunk)).await {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => panic!("read error: {e}"),
-                Err(_) => panic!("read timed out"),
+                Err(e) => panic!("read timed out: {e}"),
             };
             if n == 0 {
                 break;
@@ -654,7 +654,7 @@ mod tests {
     }
 
     fn body_of(req: &str) -> &str {
-        req.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("")
+        req.split_once("\r\n\r\n").map_or("", |(_, b)| b)
     }
 
     fn is_complete_http(buf: &[u8]) -> bool {


### PR DESCRIPTION
🚮 **Smell**: The codebase fails `cargo clippy --all-targets --all-features -- -D warnings` due to unidiomatic structures like `loop { let n = match ... }`, `unwrap_or`, catching `Err(_)` and unhandled long functions.
✨ **Solution**: Applied `while let Ok(...)`, `map_or`, concrete `Err(e)` catches, and targeted `allow(...)` overrides.
🧼 **Benefit**: Strict adherence to `-D warnings` and overall cleaner/idiomatic Rust constructs.
🛡️ **Verification**: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [750168026752963965](https://jules.google.com/task/750168026752963965) started by @madmax983*