### PR TITLE
Implement `agent apply` command with safety gates (issue #473)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ cargo run --quiet -- --log error bench inspect --sweep runs/quickstart --instanc
 
 This is the core operator loop before any sweep: run one task, inspect the
 trajectory, then decide whether the model, prompt, budget, and environment are
-ready for a broader run.
+ready for a broader run. To apply a produced patch to your local checkout, use
+`agent apply` — see [`docs/spec-agent-apply.md`](docs/spec-agent-apply.md) for
+the full selector rules, safety gates, and exit-code matrix.
 
 Export the same trajectory as shareable Markdown in one command:
 

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -33,6 +33,9 @@ parsing human-oriented output.
 | 25   | `redact_check_stale_literals` | `agent redact-check` found that at least one configured `secret_literals` entry produced zero matches against the sample input. The literal is likely stale and may not be protecting anything. |
 | 26   | `redact_check_strict_fail` | `agent redact-check --strict` found that at least one `custom_patterns` entry compiled successfully but produced zero matches. Use to catch regex typos or renamed token formats in CI. Exit 26 takes priority over exit 25 when both conditions hold. |
 | 27   | `slo_rule_failure`       | `bench assert` evaluated all rules and at least one rule (or missing-artifact in fail-closed mode) did not pass. The command ran correctly and wrote `assertions.json`; the non-zero exit means the sweep did not meet the declared SLO. Distinct from `usage_error` (2) so CI can distinguish "your gate failed" from "your invocation is broken". |
+| 28   | `apply_check_failed`     | `agent apply` ran `git apply --check` and the patch cannot be applied cleanly to the current tree. The working tree is left unchanged. |
+| 29   | `apply_redacted_refused` | `agent apply` detected `[REDACTED:…]` markers in the patch content or the source trajectory recorded patch-submission redaction. Pass `--allow-redacted` to override. |
+| 30   | `apply_dirty_tree_refused` | `agent apply` found uncommitted changes in the target working tree. Pass `--allow-dirty` to override. |
 | 130  | `interrupted`            | Graceful SIGINT / Ctrl-C cancellation (POSIX convention: 128 + SIGINT(2)). |
 | 137  | `killed`                 | SIGKILL escalation after the graceful-cancel deadline expired (128 + SIGKILL(9)). |
 
@@ -85,6 +88,7 @@ coarse sweep-level result.
 | `bench scriptability-check`     | `success`, `usage_error`, `scriptability_check_failure`, `internal_error` |
 | `agent redact-check`            | `success`, `usage_error`, `redact_check_stale_literals`, `redact_check_strict_fail`, `internal_error` |
 | `bench assert`                  | `success`, `usage_error`, `slo_rule_failure`, `internal_error` |
+| `agent apply`                   | `success`, `usage_error`, `apply_check_failed`, `apply_redacted_refused`, `apply_dirty_tree_refused`, `internal_error` |
 
 > **Note:** `hello-world` does not produce distinct outcome classes beyond
 > `success` / `internal_error`; it is an interactive debugging surface.

--- a/docs/spec-agent-apply.md
+++ b/docs/spec-agent-apply.md
@@ -1,0 +1,120 @@
+# Spec: `agent apply`
+
+Applies a captured `.patch` artifact to a working tree with the harness's
+full safety-gate stack. Implements issue #473.
+
+## Motivation
+
+`mini` (and every sweep) writes a redaction-clean `.patch` artifact, but
+the core operator loop offered no first-class way to apply that patch back
+to a checkout. Operators had to locate the artifact manually and craft a raw
+`git apply` invocation — with zero clean-tree protection and no guard against
+`[REDACTED:…]`-corrupted patches. `agent apply` fills this gap.
+
+## Usage
+
+```
+max agent apply --patch <PATH> [OPTIONS]
+max agent apply --trajectory <PATH> [OPTIONS]
+max agent apply --sweep <DIR> --instance <ID> [OPTIONS]
+```
+
+Exactly **one** patch selector must be supplied. All other flags are optional.
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--patch <PATH>` | — | Direct path to a `.patch` file. |
+| `--trajectory <PATH>` | — | Path to a `.traj.json`; the sibling `.patch` is resolved automatically. |
+| `--sweep <DIR> --instance <ID>` | — | Sweep output dir + instance ID; resolves `<dir>/<id>.patch`. |
+| `--target <DIR>` | CWD | Git working tree to apply into. |
+| `--allow-redacted` | false | Skip the redaction-corruption gate. |
+| `--allow-dirty` | false | Skip the clean-tree gate. |
+| `--dry-run` | false | Run `--check` only; print what would change; exit 0. |
+| `--3way` | false | Delegate to `git apply --3way` for fuzzy application. |
+| `--report <PATH>` | `apply-report.json` (next to target) | Where to write the JSON report. |
+
+## Selector Rules
+
+Selector flags are mutually exclusive. `clap` enforces this at parse time.
+
+| Invocation form | Patch resolved from |
+|-----------------|---------------------|
+| `--patch <PATH>` | `<PATH>` directly |
+| `--trajectory <PATH>` | sibling of `<PATH>`: `task.traj.json` → `task.patch` |
+| `--sweep <DIR> --instance <ID>` | `<DIR>/<ID>.patch` |
+
+Missing or ambiguous selectors exit **2** (`usage_error`) before any
+filesystem mutation.
+
+## Safety Gates (evaluation order)
+
+1. **Selector resolution** — Exactly one selector form must be present.
+   Ambiguous or missing selectors exit 2 before any mutation.
+
+2. **Git working tree check** — `--target` (or CWD) must be inside a git
+   working tree (`git rev-parse --is-inside-work-tree`). A non-git target
+   exits 2 before any mutation.
+
+3. **Dirty-tree check** — The working tree must have no uncommitted changes
+   (`git status --porcelain`). A dirty tree exits **30**
+   (`apply_dirty_tree_refused`). Override: `--allow-dirty`.
+
+4. **Redaction-corruption check** — Applied when `--patch` is used directly
+   *or* when a trajectory is available:
+   - The patch content is scanned for `[REDACTED:…]` markers.
+   - When a sibling trajectory is available, its `info.redaction.counts`
+     is checked for any entry with `surface == "patch_submission"`.
+   Either condition exits **29** (`apply_redacted_refused`). Override:
+   `--allow-redacted`.
+
+5. **`git apply --check`** — A dry-run application is attempted before
+   mutating the tree. On failure the rejected hunks are printed and the
+   command exits **28** (`apply_check_failed`). The tree is left unchanged.
+
+6. **`--dry-run` short-circuit** — If `--dry-run`, stop here: print the
+   files and hunk counts that would change and exit **0**.
+
+7. **Apply** — `git apply [--3way]` is run. The tree is mutated. An
+   `apply-report.json` is written.
+
+## apply-report.json
+
+Written on every non-error outcome (including empty-patch and dry-run).
+
+```json
+{
+  "schema_version": {"major": 1, "minor": 10},
+  "artifact_kind": "apply_report",
+  "source_patch_path": "/path/to/task.patch",
+  "target_git_sha": "abc123def456...",
+  "files_changed": ["src/lib.rs"],
+  "lines_added": 5,
+  "lines_removed": 2,
+  "check_result": "passed",
+  "applied": true,
+  "dry_run": false
+}
+```
+
+`check_result` values: `"passed"` | `"empty"` | `"failed"`.
+
+## Exit-Code Matrix
+
+| Code | Label | Meaning |
+|------|-------|---------|
+| 0 | `success` | Patch applied (or dry-run / empty patch). |
+| 1 | `internal_error` | I/O failure or unexpected subprocess error. |
+| 2 | `usage_error` | Missing/ambiguous selector, or non-git target. |
+| 28 | `apply_check_failed` | `git apply --check` rejected the patch. Tree unchanged. |
+| 29 | `apply_redacted_refused` | Patch has `[REDACTED:…]` markers or trajectory records patch-submission redaction. |
+| 30 | `apply_dirty_tree_refused` | Working tree has uncommitted changes. |
+
+## Out of Scope
+
+- Opening GitHub PRs (use `mini --open-pr` or sweep `--open-prs`).
+- Reverting/unapplying a previously applied patch.
+- Interactive conflict resolution (use `--3way` + manual git).
+- Applying multiple sweep instances in one invocation.
+- Re-running or re-evaluating the agent.

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -68,6 +68,7 @@ pub enum ArtifactKind {
     SuiteResults,
     ScriptabilityCheck,
     NearMissReport,
+    ApplyReport,
 }
 
 impl ArtifactKind {
@@ -93,6 +94,7 @@ impl ArtifactKind {
             Self::SuiteResults => "suite_results",
             Self::ScriptabilityCheck => "scriptability_check",
             Self::NearMissReport => "near_miss_report",
+            Self::ApplyReport => "apply_report",
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -223,6 +223,74 @@ pub struct PolicyCheckCmd {
     pub output: Option<std::path::PathBuf>,
 }
 
+/// `agent apply` — apply a captured patch artifact to a working tree.
+#[derive(Debug, Args)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct AgentApplyCmd {
+    // ── Patch selectors (exactly one required) ────────────────────────────────
+
+    /// Direct path to a `.patch` file. Mutually exclusive with `--trajectory`
+    /// and `--sweep`.
+    #[arg(long, value_name = "PATH", conflicts_with_all = &["trajectory", "sweep"])]
+    pub patch: Option<PathBuf>,
+
+    /// Path to a `.traj.json` trajectory file; the sibling `.patch` is
+    /// resolved automatically. Mutually exclusive with `--patch` and
+    /// `--sweep`.
+    #[arg(long, value_name = "PATH", conflicts_with_all = &["patch", "sweep"])]
+    pub trajectory: Option<PathBuf>,
+
+    /// Sweep output directory. Used with `--instance` to locate
+    /// `<sweep>/<instance>.patch`. Mutually exclusive with `--patch` and
+    /// `--trajectory`.
+    #[arg(
+        long,
+        value_name = "DIR",
+        requires = "instance",
+        conflicts_with_all = &["patch", "trajectory"]
+    )]
+    pub sweep: Option<PathBuf>,
+
+    /// Instance ID within the sweep (used with `--sweep`).
+    #[arg(long, value_name = "ID", requires = "sweep")]
+    pub instance: Option<String>,
+
+    // ── Target ────────────────────────────────────────────────────────────────
+
+    /// Git working tree to apply into. Defaults to the current directory.
+    #[arg(long, value_name = "DIR")]
+    pub target: Option<PathBuf>,
+
+    // ── Safety gates ──────────────────────────────────────────────────────────
+
+    /// Allow applying a patch that contains `[REDACTED:…]` markers or whose
+    /// source trajectory recorded redaction on the patch-submission surface.
+    #[arg(long, default_value_t = false)]
+    pub allow_redacted: bool,
+
+    /// Allow applying to a working tree that has uncommitted changes.
+    #[arg(long, default_value_t = false)]
+    pub allow_dirty: bool,
+
+    // ── Operation modes ───────────────────────────────────────────────────────
+
+    /// Print the files and hunk counts that would change without modifying the
+    /// tree. Exits 0.
+    #[arg(long, default_value_t = false)]
+    pub dry_run: bool,
+
+    /// Delegate to `git apply --3way` for fuzzy three-way merge application.
+    #[arg(long = "3way", default_value_t = false)]
+    pub three_way: bool,
+
+    // ── Report ────────────────────────────────────────────────────────────────
+
+    /// Where to write `apply-report.json`. Defaults to `apply-report.json`
+    /// next to the target directory.
+    #[arg(long, value_name = "PATH")]
+    pub report: Option<PathBuf>,
+}
+
 /// `agent` subcommands.
 #[derive(Debug, Subcommand)]
 pub enum AgentCmd {
@@ -239,6 +307,8 @@ pub enum AgentCmd {
     Suite(Box<SuiteCmd>),
     /// Check a command corpus against the policy config (zero-cost, no model call).
     PolicyCheck(PolicyCheckCmd),
+    /// Apply a captured patch artifact to a working tree (issue #473).
+    Apply(AgentApplyCmd),
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -228,7 +228,6 @@ pub struct PolicyCheckCmd {
 #[allow(clippy::struct_excessive_bools)]
 pub struct AgentApplyCmd {
     // ── Patch selectors (exactly one required) ────────────────────────────────
-
     /// Direct path to a `.patch` file. Mutually exclusive with `--trajectory`
     /// and `--sweep`.
     #[arg(long, value_name = "PATH", conflicts_with_all = &["trajectory", "sweep"])]
@@ -256,13 +255,11 @@ pub struct AgentApplyCmd {
     pub instance: Option<String>,
 
     // ── Target ────────────────────────────────────────────────────────────────
-
     /// Git working tree to apply into. Defaults to the current directory.
     #[arg(long, value_name = "DIR")]
     pub target: Option<PathBuf>,
 
     // ── Safety gates ──────────────────────────────────────────────────────────
-
     /// Allow applying a patch that contains `[REDACTED:…]` markers or whose
     /// source trajectory recorded redaction on the patch-submission surface.
     #[arg(long, default_value_t = false)]
@@ -273,7 +270,6 @@ pub struct AgentApplyCmd {
     pub allow_dirty: bool,
 
     // ── Operation modes ───────────────────────────────────────────────────────
-
     /// Print the files and hunk counts that would change without modifying the
     /// tree. Exits 0.
     #[arg(long, default_value_t = false)]
@@ -284,7 +280,6 @@ pub struct AgentApplyCmd {
     pub three_way: bool,
 
     // ── Report ────────────────────────────────────────────────────────────────
-
     /// Where to write `apply-report.json`. Defaults to `apply-report.json`
     /// next to the target directory.
     #[arg(long, value_name = "PATH")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -139,6 +139,7 @@ pub async fn run() -> Result<(), Error> {
             } => agent_env_preview_cmd(p),
             args::AgentCmd::Suite(s) => Box::pin(agent_suite_cmd(*s)).await,
             args::AgentCmd::PolicyCheck(p) => agent_policy_check_cmd(&p),
+            args::AgentCmd::Apply(a) => agent_apply_cmd(&a),
         },
         Command::Ui(u) => ui_cmd(u).await,
         #[cfg(feature = "docker")]
@@ -388,6 +389,94 @@ fn resolve_and_validate_workdir(
         Ok(Some(canonical))
     } else {
         Ok(None)
+    }
+}
+
+fn agent_apply_cmd(a: &args::AgentApplyCmd) -> Result<(), Error> {
+    use crate::run::apply::{AgentApplyOpts, PatchSelector, exit_code_for, run_agent_apply};
+
+    // Resolve selector
+    let selector = match (&a.patch, &a.trajectory, &a.sweep, &a.instance) {
+        (Some(p), None, None, None) => PatchSelector::PatchFile(p.clone()),
+        (None, Some(t), None, None) => PatchSelector::TrajectoryFile(t.clone()),
+        (None, None, Some(s), Some(inst)) => PatchSelector::SweepInstance {
+            sweep: s.clone(),
+            instance: inst.clone(),
+        },
+        (None, None, None, None) => {
+            return Err(Error::Config(crate::error::ConfigError::Usage(
+                "no patch selector; use --patch <PATH>, --trajectory <PATH>, \
+                 or --sweep <DIR> --instance <ID>"
+                    .to_owned(),
+            )));
+        }
+        _ => {
+            return Err(Error::Config(crate::error::ConfigError::Usage(
+                "supply exactly one of: --patch <PATH>, --trajectory <PATH>, \
+                 or --sweep <DIR> --instance <ID>"
+                    .to_owned(),
+            )));
+        }
+    };
+
+    let target = a.target.clone().unwrap_or_else(|| {
+        std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+    });
+
+    let opts = AgentApplyOpts {
+        selector,
+        target,
+        allow_redacted: a.allow_redacted,
+        allow_dirty: a.allow_dirty,
+        dry_run: a.dry_run,
+        three_way: a.three_way,
+        report_path: a.report.clone(),
+    };
+
+    match run_agent_apply(opts) {
+        Ok(report) => {
+            if report.check_result == "empty" {
+                eprintln!("no changes to apply (empty patch)");
+            } else if report.dry_run {
+                eprintln!(
+                    "dry-run: {} file(s) would change (+{} -{} lines)",
+                    report.files_changed.len(),
+                    report.lines_added,
+                    report.lines_removed
+                );
+                for f in &report.files_changed {
+                    eprintln!("  {f}");
+                }
+            } else {
+                eprintln!(
+                    "applied: {} file(s) changed (+{} -{} lines)",
+                    report.files_changed.len(),
+                    report.lines_added,
+                    report.lines_removed
+                );
+            }
+            Ok(())
+        }
+        Err(e) => {
+            let ec = exit_code_for(&e);
+            eprintln!("outcome_class: {}", ec.outcome_class());
+            eprintln!("error: {e}");
+            // Print rejected hunks on CheckFailed
+            if let crate::run::apply::ApplyError::CheckFailed(ref hunks) = e {
+                if !hunks.is_empty() {
+                    eprintln!("--- rejected hunks ---");
+                    eprintln!("{hunks}");
+                }
+            }
+            // Print dirty paths on DirtyTree
+            if let crate::run::apply::ApplyError::DirtyTree(ref paths) = e {
+                eprintln!("--- dirty paths ---");
+                for p in paths {
+                    eprintln!("  {p}");
+                }
+            }
+            std::process::exit(ec.as_i32());
+        }
     }
 }
 

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -116,6 +116,19 @@ pub enum ExitCode {
     /// from "your invocation is broken". All rules were evaluated; the gate is wired
     /// correctly but the sweep did not meet the declared SLO.
     SloRuleFailure = 27,
+    /// 28 — `agent apply` ran `git apply --check` and the patch was rejected.
+    /// The tree is byte-for-byte unchanged; the rejected hunks were printed to
+    /// stderr. Distinct from `internal_error` (1) so automation can distinguish
+    /// "the patch is inapplicable" from "something else went wrong".
+    ApplyCheckFailed = 28,
+    /// 29 — `agent apply` refused because the source trajectory recorded
+    /// redaction on the `patch_submission` surface, meaning the patch file
+    /// contains `[REDACTED:…]` markers that would corrupt the working tree.
+    /// Pass `--allow-redacted` to override.
+    ApplyRedactedRefused = 29,
+    /// 30 — `agent apply` refused because the target working tree has
+    /// uncommitted changes. Pass `--allow-dirty` to override.
+    ApplyDirtyTreeRefused = 30,
     /// 130 — user interruption (graceful SIGINT / Ctrl-C; 128 + SIGINT(2)).
     Interrupted = 130,
     /// 137 — forced kill (SIGKILL escalation after graceful-cancel deadline; 128 + SIGKILL(9)).
@@ -164,6 +177,9 @@ impl ExitCode {
             Self::RedactCheckStaleLiterals => "redact_check_stale_literals",
             Self::RedactCheckStrictFail => "redact_check_strict_fail",
             Self::SloRuleFailure => "slo_rule_failure",
+            Self::ApplyCheckFailed => "apply_check_failed",
+            Self::ApplyRedactedRefused => "apply_redacted_refused",
+            Self::ApplyDirtyTreeRefused => "apply_dirty_tree_refused",
             Self::Interrupted => "interrupted",
             Self::Killed => "killed",
         }

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -247,13 +247,7 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
     // ── 12. Apply the patch ───────────────────────────────────────────────────
     // patch_path is canonicalized (absolute); git_root avoids silent skips
     // when --target is a repo subdirectory.
-    apply_patch(
-        &git_root,
-        &patch_path,
-        opts.three_way,
-        opts.allow_dirty,
-        &files_changed,
-    )?;
+    apply_patch(&git_root, &patch_path, opts.three_way, &files_changed)?;
 
     // ── 14. Write report ──────────────────────────────────────────────────────
     let report = ApplyReport {
@@ -498,32 +492,57 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<String>, i64, i64) {
     (files, added, removed)
 }
 
+/// Return the set of file paths that have index entries (staged or unmerged)
+/// among `files`, by parsing `git ls-files --stage -- <files>`.
+fn staged_files(git_root: &Path, files: &[String]) -> std::collections::HashSet<String> {
+    let mut cmd = Command::new("git");
+    cmd.args(["ls-files", "--stage", "--"]);
+    for f in files {
+        cmd.arg(f);
+    }
+    cmd.current_dir(git_root);
+    let Ok(output) = cmd.output() else {
+        return std::collections::HashSet::new();
+    };
+    // Each line: "<mode> <sha1> <stage_num>\t<path>"
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split('\t').nth(1).map(str::to_owned))
+        .collect()
+}
+
 /// Run `git apply [--3way]` from `git_root` and return `Ok(())` on success.
 ///
 /// `affected_files` is the list of paths the patch touches (from
-/// `parse_diff_stats`). It is used for two `--3way`-specific corrections:
+/// `parse_diff_stats`). It drives two `--3way`-specific corrections that both
+/// use the pre-apply index state to avoid clobbering pre-existing staged edits:
 ///
-/// - **Failure**: `git apply --check --3way` can exit 0 even when the real
-///   merge has conflicts, so the apply may write conflict markers and leave
-///   unmerged index entries before exiting non-zero. We restore only the
-///   patch-affected files (not `.`) to preserve unrelated tracked edits.
-///   `git checkout -- <path>` is refused on unmerged paths, so we first
-///   run `git reset HEAD -- <files>` to clear the merge stages, then
-///   `git checkout -- <files>` to restore the working tree.
+/// - **Failure restore**: `git apply --check --3way` can exit 0 when the real
+///   merge has conflicts, leaving conflict markers and unmerged index entries.
+///   For each affected file that had no pre-apply index entry: clear unmerged
+///   stages with `git reset HEAD`, then restore the working tree with
+///   `git checkout --`. Files that already had a staged entry are left as-is
+///   so the caller's staged content is never silently discarded.
 ///
-/// - **Success**: `git apply --3way` stages successful merges in the index
-///   when it uses the 3-way path. We unstage the affected files afterward
-///   so both modes produce the same "modified working tree" semantics.
-///   The unstage is skipped when `allow_dirty` is set: the user may have
-///   pre-existing staged edits in those files; resetting them would
-///   silently discard those changes.
+/// - **Success unstage**: `git apply --3way` stages successful merges in the
+///   index. For each affected file that had no pre-apply staged entry: reset
+///   it to unstaged. This gives the same "modified working tree only"
+///   semantics as regular `git apply`, regardless of `--allow-dirty`, while
+///   still preserving any pre-existing staged edits in affected paths.
 fn apply_patch(
     git_root: &Path,
     patch_path: &Path,
     three_way: bool,
-    allow_dirty: bool,
     affected_files: &[String],
 ) -> Result<(), ApplyError> {
+    // Record which affected files are already in the index before we touch
+    // anything. This drives both the failure restore and the success unstage.
+    let pre_staged = if three_way && !affected_files.is_empty() {
+        staged_files(git_root, affected_files)
+    } else {
+        std::collections::HashSet::new()
+    };
+
     let mut cmd = Command::new("git");
     cmd.arg("apply");
     if three_way {
@@ -531,39 +550,42 @@ fn apply_patch(
     }
     cmd.arg(patch_path).current_dir(git_root);
     let output = cmd.output()?;
+
     if !output.status.success() {
-        if three_way && !affected_files.is_empty() {
-            // Clear unmerged index entries first; git checkout -- is refused
-            // on paths with unmerged entries.
-            let mut reset_cmd = Command::new("git");
-            reset_cmd.args(["reset", "HEAD", "--"]);
+        if three_way {
             for f in affected_files {
-                reset_cmd.arg(f);
+                if pre_staged.contains(f) {
+                    // The file already had staged content before the apply;
+                    // do not wipe it by resetting or checking out.
+                    continue;
+                }
+                // Clear any unmerged index entries (git checkout -- is refused
+                // on paths with unmerged entries), then restore to HEAD.
+                let _ = Command::new("git")
+                    .args(["reset", "HEAD", "--", f])
+                    .current_dir(git_root)
+                    .output();
+                let _ = Command::new("git")
+                    .args(["checkout", "--", f])
+                    .current_dir(git_root)
+                    .output();
             }
-            reset_cmd.current_dir(git_root);
-            let _ = reset_cmd.output();
-            // Restore working-tree content to HEAD.
-            let mut restore = Command::new("git");
-            restore.args(["checkout", "--"]);
-            for f in affected_files {
-                restore.arg(f);
-            }
-            restore.current_dir(git_root);
-            let _ = restore.output();
         }
         let msg = String::from_utf8_lossy(&output.stderr).trim().to_owned();
         return Err(ApplyError::CheckFailed(msg));
     }
-    // When --allow-dirty is set, the user may have pre-existing staged edits
-    // in patch-affected files; skipping the reset preserves those.
-    if three_way && !allow_dirty && !affected_files.is_empty() {
-        let mut unstage = Command::new("git");
-        unstage.args(["reset", "HEAD", "--"]);
+
+    // Unstage any index entries written by the 3-way path for files that were
+    // not staged before. Preserves pre-existing staged edits.
+    if three_way {
         for f in affected_files {
-            unstage.arg(f);
+            if !pre_staged.contains(f) {
+                let _ = Command::new("git")
+                    .args(["reset", "HEAD", "--", f])
+                    .current_dir(git_root)
+                    .output();
+            }
         }
-        unstage.current_dir(git_root);
-        let _ = unstage.output();
     }
     Ok(())
 }

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -578,7 +578,7 @@ fn is_git_tree(dir: &Path) -> bool {
         .args(["rev-parse", "--is-inside-work-tree"])
         .current_dir(dir)
         .output()
-        .is_ok_and(|o| o.status.success())
+        .is_ok_and(|o| o.status.success() && o.stdout.starts_with(b"true"))
 }
 
 /// Return the absolute path of the git worktree root containing `dir`.
@@ -610,6 +610,15 @@ fn dirty_paths_excluding(
         .args(["status", "--porcelain", "-z", "--untracked-files=all"])
         .current_dir(dir)
         .output()?;
+    // Fail closed: a non-zero exit (e.g. corrupt index) must not be treated as
+    // a clean tree, since git apply can still mutate the working files.
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(ApplyError::Io(std::io::Error::other(format!(
+            "git status failed: {}",
+            stderr.trim()
+        ))));
+    }
     // --porcelain -z: records are NUL-terminated, paths are never C-string-
     // quoted (unlike the default line-based format). Rename/copy entries emit
     // "XY new\0old\0"; the old-path field has no "XY " status prefix so we
@@ -710,6 +719,7 @@ fn git_head_sha(dir: &Path) -> Option<String> {
 /// survive the round-trip to git cleanup commands. For renames, both the old
 /// (`a/`) and new (`b/`) paths are included so that `--3way` cleanup can
 /// unstage both the deletion and the addition sides of the rename.
+#[allow(clippy::too_many_lines)]
 fn parse_diff_stats(patch_text: &str) -> (Vec<OsString>, i64, i64) {
     let mut files: Vec<OsString> = Vec::new();
     let mut added: i64 = 0;
@@ -816,13 +826,47 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<OsString>, i64, i64) {
             saw_git_header = false;
             pending_a = None;
             pending_b = None;
-        } else if line.starts_with("copy from ") || line.starts_with("copy to ") {
+        } else if line.starts_with("copy from ") {
             is_copy = true;
+        } else if let Some(rest) = line.strip_prefix("copy to ") {
+            is_copy = true;
+            // Override pending_b from the diff --git header: rfind(" b/") can
+            // split incorrectly when the destination path itself contains " b/".
+            // The unambiguous "copy to" header has no such ambiguity.
+            if let Some(new_name) = diff_header_path(rest, "") {
+                if let Some(ref old_b) = pending_b {
+                    if old_b != &new_name {
+                        if let Some(pos) = files.iter().rposition(|f| f == old_b) {
+                            files[pos].clone_from(&new_name);
+                        }
+                    }
+                } else if !files.contains(&new_name) {
+                    files.push(new_name.clone());
+                }
+                pending_b = Some(new_name);
+            }
         } else if let Some(rest) = line.strip_prefix("rename from ") {
             // 100% similarity renames have no "---"/"+++" pair; capture the
             // old path here so the section-end flush above can record it.
             // The path may be C-quoted (e.g. `rename from "old\tname"`).
             pending_a = diff_header_path(rest, "");
+        } else if let Some(rest) = line.strip_prefix("rename to ") {
+            // Override pending_b from the diff --git header: rfind(" b/") can
+            // split incorrectly when the destination path contains " b/".
+            // Pure renames have no "+++ " to correct this, so use the
+            // unambiguous "rename to" header.
+            if let Some(new_name) = diff_header_path(rest, "") {
+                if let Some(ref old_b) = pending_b {
+                    if old_b != &new_name {
+                        if let Some(pos) = files.iter().rposition(|f| f == old_b) {
+                            files[pos].clone_from(&new_name);
+                        }
+                    }
+                } else if !files.contains(&new_name) {
+                    files.push(new_name.clone());
+                }
+                pending_b = Some(new_name);
+            }
         } else if let Some(rest) = line.strip_prefix("--- ") {
             // Old-file header outside a hunk: track for rename detection.
             pending_a = diff_header_path(rest, "a/");

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -153,12 +153,15 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
     let git_root = git_toplevel(&opts.target).unwrap_or_else(|| opts.target.clone());
 
     // ── 4. Compute default report destination (next to, not inside, target) ───
-    // Placing the report in the parent of the target prevents it from
-    // colliding with any file the applied patch adds at the repo root.
+    // Canonicalize first: `--target .` gives Path::new(".")  whose parent() is
+    // None, which would put the report inside the repo. After canonicalization
+    // the parent is always the directory that contains the target.
+    let canonical_target =
+        std::fs::canonicalize(&opts.target).unwrap_or_else(|_| opts.target.clone());
     let report_dest = opts.report_path.clone().unwrap_or_else(|| {
-        opts.target
+        canonical_target
             .parent()
-            .unwrap_or(&opts.target)
+            .unwrap_or(&canonical_target)
             .join("apply-report.json")
     });
 
@@ -253,7 +256,7 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
     // ── 13. Apply the patch ───────────────────────────────────────────────────
     // patch_path is canonicalized (absolute); git_root avoids silent skips
     // when --target is a repo subdirectory.
-    apply_patch(&git_root, &patch_path, opts.three_way)?;
+    apply_patch(&git_root, &patch_path, opts.three_way, &files_changed)?;
 
     // ── 14. Write report ──────────────────────────────────────────────────────
     let report = ApplyReport {
@@ -289,15 +292,23 @@ fn resolve_patch_and_redaction(selector: &PatchSelector) -> (PathBuf, Option<Pat
             (patch_path, Some(traj_path.clone()), redacted)
         }
         PatchSelector::SweepInstance { sweep, instance } => {
-            // Canonical nested layout: <sweep>/<instance>/run-1.patch
+            // Try layouts in priority order matching bundle.rs find_patch_path_for_run:
+            // 1. Canonical nested: <sweep>/<instance>/run-1.{patch,traj.json}
             let nested_patch = sweep.join(instance).join("run-1.patch");
             let nested_traj = sweep.join(instance).join("run-1.traj.json");
-            // Legacy flat layout: <sweep>/<instance>.patch
+            // 2. Bundle layout: <sweep>/patches/<instance>.patch + trajectories/<instance>.traj.json
+            let bundle_patch = sweep.join("patches").join(format!("{instance}.patch"));
+            let bundle_traj = sweep
+                .join("trajectories")
+                .join(format!("{instance}.traj.json"));
+            // 3. Legacy flat: <sweep>/<instance>.{patch,traj.json}
             let legacy_patch = sweep.join(format!("{instance}.patch"));
             let legacy_traj = sweep.join(format!("{instance}.traj.json"));
 
             let (patch_path, traj_path) = if nested_patch.exists() || nested_traj.exists() {
                 (nested_patch, nested_traj)
+            } else if bundle_patch.exists() || bundle_traj.exists() {
+                (bundle_patch, bundle_traj)
             } else {
                 (legacy_patch, legacy_traj)
             };
@@ -492,11 +503,24 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<String>, i64, i64) {
 
 /// Run `git apply [--3way]` from `git_root` and return `Ok(())` on success.
 ///
-/// On failure with `--3way`: `git apply --check --3way` can exit 0 even when
-/// the real merge has conflicts; when the actual apply then exits non-zero it
-/// may have written conflict markers. This function restores tracked files to
-/// HEAD so the safety contract (failed apply = checkout unchanged) holds.
-fn apply_patch(git_root: &Path, patch_path: &Path, three_way: bool) -> Result<(), ApplyError> {
+/// `affected_files` is the list of paths the patch touches (from
+/// `parse_diff_stats`). It is used for two `--3way`-specific corrections:
+///
+/// - **Failure**: `git apply --check --3way` can exit 0 even when the real
+///   merge has conflicts, so the apply may write conflict markers before
+///   exiting non-zero. We restore only the patch-affected files (not `.`)
+///   so that any pre-existing unrelated tracked edits are left intact.
+///
+/// - **Success**: `git apply --3way` stages successful merges in the index
+///   (reports `M  file` in `git status --porcelain`), while the non-3way
+///   path leaves changes unstaged. We unstage the affected files afterward
+///   so both modes produce the same "modified working tree" semantics.
+fn apply_patch(
+    git_root: &Path,
+    patch_path: &Path,
+    three_way: bool,
+    affected_files: &[String],
+) -> Result<(), ApplyError> {
     let mut cmd = Command::new("git");
     cmd.arg("apply");
     if three_way {
@@ -505,14 +529,31 @@ fn apply_patch(git_root: &Path, patch_path: &Path, three_way: bool) -> Result<()
     cmd.arg(patch_path).current_dir(git_root);
     let output = cmd.output()?;
     if !output.status.success() {
-        if three_way {
-            let _ = Command::new("git")
-                .args(["checkout", "--", "."])
-                .current_dir(git_root)
-                .output();
+        if three_way && !affected_files.is_empty() {
+            // Restore only patch-affected files, not the entire worktree, so
+            // pre-existing unrelated tracked edits are not discarded.
+            let mut restore = Command::new("git");
+            restore.args(["checkout", "--"]);
+            for f in affected_files {
+                restore.arg(f);
+            }
+            restore.current_dir(git_root);
+            let _ = restore.output();
         }
         let msg = String::from_utf8_lossy(&output.stderr).trim().to_owned();
         return Err(ApplyError::CheckFailed(msg));
+    }
+    if three_way && !affected_files.is_empty() {
+        // Unstage any changes written to the index by the 3way path so the
+        // caller sees the same "modified working tree only" semantics as a
+        // regular git apply.
+        let mut unstage = Command::new("git");
+        unstage.args(["reset", "HEAD", "--"]);
+        for f in affected_files {
+            unstage.arg(f);
+        }
+        unstage.current_dir(git_root);
+        let _ = unstage.output();
     }
     Ok(())
 }

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -422,23 +422,39 @@ fn sibling_patch_of_trajectory(traj_path: &Path) -> PathBuf {
 ///
 /// `task.patch` → `task.traj.json`
 fn sibling_trajectory_of_patch(patch_path: &Path) -> Option<PathBuf> {
-    let stem = patch_path
-        .file_name()
-        .map(|n| n.to_string_lossy())
-        .unwrap_or_default();
-    let base = stem.strip_suffix(".patch").unwrap_or(&stem);
+    let file_name = patch_path.file_name()?;
+
+    // Strip the ".patch" suffix using raw bytes so non-UTF-8 filenames are
+    // preserved and the resulting sibling path is correct on Unix.
+    #[cfg(unix)]
+    let traj_name: OsString = {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+        let bytes = file_name.as_bytes();
+        let base = if bytes.ends_with(b".patch") {
+            &bytes[..bytes.len() - 6]
+        } else {
+            bytes
+        };
+        let mut name = OsString::from_vec(base.to_vec());
+        name.push(".traj.json");
+        name
+    };
+    #[cfg(not(unix))]
+    let traj_name: OsString = {
+        let s = file_name.to_string_lossy();
+        let base = s.strip_suffix(".patch").unwrap_or(&s);
+        OsString::from(format!("{base}.traj.json"))
+    };
 
     // Primary: same-directory sibling (most common).
-    let sibling = patch_path.with_file_name(format!("{base}.traj.json"));
+    let sibling = patch_path.with_file_name(&traj_name);
     if sibling.exists() {
         return Some(sibling);
     }
 
     // Bundle layout: patches/<id>.patch → ../trajectories/<id>.traj.json.
     if let Some(bundle_root) = patch_path.parent().and_then(|p| p.parent()) {
-        let bundle_traj = bundle_root
-            .join("trajectories")
-            .join(format!("{base}.traj.json"));
+        let bundle_traj = bundle_root.join("trajectories").join(&traj_name);
         if bundle_traj.exists() {
             return Some(bundle_traj);
         }
@@ -496,13 +512,19 @@ fn is_git_tree(dir: &Path) -> bool {
 
 /// Return the absolute path of the git worktree root containing `dir`.
 fn git_toplevel(dir: &Path) -> Option<PathBuf> {
-    Command::new("git")
+    let output = Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
         .current_dir(dir)
         .output()
         .ok()
-        .filter(|o| o.status.success())
-        .map(|o| PathBuf::from(String::from_utf8_lossy(&o.stdout).trim().to_owned()))
+        .filter(|o| o.status.success())?;
+    // Trim trailing newline from raw bytes before converting so that
+    // non-UTF-8 directory names in the path are not corrupted.
+    let mut bytes = output.stdout;
+    while bytes.last().copied() == Some(b'\n') || bytes.last().copied() == Some(b'\r') {
+        bytes.pop();
+    }
+    Some(PathBuf::from(bytes_to_os_string(bytes)))
 }
 
 /// Return dirty paths, excluding any paths that resolve to an entry in
@@ -1126,6 +1148,9 @@ fn preflight_report_path(path: &Path) -> Result<(), ApplyError> {
     }
     // Walk up to the nearest existing ancestor to place the probe file,
     // since missing intermediate directories have not been created yet.
+    // Treat an empty parent (relative path with no directory component) as
+    // "." so that e.g. `--report out/report.json` (where `out` is missing)
+    // continues walking rather than breaking out of the loop early.
     let parent = path
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
@@ -1134,8 +1159,15 @@ fn preflight_report_path(path: &Path) -> Result<(), ApplyError> {
     while !probe_dir.exists() {
         probe_dir = match probe_dir.parent() {
             Some(p) if !p.as_os_str().is_empty() => p,
-            _ => break,
+            Some(_) => Path::new("."), // empty parent → fall back to cwd
+            None => break,
         };
+    }
+    // If the report file already exists, verify it is writable directly
+    // rather than relying on a sibling probe. A read-only existing report
+    // would pass the sibling probe but fail in write_report after apply.
+    if path.is_file() {
+        std::fs::OpenOptions::new().write(true).open(path)?;
     }
     let probe = probe_dir.join(format!(".apply-probe-{}.tmp", std::process::id()));
     std::fs::write(&probe, b"")?;

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -457,15 +457,28 @@ fn git_apply_check(apply_dir: &Path, patch_path: &Path, three_way: bool) -> Resu
     cmd.arg(patch_path).current_dir(apply_dir);
     let output = cmd.output().map_err(|e| e.to_string())?;
 
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
     if output.status.success() {
+        // When --3way is active, git apply --check can exit 0 even though the
+        // real apply would produce conflict markers (it reports "Applied patch X
+        // with conflicts." on stdout/stderr). Treat this as a failure so that
+        // --dry-run correctly reports the patch as not cleanly applicable.
+        if three_way
+            && (stdout.contains("with conflicts") || stderr.contains("with conflicts"))
+        {
+            let combined = format!("{}\n{}", stderr.trim(), stdout.trim());
+            return Err(combined.trim().to_owned());
+        }
         Ok(())
     } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-        let msg = if stdout.is_empty() {
-            stderr
+        let stderr_s = stderr.trim().to_owned();
+        let stdout_s = stdout.trim().to_owned();
+        let msg = if stdout_s.is_empty() {
+            stderr_s
         } else {
-            format!("{stderr}\n{stdout}")
+            format!("{stderr_s}\n{stdout_s}")
         };
         Err(msg)
     }
@@ -597,13 +610,6 @@ fn git_diff_b_path(rest: &str) -> Option<OsString> {
 /// `None` for `/dev/null` and empty paths.  Returns an `OsString` to preserve
 /// non-UTF-8 bytes encoded via C-string octal escapes.
 fn diff_header_path(s: &str, prefix: &str) -> Option<OsString> {
-    // `/dev/null` is git's sentinel for new-file / deleted-file patches.
-    // It appears as a bare absolute path (without `a/` prefix), so check it
-    // before any prefix stripping to avoid returning `"dev/null"` after the
-    // leading-slash component strip applied to plain-diff paths.
-    if s == "/dev/null" {
-        return None;
-    }
     if let Some(without_open) = s.strip_prefix('"') {
         // Quoted: '"prefix/path"'
         let end = find_unescaped_quote(without_open)?;
@@ -611,6 +617,16 @@ fn diff_header_path(s: &str, prefix: &str) -> Option<OsString> {
         let name = unescape_c_string_os(inner.strip_prefix(prefix).unwrap_or(inner));
         if name.is_empty() { None } else { Some(name) }
     } else {
+        // Strip trailing tab+timestamp before any other checks. Plain unified
+        // diffs include a TAB+datetime after the path (e.g. "--- /dev/null\t
+        // 2024-01-01 00:00:00 +0000"). Stripping it here ensures the sentinel
+        // check and component strip operate on the bare path in both the
+        // bare-sentinel ("--- /dev/null") and timestamped forms.
+        let s = s.split('\t').next().unwrap_or(s).trim();
+        // `/dev/null` is git's sentinel for new-file / deleted-file patches.
+        if s == "/dev/null" {
+            return None;
+        }
         let path = if let Some(stripped) = s.strip_prefix(prefix) {
             stripped
         } else {
@@ -620,7 +636,6 @@ fn diff_header_path(s: &str, prefix: &str) -> Option<OsString> {
             // what git actually applied.
             s.find('/').map_or(s, |i| &s[i + 1..])
         };
-        let path = path.split('\t').next().unwrap_or(path).trim();
         if path.is_empty() || path == "/dev/null" {
             None
         } else {

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -235,34 +235,10 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
         .collect();
     let target_sha = git_head_sha(&git_root);
 
-    // ── 11. Dry-run: report without mutating ──────────────────────────────────
-    if opts.dry_run {
-        let report = ApplyReport {
-            schema_version: ArtifactSchemaVersion::CURRENT,
-            artifact_kind: ArtifactKind::ApplyReport,
-            source_patch_path: patch_path.to_string_lossy().into_owned(),
-            target_git_sha: target_sha,
-            files_changed,
-            lines_added,
-            lines_removed,
-            check_result: "passed".into(),
-            applied: false,
-            dry_run: true,
-        };
-        write_report(&report_dest, &report)?;
-        return Ok(report);
-    }
-
-    // ── 12. Apply the patch ───────────────────────────────────────────────────
-    // Preflight the report destination *before* mutating the tree so that a
-    // bad report path (unwritable directory, missing parent, etc.) fails
-    // cleanly instead of leaving a modified-but-unreported checkout.
-    preflight_report_path(&report_dest)?;
-
-    // ── 12.5. Pre-apply overlap check ────────────────────────────────────────
-    // Detect report/patch-output overlap BEFORE mutating the tree so a
-    // conflict leaves the tree unchanged. Canonicalize the report parent
-    // (exists after preflight) and compare against the patch's file list.
+    // ── 10.5. Pre-apply overlap check ───────────────────────────────────────
+    // Run for both dry-run and wet-run so that a report path that overlaps
+    // the patch output is caught before any write (including the dry-run
+    // report) leaves the tree in an unexpected state.
     {
         let rp_parent = report_dest
             .parent()
@@ -303,6 +279,30 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
             }
         }
     }
+
+    // ── 11. Dry-run: report without mutating ──────────────────────────────────
+    if opts.dry_run {
+        let report = ApplyReport {
+            schema_version: ArtifactSchemaVersion::CURRENT,
+            artifact_kind: ArtifactKind::ApplyReport,
+            source_patch_path: patch_path.to_string_lossy().into_owned(),
+            target_git_sha: target_sha,
+            files_changed,
+            lines_added,
+            lines_removed,
+            check_result: "passed".into(),
+            applied: false,
+            dry_run: true,
+        };
+        write_report(&report_dest, &report)?;
+        return Ok(report);
+    }
+
+    // ── 12. Apply the patch ───────────────────────────────────────────────────
+    // Preflight the report destination *before* mutating the tree so that a
+    // bad report path (unwritable directory, missing parent, etc.) fails
+    // cleanly instead of leaving a modified-but-unreported checkout.
+    preflight_report_path(&report_dest)?;
 
     // patch_path is canonicalized (absolute); git_root avoids silent skips
     // when --target is a repo subdirectory.
@@ -506,10 +506,15 @@ fn sibling_trajectory_of_patch(patch_path: &Path) -> Option<PathBuf> {
     }
 
     // Bundle layout: patches/<id>.patch → ../trajectories/<id>.traj.json.
-    if let Some(bundle_root) = patch_path.parent().and_then(|p| p.parent()) {
-        let bundle_traj = bundle_root.join("trajectories").join(&traj_name);
-        if bundle_traj.exists() {
-            return Some(bundle_traj);
+    // Only apply this fallback when the patch actually lives in a directory
+    // named "patches" to avoid matching an unrelated trajectories/ subtree
+    // in non-bundle workspaces.
+    if patch_path.parent().and_then(|p| p.file_name()) == Some(std::ffi::OsStr::new("patches")) {
+        if let Some(bundle_root) = patch_path.parent().and_then(|p| p.parent()) {
+            let bundle_traj = bundle_root.join("trajectories").join(&traj_name);
+            if bundle_traj.exists() {
+                return Some(bundle_traj);
+            }
         }
     }
 
@@ -779,6 +784,11 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<OsString>, i64, i64) {
                 if let Some(ref name) = b_name {
                     if !files.contains(name) {
                         files.push(name.clone());
+                    }
+                } else if let Some(ref a) = pending_a {
+                    // +++ /dev/null: plain deletion; record the old path.
+                    if !files.contains(a) {
+                        files.push(a.clone());
                     }
                 }
                 pending_b.clone_from(&b_name);

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -1,0 +1,474 @@
+//! `agent apply` — safely apply a captured `.patch` artifact to a working tree.
+//!
+//! Safety gates (in evaluation order):
+//! 1. Patch selector must be unambiguous (exit 2 on ambiguity).
+//! 2. Target must be a git working tree (exit 2 before any mutation).
+//! 3. Working tree must be clean unless `--allow-dirty` (exit 30).
+//! 4. Patch must not contain `[REDACTED:…]` markers, and the source
+//!    trajectory (when available) must not record patch-submission
+//!    redaction, unless `--allow-redacted` (exit 29).
+//! 5. `git apply --check` must succeed (exit 28 on rejection).
+//! 6. On `--dry-run`, stop here and report what would change (exit 0).
+//! 7. Apply the patch; write `apply-report.json`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+use crate::artifact::{ArtifactKind, ArtifactSchemaVersion};
+
+/// The `[REDACTED:` prefix written by the harness redactor.
+const REDACTION_MARKER: &str = "[REDACTED:";
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+/// How the source patch file is located.
+pub enum PatchSelector {
+    /// Direct path to a `.patch` file.
+    PatchFile(PathBuf),
+    /// Path to a `.traj.json` file; the sibling `.patch` is derived by
+    /// replacing the `.traj.json` extension with `.patch`.
+    TrajectoryFile(PathBuf),
+    /// Sweep output directory + instance ID; patch is at
+    /// `<sweep>/<instance>.patch`.
+    SweepInstance {
+        sweep: PathBuf,
+        instance: String,
+    },
+}
+
+/// Options for a single `agent apply` invocation.
+pub struct AgentApplyOpts {
+    pub selector: PatchSelector,
+    /// Git working tree to apply into. Defaults to CWD at the call site.
+    pub target: PathBuf,
+    /// Skip the redaction-corruption gate.
+    pub allow_redacted: bool,
+    /// Skip the clean-tree gate.
+    pub allow_dirty: bool,
+    /// Run `git apply --check` but do not mutate the tree.
+    pub dry_run: bool,
+    /// Delegate to `git apply --3way` for fuzzy application.
+    pub three_way: bool,
+    /// Where to write `apply-report.json`. When `None`, the report is
+    /// written next to the target directory as `apply-report.json`.
+    pub report_path: Option<PathBuf>,
+}
+
+/// Schema-versioned report written on every non-error outcome.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ApplyReport {
+    pub schema_version: ArtifactSchemaVersion,
+    pub artifact_kind: ArtifactKind,
+    pub source_patch_path: String,
+    pub target_git_sha: Option<String>,
+    pub files_changed: Vec<String>,
+    pub lines_added: i64,
+    pub lines_removed: i64,
+    /// `"passed"` | `"empty"` | `"failed"`
+    pub check_result: String,
+    pub applied: bool,
+    pub dry_run: bool,
+}
+
+/// Error variants returned by [`run_agent_apply`].
+#[derive(Debug)]
+pub enum ApplyError {
+    /// The target path exists but is not inside a git working tree (exit 2).
+    NotGitTree(PathBuf),
+    /// The working tree has uncommitted changes; `--allow-dirty` overrides
+    /// (exit 30).
+    DirtyTree(Vec<String>),
+    /// The patch (or its source trajectory) contains redaction markers; use
+    /// `--allow-redacted` to override (exit 29).
+    RedactedRefused,
+    /// `git apply --check` rejected the patch; the message holds the trimmed
+    /// stderr from git (exit 28).
+    CheckFailed(String),
+    /// An I/O or subprocess error that is not one of the above (exit 1).
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for ApplyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotGitTree(p) => {
+                write!(f, "target '{}' is not inside a git working tree", p.display())
+            }
+            Self::DirtyTree(paths) => {
+                write!(f, "target tree has uncommitted changes: {}", paths.join(", "))
+            }
+            Self::RedactedRefused => write!(
+                f,
+                "patch contains [REDACTED:…] markers or the source trajectory \
+                 recorded redaction on the patch-submission surface; use \
+                 --allow-redacted to override"
+            ),
+            Self::CheckFailed(msg) => write!(f, "git apply --check failed: {msg}"),
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+        }
+    }
+}
+
+impl From<std::io::Error> for ApplyError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+/// Apply a captured patch to a working tree with the configured safety gates.
+///
+/// Returns the populated [`ApplyReport`] on success (including dry-run and
+/// empty-patch cases). On any gate failure the tree is left byte-for-byte
+/// unchanged.
+pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> {
+    // ── 1. Resolve patch path and optionally load the sibling trajectory ──────
+    let (patch_path, trajectory_redacted) = resolve_patch_and_redaction(&opts.selector)?;
+
+    // ── 2. Verify target is a git working tree ────────────────────────────────
+    if !is_git_tree(&opts.target) {
+        return Err(ApplyError::NotGitTree(opts.target.clone()));
+    }
+
+    // ── 3. Dirty-tree gate ────────────────────────────────────────────────────
+    if !opts.allow_dirty {
+        let dirty = dirty_paths(&opts.target)?;
+        if !dirty.is_empty() {
+            return Err(ApplyError::DirtyTree(dirty));
+        }
+    }
+
+    // ── 4. Read patch content ─────────────────────────────────────────────────
+    let patch_text = std::fs::read_to_string(&patch_path)?;
+
+    // ── 5. Redaction gate ─────────────────────────────────────────────────────
+    if !opts.allow_redacted {
+        let patch_has_markers = patch_text.contains(REDACTION_MARKER);
+        if patch_has_markers || trajectory_redacted {
+            return Err(ApplyError::RedactedRefused);
+        }
+    }
+
+    // ── 6. Empty-patch fast path ──────────────────────────────────────────────
+    if patch_text.trim().is_empty() {
+        let target_sha = git_head_sha(&opts.target);
+        let report = ApplyReport {
+            schema_version: ArtifactSchemaVersion::CURRENT,
+            artifact_kind: ArtifactKind::ApplyReport,
+            source_patch_path: patch_path.to_string_lossy().into_owned(),
+            target_git_sha: target_sha,
+            files_changed: vec![],
+            lines_added: 0,
+            lines_removed: 0,
+            check_result: "empty".into(),
+            applied: false,
+            dry_run: opts.dry_run,
+        };
+        if let Some(rp) = &opts.report_path {
+            write_report(rp, &report)?;
+        }
+        return Ok(report);
+    }
+
+    // ── 7. git apply --check ──────────────────────────────────────────────────
+    let check_result = git_apply_check(&opts.target, &patch_path);
+    match check_result {
+        Err(msg) => return Err(ApplyError::CheckFailed(msg)),
+        Ok(()) => {}
+    }
+
+    // ── 8. Collect diff stats from patch text ─────────────────────────────────
+    let (files_changed, lines_added, lines_removed) = parse_diff_stats(&patch_text);
+    let target_sha = git_head_sha(&opts.target);
+
+    // ── 9. Dry-run: report without mutating ──────────────────────────────────
+    if opts.dry_run {
+        let report = ApplyReport {
+            schema_version: ArtifactSchemaVersion::CURRENT,
+            artifact_kind: ArtifactKind::ApplyReport,
+            source_patch_path: patch_path.to_string_lossy().into_owned(),
+            target_git_sha: target_sha,
+            files_changed,
+            lines_added,
+            lines_removed,
+            check_result: "passed".into(),
+            applied: false,
+            dry_run: true,
+        };
+        if let Some(rp) = &opts.report_path {
+            write_report(rp, &report)?;
+        }
+        return Ok(report);
+    }
+
+    // ── 10. Apply the patch ───────────────────────────────────────────────────
+    let mut cmd = Command::new("git");
+    cmd.arg("apply");
+    if opts.three_way {
+        cmd.arg("--3way");
+    }
+    cmd.arg(&patch_path).current_dir(&opts.target);
+    let output = cmd.output()?;
+    if !output.status.success() {
+        let msg = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        return Err(ApplyError::CheckFailed(msg));
+    }
+
+    // ── 11. Write report ──────────────────────────────────────────────────────
+    let report = ApplyReport {
+        schema_version: ArtifactSchemaVersion::CURRENT,
+        artifact_kind: ArtifactKind::ApplyReport,
+        source_patch_path: patch_path.to_string_lossy().into_owned(),
+        target_git_sha: target_sha,
+        files_changed,
+        lines_added,
+        lines_removed,
+        check_result: "passed".into(),
+        applied: true,
+        dry_run: false,
+    };
+
+    let report_dest = opts.report_path.unwrap_or_else(|| {
+        opts.target.join("apply-report.json")
+    });
+    write_report(&report_dest, &report)?;
+
+    Ok(report)
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Resolve the patch `PathBuf` from the selector and check whether the source
+/// trajectory recorded patch-submission redaction.
+///
+/// Returns `(patch_path, trajectory_recorded_redaction)`.
+fn resolve_patch_and_redaction(
+    selector: &PatchSelector,
+) -> Result<(PathBuf, bool), ApplyError> {
+    match selector {
+        PatchSelector::PatchFile(p) => Ok((p.clone(), false)),
+        PatchSelector::TrajectoryFile(traj_path) => {
+            // Derive sibling .patch path
+            let patch_path = sibling_patch_of_trajectory(traj_path);
+            let redacted = trajectory_has_patch_submission_redaction(traj_path);
+            Ok((patch_path, redacted))
+        }
+        PatchSelector::SweepInstance { sweep, instance } => {
+            let patch_path = sweep.join(format!("{instance}.patch"));
+            // Try to load the sibling trajectory for redaction info
+            let traj_path = sweep.join(format!("{instance}.traj.json"));
+            let redacted = trajectory_has_patch_submission_redaction(&traj_path);
+            Ok((patch_path, redacted))
+        }
+    }
+}
+
+/// Derive the `.patch` sibling of a `.traj.json` trajectory file.
+///
+/// `task.traj.json` → `task.patch`
+/// `task.json`      → `task.patch`
+/// `task`           → `task.patch`
+fn sibling_patch_of_trajectory(traj_path: &Path) -> PathBuf {
+    let stem = traj_path
+        .file_name()
+        .map(|n| n.to_string_lossy())
+        .unwrap_or_default();
+
+    // Strip known double-extension ".traj.json" first
+    let base = if let Some(s) = stem.strip_suffix(".traj.json") {
+        s.to_owned()
+    } else if let Some(s) = stem.strip_suffix(".json") {
+        s.to_owned()
+    } else {
+        // No recognised extension; keep as-is
+        stem.into_owned()
+    };
+
+    traj_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!("{base}.patch"))
+}
+
+/// Return `true` if the trajectory file at `traj_path` records at least one
+/// redaction event on the `patch_submission` surface.
+fn trajectory_has_patch_submission_redaction(traj_path: &Path) -> bool {
+    let text = match std::fs::read_to_string(traj_path) {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    let value: serde_json::Value = match serde_json::from_str(&text) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    // Check info.redaction.counts[*].surface == "patch_submission"
+    if let Some(counts) = value
+        .pointer("/info/redaction/counts")
+        .and_then(|v| v.as_array())
+    {
+        for entry in counts {
+            if entry
+                .get("surface")
+                .and_then(|s| s.as_str())
+                == Some("patch_submission")
+            {
+                return true;
+            }
+        }
+    }
+    // Also catch the legacy secret_leak_detected marker in info.other
+    if value
+        .pointer("/info/secret_leak_detected/surface")
+        .and_then(|s| s.as_str())
+        == Some("patch_submission")
+    {
+        return true;
+    }
+    false
+}
+
+/// Return `true` if `dir` is inside a git working tree.
+fn is_git_tree(dir: &Path) -> bool {
+    Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(dir)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Return the list of paths that make the working tree "dirty":
+/// modified tracked files, staged changes, and untracked files.
+fn dirty_paths(dir: &Path) -> Result<Vec<String>, ApplyError> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(dir)
+        .output()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let paths: Vec<String> = stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| {
+            // Porcelain format: "XY filename"
+            l.get(3..).unwrap_or(l).trim().to_owned()
+        })
+        .collect();
+    Ok(paths)
+}
+
+/// Run `git apply --check` and return `Ok(())` if the patch can be applied,
+/// or `Err(rejected_hunks_message)` if it cannot.
+fn git_apply_check(dir: &Path, patch_path: &Path) -> Result<(), String> {
+    let output = Command::new("git")
+        .args(["apply", "--check"])
+        .arg(patch_path)
+        .current_dir(dir)
+        .output()
+        .map_err(|e| e.to_string())?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        let msg = if stdout.is_empty() { stderr } else { format!("{stderr}\n{stdout}") };
+        Err(msg)
+    }
+}
+
+/// Get the current HEAD SHA of the git repo at `dir`.
+fn git_head_sha(dir: &Path) -> Option<String> {
+    Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(dir)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
+        .filter(|s| !s.is_empty())
+}
+
+/// Parse a unified diff to extract `(files_changed, lines_added, lines_removed)`.
+fn parse_diff_stats(patch_text: &str) -> (Vec<String>, i64, i64) {
+    let mut files: Vec<String> = Vec::new();
+    let mut added: i64 = 0;
+    let mut removed: i64 = 0;
+    let mut in_hunk = false;
+
+    for line in patch_text.lines() {
+        if line.starts_with("diff --git ") {
+            in_hunk = false;
+            // Extract filename from "diff --git a/foo b/foo"
+            if let Some(b_part) = line.strip_prefix("diff --git ").and_then(|s| {
+                // Find " b/" to get the new filename
+                s.find(" b/").map(|i| &s[i + 3..])
+            }) {
+                let name = b_part.trim().to_owned();
+                if !files.contains(&name) {
+                    files.push(name);
+                }
+            }
+        } else if line.starts_with("+++ ") {
+            in_hunk = false;
+        } else if line.starts_with("--- ") {
+            // nothing
+        } else if line.starts_with("@@ ") {
+            in_hunk = true;
+        } else if in_hunk {
+            if line.starts_with('+') && !line.starts_with("+++") {
+                added += 1;
+            } else if line.starts_with('-') && !line.starts_with("---") {
+                removed += 1;
+            }
+        }
+    }
+
+    (files, added, removed)
+}
+
+/// Serialize and write the report JSON to `path`.
+fn write_report(path: &Path, report: &ApplyReport) -> Result<(), ApplyError> {
+    let json = serde_json::to_string_pretty(report)
+        .map_err(|e| ApplyError::Io(std::io::Error::other(e.to_string())))?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+// ── CLI message helpers (public so cli/mod.rs can use them) ───────────────────
+
+/// Human-readable one-liner for `run_agent_apply` errors, for printing to
+/// stderr from the CLI layer.
+pub fn error_message(e: &ApplyError) -> String {
+    e.to_string()
+}
+
+/// Short outcome label written to stderr on non-zero exits.
+pub fn error_outcome_class(e: &ApplyError) -> &'static str {
+    match e {
+        ApplyError::NotGitTree(_) => crate::exit_code::ExitCode::UsageError.outcome_class(),
+        ApplyError::DirtyTree(_) => {
+            crate::exit_code::ExitCode::ApplyDirtyTreeRefused.outcome_class()
+        }
+        ApplyError::RedactedRefused => {
+            crate::exit_code::ExitCode::ApplyRedactedRefused.outcome_class()
+        }
+        ApplyError::CheckFailed(_) => {
+            crate::exit_code::ExitCode::ApplyCheckFailed.outcome_class()
+        }
+        ApplyError::Io(_) => crate::exit_code::ExitCode::InternalError.outcome_class(),
+    }
+}
+
+/// Map an [`ApplyError`] to its exit code.
+pub fn exit_code_for(e: &ApplyError) -> crate::exit_code::ExitCode {
+    match e {
+        ApplyError::NotGitTree(_) => crate::exit_code::ExitCode::UsageError,
+        ApplyError::DirtyTree(_) => crate::exit_code::ExitCode::ApplyDirtyTreeRefused,
+        ApplyError::RedactedRefused => crate::exit_code::ExitCode::ApplyRedactedRefused,
+        ApplyError::CheckFailed(_) => crate::exit_code::ExitCode::ApplyCheckFailed,
+        ApplyError::Io(_) => crate::exit_code::ExitCode::InternalError,
+    }
+}

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -32,13 +32,11 @@ pub enum PatchSelector {
     TrajectoryFile(PathBuf),
     /// Sweep output directory + instance ID; patch is at
     /// `<sweep>/<instance>.patch`.
-    SweepInstance {
-        sweep: PathBuf,
-        instance: String,
-    },
+    SweepInstance { sweep: PathBuf, instance: String },
 }
 
 /// Options for a single `agent apply` invocation.
+#[allow(clippy::struct_excessive_bools)]
 pub struct AgentApplyOpts {
     pub selector: PatchSelector,
     /// Git working tree to apply into. Defaults to CWD at the call site.
@@ -57,7 +55,7 @@ pub struct AgentApplyOpts {
 }
 
 /// Schema-versioned report written on every non-error outcome.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ApplyReport {
     pub schema_version: ArtifactSchemaVersion,
     pub artifact_kind: ArtifactKind,
@@ -94,10 +92,18 @@ impl std::fmt::Display for ApplyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::NotGitTree(p) => {
-                write!(f, "target '{}' is not inside a git working tree", p.display())
+                write!(
+                    f,
+                    "target '{}' is not inside a git working tree",
+                    p.display()
+                )
             }
             Self::DirtyTree(paths) => {
-                write!(f, "target tree has uncommitted changes: {}", paths.join(", "))
+                write!(
+                    f,
+                    "target tree has uncommitted changes: {}",
+                    paths.join(", ")
+                )
             }
             Self::RedactedRefused => write!(
                 f,
@@ -126,11 +132,11 @@ impl From<std::io::Error> for ApplyError {
 /// unchanged.
 pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> {
     // ── 1. Resolve patch path and optionally load the sibling trajectory ──────
-    let (patch_path, trajectory_redacted) = resolve_patch_and_redaction(&opts.selector)?;
+    let (patch_path, trajectory_redacted) = resolve_patch_and_redaction(&opts.selector);
 
     // ── 2. Verify target is a git working tree ────────────────────────────────
     if !is_git_tree(&opts.target) {
-        return Err(ApplyError::NotGitTree(opts.target.clone()));
+        return Err(ApplyError::NotGitTree(opts.target));
     }
 
     // ── 3. Dirty-tree gate ────────────────────────────────────────────────────
@@ -175,9 +181,8 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
 
     // ── 7. git apply --check ──────────────────────────────────────────────────
     let check_result = git_apply_check(&opts.target, &patch_path);
-    match check_result {
-        Err(msg) => return Err(ApplyError::CheckFailed(msg)),
-        Ok(()) => {}
+    if let Err(msg) = check_result {
+        return Err(ApplyError::CheckFailed(msg));
     }
 
     // ── 8. Collect diff stats from patch text ─────────────────────────────────
@@ -231,9 +236,9 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
         dry_run: false,
     };
 
-    let report_dest = opts.report_path.unwrap_or_else(|| {
-        opts.target.join("apply-report.json")
-    });
+    let report_dest = opts
+        .report_path
+        .unwrap_or_else(|| opts.target.join("apply-report.json"));
     write_report(&report_dest, &report)?;
 
     Ok(report)
@@ -245,23 +250,19 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
 /// trajectory recorded patch-submission redaction.
 ///
 /// Returns `(patch_path, trajectory_recorded_redaction)`.
-fn resolve_patch_and_redaction(
-    selector: &PatchSelector,
-) -> Result<(PathBuf, bool), ApplyError> {
+fn resolve_patch_and_redaction(selector: &PatchSelector) -> (PathBuf, bool) {
     match selector {
-        PatchSelector::PatchFile(p) => Ok((p.clone(), false)),
+        PatchSelector::PatchFile(p) => (p.clone(), false),
         PatchSelector::TrajectoryFile(traj_path) => {
-            // Derive sibling .patch path
             let patch_path = sibling_patch_of_trajectory(traj_path);
             let redacted = trajectory_has_patch_submission_redaction(traj_path);
-            Ok((patch_path, redacted))
+            (patch_path, redacted)
         }
         PatchSelector::SweepInstance { sweep, instance } => {
             let patch_path = sweep.join(format!("{instance}.patch"));
-            // Try to load the sibling trajectory for redaction info
             let traj_path = sweep.join(format!("{instance}.traj.json"));
             let redacted = trajectory_has_patch_submission_redaction(&traj_path);
-            Ok((patch_path, redacted))
+            (patch_path, redacted)
         }
     }
 }
@@ -296,13 +297,11 @@ fn sibling_patch_of_trajectory(traj_path: &Path) -> PathBuf {
 /// Return `true` if the trajectory file at `traj_path` records at least one
 /// redaction event on the `patch_submission` surface.
 fn trajectory_has_patch_submission_redaction(traj_path: &Path) -> bool {
-    let text = match std::fs::read_to_string(traj_path) {
-        Ok(t) => t,
-        Err(_) => return false,
+    let Ok(text) = std::fs::read_to_string(traj_path) else {
+        return false;
     };
-    let value: serde_json::Value = match serde_json::from_str(&text) {
-        Ok(v) => v,
-        Err(_) => return false,
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return false;
     };
     // Check info.redaction.counts[*].surface == "patch_submission"
     if let Some(counts) = value
@@ -310,11 +309,7 @@ fn trajectory_has_patch_submission_redaction(traj_path: &Path) -> bool {
         .and_then(|v| v.as_array())
     {
         for entry in counts {
-            if entry
-                .get("surface")
-                .and_then(|s| s.as_str())
-                == Some("patch_submission")
-            {
+            if entry.get("surface").and_then(|s| s.as_str()) == Some("patch_submission") {
                 return true;
             }
         }
@@ -374,7 +369,11 @@ fn git_apply_check(dir: &Path, patch_path: &Path) -> Result<(), String> {
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-        let msg = if stdout.is_empty() { stderr } else { format!("{stderr}\n{stdout}") };
+        let msg = if stdout.is_empty() {
+            stderr
+        } else {
+            format!("{stderr}\n{stdout}")
+        };
         Err(msg)
     }
 }
@@ -455,9 +454,7 @@ pub fn error_outcome_class(e: &ApplyError) -> &'static str {
         ApplyError::RedactedRefused => {
             crate::exit_code::ExitCode::ApplyRedactedRefused.outcome_class()
         }
-        ApplyError::CheckFailed(_) => {
-            crate::exit_code::ExitCode::ApplyCheckFailed.outcome_class()
-        }
+        ApplyError::CheckFailed(_) => crate::exit_code::ExitCode::ApplyCheckFailed.outcome_class(),
         ApplyError::Io(_) => crate::exit_code::ExitCode::InternalError.outcome_class(),
     }
 }

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -488,8 +488,7 @@ fn git_apply_check(apply_dir: &Path, patch_path: &Path, three_way: bool) -> Resu
         // ends the line with " with conflicts." — check each line's suffix so
         // a filename like "foo with conflicts." ("Applied patch ... cleanly.")
         // doesn't trigger a false-positive.
-        let ends_with_conflicts =
-            |s: &str| s.lines().any(|l| l.ends_with(" with conflicts."));
+        let ends_with_conflicts = |s: &str| s.lines().any(|l| l.ends_with(" with conflicts."));
         if three_way && (ends_with_conflicts(&stdout) || ends_with_conflicts(&stderr)) {
             let combined = format!("{}\n{}", stderr.trim(), stdout.trim());
             return Err(combined.trim().to_owned());

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -392,15 +392,27 @@ fn dirty_paths_excluding(
     exclude_abs: &[&Path],
 ) -> Result<Vec<String>, ApplyError> {
     let output = Command::new("git")
-        .args(["status", "--porcelain", "--untracked-files=all"])
+        .args(["status", "--porcelain", "-z", "--untracked-files=all"])
         .current_dir(dir)
         .output()?;
+    // --porcelain -z: records are NUL-terminated, paths are never C-string-
+    // quoted (unlike the default line-based format). Rename/copy entries emit
+    // "XY new\0old\0"; the old-path field has no "XY " status prefix so we
+    // detect and skip it to avoid treating it as an additional dirty file.
     let stdout = String::from_utf8_lossy(&output.stdout);
     let paths: Vec<String> = stdout
-        .lines()
+        .split('\0')
         .filter(|l| !l.trim().is_empty())
         .filter_map(|l| {
+            // Skip old-name fields from rename/copy entries — they have no
+            // "XY " status prefix (byte 2 is not a space).
+            if l.as_bytes().get(2) != Some(&b' ') {
+                return None;
+            }
             let rel = l.get(3..)?.trim();
+            if rel.is_empty() {
+                return None;
+            }
             let abs = git_root.join(rel);
             // Canonicalize for comparison; fall back to raw path if it doesn't
             // exist yet (e.g. untracked file whose parent isn't resolved).
@@ -485,10 +497,15 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<String>, i64, i64) {
                 }
             }
         } else if in_hunk {
-            // Inside a hunk: count added/removed lines only.
-            // "+++ " and "--- " are NOT file headers here — they are content
-            // lines whose original text started with "++" or "--".
-            if line.starts_with('+') && !line.starts_with("+++") {
+            // Count added/removed hunk lines. Also detect "--- " as the start
+            // of a new file section in multi-file plain unified diffs: without
+            // a "diff --git" header, "--- " reliably signals the next file.
+            // (Edge case: a removed content line whose original starts with
+            // "-- " is indistinguishable; it is accepted as a known trade-off.)
+            if let Some(rest) = line.strip_prefix("--- ") {
+                in_hunk = false;
+                pending_a = diff_header_path(rest, "a/");
+            } else if line.starts_with('+') && !line.starts_with("+++") {
                 added += 1;
             } else if line.starts_with('-') && !line.starts_with("---") {
                 removed += 1;
@@ -566,7 +583,15 @@ fn diff_header_path(s: &str, prefix: &str) -> Option<String> {
             Some(name)
         }
     } else {
-        let path = s.strip_prefix(prefix).unwrap_or(s);
+        let path = if let Some(stripped) = s.strip_prefix(prefix) {
+            stripped
+        } else {
+            // Plain-diff path without git's a/b convention (e.g. "diff -ru old
+            // new" produces "+++ new/f1"). Strip one leading component to match
+            // git apply's default -p1 strip level so the reported path matches
+            // what git actually applied.
+            s.find('/').map_or(s, |i| &s[i + 1..])
+        };
         let path = path.split('\t').next().unwrap_or(path).trim();
         if path.is_empty() || path == "/dev/null" {
             None
@@ -798,13 +823,21 @@ fn apply_patch(
         return Err(ApplyError::CheckFailed(msg));
     }
 
-    // Unstage any index entries written by the 3-way path for files that were
-    // not staged before. Preserves pre-existing staged edits.
+    // Restore the pre-apply index state for every affected file.
+    // git apply --3way stages the merged result; we always clear that so the
+    // apply behaves like regular git apply (working-tree only). Then for files
+    // that had pre-existing staged edits, re-apply the original cached entry
+    // so the caller's staged work is exactly preserved.
     if three_way {
         for f in affected_files {
-            if !pre_staged.contains_key(f) {
+            let _ = Command::new("git")
+                .args(["reset", "HEAD", "--", &format!(":(literal){f}")])
+                .current_dir(git_root)
+                .output();
+            if let Some((mode, sha)) = pre_staged.get(f) {
+                let cacheinfo = format!("{mode},{sha},{f}");
                 let _ = Command::new("git")
-                    .args(["reset", "HEAD", "--", &format!(":(literal){f}")])
+                    .args(["update-index", "--cacheinfo", &cacheinfo])
                     .current_dir(git_root)
                     .output();
             }

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -4,10 +4,11 @@
 //! 1. Patch selector must be unambiguous (exit 2 on ambiguity).
 //! 2. Target must be a git working tree (exit 2 before any mutation).
 //! 3. Working tree must be clean unless `--allow-dirty` (exit 30).
+//!    The selected patch file is excluded from the dirty check.
 //! 4. Patch must not contain `[REDACTED:…]` markers, and the source
 //!    trajectory (when available) must not record patch-submission
 //!    redaction, unless `--allow-redacted` (exit 29).
-//! 5. `git apply --check` must succeed (exit 28 on rejection).
+//! 5. `git apply --check [--3way]` must succeed (exit 28 on rejection).
 //! 6. On `--dry-run`, stop here and report what would change (exit 0).
 //! 7. Apply the patch; write `apply-report.json`.
 
@@ -30,8 +31,9 @@ pub enum PatchSelector {
     /// Path to a `.traj.json` file; the sibling `.patch` is derived by
     /// replacing the `.traj.json` extension with `.patch`.
     TrajectoryFile(PathBuf),
-    /// Sweep output directory + instance ID; patch is at
-    /// `<sweep>/<instance>.patch`.
+    /// Sweep output directory + instance ID. Tries the canonical nested
+    /// layout `<sweep>/<instance>/run-1.patch` first, then falls back to
+    /// the legacy flat path `<sweep>/<instance>.patch`.
     SweepInstance { sweep: PathBuf, instance: String },
 }
 
@@ -50,7 +52,7 @@ pub struct AgentApplyOpts {
     /// Delegate to `git apply --3way` for fuzzy application.
     pub three_way: bool,
     /// Where to write `apply-report.json`. When `None`, the report is
-    /// written next to the target directory as `apply-report.json`.
+    /// written next to (in the parent of) the target directory.
     pub report_path: Option<PathBuf>,
 }
 
@@ -131,26 +133,42 @@ impl From<std::io::Error> for ApplyError {
 /// empty-patch cases). On any gate failure the tree is left byte-for-byte
 /// unchanged.
 pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> {
-    // ── 1. Resolve patch path and optionally load the sibling trajectory ──────
+    // ── 1. Resolve patch path and optionally check trajectory redaction ────────
     let (patch_path, trajectory_redacted) = resolve_patch_and_redaction(&opts.selector);
+
+    // Canonicalize the patch path so that relative paths are anchored to the
+    // caller's CWD before any `current_dir()` changes in git subprocess calls.
+    let patch_path = std::fs::canonicalize(&patch_path).unwrap_or(patch_path);
 
     // ── 2. Verify target is a git working tree ────────────────────────────────
     if !is_git_tree(&opts.target) {
         return Err(ApplyError::NotGitTree(opts.target));
     }
 
-    // ── 3. Dirty-tree gate ────────────────────────────────────────────────────
+    // ── 3. Compute default report destination (next to, not inside, target) ───
+    // Placing the report in the parent of the target prevents it from
+    // colliding with any file the applied patch adds at the repo root.
+    let report_dest = opts.report_path.clone().unwrap_or_else(|| {
+        opts.target
+            .parent()
+            .unwrap_or(&opts.target)
+            .join("apply-report.json")
+    });
+
+    // ── 4. Dirty-tree gate ────────────────────────────────────────────────────
+    // Exclude the patch file itself so that an untracked (but non-gitignored)
+    // patch inside the target doesn't trip the gate for the normal workflow.
     if !opts.allow_dirty {
-        let dirty = dirty_paths(&opts.target)?;
+        let dirty = dirty_paths_excluding(&opts.target, &[&patch_path])?;
         if !dirty.is_empty() {
             return Err(ApplyError::DirtyTree(dirty));
         }
     }
 
-    // ── 4. Read patch content ─────────────────────────────────────────────────
+    // ── 5. Read patch content ─────────────────────────────────────────────────
     let patch_text = std::fs::read_to_string(&patch_path)?;
 
-    // ── 5. Redaction gate ─────────────────────────────────────────────────────
+    // ── 6. Redaction gate ─────────────────────────────────────────────────────
     if !opts.allow_redacted {
         let patch_has_markers = patch_text.contains(REDACTION_MARKER);
         if patch_has_markers || trajectory_redacted {
@@ -158,7 +176,7 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
         }
     }
 
-    // ── 6. Empty-patch fast path ──────────────────────────────────────────────
+    // ── 7. Empty-patch fast path ──────────────────────────────────────────────
     if patch_text.trim().is_empty() {
         let target_sha = git_head_sha(&opts.target);
         let report = ApplyReport {
@@ -173,23 +191,22 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
             applied: false,
             dry_run: opts.dry_run,
         };
-        if let Some(rp) = &opts.report_path {
-            write_report(rp, &report)?;
-        }
+        write_report(&report_dest, &report)?;
         return Ok(report);
     }
 
-    // ── 7. git apply --check ──────────────────────────────────────────────────
-    let check_result = git_apply_check(&opts.target, &patch_path);
-    if let Err(msg) = check_result {
+    // ── 8. git apply --check [--3way] ─────────────────────────────────────────
+    // Pass --3way to the preflight check when requested so that patches that
+    // only succeed via three-way merge are not falsely rejected here.
+    if let Err(msg) = git_apply_check(&opts.target, &patch_path, opts.three_way) {
         return Err(ApplyError::CheckFailed(msg));
     }
 
-    // ── 8. Collect diff stats from patch text ─────────────────────────────────
+    // ── 9. Collect diff stats from patch text ─────────────────────────────────
     let (files_changed, lines_added, lines_removed) = parse_diff_stats(&patch_text);
     let target_sha = git_head_sha(&opts.target);
 
-    // ── 9. Dry-run: report without mutating ──────────────────────────────────
+    // ── 10. Dry-run: report without mutating ──────────────────────────────────
     if opts.dry_run {
         let report = ApplyReport {
             schema_version: ArtifactSchemaVersion::CURRENT,
@@ -203,18 +220,17 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
             applied: false,
             dry_run: true,
         };
-        if let Some(rp) = &opts.report_path {
-            write_report(rp, &report)?;
-        }
+        write_report(&report_dest, &report)?;
         return Ok(report);
     }
 
-    // ── 10. Apply the patch ───────────────────────────────────────────────────
+    // ── 11. Apply the patch ───────────────────────────────────────────────────
     let mut cmd = Command::new("git");
     cmd.arg("apply");
     if opts.three_way {
         cmd.arg("--3way");
     }
+    // patch_path is canonicalized (absolute), so current_dir does not affect it.
     cmd.arg(&patch_path).current_dir(&opts.target);
     let output = cmd.output()?;
     if !output.status.success() {
@@ -222,7 +238,7 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
         return Err(ApplyError::CheckFailed(msg));
     }
 
-    // ── 11. Write report ──────────────────────────────────────────────────────
+    // ── 12. Write report ──────────────────────────────────────────────────────
     let report = ApplyReport {
         schema_version: ArtifactSchemaVersion::CURRENT,
         artifact_kind: ArtifactKind::ApplyReport,
@@ -235,10 +251,6 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
         applied: true,
         dry_run: false,
     };
-
-    let report_dest = opts
-        .report_path
-        .unwrap_or_else(|| opts.target.join("apply-report.json"));
     write_report(&report_dest, &report)?;
 
     Ok(report)
@@ -259,8 +271,19 @@ fn resolve_patch_and_redaction(selector: &PatchSelector) -> (PathBuf, bool) {
             (patch_path, redacted)
         }
         PatchSelector::SweepInstance { sweep, instance } => {
-            let patch_path = sweep.join(format!("{instance}.patch"));
-            let traj_path = sweep.join(format!("{instance}.traj.json"));
+            // Canonical nested layout: <sweep>/<instance>/run-1.patch
+            let nested_patch = sweep.join(instance).join("run-1.patch");
+            let nested_traj = sweep.join(instance).join("run-1.traj.json");
+            // Legacy flat layout: <sweep>/<instance>.patch
+            let legacy_patch = sweep.join(format!("{instance}.patch"));
+            let legacy_traj = sweep.join(format!("{instance}.traj.json"));
+
+            let (patch_path, traj_path) = if nested_patch.exists() || nested_traj.exists() {
+                (nested_patch, nested_traj)
+            } else {
+                (legacy_patch, legacy_traj)
+            };
+
             let redacted = trajectory_has_patch_submission_redaction(&traj_path);
             (patch_path, redacted)
         }
@@ -278,13 +301,11 @@ fn sibling_patch_of_trajectory(traj_path: &Path) -> PathBuf {
         .map(|n| n.to_string_lossy())
         .unwrap_or_default();
 
-    // Strip known double-extension ".traj.json" first
     let base = if let Some(s) = stem.strip_suffix(".traj.json") {
         s.to_owned()
     } else if let Some(s) = stem.strip_suffix(".json") {
         s.to_owned()
     } else {
-        // No recognised extension; keep as-is
         stem.into_owned()
     };
 
@@ -303,7 +324,6 @@ fn trajectory_has_patch_submission_redaction(traj_path: &Path) -> bool {
     let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
         return false;
     };
-    // Check info.redaction.counts[*].surface == "patch_submission"
     if let Some(counts) = value
         .pointer("/info/redaction/counts")
         .and_then(|v| v.as_array())
@@ -314,7 +334,7 @@ fn trajectory_has_patch_submission_redaction(traj_path: &Path) -> bool {
             }
         }
     }
-    // Also catch the legacy secret_leak_detected marker in info.other
+    // Legacy secret_leak_detected marker
     if value
         .pointer("/info/secret_leak_detected/surface")
         .and_then(|s| s.as_str())
@@ -335,9 +355,22 @@ fn is_git_tree(dir: &Path) -> bool {
         .unwrap_or(false)
 }
 
-/// Return the list of paths that make the working tree "dirty":
-/// modified tracked files, staged changes, and untracked files.
-fn dirty_paths(dir: &Path) -> Result<Vec<String>, ApplyError> {
+/// Return dirty paths, excluding any paths that resolve to an entry in
+/// `exclude_abs`. The patch file itself is excluded so that an untracked
+/// patch inside the target does not trip the clean-tree gate.
+fn dirty_paths_excluding(dir: &Path, exclude_abs: &[&Path]) -> Result<Vec<String>, ApplyError> {
+    // Get the git root so we can compute absolute paths for comparison.
+    let git_root = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(dir)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map_or_else(
+            || dir.to_owned(),
+            |o| PathBuf::from(String::from_utf8_lossy(&o.stdout).trim().to_owned()),
+        );
+
     let output = Command::new("git")
         .args(["status", "--porcelain"])
         .current_dir(dir)
@@ -346,23 +379,33 @@ fn dirty_paths(dir: &Path) -> Result<Vec<String>, ApplyError> {
     let paths: Vec<String> = stdout
         .lines()
         .filter(|l| !l.trim().is_empty())
-        .map(|l| {
-            // Porcelain format: "XY filename"
-            l.get(3..).unwrap_or(l).trim().to_owned()
+        .filter_map(|l| {
+            let rel = l.get(3..)?.trim();
+            let abs = git_root.join(rel);
+            // Canonicalize for comparison; fall back to raw path if it doesn't
+            // exist yet (e.g. untracked file whose parent isn't resolved).
+            let abs_canon = std::fs::canonicalize(&abs).unwrap_or(abs);
+            let excluded = exclude_abs.iter().any(|ex| {
+                let ex_canon = std::fs::canonicalize(ex).unwrap_or_else(|_| ex.to_path_buf());
+                abs_canon == ex_canon
+            });
+            if excluded { None } else { Some(rel.to_owned()) }
         })
         .collect();
     Ok(paths)
 }
 
-/// Run `git apply --check` and return `Ok(())` if the patch can be applied,
-/// or `Err(rejected_hunks_message)` if it cannot.
-fn git_apply_check(dir: &Path, patch_path: &Path) -> Result<(), String> {
-    let output = Command::new("git")
-        .args(["apply", "--check"])
-        .arg(patch_path)
-        .current_dir(dir)
-        .output()
-        .map_err(|e| e.to_string())?;
+/// Run `git apply --check [--3way]` and return `Ok(())` on success.
+/// Passing `three_way` ensures patches that only apply via three-way merge
+/// are not falsely rejected during the preflight check.
+fn git_apply_check(dir: &Path, patch_path: &Path, three_way: bool) -> Result<(), String> {
+    let mut cmd = Command::new("git");
+    cmd.args(["apply", "--check"]);
+    if three_way {
+        cmd.arg("--3way");
+    }
+    cmd.arg(patch_path).current_dir(dir);
+    let output = cmd.output().map_err(|e| e.to_string())?;
 
     if output.status.success() {
         Ok(())
@@ -400,11 +443,10 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<String>, i64, i64) {
     for line in patch_text.lines() {
         if line.starts_with("diff --git ") {
             in_hunk = false;
-            // Extract filename from "diff --git a/foo b/foo"
-            if let Some(b_part) = line.strip_prefix("diff --git ").and_then(|s| {
-                // Find " b/" to get the new filename
-                s.find(" b/").map(|i| &s[i + 3..])
-            }) {
+            if let Some(b_part) = line
+                .strip_prefix("diff --git ")
+                .and_then(|s| s.find(" b/").map(|i| &s[i + 3..]))
+            {
                 let name = b_part.trim().to_owned();
                 if !files.contains(&name) {
                     files.push(name);
@@ -436,13 +478,7 @@ fn write_report(path: &Path, report: &ApplyReport) -> Result<(), ApplyError> {
     Ok(())
 }
 
-// ── CLI message helpers (public so cli/mod.rs can use them) ───────────────────
-
-/// Human-readable one-liner for `run_agent_apply` errors, for printing to
-/// stderr from the CLI layer.
-pub fn error_message(e: &ApplyError) -> String {
-    e.to_string()
-}
+// ── CLI helpers (public for cli/mod.rs) ───────────────────────────────────────
 
 /// Short outcome label written to stderr on non-zero exits.
 pub fn error_outcome_class(e: &ApplyError) -> &'static str {

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -259,34 +259,38 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
     // cleanly instead of leaving a modified-but-unreported checkout.
     preflight_report_path(&report_dest)?;
 
-    // patch_path is canonicalized (absolute); git_root avoids silent skips
-    // when --target is a repo subdirectory.
-    apply_patch(&git_root, &patch_path, opts.three_way, &files_os)?;
-
-    // ── 13.5. Overlap check ───────────────────────────────────────────────────
-    // If report_dest coincides with a file the patch just added or modified,
-    // write_report would silently overwrite that content with JSON. Detect this
-    // by comparing canonical paths now that the patch has been applied and the
-    // files exist on disk.
-    if let Ok(report_canon) = report_dest
-        .parent()
-        .and_then(|p| std::fs::canonicalize(p).ok())
-        .map(|p| p.join(report_dest.file_name().unwrap_or_default()))
-        .ok_or(())
+    // ── 12.5. Pre-apply overlap check ────────────────────────────────────────
+    // Detect report/patch-output overlap BEFORE mutating the tree so a
+    // conflict leaves the tree unchanged. Canonicalize the report parent
+    // (exists after preflight) and compare against the patch's file list.
     {
-        for f in &files_os {
-            if std::fs::canonicalize(git_root.join(f)).is_ok_and(|c| c == report_canon) {
-                return Err(ApplyError::Io(std::io::Error::new(
-                    std::io::ErrorKind::AlreadyExists,
-                    format!(
-                        "report path '{}' overlaps a file modified by the patch; \
-                         use --report to choose a different destination",
-                        report_dest.display()
-                    ),
-                )));
+        let rp_parent = report_dest
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let report_abs = std::fs::canonicalize(rp_parent)
+            .or_else(|_| std::path::absolute(rp_parent))
+            .ok()
+            .map(|p| p.join(report_dest.file_name().unwrap_or_default()));
+        if let Some(ref report_abs) = report_abs {
+            for f in &files_os {
+                if &git_root.join(f) == report_abs {
+                    return Err(ApplyError::Io(std::io::Error::new(
+                        std::io::ErrorKind::AlreadyExists,
+                        format!(
+                            "report path '{}' overlaps a file in the patch; \
+                             use --report to choose a different destination",
+                            report_dest.display()
+                        ),
+                    )));
+                }
             }
         }
     }
+
+    // patch_path is canonicalized (absolute); git_root avoids silent skips
+    // when --target is a repo subdirectory.
+    apply_patch(&git_root, &patch_path, opts.three_way, &files_os)?;
 
     // ── 14. Write report ──────────────────────────────────────────────────────
     let report = ApplyReport {
@@ -423,8 +427,24 @@ fn sibling_trajectory_of_patch(patch_path: &Path) -> Option<PathBuf> {
         .map(|n| n.to_string_lossy())
         .unwrap_or_default();
     let base = stem.strip_suffix(".patch").unwrap_or(&stem);
-    let traj = patch_path.with_file_name(format!("{base}.traj.json"));
-    if traj.exists() { Some(traj) } else { None }
+
+    // Primary: same-directory sibling (most common).
+    let sibling = patch_path.with_file_name(format!("{base}.traj.json"));
+    if sibling.exists() {
+        return Some(sibling);
+    }
+
+    // Bundle layout: patches/<id>.patch → ../trajectories/<id>.traj.json.
+    if let Some(bundle_root) = patch_path.parent().and_then(|p| p.parent()) {
+        let bundle_traj = bundle_root
+            .join("trajectories")
+            .join(format!("{base}.traj.json"));
+        if bundle_traj.exists() {
+            return Some(bundle_traj);
+        }
+    }
+
+    None
 }
 
 /// Return `true` if the trajectory file at `traj_path` records at least one
@@ -501,21 +521,24 @@ fn dirty_paths_excluding(
     // quoted (unlike the default line-based format). Rename/copy entries emit
     // "XY new\0old\0"; the old-path field has no "XY " status prefix so we
     // detect and skip it to avoid treating it as an additional dirty file.
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let paths: Vec<String> = stdout
-        .split('\0')
-        .filter(|l| !l.trim().is_empty())
+    // Work at the byte level so non-UTF-8 filenames survive the comparison
+    // with exclude_abs without being corrupted by from_utf8_lossy.
+    let paths: Vec<String> = output
+        .stdout
+        .split(|&b| b == 0)
+        .filter(|l| !l.trim_ascii().is_empty())
         .filter_map(|l| {
             // Skip old-name fields from rename/copy entries — they have no
             // "XY " status prefix (byte 2 is not a space).
-            if l.as_bytes().get(2) != Some(&b' ') {
+            if l.get(2) != Some(&b' ') {
                 return None;
             }
-            let rel = l.get(3..)?.trim();
-            if rel.is_empty() {
+            let rel_bytes = l.get(3..)?.trim_ascii();
+            if rel_bytes.is_empty() {
                 return None;
             }
-            let abs = git_root.join(rel);
+            let rel_os = bytes_to_os_string(rel_bytes.to_vec());
+            let abs = git_root.join(&rel_os);
             // Canonicalize for comparison; fall back to raw path if it doesn't
             // exist yet (e.g. untracked file whose parent isn't resolved).
             let abs_canon = std::fs::canonicalize(&abs).unwrap_or(abs);
@@ -523,7 +546,13 @@ fn dirty_paths_excluding(
                 let ex_canon = std::fs::canonicalize(ex).unwrap_or_else(|_| ex.to_path_buf());
                 abs_canon == ex_canon
             });
-            if excluded { None } else { Some(rel.to_owned()) }
+            if excluded {
+                None
+            } else {
+                // Lossy conversion is acceptable here: these strings are
+                // only used in the DirtyTree error message for display.
+                Some(rel_os.to_string_lossy().into_owned())
+            }
         })
         .collect();
     Ok(paths)
@@ -599,12 +628,16 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<OsString>, i64, i64) {
     let mut pending_b: Option<OsString> = None;
     // a/ (old) name set by "--- "; compared with b/ to detect renames.
     let mut pending_a: Option<OsString> = None;
+    // True when the current section is a copy (not a rename). For copies the
+    // source file is untouched, so it must not be added to the affected list.
+    let mut is_copy = false;
 
     for line in patch_text.lines() {
         if let Some(rest) = line.strip_prefix("diff --git ") {
             // New file section; always terminates any active hunk.
             in_hunk = false;
             saw_git_header = true;
+            is_copy = false;
             pending_a = None;
             pending_b = git_diff_b_path(rest);
             if let Some(ref name) = pending_b {
@@ -663,15 +696,21 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<OsString>, i64, i64) {
             }
             // Rename detection: if a/ ≠ b/, the old name is also affected
             // (git stages its deletion; cleanup must unstage that too).
+            // Skip this for copies: the source file is unchanged by the patch.
             let effective_b = pending_b.as_ref().or(b_name.as_ref());
-            if let (Some(a), Some(b)) = (&pending_a, effective_b) {
-                if a != b && !files.contains(a) {
-                    files.push(a.clone());
+            if !is_copy {
+                if let (Some(a), Some(b)) = (&pending_a, effective_b) {
+                    if a != b && !files.contains(a) {
+                        files.push(a.clone());
+                    }
                 }
             }
+            is_copy = false;
             saw_git_header = false;
             pending_a = None;
             pending_b = None;
+        } else if line.starts_with("copy from ") || line.starts_with("copy to ") {
+            is_copy = true;
         } else if let Some(rest) = line.strip_prefix("--- ") {
             // Old-file header outside a hunk: track for rename detection.
             pending_a = diff_header_path(rest, "a/");

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -289,7 +289,16 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
 /// Returns `(patch_path, trajectory_path_opt, trajectory_recorded_redaction)`.
 fn resolve_patch_and_redaction(selector: &PatchSelector) -> (PathBuf, Option<PathBuf>, bool) {
     match selector {
-        PatchSelector::PatchFile(p) => (p.clone(), None, false),
+        PatchSelector::PatchFile(p) => {
+            // For a direct --patch selector, also probe the sibling trajectory
+            // so that redaction recorded only in metadata cannot be bypassed by
+            // choosing --patch instead of --trajectory.
+            let sibling_traj = sibling_trajectory_of_patch(p);
+            let redacted = sibling_traj
+                .as_deref()
+                .map_or(false, trajectory_has_patch_submission_redaction);
+            (p.clone(), sibling_traj, redacted)
+        }
         PatchSelector::TrajectoryFile(traj_path) => {
             let patch_path = sibling_patch_of_trajectory(traj_path);
             let redacted = trajectory_has_patch_submission_redaction(traj_path);
@@ -363,6 +372,20 @@ fn sibling_patch_of_trajectory(traj_path: &Path) -> PathBuf {
 
     // Fall back to the sibling path (may not exist; caller handles I/O error).
     sibling
+}
+
+/// Derive the `.traj.json` sibling of a `.patch` file, returning `Some` only
+/// if the trajectory file actually exists on disk.
+///
+/// `task.patch` → `task.traj.json`
+fn sibling_trajectory_of_patch(patch_path: &Path) -> Option<PathBuf> {
+    let stem = patch_path
+        .file_name()
+        .map(|n| n.to_string_lossy())
+        .unwrap_or_default();
+    let base = stem.strip_suffix(".patch").unwrap_or(&stem);
+    let traj = patch_path.with_file_name(format!("{base}.traj.json"));
+    if traj.exists() { Some(traj) } else { None }
 }
 
 /// Return `true` if the trajectory file at `traj_path` records at least one
@@ -1008,19 +1031,41 @@ fn apply_patch(
 
 /// Verify the report destination is writable *before* mutating the tree.
 ///
-/// Creates parent directories and probes the file for write access so that a
-/// bad path fails before `apply_patch` runs, rather than after.
+/// Probes the report path for write access before `apply_patch` runs.
+///
+/// Does NOT create missing parent directories — that is deferred to
+/// `write_report` after the patch succeeds, so a missing parent can never
+/// conflict with a path the patch adds. Parent creation here would leave
+/// behind untracked directories if the apply subsequently fails.
 fn preflight_report_path(path: &Path) -> Result<(), ApplyError> {
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)?;
-        }
+    // Reject immediately if the report path itself is already a directory;
+    // write_report would fail with IsADirectory after mutating the tree.
+    if path.is_dir() {
+        return Err(ApplyError::Io(std::io::Error::new(
+            std::io::ErrorKind::IsADirectory,
+            format!("report path is a directory: {}", path.display()),
+        )));
     }
-    // Probe writability with a temporary sibling rather than creating the
-    // final report file; creating the real path here would conflict with a
-    // patch that adds a file at that same location.
-    let parent_dir = path.parent().unwrap_or_else(|| Path::new("."));
-    let probe = parent_dir.join(format!(".apply-probe-{}.tmp", std::process::id()));
+    // Walk up to the nearest existing ancestor to place the probe file,
+    // since missing intermediate directories have not been created yet.
+    let parent = path
+        .parent()
+        .map(|p| {
+            if p.as_os_str().is_empty() {
+                Path::new(".")
+            } else {
+                p
+            }
+        })
+        .unwrap_or(Path::new("."));
+    let mut probe_dir = parent;
+    while !probe_dir.exists() {
+        probe_dir = match probe_dir.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p,
+            _ => break,
+        };
+    }
+    let probe = probe_dir.join(format!(".apply-probe-{}.tmp", std::process::id()));
     std::fs::write(&probe, b"")?;
     let _ = std::fs::remove_file(&probe);
     Ok(())

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -492,23 +492,68 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<String>, i64, i64) {
     (files, added, removed)
 }
 
-/// Return the set of file paths that have index entries (staged or unmerged)
-/// among `files`, by parsing `git ls-files --stage -- <files>`.
-fn staged_files(git_root: &Path, files: &[String]) -> std::collections::HashSet<String> {
-    let mut cmd = Command::new("git");
-    cmd.args(["ls-files", "--stage", "--"]);
+/// Return a map of `path → (mode, sha1)` for files among `files` that have
+/// genuinely staged changes (index ≠ HEAD) before the apply runs.
+///
+/// Two-step:
+/// 1. `git diff --cached --name-only -- <files>` → only paths with real staged
+///    edits (unlike `git ls-files --stage` which returns every tracked file).
+/// 2. `git ls-files --stage -- <staged>` → capture mode + sha1 so they can
+///    be restored via `update-index --cacheinfo` if the apply fails.
+fn pre_staged_entries(
+    git_root: &Path,
+    files: &[String],
+) -> std::collections::HashMap<String, (String, String)> {
+    let mut result = std::collections::HashMap::new();
+
+    // Step 1: which of the affected files actually have staged edits?
+    let mut diff_cmd = Command::new("git");
+    diff_cmd.args(["diff", "--cached", "--name-only", "--"]);
     for f in files {
-        cmd.arg(f);
+        diff_cmd.arg(f);
     }
-    cmd.current_dir(git_root);
-    let Ok(output) = cmd.output() else {
-        return std::collections::HashSet::new();
+    diff_cmd.current_dir(git_root);
+    let Ok(diff_output) = diff_cmd.output() else {
+        return result;
     };
-    // Each line: "<mode> <sha1> <stage_num>\t<path>"
-    String::from_utf8_lossy(&output.stdout)
+    let diff_text = String::from_utf8_lossy(&diff_output.stdout);
+    let staged_names: Vec<String> = diff_text
         .lines()
-        .filter_map(|line| line.split('\t').nth(1).map(str::to_owned))
-        .collect()
+        .filter(|l| !l.trim().is_empty())
+        .map(str::to_owned)
+        .collect();
+    if staged_names.is_empty() {
+        return result;
+    }
+
+    // Step 2: record mode + sha1 for each genuinely staged file.
+    let mut ls_cmd = Command::new("git");
+    ls_cmd.args(["ls-files", "--stage", "--"]);
+    for f in &staged_names {
+        ls_cmd.arg(f);
+    }
+    ls_cmd.current_dir(git_root);
+    let Ok(ls_output) = ls_cmd.output() else {
+        return result;
+    };
+    let ls_text = String::from_utf8_lossy(&ls_output.stdout);
+    for line in ls_text.lines() {
+        // Format: "<mode> <sha1> <stage>\t<path>"
+        let Some((meta, path)) = line.split_once('\t') else {
+            continue;
+        };
+        let mut meta_parts = meta.split(' ');
+        let (Some(mode), Some(sha), Some(stage)) =
+            (meta_parts.next(), meta_parts.next(), meta_parts.next())
+        else {
+            continue;
+        };
+        if stage != "0" {
+            continue; // skip unmerged entries (stages 1–3)
+        }
+        result.insert(path.to_owned(), (mode.to_owned(), sha.to_owned()));
+    }
+    result
 }
 
 /// Run `git apply [--3way]` from `git_root` and return `Ok(())` on success.
@@ -519,28 +564,29 @@ fn staged_files(git_root: &Path, files: &[String]) -> std::collections::HashSet<
 ///
 /// - **Failure restore**: `git apply --check --3way` can exit 0 when the real
 ///   merge has conflicts, leaving conflict markers and unmerged index entries.
-///   For each affected file that had no pre-apply index entry: clear unmerged
-///   stages with `git reset HEAD`, then restore the working tree with
-///   `git checkout --`. Files that already had a staged entry are left as-is
-///   so the caller's staged content is never silently discarded.
+///   For every affected file: clear unmerged stages with `git reset HEAD --`,
+///   then for files that had pre-existing staged edits restore their index
+///   entry via `git update-index --cacheinfo` and working tree via
+///   `git checkout-index --force`; for files that were not staged restore
+///   the working tree with `git checkout --`.
 ///
 /// - **Success unstage**: `git apply --3way` stages successful merges in the
 ///   index. For each affected file that had no pre-apply staged entry: reset
 ///   it to unstaged. This gives the same "modified working tree only"
-///   semantics as regular `git apply`, regardless of `--allow-dirty`, while
-///   still preserving any pre-existing staged edits in affected paths.
+///   semantics as regular `git apply`, while still preserving any pre-existing
+///   staged edits in affected paths.
 fn apply_patch(
     git_root: &Path,
     patch_path: &Path,
     three_way: bool,
     affected_files: &[String],
 ) -> Result<(), ApplyError> {
-    // Record which affected files are already in the index before we touch
-    // anything. This drives both the failure restore and the success unstage.
+    // Record which affected files have genuinely staged changes (index ≠ HEAD)
+    // before we touch anything, capturing their mode + sha1 for restoration.
     let pre_staged = if three_way && !affected_files.is_empty() {
-        staged_files(git_root, affected_files)
+        pre_staged_entries(git_root, affected_files)
     } else {
-        std::collections::HashSet::new()
+        std::collections::HashMap::new()
     };
 
     let mut cmd = Command::new("git");
@@ -554,21 +600,31 @@ fn apply_patch(
     if !output.status.success() {
         if three_way {
             for f in affected_files {
-                if pre_staged.contains(f) {
-                    // The file already had staged content before the apply;
-                    // do not wipe it by resetting or checking out.
-                    continue;
-                }
-                // Clear any unmerged index entries (git checkout -- is refused
-                // on paths with unmerged entries), then restore to HEAD.
+                // Clear any unmerged index entries for this path so that
+                // subsequent checkout commands are not refused.
                 let _ = Command::new("git")
                     .args(["reset", "HEAD", "--", f])
                     .current_dir(git_root)
                     .output();
-                let _ = Command::new("git")
-                    .args(["checkout", "--", f])
-                    .current_dir(git_root)
-                    .output();
+                if let Some((mode, sha)) = pre_staged.get(f) {
+                    // Restore the pre-apply staged state, then check out that
+                    // version into the working tree.
+                    let cacheinfo = format!("{mode},{sha},{f}");
+                    let _ = Command::new("git")
+                        .args(["update-index", "--cacheinfo", &cacheinfo])
+                        .current_dir(git_root)
+                        .output();
+                    let _ = Command::new("git")
+                        .args(["checkout-index", "--force", "--", f])
+                        .current_dir(git_root)
+                        .output();
+                } else {
+                    // No pre-existing staged edit: restore working tree from HEAD.
+                    let _ = Command::new("git")
+                        .args(["checkout", "--", f])
+                        .current_dir(git_root)
+                        .output();
+                }
             }
         }
         let msg = String::from_utf8_lossy(&output.stderr).trim().to_owned();
@@ -579,7 +635,7 @@ fn apply_patch(
     // not staged before. Preserves pre-existing staged edits.
     if three_way {
         for f in affected_files {
-            if !pre_staged.contains(f) {
+            if !pre_staged.contains_key(f) {
                 let _ = Command::new("git")
                     .args(["reset", "HEAD", "--", f])
                     .current_dir(git_root)

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -253,6 +253,11 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
     }
 
     // ── 12. Apply the patch ───────────────────────────────────────────────────
+    // Preflight the report destination *before* mutating the tree so that a
+    // bad report path (unwritable directory, missing parent, etc.) fails
+    // cleanly instead of leaving a modified-but-unreported checkout.
+    preflight_report_path(&report_dest)?;
+
     // patch_path is canonicalized (absolute); git_root avoids silent skips
     // when --target is a repo subdirectory.
     apply_patch(&git_root, &patch_path, opts.three_way, &files_os)?;
@@ -337,10 +342,27 @@ fn sibling_patch_of_trajectory(traj_path: &Path) -> PathBuf {
         stem.into_owned()
     };
 
-    traj_path
-        .parent()
-        .unwrap_or_else(|| Path::new("."))
-        .join(format!("{base}.patch"))
+    let traj_dir = traj_path.parent().unwrap_or_else(|| Path::new("."));
+
+    // Primary: sibling .patch in the same directory (most common).
+    let sibling = traj_dir.join(format!("{base}.patch"));
+    if sibling.exists() {
+        return sibling;
+    }
+
+    // Bundle layout: trajectories/<id>.traj.json → ../patches/<id>.patch.
+    // `bench bundle` places trajectories and patches in separate sub-directories
+    // under the same bundle root, so the patch is one level up from the
+    // trajectory's directory and then under `patches/`.
+    if let Some(bundle_root) = traj_dir.parent() {
+        let bundle_patch = bundle_root.join("patches").join(format!("{base}.patch"));
+        if bundle_patch.exists() {
+            return bundle_patch;
+        }
+    }
+
+    // Fall back to the sibling path (may not exist; caller handles I/O error).
+    sibling
 }
 
 /// Return `true` if the trajectory file at `traj_path` records at least one
@@ -462,10 +484,12 @@ fn git_apply_check(apply_dir: &Path, patch_path: &Path, three_way: bool) -> Resu
 
     if output.status.success() {
         // When --3way is active, git apply --check can exit 0 even though the
-        // real apply would produce conflict markers (it reports "Applied patch X
-        // with conflicts." on stdout/stderr). Treat this as a failure so that
-        // --dry-run correctly reports the patch as not cleanly applicable.
-        if three_way && (stdout.contains("with conflicts") || stderr.contains("with conflicts")) {
+        // real apply would produce conflict markers. git's conflict diagnostic
+        // is "Applied patch X with conflicts." — check for the specific
+        // " with conflicts." suffix (space + period) to avoid false-positives
+        // from filenames that literally contain the words "with conflicts".
+        if three_way && (stdout.contains(" with conflicts.") || stderr.contains(" with conflicts."))
+        {
             let combined = format!("{}\n{}", stderr.trim(), stdout.trim());
             return Err(combined.trim().to_owned());
         }
@@ -543,7 +567,30 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<OsString>, i64, i64) {
         } else if let Some(rest) = line.strip_prefix("+++ ") {
             // New-file header outside a hunk: end of the header pair.
             let b_name = diff_header_path(rest, "b/");
-            if !saw_git_header {
+            if saw_git_header {
+                // The +++ path is parsed unambiguously (just strip "b/") while
+                // the diff --git header's rfind(" b/") can split incorrectly
+                // when the filename contains the literal substring " b/". When
+                // the two disagree, replace the wrongly-split git-header entry
+                // in `files` with the correctly-parsed +++ path.
+                if let Some(ref b) = b_name {
+                    match &pending_b {
+                        Some(old) if old != b => {
+                            if let Some(pos) = files.iter().rposition(|f| f == old) {
+                                files[pos].clone_from(b);
+                            }
+                            pending_b.clone_from(&b_name);
+                        }
+                        None => {
+                            if !files.contains(b) {
+                                files.push(b.clone());
+                            }
+                            pending_b.clone_from(&b_name);
+                        }
+                        _ => {}
+                    }
+                }
+            } else {
                 // Plain unified-diff fallback (no "diff --git" seen).
                 if let Some(ref name) = b_name {
                     if !files.contains(name) {
@@ -956,6 +1003,26 @@ fn apply_patch(
             }
         }
     }
+    Ok(())
+}
+
+/// Verify the report destination is writable *before* mutating the tree.
+///
+/// Creates parent directories and probes the file for write access so that a
+/// bad path fails before `apply_patch` runs, rather than after.
+fn preflight_report_path(path: &Path) -> Result<(), ApplyError> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    // Open (or create) the file without truncating so we don't corrupt a
+    // pre-existing report, but do verify the path is writable.
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)?;
     Ok(())
 }
 

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -812,6 +812,17 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<OsString>, i64, i64) {
         }
     }
 
+    // Flush the final section: a trailing 100% rename has no following
+    // "diff --git" to trigger the section-start flush.
+    if !is_copy {
+        let effective_b = pending_b.as_ref();
+        if let (Some(a), Some(b)) = (&pending_a, effective_b) {
+            if a != b && !files.contains(a) {
+                files.push(a.clone());
+            }
+        }
+    }
+
     (files, added, removed)
 }
 

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -8,10 +8,11 @@
 //! 4. Patch must not contain `[REDACTED:…]` markers, and the source
 //!    trajectory (when available) must not record patch-submission
 //!    redaction, unless `--allow-redacted` (exit 29).
-//! 5. `git apply --check [--3way]` must succeed (exit 28 on rejection).
+//! 5. `git apply --check [--3way]` must succeed (exit 29 on rejection).
 //! 6. On `--dry-run`, stop here and report what would change (exit 0).
 //! 7. Apply the patch; write `apply-report.json`.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -184,7 +185,10 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
     }
 
     // ── 6. Read patch content ─────────────────────────────────────────────────
-    let patch_text = std::fs::read_to_string(&patch_path)?;
+    // Read as raw bytes so that patches touching files with non-UTF-8 content
+    // don't fail with InvalidData before the redaction or apply gates run.
+    let patch_bytes = std::fs::read(&patch_path)?;
+    let patch_text = String::from_utf8_lossy(&patch_bytes);
 
     // ── 7. Redaction gate ─────────────────────────────────────────────────────
     if !opts.allow_redacted {
@@ -221,7 +225,13 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
     }
 
     // ── 10. Collect diff stats from patch text ────────────────────────────────
-    let (files_changed, lines_added, lines_removed) = parse_diff_stats(&patch_text);
+    // files_os: raw OsString paths used for git cleanup (preserves non-UTF-8).
+    // files_changed: lossy-string version written to the JSON report.
+    let (files_os, lines_added, lines_removed) = parse_diff_stats(&patch_text);
+    let files_changed: Vec<String> = files_os
+        .iter()
+        .map(|f| f.to_string_lossy().into_owned())
+        .collect();
     let target_sha = git_head_sha(&git_root);
 
     // ── 11. Dry-run: report without mutating ──────────────────────────────────
@@ -245,7 +255,7 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
     // ── 12. Apply the patch ───────────────────────────────────────────────────
     // patch_path is canonicalized (absolute); git_root avoids silent skips
     // when --target is a repo subdirectory.
-    apply_patch(&git_root, &patch_path, opts.three_way, &files_changed)?;
+    apply_patch(&git_root, &patch_path, opts.three_way, &files_os)?;
 
     // ── 14. Write report ──────────────────────────────────────────────────────
     let report = ApplyReport {
@@ -352,9 +362,17 @@ fn trajectory_has_patch_submission_redaction(traj_path: &Path) -> bool {
             }
         }
     }
-    // Legacy secret_leak_detected marker
+    // Legacy secret_leak_detected marker (direct path).
     if value
         .pointer("/info/secret_leak_detected/surface")
+        .and_then(|s| s.as_str())
+        == Some("patch_submission")
+    {
+        return true;
+    }
+    // Legacy secret_leak_detected marker (stored under info/other by some mini versions).
+    if value
+        .pointer("/info/other/secret_leak_detected/surface")
         .and_then(|s| s.as_str())
         == Some("patch_submission")
     {
@@ -469,20 +487,21 @@ fn git_head_sha(dir: &Path) -> Option<String> {
 ///
 /// Handles both `diff --git` extended headers and plain `---`/`+++` headers
 /// (e.g. from `diff -u`). Quoted filenames (git C-string escaping) are
-/// unescaped. For renames, both the old (`a/`) and new (`b/`) paths are
-/// included in the returned file list so that `--3way` cleanup can unstage
-/// both the deletion and the addition sides of the rename.
-fn parse_diff_stats(patch_text: &str) -> (Vec<String>, i64, i64) {
-    let mut files: Vec<String> = Vec::new();
+/// unescaped to raw bytes (preserved as `OsString`) so that non-UTF-8 paths
+/// survive the round-trip to git cleanup commands. For renames, both the old
+/// (`a/`) and new (`b/`) paths are included so that `--3way` cleanup can
+/// unstage both the deletion and the addition sides of the rename.
+fn parse_diff_stats(patch_text: &str) -> (Vec<OsString>, i64, i64) {
+    let mut files: Vec<OsString> = Vec::new();
     let mut added: i64 = 0;
     let mut removed: i64 = 0;
     let mut in_hunk = false;
     // Whether the current file section opened with a "diff --git" header.
     let mut saw_git_header = false;
     // b/ (new) name set by "diff --git" or "+++ "; held for rename detection.
-    let mut pending_b: Option<String> = None;
+    let mut pending_b: Option<OsString> = None;
     // a/ (old) name set by "--- "; compared with b/ to detect renames.
-    let mut pending_a: Option<String> = None;
+    let mut pending_a: Option<OsString> = None;
 
     for line in patch_text.lines() {
         if let Some(rest) = line.strip_prefix("diff --git ") {
@@ -549,20 +568,25 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<String>, i64, i64) {
 /// Handles the unquoted format (`a/foo b/bar`) and git's C-string-quoted
 /// format (`"a/foo bar" "b/bar baz"`).  Uses `rfind` for the unquoted case so
 /// that an `a/` path containing the substring ` b/` is less likely to confuse
-/// the split point.
-fn git_diff_b_path(rest: &str) -> Option<String> {
+/// the split point.  Returns an `OsString` to preserve non-UTF-8 bytes that
+/// survive git's C-string octal-escape encoding.
+fn git_diff_b_path(rest: &str) -> Option<OsString> {
     if rest.starts_with('"') {
         // Quoted: '"a/…" "b/…"'
         let sep = rest.find(" \"b/")?;
         let b_start = sep + 4; // skip ' "b/'
         let b_end = find_unescaped_quote(&rest[b_start..]).map(|i| b_start + i)?;
-        let name = unescape_c_string(&rest[b_start..b_end]);
+        let name = unescape_c_string_os(&rest[b_start..b_end]);
         if name.is_empty() { None } else { Some(name) }
     } else {
         // Unquoted: rfind keeps the b/ path intact when a/ contains " b/".
         let pos = rest.rfind(" b/")?;
-        let name = rest[pos + 3..].trim().to_owned();
-        if name.is_empty() { None } else { Some(name) }
+        let name = rest[pos + 3..].trim();
+        if name.is_empty() {
+            None
+        } else {
+            Some(OsString::from(name))
+        }
     }
 }
 
@@ -570,18 +594,22 @@ fn git_diff_b_path(rest: &str) -> Option<String> {
 ///
 /// `prefix` is `"a/"` or `"b/"`.  Handles git's C-string-quoted format and
 /// strips trailing timestamps (plain-diff `\t<datetime>` suffix).  Returns
-/// `None` for `/dev/null` and empty paths.
-fn diff_header_path(s: &str, prefix: &str) -> Option<String> {
+/// `None` for `/dev/null` and empty paths.  Returns an `OsString` to preserve
+/// non-UTF-8 bytes encoded via C-string octal escapes.
+fn diff_header_path(s: &str, prefix: &str) -> Option<OsString> {
+    // `/dev/null` is git's sentinel for new-file / deleted-file patches.
+    // It appears as a bare absolute path (without `a/` prefix), so check it
+    // before any prefix stripping to avoid returning `"dev/null"` after the
+    // leading-slash component strip applied to plain-diff paths.
+    if s == "/dev/null" {
+        return None;
+    }
     if let Some(without_open) = s.strip_prefix('"') {
         // Quoted: '"prefix/path"'
         let end = find_unescaped_quote(without_open)?;
         let inner = &without_open[..end];
-        let name = unescape_c_string(inner.strip_prefix(prefix).unwrap_or(inner));
-        if name.is_empty() || name == "/dev/null" {
-            None
-        } else {
-            Some(name)
-        }
+        let name = unescape_c_string_os(inner.strip_prefix(prefix).unwrap_or(inner));
+        if name.is_empty() { None } else { Some(name) }
     } else {
         let path = if let Some(stripped) = s.strip_prefix(prefix) {
             stripped
@@ -596,15 +624,32 @@ fn diff_header_path(s: &str, prefix: &str) -> Option<String> {
         if path.is_empty() || path == "/dev/null" {
             None
         } else {
-            Some(path.to_owned())
+            Some(OsString::from(path))
         }
     }
 }
 
-/// Unescape a git C-string (the content between double-quotes, without them).
-fn unescape_c_string(s: &str) -> String {
+/// Unescape a git C-string and return the raw bytes as an `OsString`.
+///
+/// On Unix the byte sequence is preserved exactly; on other platforms the
+/// bytes are converted through `from_utf8_lossy` (non-UTF-8 paths are
+/// extremely rare outside Unix).
+fn unescape_c_string_os(s: &str) -> OsString {
     let bytes = unescape_c_string_bytes(s.as_bytes());
-    String::from_utf8_lossy(&bytes).into_owned()
+    bytes_to_os_string(bytes)
+}
+
+/// Build an `OsString` from a raw byte vec, preserving non-UTF-8 bytes on Unix.
+fn bytes_to_os_string(bytes: Vec<u8>) -> OsString {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+        OsString::from_vec(bytes)
+    }
+    #[cfg(not(unix))]
+    {
+        OsString::from(String::from_utf8_lossy(&bytes).into_owned())
+    }
 }
 
 /// Find the index of the first unescaped `"` in `s`.
@@ -713,59 +758,74 @@ fn unescape_c_string_bytes(input: &[u8]) -> Vec<u8> {
     out
 }
 
+/// Build a `:(literal)<path>` pathspec arg as an `OsString`.
+fn literal_pathspec(f: &OsString) -> OsString {
+    let mut arg = OsString::from(":(literal)");
+    arg.push(f.as_os_str());
+    arg
+}
+
 /// Return a map of `path → (mode, sha1)` for files among `files` that have
 /// genuinely staged changes (index ≠ HEAD) before the apply runs.
 ///
 /// Two-step:
-/// 1. `git diff --cached --name-only -- <files>` → only paths with real staged
-///    edits (unlike `git ls-files --stage` which returns every tracked file).
-/// 2. `git ls-files --stage -- <staged>` → capture mode + sha1 so they can
-///    be restored via `update-index --cacheinfo` if the apply fails.
+/// 1. `git diff --cached --name-only -z -- <files>` → only paths with real
+///    staged edits (unlike `git ls-files --stage` which returns every tracked
+///    file). `-z` output is NUL-terminated so paths with special bytes are
+///    never C-string-quoted, and we preserve them as raw `OsString` values.
+/// 2. `git ls-files --stage -z -- <staged>` → capture mode + sha1 so they
+///    can be restored via `update-index --cacheinfo` if the apply fails.
 fn pre_staged_entries(
     git_root: &Path,
-    files: &[String],
-) -> std::collections::HashMap<String, (String, String)> {
+    files: &[OsString],
+) -> std::collections::HashMap<OsString, (String, String)> {
     let mut result = std::collections::HashMap::new();
 
     // Step 1: which of the affected files actually have staged edits?
-    // Use -z so git never C-string-quotes paths (e.g. for files with
-    // newlines or non-ASCII bytes in their names).
+    // Use -z so git emits NUL-terminated raw paths — never C-string-quoted.
     let mut diff_cmd = Command::new("git");
     diff_cmd.args(["diff", "--cached", "--name-only", "-z", "--"]);
     for f in files {
-        diff_cmd.arg(format!(":(literal){f}"));
+        diff_cmd.arg(literal_pathspec(f));
     }
     diff_cmd.current_dir(git_root);
     let Ok(diff_output) = diff_cmd.output() else {
         return result;
     };
-    let diff_text = String::from_utf8_lossy(&diff_output.stdout);
-    let staged_names: Vec<String> = diff_text
-        .split('\0')
-        .filter(|l| !l.trim().is_empty())
-        .map(str::to_owned)
+    // Split on NUL; each segment is a raw path (preserved as OsString).
+    let staged_os: Vec<OsString> = diff_output
+        .stdout
+        .split(|&b| b == b'\0')
+        .filter(|s| !s.is_empty())
+        .map(|s| bytes_to_os_string(s.to_vec()))
         .collect();
-    if staged_names.is_empty() {
+    if staged_os.is_empty() {
         return result;
     }
 
     // Step 2: record mode + sha1 for each genuinely staged file.
+    // Use -z so git emits NUL-terminated records; format per record:
+    // "<mode> <sha1> <stage>\t<path>\0"
     let mut ls_cmd = Command::new("git");
-    ls_cmd.args(["ls-files", "--stage", "--"]);
-    for f in &staged_names {
-        ls_cmd.arg(format!(":(literal){f}"));
+    ls_cmd.args(["ls-files", "--stage", "-z", "--"]);
+    for f in &staged_os {
+        ls_cmd.arg(literal_pathspec(f));
     }
     ls_cmd.current_dir(git_root);
     let Ok(ls_output) = ls_cmd.output() else {
         return result;
     };
-    let ls_text = String::from_utf8_lossy(&ls_output.stdout);
-    for line in ls_text.lines() {
-        // Format: "<mode> <sha1> <stage>\t<path>"
-        let Some((meta, path)) = line.split_once('\t') else {
+    for record in ls_output.stdout.split(|&b| b == b'\0') {
+        if record.is_empty() {
+            continue;
+        }
+        // Each record: "<mode> <sha1> <stage>\t<path>"
+        let Some(tab_pos) = record.iter().position(|&b| b == b'\t') else {
             continue;
         };
-        let mut meta_parts = meta.split(' ');
+        let meta_str = String::from_utf8_lossy(&record[..tab_pos]);
+        let path_os = bytes_to_os_string(record[tab_pos + 1..].to_vec());
+        let mut meta_parts = meta_str.split(' ');
         let (Some(mode), Some(sha), Some(stage)) =
             (meta_parts.next(), meta_parts.next(), meta_parts.next())
         else {
@@ -774,7 +834,7 @@ fn pre_staged_entries(
         if stage != "0" {
             continue; // skip unmerged entries (stages 1–3)
         }
-        result.insert(path.to_owned(), (mode.to_owned(), sha.to_owned()));
+        result.insert(path_os, (mode.to_owned(), sha.to_owned()));
     }
     result
 }
@@ -802,7 +862,7 @@ fn apply_patch(
     git_root: &Path,
     patch_path: &Path,
     three_way: bool,
-    affected_files: &[String],
+    affected_files: &[OsString],
 ) -> Result<(), ApplyError> {
     // Record which affected files have genuinely staged changes (index ≠ HEAD)
     // before we touch anything, capturing their mode + sha1 for restoration.
@@ -825,30 +885,34 @@ fn apply_patch(
             for f in affected_files {
                 // Use :(literal) to prevent git from treating file names that
                 // contain pathspec metacharacters (e.g. '*') as globs.
-                let lit = format!(":(literal){f}");
                 // Clear any unmerged index entries for this path so that
                 // subsequent checkout commands are not refused.
                 let _ = Command::new("git")
-                    .args(["reset", "HEAD", "--", &lit])
+                    .args(["reset", "HEAD", "--"])
+                    .arg(literal_pathspec(f))
                     .current_dir(git_root)
                     .output();
                 if let Some((mode, sha)) = pre_staged.get(f) {
                     // Restore the pre-apply staged state, then check out that
                     // version into the working tree.
-                    let cacheinfo = format!("{mode},{sha},{f}");
+                    // Use three-arg --cacheinfo form so the path is an OsStr
+                    // arg rather than embedded in a comma-delimited string.
                     let _ = Command::new("git")
-                        .args(["update-index", "--cacheinfo", &cacheinfo])
+                        .args(["update-index", "--cacheinfo", mode, sha])
+                        .arg(f)
                         .current_dir(git_root)
                         .output();
                     // checkout-index takes literal file names (not pathspecs).
                     let _ = Command::new("git")
-                        .args(["checkout-index", "--force", "--", f])
+                        .args(["checkout-index", "--force", "--"])
+                        .arg(f)
                         .current_dir(git_root)
                         .output();
                 } else {
                     // No pre-existing staged edit: restore working tree from HEAD.
                     let _ = Command::new("git")
-                        .args(["checkout", "--", &lit])
+                        .args(["checkout", "--"])
+                        .arg(literal_pathspec(f))
                         .current_dir(git_root)
                         .output();
                 }
@@ -866,13 +930,14 @@ fn apply_patch(
     if three_way {
         for f in affected_files {
             let _ = Command::new("git")
-                .args(["reset", "HEAD", "--", &format!(":(literal){f}")])
+                .args(["reset", "HEAD", "--"])
+                .arg(literal_pathspec(f))
                 .current_dir(git_root)
                 .output();
             if let Some((mode, sha)) = pre_staged.get(f) {
-                let cacheinfo = format!("{mode},{sha},{f}");
                 let _ = Command::new("git")
-                    .args(["update-index", "--cacheinfo", &cacheinfo])
+                    .args(["update-index", "--cacheinfo", mode, sha])
+                    .arg(f)
                     .current_dir(git_root)
                     .output();
             }

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -244,19 +244,16 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
         return Ok(report);
     }
 
-    // ── 12. Ensure report parent directory exists before mutating the tree ────
-    // Detecting a missing directory now prevents an I/O error from leaving
-    // the tree mutated with no report written.
-    if let Some(parent) = report_dest.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)?;
-        }
-    }
-
-    // ── 13. Apply the patch ───────────────────────────────────────────────────
+    // ── 12. Apply the patch ───────────────────────────────────────────────────
     // patch_path is canonicalized (absolute); git_root avoids silent skips
     // when --target is a repo subdirectory.
-    apply_patch(&git_root, &patch_path, opts.three_way, &files_changed)?;
+    apply_patch(
+        &git_root,
+        &patch_path,
+        opts.three_way,
+        opts.allow_dirty,
+        &files_changed,
+    )?;
 
     // ── 14. Write report ──────────────────────────────────────────────────────
     let report = ApplyReport {
@@ -403,7 +400,7 @@ fn dirty_paths_excluding(
     exclude_abs: &[&Path],
 ) -> Result<Vec<String>, ApplyError> {
     let output = Command::new("git")
-        .args(["status", "--porcelain"])
+        .args(["status", "--porcelain", "--untracked-files=all"])
         .current_dir(dir)
         .output()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -507,18 +504,24 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<String>, i64, i64) {
 /// `parse_diff_stats`). It is used for two `--3way`-specific corrections:
 ///
 /// - **Failure**: `git apply --check --3way` can exit 0 even when the real
-///   merge has conflicts, so the apply may write conflict markers before
-///   exiting non-zero. We restore only the patch-affected files (not `.`)
-///   so that any pre-existing unrelated tracked edits are left intact.
+///   merge has conflicts, so the apply may write conflict markers and leave
+///   unmerged index entries before exiting non-zero. We restore only the
+///   patch-affected files (not `.`) to preserve unrelated tracked edits.
+///   `git checkout -- <path>` is refused on unmerged paths, so we first
+///   run `git reset HEAD -- <files>` to clear the merge stages, then
+///   `git checkout -- <files>` to restore the working tree.
 ///
 /// - **Success**: `git apply --3way` stages successful merges in the index
-///   (reports `M  file` in `git status --porcelain`), while the non-3way
-///   path leaves changes unstaged. We unstage the affected files afterward
+///   when it uses the 3-way path. We unstage the affected files afterward
 ///   so both modes produce the same "modified working tree" semantics.
+///   The unstage is skipped when `allow_dirty` is set: the user may have
+///   pre-existing staged edits in those files; resetting them would
+///   silently discard those changes.
 fn apply_patch(
     git_root: &Path,
     patch_path: &Path,
     three_way: bool,
+    allow_dirty: bool,
     affected_files: &[String],
 ) -> Result<(), ApplyError> {
     let mut cmd = Command::new("git");
@@ -530,8 +533,16 @@ fn apply_patch(
     let output = cmd.output()?;
     if !output.status.success() {
         if three_way && !affected_files.is_empty() {
-            // Restore only patch-affected files, not the entire worktree, so
-            // pre-existing unrelated tracked edits are not discarded.
+            // Clear unmerged index entries first; git checkout -- is refused
+            // on paths with unmerged entries.
+            let mut reset_cmd = Command::new("git");
+            reset_cmd.args(["reset", "HEAD", "--"]);
+            for f in affected_files {
+                reset_cmd.arg(f);
+            }
+            reset_cmd.current_dir(git_root);
+            let _ = reset_cmd.output();
+            // Restore working-tree content to HEAD.
             let mut restore = Command::new("git");
             restore.args(["checkout", "--"]);
             for f in affected_files {
@@ -543,10 +554,9 @@ fn apply_patch(
         let msg = String::from_utf8_lossy(&output.stderr).trim().to_owned();
         return Err(ApplyError::CheckFailed(msg));
     }
-    if three_way && !affected_files.is_empty() {
-        // Unstage any changes written to the index by the 3way path so the
-        // caller sees the same "modified working tree only" semantics as a
-        // regular git apply.
+    // When --allow-dirty is set, the user may have pre-existing staged edits
+    // in patch-affected files; skipping the reset preserves those.
+    if three_way && !allow_dirty && !affected_files.is_empty() {
         let mut unstage = Command::new("git");
         unstage.args(["reset", "HEAD", "--"]);
         for f in affected_files {
@@ -558,8 +568,15 @@ fn apply_patch(
     Ok(())
 }
 
-/// Serialize and write the report JSON to `path`.
+/// Serialize and write the report JSON to `path`, creating parent directories
+/// as needed. Creating directories here (after a successful apply) avoids
+/// materializing directories that could conflict with paths the patch adds.
 fn write_report(path: &Path, report: &ApplyReport) -> Result<(), ApplyError> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
     let json = serde_json::to_string_pretty(report)
         .map_err(|e| ApplyError::Io(std::io::Error::other(e.to_string())))?;
     std::fs::write(path, json)?;

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -274,13 +274,29 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
             .map(|p| p.join(report_dest.file_name().unwrap_or_default()));
         if let Some(ref report_abs) = report_abs {
             for f in &files_os {
-                if &git_root.join(f) == report_abs {
+                let file_abs = git_root.join(f);
+                // Direct conflict: the patch touches exactly the report file.
+                if file_abs == *report_abs {
                     return Err(ApplyError::Io(std::io::Error::new(
                         std::io::ErrorKind::AlreadyExists,
                         format!(
                             "report path '{}' overlaps a file in the patch; \
                              use --report to choose a different destination",
                             report_dest.display()
+                        ),
+                    )));
+                }
+                // Ancestor conflict: the patch creates a regular file at a path
+                // that is a parent directory of report_dest. write_report would
+                // then fail with NotADirectory after the patch has been applied.
+                if report_abs.starts_with(&file_abs) {
+                    return Err(ApplyError::Io(std::io::Error::new(
+                        std::io::ErrorKind::NotADirectory,
+                        format!(
+                            "report path '{}' is under '{}' which the patch adds as a file; \
+                             use --report to choose a different destination",
+                            report_dest.display(),
+                            file_abs.display()
                         ),
                     )));
                 }
@@ -359,6 +375,21 @@ fn resolve_patch_and_redaction(selector: &PatchSelector) -> (PathBuf, Option<Pat
                 .join(format!("{instance}.traj.json"));
             let legacy_traj = sweep.join(format!("{instance}.traj.json"));
 
+            // Check ALL candidate trajectories: if any records patch_submission
+            // redaction the patch is refused. A stale clean nested trajectory
+            // must not shadow redaction in the bundle trajectory that actually
+            // corresponds to the selected patch.
+            let redacted = [
+                &nested_traj,
+                &nested_traj_legacy,
+                &bundle_traj,
+                &legacy_traj,
+            ]
+            .iter()
+            .filter(|p| p.exists())
+            .any(|p| trajectory_has_patch_submission_redaction(p));
+
+            // For reporting purposes, pick the first existing trajectory.
             let traj_path = if nested_traj.exists() {
                 nested_traj
             } else if nested_traj_legacy.exists() {
@@ -369,7 +400,6 @@ fn resolve_patch_and_redaction(selector: &PatchSelector) -> (PathBuf, Option<Pat
                 legacy_traj
             };
 
-            let redacted = trajectory_has_patch_submission_redaction(&traj_path);
             (patch_path, Some(traj_path), redacted)
         }
     }
@@ -381,35 +411,58 @@ fn resolve_patch_and_redaction(selector: &PatchSelector) -> (PathBuf, Option<Pat
 /// `task.json`      → `task.patch`
 /// `task`           → `task.patch`
 fn sibling_patch_of_trajectory(traj_path: &Path) -> PathBuf {
-    let stem = traj_path
-        .file_name()
-        .map(|n| n.to_string_lossy())
-        .unwrap_or_default();
+    let file_name = traj_path.file_name().unwrap_or_default();
 
-    let base = if let Some(s) = stem.strip_suffix(".traj.json") {
-        s.to_owned()
-    } else if let Some(s) = stem.strip_suffix(".json") {
-        s.to_owned()
-    } else {
-        stem.into_owned()
+    // Strip the ".traj.json" / ".json" suffix using raw bytes so non-UTF-8
+    // filenames are not corrupted before the sibling patch path is built.
+    #[cfg(unix)]
+    let (base, patch_name): (OsString, OsString) = {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+        let bytes = file_name.as_bytes();
+        let base_bytes = if bytes.ends_with(b".traj.json") {
+            &bytes[..bytes.len() - 10]
+        } else if bytes.ends_with(b".json") {
+            &bytes[..bytes.len() - 5]
+        } else {
+            bytes
+        };
+        let mut pname = OsString::from_vec(base_bytes.to_vec());
+        pname.push(".patch");
+        (OsString::from_vec(base_bytes.to_vec()), pname)
     };
+    #[cfg(not(unix))]
+    let (base, patch_name): (OsString, OsString) = {
+        let stem = file_name.to_string_lossy();
+        let base_str = if let Some(s) = stem.strip_suffix(".traj.json") {
+            s.to_owned()
+        } else if let Some(s) = stem.strip_suffix(".json") {
+            s.to_owned()
+        } else {
+            stem.into_owned()
+        };
+        let pname = OsString::from(format!("{base_str}.patch"));
+        (OsString::from(base_str), pname)
+    };
+    let _ = base; // used only in some cfg branches
 
     let traj_dir = traj_path.parent().unwrap_or_else(|| Path::new("."));
 
     // Primary: sibling .patch in the same directory (most common).
-    let sibling = traj_dir.join(format!("{base}.patch"));
+    let sibling = traj_dir.join(&patch_name);
     if sibling.exists() {
         return sibling;
     }
 
     // Bundle layout: trajectories/<id>.traj.json → ../patches/<id>.patch.
-    // `bench bundle` places trajectories and patches in separate sub-directories
-    // under the same bundle root, so the patch is one level up from the
-    // trajectory's directory and then under `patches/`.
-    if let Some(bundle_root) = traj_dir.parent() {
-        let bundle_patch = bundle_root.join("patches").join(format!("{base}.patch"));
-        if bundle_patch.exists() {
-            return bundle_patch;
+    // Only apply this fallback when the trajectory lives inside a directory
+    // named "trajectories" so we don't accidentally pick up an unrelated
+    // patches/<base>.patch in non-bundle layouts.
+    if traj_dir.file_name() == Some(std::ffi::OsStr::new("trajectories")) {
+        if let Some(bundle_root) = traj_dir.parent() {
+            let bundle_patch = bundle_root.join("patches").join(&patch_name);
+            if bundle_patch.exists() {
+                return bundle_patch;
+            }
         }
     }
 
@@ -466,11 +519,16 @@ fn sibling_trajectory_of_patch(patch_path: &Path) -> Option<PathBuf> {
 /// Return `true` if the trajectory file at `traj_path` records at least one
 /// redaction event on the `patch_submission` surface.
 fn trajectory_has_patch_submission_redaction(traj_path: &Path) -> bool {
-    let Ok(text) = std::fs::read_to_string(traj_path) else {
-        return false;
+    let text = match std::fs::read_to_string(traj_path) {
+        Ok(t) => t,
+        // Missing trajectory → no redaction metadata recorded.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return false,
+        // Unreadable trajectory → fail closed (treat as redacted).
+        Err(_) => return true,
     };
+    // Malformed trajectory → fail closed.
     let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
-        return false;
+        return true;
     };
     if let Some(counts) = value
         .pointer("/info/redaction/counts")
@@ -656,7 +714,16 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<OsString>, i64, i64) {
 
     for line in patch_text.lines() {
         if let Some(rest) = line.strip_prefix("diff --git ") {
-            // New file section; always terminates any active hunk.
+            // New file section; flush any rename that had no "+++" pair
+            // (e.g. 100% similarity renames produce no hunk lines).
+            if !is_copy {
+                let effective_b = pending_b.as_ref();
+                if let (Some(a), Some(b)) = (&pending_a, effective_b) {
+                    if a != b && !files.contains(a) {
+                        files.push(a.clone());
+                    }
+                }
+            }
             in_hunk = false;
             saw_git_header = true;
             is_copy = false;
@@ -733,6 +800,10 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<OsString>, i64, i64) {
             pending_b = None;
         } else if line.starts_with("copy from ") || line.starts_with("copy to ") {
             is_copy = true;
+        } else if let Some(rest) = line.strip_prefix("rename from ") {
+            // 100% similarity renames have no "---"/"+++" pair; capture the
+            // old path here so the section-end flush above can record it.
+            pending_a = Some(OsString::from(rest));
         } else if let Some(rest) = line.strip_prefix("--- ") {
             // Old-file header outside a hunk: track for rename detection.
             pending_a = diff_header_path(rest, "a/");
@@ -787,10 +858,9 @@ fn diff_header_path(s: &str, prefix: &str) -> Option<OsString> {
     } else {
         // Strip trailing tab+timestamp before any other checks. Plain unified
         // diffs include a TAB+datetime after the path (e.g. "--- /dev/null\t
-        // 2024-01-01 00:00:00 +0000"). Stripping it here ensures the sentinel
-        // check and component strip operate on the bare path in both the
-        // bare-sentinel ("--- /dev/null") and timestamped forms.
-        let s = s.split('\t').next().unwrap_or(s).trim();
+        // 2024-01-01 00:00:00 +0000"). Use only the tab split — do not trim()
+        // the result since filenames may legitimately end with a space.
+        let s = s.split('\t').next().unwrap_or(s);
         // `/dev/null` is git's sentinel for new-file / deleted-file patches.
         if s == "/dev/null" {
             return None;

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -240,17 +240,25 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
     // the patch output is caught before any write (including the dry-run
     // report) leaves the tree in an unexpected state.
     {
-        let rp_parent = report_dest
-            .parent()
-            .filter(|p| !p.as_os_str().is_empty())
-            .unwrap_or_else(|| Path::new("."));
-        let report_abs = std::fs::canonicalize(rp_parent)
-            .or_else(|_| std::path::absolute(rp_parent))
-            .ok()
-            .map(|p| p.join(report_dest.file_name().unwrap_or_default()));
+        // When report_dest already exists (including as a symlink), canonicalize
+        // it fully so that a symlink pointing at a patched file is detected.
+        // When it doesn't exist yet, canonicalize the parent and append the name.
+        let report_abs = std::fs::canonicalize(&report_dest).ok().or_else(|| {
+            let rp_parent = report_dest
+                .parent()
+                .filter(|p| !p.as_os_str().is_empty())
+                .unwrap_or_else(|| Path::new("."));
+            std::fs::canonicalize(rp_parent)
+                .or_else(|_| std::path::absolute(rp_parent))
+                .ok()
+                .map(|p| p.join(report_dest.file_name().unwrap_or_default()))
+        });
         if let Some(ref report_abs) = report_abs {
             for f in &files_os {
                 let file_abs = git_root.join(f);
+                // Canonicalize the patch file path too so that symlinks in the
+                // working tree are followed before the comparison.
+                let file_abs = std::fs::canonicalize(&file_abs).unwrap_or(file_abs);
                 // Direct conflict: the patch touches exactly the report file.
                 if file_abs == *report_abs {
                     return Err(ApplyError::Io(std::io::Error::new(
@@ -618,7 +626,7 @@ fn dirty_paths_excluding(
             if l.get(2) != Some(&b' ') {
                 return None;
             }
-            let rel_bytes = l.get(3..)?.trim_ascii();
+            let rel_bytes = l.get(3..)?;
             if rel_bytes.is_empty() {
                 return None;
             }
@@ -813,7 +821,8 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<OsString>, i64, i64) {
         } else if let Some(rest) = line.strip_prefix("rename from ") {
             // 100% similarity renames have no "---"/"+++" pair; capture the
             // old path here so the section-end flush above can record it.
-            pending_a = Some(OsString::from(rest));
+            // The path may be C-quoted (e.g. `rename from "old\tname"`).
+            pending_a = diff_header_path(rest, "");
         } else if let Some(rest) = line.strip_prefix("--- ") {
             // Old-file header outside a hunk: track for rename detection.
             pending_a = diff_header_path(rest, "a/");
@@ -1237,6 +1246,14 @@ fn preflight_report_path(path: &Path) -> Result<(), ApplyError> {
             format!("report path is a directory: {}", path.display()),
         )));
     }
+    // Reject broken symlinks: symlink_metadata() succeeds but exists() is false.
+    // write_report would follow the link and fail with NotFound after apply.
+    if path.symlink_metadata().is_ok() && !path.exists() {
+        return Err(ApplyError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("report path is a broken symlink: {}", path.display()),
+        )));
+    }
     // Walk up to the nearest existing ancestor to place the probe file,
     // since missing intermediate directories have not been created yet.
     // Treat an empty parent (relative path with no directory component) as
@@ -1260,8 +1277,17 @@ fn preflight_report_path(path: &Path) -> Result<(), ApplyError> {
     if path.is_file() {
         std::fs::OpenOptions::new().write(true).open(path)?;
     }
-    let probe = probe_dir.join(format!(".apply-probe-{}.tmp", std::process::id()));
-    std::fs::write(&probe, b"")?;
+    // Use exclusive creation (O_CREAT|O_EXCL) with a name that combines PID
+    // and nanosecond time so that the probe never overwrites an existing file.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.subsec_nanos());
+    let probe = probe_dir.join(format!(".apply-probe-{}-{}.tmp", std::process::id(), nanos));
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe)
+        .map_err(ApplyError::Io)?;
     let _ = std::fs::remove_file(&probe);
     Ok(())
 }

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -454,61 +454,205 @@ fn git_head_sha(dir: &Path) -> Option<String> {
 }
 
 /// Parse a unified diff to extract `(files_changed, lines_added, lines_removed)`.
+///
+/// Handles both `diff --git` extended headers and plain `---`/`+++` headers
+/// (e.g. from `diff -u`). Quoted filenames (git C-string escaping) are
+/// unescaped. For renames, both the old (`a/`) and new (`b/`) paths are
+/// included in the returned file list so that `--3way` cleanup can unstage
+/// both the deletion and the addition sides of the rename.
 fn parse_diff_stats(patch_text: &str) -> (Vec<String>, i64, i64) {
     let mut files: Vec<String> = Vec::new();
     let mut added: i64 = 0;
     let mut removed: i64 = 0;
     let mut in_hunk = false;
-    // Track whether the current file section opened with a "diff --git" header.
-    // When false and we hit "+++", fall back to extracting the name from there
-    // (handles plain unified diffs produced by `diff -u` or `git diff --no-index`
-    // without the git-specific extended header).
+    // Whether the current file section opened with a "diff --git" header.
     let mut saw_git_header = false;
+    // b/ (new) name set by "diff --git" or "+++ "; held for rename detection.
+    let mut pending_b: Option<String> = None;
+    // a/ (old) name set by "--- "; compared with b/ to detect renames.
+    let mut pending_a: Option<String> = None;
 
     for line in patch_text.lines() {
-        if line.starts_with("diff --git ") {
+        if let Some(rest) = line.strip_prefix("diff --git ") {
+            // New file section; always terminates any active hunk.
             in_hunk = false;
             saw_git_header = true;
-            if let Some(b_part) = line
-                .strip_prefix("diff --git ")
-                .and_then(|s| s.find(" b/").map(|i| &s[i + 3..]))
-            {
-                let name = b_part.trim().to_owned();
-                if !files.contains(&name) {
-                    files.push(name);
+            pending_a = None;
+            pending_b = git_diff_b_path(rest);
+            if let Some(ref name) = pending_b {
+                if !files.contains(name) {
+                    files.push(name.clone());
                 }
             }
-        } else if let Some(rest) = line.strip_prefix("+++ ") {
-            in_hunk = false;
-            if !saw_git_header {
-                // Fallback: extract the file name from the "+++ " header.
-                // Strip optional "b/" prefix (git-format without diff --git),
-                // then any trailing tab + timestamp (plain-diff format).
-                let path = rest.strip_prefix("b/").unwrap_or(rest);
-                let path = path.split('\t').next().unwrap_or(path).trim();
-                if !path.is_empty() && path != "/dev/null" {
-                    let name = path.to_owned();
-                    if !files.contains(&name) {
-                        files.push(name);
-                    }
-                }
-            }
-            // Reset for the next file section.
-            saw_git_header = false;
-        } else if line.starts_with("--- ") {
-            in_hunk = false;
-        } else if line.starts_with("@@ ") {
-            in_hunk = true;
         } else if in_hunk {
+            // Inside a hunk: count added/removed lines only.
+            // "+++ " and "--- " are NOT file headers here — they are content
+            // lines whose original text started with "++" or "--".
             if line.starts_with('+') && !line.starts_with("+++") {
                 added += 1;
             } else if line.starts_with('-') && !line.starts_with("---") {
                 removed += 1;
             }
+        } else if let Some(rest) = line.strip_prefix("+++ ") {
+            // New-file header outside a hunk: end of the header pair.
+            let b_name = diff_header_path(rest, "b/");
+            if !saw_git_header {
+                // Plain unified-diff fallback (no "diff --git" seen).
+                if let Some(ref name) = b_name {
+                    if !files.contains(name) {
+                        files.push(name.clone());
+                    }
+                }
+                pending_b.clone_from(&b_name);
+            }
+            // Rename detection: if a/ ≠ b/, the old name is also affected
+            // (git stages its deletion; cleanup must unstage that too).
+            let effective_b = pending_b.as_ref().or(b_name.as_ref());
+            if let (Some(a), Some(b)) = (&pending_a, effective_b) {
+                if a != b && !files.contains(a) {
+                    files.push(a.clone());
+                }
+            }
+            saw_git_header = false;
+            pending_a = None;
+            pending_b = None;
+        } else if let Some(rest) = line.strip_prefix("--- ") {
+            // Old-file header outside a hunk: track for rename detection.
+            pending_a = diff_header_path(rest, "a/");
+        } else if line.starts_with("@@ ") {
+            in_hunk = true;
         }
     }
 
     (files, added, removed)
+}
+
+/// Extract the `b/` path from the tail of a `diff --git a/… b/…` line.
+///
+/// Handles the unquoted format (`a/foo b/bar`) and git's C-string-quoted
+/// format (`"a/foo bar" "b/bar baz"`).  Uses `rfind` for the unquoted case so
+/// that an `a/` path containing the substring ` b/` is less likely to confuse
+/// the split point.
+fn git_diff_b_path(rest: &str) -> Option<String> {
+    if rest.starts_with('"') {
+        // Quoted: '"a/…" "b/…"'
+        let sep = rest.find(" \"b/")?;
+        let b_start = sep + 4; // skip ' "b/'
+        let b_end = rest[b_start..].find('"').map(|i| b_start + i)?;
+        let name = unescape_c_string(&rest[b_start..b_end]);
+        if name.is_empty() { None } else { Some(name) }
+    } else {
+        // Unquoted: rfind keeps the b/ path intact when a/ contains " b/".
+        let pos = rest.rfind(" b/")?;
+        let name = rest[pos + 3..].trim().to_owned();
+        if name.is_empty() { None } else { Some(name) }
+    }
+}
+
+/// Extract a file path from a `---` or `+++` diff header line.
+///
+/// `prefix` is `"a/"` or `"b/"`.  Handles git's C-string-quoted format and
+/// strips trailing timestamps (plain-diff `\t<datetime>` suffix).  Returns
+/// `None` for `/dev/null` and empty paths.
+fn diff_header_path(s: &str, prefix: &str) -> Option<String> {
+    if let Some(without_open) = s.strip_prefix('"') {
+        // Quoted: '"prefix/path"'
+        let end = without_open.find('"')?;
+        let inner = &without_open[..end];
+        let name = unescape_c_string(inner.strip_prefix(prefix).unwrap_or(inner));
+        if name.is_empty() || name == "/dev/null" {
+            None
+        } else {
+            Some(name)
+        }
+    } else {
+        let path = s.strip_prefix(prefix).unwrap_or(s);
+        let path = path.split('\t').next().unwrap_or(path).trim();
+        if path.is_empty() || path == "/dev/null" {
+            None
+        } else {
+            Some(path.to_owned())
+        }
+    }
+}
+
+/// Unescape a git C-string (the content between double-quotes, without them).
+fn unescape_c_string(s: &str) -> String {
+    let bytes = unescape_c_string_bytes(s.as_bytes());
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// Byte-level C-string unescape as used by git for quoting special filenames.
+fn unescape_c_string_bytes(input: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(input.len());
+    let mut i = 0;
+    while i < input.len() {
+        if input[i] != b'\\' || i + 1 >= input.len() {
+            out.push(input[i]);
+            i += 1;
+            continue;
+        }
+        i += 1;
+        match input[i] {
+            b't' => {
+                out.push(b'\t');
+                i += 1;
+            }
+            b'n' => {
+                out.push(b'\n');
+                i += 1;
+            }
+            b'r' => {
+                out.push(b'\r');
+                i += 1;
+            }
+            b'"' => {
+                out.push(b'"');
+                i += 1;
+            }
+            b'\\' => {
+                out.push(b'\\');
+                i += 1;
+            }
+            b'a' => {
+                out.push(b'\x07');
+                i += 1;
+            }
+            b'b' => {
+                out.push(b'\x08');
+                i += 1;
+            }
+            b'f' => {
+                out.push(b'\x0C');
+                i += 1;
+            }
+            b'v' => {
+                out.push(b'\x0B');
+                i += 1;
+            }
+            d @ b'0'..=b'7' => {
+                // Octal escape: git uses \nnn for non-ASCII bytes in path names.
+                let mut val = u32::from(d - b'0');
+                i += 1;
+                for _ in 0..2 {
+                    if i < input.len() && input[i] >= b'0' && input[i] <= b'7' {
+                        val = val * 8 + u32::from(input[i] - b'0');
+                        i += 1;
+                    } else {
+                        break;
+                    }
+                }
+                #[allow(clippy::cast_possible_truncation)]
+                out.push(val as u8); // max octal git produces is \377 = 255
+            }
+            _ => {
+                out.push(b'\\');
+                out.push(input[i]);
+                i += 1;
+            }
+        }
+    }
+    out
 }
 
 /// Return a map of `path → (mode, sha1)` for files among `files` that have

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -351,8 +351,7 @@ fn is_git_tree(dir: &Path) -> bool {
         .args(["rev-parse", "--is-inside-work-tree"])
         .current_dir(dir)
         .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+        .is_ok_and(|o| o.status.success())
 }
 
 /// Return dirty paths, excluding any paths that resolve to an entry in

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -485,11 +485,12 @@ fn git_apply_check(apply_dir: &Path, patch_path: &Path, three_way: bool) -> Resu
     if output.status.success() {
         // When --3way is active, git apply --check can exit 0 even though the
         // real apply would produce conflict markers. git's conflict diagnostic
-        // is "Applied patch X with conflicts." — check for the specific
-        // " with conflicts." suffix (space + period) to avoid false-positives
-        // from filenames that literally contain the words "with conflicts".
-        if three_way && (stdout.contains(" with conflicts.") || stderr.contains(" with conflicts."))
-        {
+        // ends the line with " with conflicts." — check each line's suffix so
+        // a filename like "foo with conflicts." ("Applied patch ... cleanly.")
+        // doesn't trigger a false-positive.
+        let ends_with_conflicts =
+            |s: &str| s.lines().any(|l| l.ends_with(" with conflicts."));
+        if three_way && (ends_with_conflicts(&stdout) || ends_with_conflicts(&stderr)) {
             let combined = format!("{}\n{}", stderr.trim(), stdout.trim());
             return Err(combined.trim().to_owned());
         }
@@ -1016,13 +1017,13 @@ fn preflight_report_path(path: &Path) -> Result<(), ApplyError> {
             std::fs::create_dir_all(parent)?;
         }
     }
-    // Open (or create) the file without truncating so we don't corrupt a
-    // pre-existing report, but do verify the path is writable.
-    std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(path)?;
+    // Probe writability with a temporary sibling rather than creating the
+    // final report file; creating the real path here would conflict with a
+    // patch that adds a file at that same location.
+    let parent_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let probe = parent_dir.join(format!(".apply-probe-{}.tmp", std::process::id()));
+    std::fs::write(&probe, b"")?;
+    let _ = std::fs::remove_file(&probe);
     Ok(())
 }
 

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -555,7 +555,7 @@ fn git_diff_b_path(rest: &str) -> Option<String> {
         // Quoted: '"a/…" "b/…"'
         let sep = rest.find(" \"b/")?;
         let b_start = sep + 4; // skip ' "b/'
-        let b_end = rest[b_start..].find('"').map(|i| b_start + i)?;
+        let b_end = find_unescaped_quote(&rest[b_start..]).map(|i| b_start + i)?;
         let name = unescape_c_string(&rest[b_start..b_end]);
         if name.is_empty() { None } else { Some(name) }
     } else {
@@ -574,7 +574,7 @@ fn git_diff_b_path(rest: &str) -> Option<String> {
 fn diff_header_path(s: &str, prefix: &str) -> Option<String> {
     if let Some(without_open) = s.strip_prefix('"') {
         // Quoted: '"prefix/path"'
-        let end = without_open.find('"')?;
+        let end = find_unescaped_quote(without_open)?;
         let inner = &without_open[..end];
         let name = unescape_c_string(inner.strip_prefix(prefix).unwrap_or(inner));
         if name.is_empty() || name == "/dev/null" {
@@ -605,6 +605,39 @@ fn diff_header_path(s: &str, prefix: &str) -> Option<String> {
 fn unescape_c_string(s: &str) -> String {
     let bytes = unescape_c_string_bytes(s.as_bytes());
     String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// Find the index of the first unescaped `"` in `s`.
+///
+/// A `"` preceded by a backslash (itself part of a C-string escape sequence)
+/// is not a closing quote. Octal escapes (`\nnn`) are also stepped over so
+/// their digits are not mistaken for a quote.
+fn find_unescaped_quote(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => return Some(i),
+            b'\\' => {
+                i += 1;
+                if i < bytes.len() && bytes[i] >= b'0' && bytes[i] <= b'7' {
+                    // Octal escape: skip up to 2 more octal digits.
+                    i += 1;
+                    for _ in 0..2 {
+                        if i < bytes.len() && bytes[i] >= b'0' && bytes[i] <= b'7' {
+                            i += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                } else if i < bytes.len() {
+                    i += 1; // single-char escape (e.g. \", \\, \t)
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    None
 }
 
 /// Byte-level C-string unescape as used by git for quoting special filenames.
@@ -695,8 +728,10 @@ fn pre_staged_entries(
     let mut result = std::collections::HashMap::new();
 
     // Step 1: which of the affected files actually have staged edits?
+    // Use -z so git never C-string-quotes paths (e.g. for files with
+    // newlines or non-ASCII bytes in their names).
     let mut diff_cmd = Command::new("git");
-    diff_cmd.args(["diff", "--cached", "--name-only", "--"]);
+    diff_cmd.args(["diff", "--cached", "--name-only", "-z", "--"]);
     for f in files {
         diff_cmd.arg(format!(":(literal){f}"));
     }
@@ -706,7 +741,7 @@ fn pre_staged_entries(
     };
     let diff_text = String::from_utf8_lossy(&diff_output.stdout);
     let staged_names: Vec<String> = diff_text
-        .lines()
+        .split('\0')
         .filter(|l| !l.trim().is_empty())
         .map(str::to_owned)
         .collect();

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -152,16 +152,14 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
     // that subdirectory (it prints "Skipped patch" and exits 0).
     let git_root = git_toplevel(&opts.target).unwrap_or_else(|| opts.target.clone());
 
-    // ── 4. Compute default report destination (next to, not inside, target) ───
-    // Canonicalize first: `--target .` gives Path::new(".")  whose parent() is
-    // None, which would put the report inside the repo. After canonicalization
-    // the parent is always the directory that contains the target.
-    let canonical_target =
-        std::fs::canonicalize(&opts.target).unwrap_or_else(|_| opts.target.clone());
+    // ── 4. Compute default report destination ────────────────────────────────
+    // Anchor on the worktree root, not the target directory: if --target is a
+    // subdirectory the target's parent() is inside the repo, which would write
+    // the report (and create a directory) inside the checkout on dry-run.
     let report_dest = opts.report_path.clone().unwrap_or_else(|| {
-        canonical_target
+        git_root
             .parent()
-            .unwrap_or(&canonical_target)
+            .unwrap_or(&git_root)
             .join("apply-report.json")
     });
 
@@ -461,10 +459,16 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<String>, i64, i64) {
     let mut added: i64 = 0;
     let mut removed: i64 = 0;
     let mut in_hunk = false;
+    // Track whether the current file section opened with a "diff --git" header.
+    // When false and we hit "+++", fall back to extracting the name from there
+    // (handles plain unified diffs produced by `diff -u` or `git diff --no-index`
+    // without the git-specific extended header).
+    let mut saw_git_header = false;
 
     for line in patch_text.lines() {
         if line.starts_with("diff --git ") {
             in_hunk = false;
+            saw_git_header = true;
             if let Some(b_part) = line
                 .strip_prefix("diff --git ")
                 .and_then(|s| s.find(" b/").map(|i| &s[i + 3..]))
@@ -474,10 +478,25 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<String>, i64, i64) {
                     files.push(name);
                 }
             }
-        } else if line.starts_with("+++ ") {
+        } else if let Some(rest) = line.strip_prefix("+++ ") {
             in_hunk = false;
+            if !saw_git_header {
+                // Fallback: extract the file name from the "+++ " header.
+                // Strip optional "b/" prefix (git-format without diff --git),
+                // then any trailing tab + timestamp (plain-diff format).
+                let path = rest.strip_prefix("b/").unwrap_or(rest);
+                let path = path.split('\t').next().unwrap_or(path).trim();
+                if !path.is_empty() && path != "/dev/null" {
+                    let name = path.to_owned();
+                    if !files.contains(&name) {
+                        files.push(name);
+                    }
+                }
+            }
+            // Reset for the next file section.
+            saw_git_header = false;
         } else if line.starts_with("--- ") {
-            // nothing
+            in_hunk = false;
         } else if line.starts_with("@@ ") {
             in_hunk = true;
         } else if in_hunk {
@@ -510,7 +529,7 @@ fn pre_staged_entries(
     let mut diff_cmd = Command::new("git");
     diff_cmd.args(["diff", "--cached", "--name-only", "--"]);
     for f in files {
-        diff_cmd.arg(f);
+        diff_cmd.arg(format!(":(literal){f}"));
     }
     diff_cmd.current_dir(git_root);
     let Ok(diff_output) = diff_cmd.output() else {
@@ -530,7 +549,7 @@ fn pre_staged_entries(
     let mut ls_cmd = Command::new("git");
     ls_cmd.args(["ls-files", "--stage", "--"]);
     for f in &staged_names {
-        ls_cmd.arg(f);
+        ls_cmd.arg(format!(":(literal){f}"));
     }
     ls_cmd.current_dir(git_root);
     let Ok(ls_output) = ls_cmd.output() else {
@@ -600,10 +619,13 @@ fn apply_patch(
     if !output.status.success() {
         if three_way {
             for f in affected_files {
+                // Use :(literal) to prevent git from treating file names that
+                // contain pathspec metacharacters (e.g. '*') as globs.
+                let lit = format!(":(literal){f}");
                 // Clear any unmerged index entries for this path so that
                 // subsequent checkout commands are not refused.
                 let _ = Command::new("git")
-                    .args(["reset", "HEAD", "--", f])
+                    .args(["reset", "HEAD", "--", &lit])
                     .current_dir(git_root)
                     .output();
                 if let Some((mode, sha)) = pre_staged.get(f) {
@@ -614,6 +636,7 @@ fn apply_patch(
                         .args(["update-index", "--cacheinfo", &cacheinfo])
                         .current_dir(git_root)
                         .output();
+                    // checkout-index takes literal file names (not pathspecs).
                     let _ = Command::new("git")
                         .args(["checkout-index", "--force", "--", f])
                         .current_dir(git_root)
@@ -621,7 +644,7 @@ fn apply_patch(
                 } else {
                     // No pre-existing staged edit: restore working tree from HEAD.
                     let _ = Command::new("git")
-                        .args(["checkout", "--", f])
+                        .args(["checkout", "--", &lit])
                         .current_dir(git_root)
                         .output();
                 }
@@ -637,7 +660,7 @@ fn apply_patch(
         for f in affected_files {
             if !pre_staged.contains_key(f) {
                 let _ = Command::new("git")
-                    .args(["reset", "HEAD", "--", f])
+                    .args(["reset", "HEAD", "--", &format!(":(literal){f}")])
                     .current_dir(git_root)
                     .output();
             }

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -465,9 +465,7 @@ fn git_apply_check(apply_dir: &Path, patch_path: &Path, three_way: bool) -> Resu
         // real apply would produce conflict markers (it reports "Applied patch X
         // with conflicts." on stdout/stderr). Treat this as a failure so that
         // --dry-run correctly reports the patch as not cleanly applicable.
-        if three_way
-            && (stdout.contains("with conflicts") || stderr.contains("with conflicts"))
-        {
+        if three_way && (stdout.contains("with conflicts") || stderr.contains("with conflicts")) {
             let combined = format!("{}\n{}", stderr.trim(), stdout.trim());
             return Err(combined.trim().to_owned());
         }

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -4,7 +4,7 @@
 //! 1. Patch selector must be unambiguous (exit 2 on ambiguity).
 //! 2. Target must be a git working tree (exit 2 before any mutation).
 //! 3. Working tree must be clean unless `--allow-dirty` (exit 30).
-//!    The selected patch file is excluded from the dirty check.
+//!    The selected patch file and trajectory file are excluded from the dirty check.
 //! 4. Patch must not contain `[REDACTED:…]` markers, and the source
 //!    trajectory (when available) must not record patch-submission
 //!    redaction, unless `--allow-redacted` (exit 29).
@@ -134,7 +134,8 @@ impl From<std::io::Error> for ApplyError {
 /// unchanged.
 pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> {
     // ── 1. Resolve patch path and optionally check trajectory redaction ────────
-    let (patch_path, trajectory_redacted) = resolve_patch_and_redaction(&opts.selector);
+    let (patch_path, traj_path_opt, trajectory_redacted) =
+        resolve_patch_and_redaction(&opts.selector);
 
     // Canonicalize the patch path so that relative paths are anchored to the
     // caller's CWD before any `current_dir()` changes in git subprocess calls.
@@ -145,7 +146,13 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
         return Err(ApplyError::NotGitTree(opts.target));
     }
 
-    // ── 3. Compute default report destination (next to, not inside, target) ───
+    // ── 3. Resolve the git worktree root ─────────────────────────────────────
+    // All git apply commands must run from the worktree root. Running from a
+    // subdirectory causes git apply to silently skip patches for paths outside
+    // that subdirectory (it prints "Skipped patch" and exits 0).
+    let git_root = git_toplevel(&opts.target).unwrap_or_else(|| opts.target.clone());
+
+    // ── 4. Compute default report destination (next to, not inside, target) ───
     // Placing the report in the parent of the target prevents it from
     // colliding with any file the applied patch adds at the repo root.
     let report_dest = opts.report_path.clone().unwrap_or_else(|| {
@@ -155,20 +162,30 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
             .join("apply-report.json")
     });
 
-    // ── 4. Dirty-tree gate ────────────────────────────────────────────────────
-    // Exclude the patch file itself so that an untracked (but non-gitignored)
-    // patch inside the target doesn't trip the gate for the normal workflow.
+    // ── 5. Dirty-tree gate ────────────────────────────────────────────────────
+    // Exclude the patch file AND the trajectory file (when using the
+    // trajectory or sweep selectors) so that an untracked artifact bundle
+    // sitting inside the target repo doesn't trip the gate.
     if !opts.allow_dirty {
-        let dirty = dirty_paths_excluding(&opts.target, &[&patch_path])?;
+        let traj_canon = traj_path_opt
+            .as_deref()
+            .map(|tp| std::fs::canonicalize(tp).unwrap_or_else(|_| tp.to_owned()));
+
+        let mut exclude: Vec<&Path> = vec![patch_path.as_path()];
+        if let Some(ref tc) = traj_canon {
+            exclude.push(tc.as_path());
+        }
+
+        let dirty = dirty_paths_excluding(&git_root, &opts.target, &exclude)?;
         if !dirty.is_empty() {
             return Err(ApplyError::DirtyTree(dirty));
         }
     }
 
-    // ── 5. Read patch content ─────────────────────────────────────────────────
+    // ── 6. Read patch content ─────────────────────────────────────────────────
     let patch_text = std::fs::read_to_string(&patch_path)?;
 
-    // ── 6. Redaction gate ─────────────────────────────────────────────────────
+    // ── 7. Redaction gate ─────────────────────────────────────────────────────
     if !opts.allow_redacted {
         let patch_has_markers = patch_text.contains(REDACTION_MARKER);
         if patch_has_markers || trajectory_redacted {
@@ -176,9 +193,9 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
         }
     }
 
-    // ── 7. Empty-patch fast path ──────────────────────────────────────────────
+    // ── 8. Empty-patch fast path ──────────────────────────────────────────────
     if patch_text.trim().is_empty() {
-        let target_sha = git_head_sha(&opts.target);
+        let target_sha = git_head_sha(&git_root);
         let report = ApplyReport {
             schema_version: ArtifactSchemaVersion::CURRENT,
             artifact_kind: ArtifactKind::ApplyReport,
@@ -195,18 +212,18 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
         return Ok(report);
     }
 
-    // ── 8. git apply --check [--3way] ─────────────────────────────────────────
+    // ── 9. git apply --check [--3way] ─────────────────────────────────────────
     // Pass --3way to the preflight check when requested so that patches that
     // only succeed via three-way merge are not falsely rejected here.
-    if let Err(msg) = git_apply_check(&opts.target, &patch_path, opts.three_way) {
+    if let Err(msg) = git_apply_check(&git_root, &patch_path, opts.three_way) {
         return Err(ApplyError::CheckFailed(msg));
     }
 
-    // ── 9. Collect diff stats from patch text ─────────────────────────────────
+    // ── 10. Collect diff stats from patch text ────────────────────────────────
     let (files_changed, lines_added, lines_removed) = parse_diff_stats(&patch_text);
-    let target_sha = git_head_sha(&opts.target);
+    let target_sha = git_head_sha(&git_root);
 
-    // ── 10. Dry-run: report without mutating ──────────────────────────────────
+    // ── 11. Dry-run: report without mutating ──────────────────────────────────
     if opts.dry_run {
         let report = ApplyReport {
             schema_version: ArtifactSchemaVersion::CURRENT,
@@ -224,21 +241,21 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
         return Ok(report);
     }
 
-    // ── 11. Apply the patch ───────────────────────────────────────────────────
-    let mut cmd = Command::new("git");
-    cmd.arg("apply");
-    if opts.three_way {
-        cmd.arg("--3way");
-    }
-    // patch_path is canonicalized (absolute), so current_dir does not affect it.
-    cmd.arg(&patch_path).current_dir(&opts.target);
-    let output = cmd.output()?;
-    if !output.status.success() {
-        let msg = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-        return Err(ApplyError::CheckFailed(msg));
+    // ── 12. Ensure report parent directory exists before mutating the tree ────
+    // Detecting a missing directory now prevents an I/O error from leaving
+    // the tree mutated with no report written.
+    if let Some(parent) = report_dest.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
     }
 
-    // ── 12. Write report ──────────────────────────────────────────────────────
+    // ── 13. Apply the patch ───────────────────────────────────────────────────
+    // patch_path is canonicalized (absolute); git_root avoids silent skips
+    // when --target is a repo subdirectory.
+    apply_patch(&git_root, &patch_path, opts.three_way)?;
+
+    // ── 14. Write report ──────────────────────────────────────────────────────
     let report = ApplyReport {
         schema_version: ArtifactSchemaVersion::CURRENT,
         artifact_kind: ArtifactKind::ApplyReport,
@@ -258,17 +275,18 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/// Resolve the patch `PathBuf` from the selector and check whether the source
-/// trajectory recorded patch-submission redaction.
+/// Resolve the patch `PathBuf` and the trajectory `PathBuf` (if any) from the
+/// selector, and check whether the source trajectory recorded patch-submission
+/// redaction.
 ///
-/// Returns `(patch_path, trajectory_recorded_redaction)`.
-fn resolve_patch_and_redaction(selector: &PatchSelector) -> (PathBuf, bool) {
+/// Returns `(patch_path, trajectory_path_opt, trajectory_recorded_redaction)`.
+fn resolve_patch_and_redaction(selector: &PatchSelector) -> (PathBuf, Option<PathBuf>, bool) {
     match selector {
-        PatchSelector::PatchFile(p) => (p.clone(), false),
+        PatchSelector::PatchFile(p) => (p.clone(), None, false),
         PatchSelector::TrajectoryFile(traj_path) => {
             let patch_path = sibling_patch_of_trajectory(traj_path);
             let redacted = trajectory_has_patch_submission_redaction(traj_path);
-            (patch_path, redacted)
+            (patch_path, Some(traj_path.clone()), redacted)
         }
         PatchSelector::SweepInstance { sweep, instance } => {
             // Canonical nested layout: <sweep>/<instance>/run-1.patch
@@ -285,7 +303,7 @@ fn resolve_patch_and_redaction(selector: &PatchSelector) -> (PathBuf, bool) {
             };
 
             let redacted = trajectory_has_patch_submission_redaction(&traj_path);
-            (patch_path, redacted)
+            (patch_path, Some(traj_path), redacted)
         }
     }
 }
@@ -354,22 +372,25 @@ fn is_git_tree(dir: &Path) -> bool {
         .is_ok_and(|o| o.status.success())
 }
 
-/// Return dirty paths, excluding any paths that resolve to an entry in
-/// `exclude_abs`. The patch file itself is excluded so that an untracked
-/// patch inside the target does not trip the clean-tree gate.
-fn dirty_paths_excluding(dir: &Path, exclude_abs: &[&Path]) -> Result<Vec<String>, ApplyError> {
-    // Get the git root so we can compute absolute paths for comparison.
-    let git_root = Command::new("git")
+/// Return the absolute path of the git worktree root containing `dir`.
+fn git_toplevel(dir: &Path) -> Option<PathBuf> {
+    Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
         .current_dir(dir)
         .output()
         .ok()
         .filter(|o| o.status.success())
-        .map_or_else(
-            || dir.to_owned(),
-            |o| PathBuf::from(String::from_utf8_lossy(&o.stdout).trim().to_owned()),
-        );
+        .map(|o| PathBuf::from(String::from_utf8_lossy(&o.stdout).trim().to_owned()))
+}
 
+/// Return dirty paths, excluding any paths that resolve to an entry in
+/// `exclude_abs`. The patch file and trajectory file are excluded so that an
+/// untracked artifact bundle inside the target does not trip the clean-tree gate.
+fn dirty_paths_excluding(
+    git_root: &Path,
+    dir: &Path,
+    exclude_abs: &[&Path],
+) -> Result<Vec<String>, ApplyError> {
     let output = Command::new("git")
         .args(["status", "--porcelain"])
         .current_dir(dir)
@@ -397,13 +418,13 @@ fn dirty_paths_excluding(dir: &Path, exclude_abs: &[&Path]) -> Result<Vec<String
 /// Run `git apply --check [--3way]` and return `Ok(())` on success.
 /// Passing `three_way` ensures patches that only apply via three-way merge
 /// are not falsely rejected during the preflight check.
-fn git_apply_check(dir: &Path, patch_path: &Path, three_way: bool) -> Result<(), String> {
+fn git_apply_check(apply_dir: &Path, patch_path: &Path, three_way: bool) -> Result<(), String> {
     let mut cmd = Command::new("git");
     cmd.args(["apply", "--check"]);
     if three_way {
         cmd.arg("--3way");
     }
-    cmd.arg(patch_path).current_dir(dir);
+    cmd.arg(patch_path).current_dir(apply_dir);
     let output = cmd.output().map_err(|e| e.to_string())?;
 
     if output.status.success() {
@@ -467,6 +488,33 @@ fn parse_diff_stats(patch_text: &str) -> (Vec<String>, i64, i64) {
     }
 
     (files, added, removed)
+}
+
+/// Run `git apply [--3way]` from `git_root` and return `Ok(())` on success.
+///
+/// On failure with `--3way`: `git apply --check --3way` can exit 0 even when
+/// the real merge has conflicts; when the actual apply then exits non-zero it
+/// may have written conflict markers. This function restores tracked files to
+/// HEAD so the safety contract (failed apply = checkout unchanged) holds.
+fn apply_patch(git_root: &Path, patch_path: &Path, three_way: bool) -> Result<(), ApplyError> {
+    let mut cmd = Command::new("git");
+    cmd.arg("apply");
+    if three_way {
+        cmd.arg("--3way");
+    }
+    cmd.arg(patch_path).current_dir(git_root);
+    let output = cmd.output()?;
+    if !output.status.success() {
+        if three_way {
+            let _ = Command::new("git")
+                .args(["checkout", "--", "."])
+                .current_dir(git_root)
+                .output();
+        }
+        let msg = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        return Err(ApplyError::CheckFailed(msg));
+    }
+    Ok(())
 }
 
 /// Serialize and write the report JSON to `path`.

--- a/src/run/apply.rs
+++ b/src/run/apply.rs
@@ -133,6 +133,7 @@ impl From<std::io::Error> for ApplyError {
 /// Returns the populated [`ApplyReport`] on success (including dry-run and
 /// empty-patch cases). On any gate failure the tree is left byte-for-byte
 /// unchanged.
+#[allow(clippy::too_many_lines)]
 pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> {
     // ── 1. Resolve patch path and optionally check trajectory redaction ────────
     let (patch_path, traj_path_opt, trajectory_redacted) =
@@ -262,6 +263,31 @@ pub fn run_agent_apply(opts: AgentApplyOpts) -> Result<ApplyReport, ApplyError> 
     // when --target is a repo subdirectory.
     apply_patch(&git_root, &patch_path, opts.three_way, &files_os)?;
 
+    // ── 13.5. Overlap check ───────────────────────────────────────────────────
+    // If report_dest coincides with a file the patch just added or modified,
+    // write_report would silently overwrite that content with JSON. Detect this
+    // by comparing canonical paths now that the patch has been applied and the
+    // files exist on disk.
+    if let Ok(report_canon) = report_dest
+        .parent()
+        .and_then(|p| std::fs::canonicalize(p).ok())
+        .map(|p| p.join(report_dest.file_name().unwrap_or_default()))
+        .ok_or(())
+    {
+        for f in &files_os {
+            if std::fs::canonicalize(git_root.join(f)).is_ok_and(|c| c == report_canon) {
+                return Err(ApplyError::Io(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    format!(
+                        "report path '{}' overlaps a file modified by the patch; \
+                         use --report to choose a different destination",
+                        report_dest.display()
+                    ),
+                )));
+            }
+        }
+    }
+
     // ── 14. Write report ──────────────────────────────────────────────────────
     let report = ApplyReport {
         schema_version: ArtifactSchemaVersion::CURRENT,
@@ -296,7 +322,7 @@ fn resolve_patch_and_redaction(selector: &PatchSelector) -> (PathBuf, Option<Pat
             let sibling_traj = sibling_trajectory_of_patch(p);
             let redacted = sibling_traj
                 .as_deref()
-                .map_or(false, trajectory_has_patch_submission_redaction);
+                .is_some_and(trajectory_has_patch_submission_redaction);
             (p.clone(), sibling_traj, redacted)
         }
         PatchSelector::TrajectoryFile(traj_path) => {
@@ -305,25 +331,38 @@ fn resolve_patch_and_redaction(selector: &PatchSelector) -> (PathBuf, Option<Pat
             (patch_path, Some(traj_path.clone()), redacted)
         }
         PatchSelector::SweepInstance { sweep, instance } => {
-            // Try layouts in priority order matching bundle.rs find_patch_path_for_run:
-            // 1. Canonical nested: <sweep>/<instance>/run-1.{patch,traj.json}
+            // Select patch by existence to avoid choosing a nonexistent patch
+            // just because the trajectory for that layout is present.
             let nested_patch = sweep.join(instance).join("run-1.patch");
-            let nested_traj = sweep.join(instance).join("run-1.traj.json");
-            // 2. Bundle layout: <sweep>/patches/<instance>.patch + trajectories/<instance>.traj.json
             let bundle_patch = sweep.join("patches").join(format!("{instance}.patch"));
+            let legacy_patch = sweep.join(format!("{instance}.patch"));
+
+            let patch_path = if nested_patch.exists() {
+                nested_patch
+            } else if bundle_patch.exists() {
+                bundle_patch
+            } else {
+                legacy_patch
+            };
+
+            // Resolve trajectory independently; also check "trajectory.json"
+            // (the legacy nested name used by some sweep versions) before
+            // falling back to the bundle / flat layouts.
+            let nested_traj = sweep.join(instance).join("run-1.traj.json");
+            let nested_traj_legacy = sweep.join(instance).join("trajectory.json");
             let bundle_traj = sweep
                 .join("trajectories")
                 .join(format!("{instance}.traj.json"));
-            // 3. Legacy flat: <sweep>/<instance>.{patch,traj.json}
-            let legacy_patch = sweep.join(format!("{instance}.patch"));
             let legacy_traj = sweep.join(format!("{instance}.traj.json"));
 
-            let (patch_path, traj_path) = if nested_patch.exists() || nested_traj.exists() {
-                (nested_patch, nested_traj)
-            } else if bundle_patch.exists() || bundle_traj.exists() {
-                (bundle_patch, bundle_traj)
+            let traj_path = if nested_traj.exists() {
+                nested_traj
+            } else if nested_traj_legacy.exists() {
+                nested_traj_legacy
+            } else if bundle_traj.exists() {
+                bundle_traj
             } else {
-                (legacy_patch, legacy_traj)
+                legacy_traj
             };
 
             let redacted = trajectory_has_patch_submission_redaction(&traj_path);
@@ -1050,14 +1089,8 @@ fn preflight_report_path(path: &Path) -> Result<(), ApplyError> {
     // since missing intermediate directories have not been created yet.
     let parent = path
         .parent()
-        .map(|p| {
-            if p.as_os_str().is_empty() {
-                Path::new(".")
-            } else {
-                p
-            }
-        })
-        .unwrap_or(Path::new("."));
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
     let mut probe_dir = parent;
     while !probe_dir.exists() {
         probe_dir = match probe_dir.parent() {

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -2,6 +2,7 @@
 //! and writes trajectories to disk.
 
 pub mod annotate;
+pub mod apply;
 pub mod assert;
 pub mod audit;
 pub mod behavior;

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -1395,3 +1395,114 @@ fn apply_sweep_nested_legacy_trajectory_json_blocks_redacted_patch() {
         "expected RedactedRefused from trajectory.json redaction, got {err:?}"
     );
 }
+
+#[test]
+fn apply_report_overlap_fails_before_mutation() {
+    // When --report points at a file the patch adds, the command must fail
+    // BEFORE apply so the tree stays unchanged.
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    // Build a patch that adds a new file "new.txt"
+    std::fs::write(repo.join("new.txt"), "content\n").unwrap();
+    let out = Command::new("git")
+        .args(["diff", "--cached", "--"])
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    // Use git add + diff HEAD for new file
+    Command::new("git")
+        .args(["add", "new.txt"])
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    let out = Command::new("git")
+        .args(["diff", "--cached"])
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    let patch = String::from_utf8(out.stdout).unwrap();
+    Command::new("git")
+        .args(["reset", "HEAD", "new.txt"])
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    std::fs::remove_file(repo.join("new.txt")).unwrap();
+
+    let patch_path = work.path().join("add.patch");
+    std::fs::write(&patch_path, &patch).unwrap();
+
+    // Point --report at the file the patch adds (inside the repo).
+    let report_path = repo.join("new.txt");
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    let err = run_agent_apply(opts).unwrap_err();
+    assert!(
+        matches!(err, ApplyError::Io(_)),
+        "expected Io error for report/patch overlap, got {err:?}"
+    );
+    // Tree must be unchanged — new.txt must not exist.
+    assert!(
+        !repo.join("new.txt").exists(),
+        "tree must not be mutated when report overlaps patch output"
+    );
+}
+
+#[test]
+fn apply_patch_bundle_layout_sibling_trajectory_refused() {
+    // When using --patch patches/inst.patch in a bundle layout, the sibling
+    // trajectory at ../trajectories/inst.traj.json must be detected and its
+    // redaction metadata respected.
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let bundle = work.path().join("bundle");
+    std::fs::create_dir_all(bundle.join("patches")).unwrap();
+    std::fs::create_dir_all(bundle.join("trajectories")).unwrap();
+
+    let patch_path = bundle.join("patches").join("inst.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    let traj_json = r#"{
+        "format": "mini-swe-agent-1.3",
+        "info": {
+            "redaction": {
+                "enabled": true,
+                "redacted": true,
+                "counts": [
+                    {"surface": "patch_submission", "kind": "configured_literal", "count": 1}
+                ]
+            }
+        },
+        "messages": []
+    }"#;
+    std::fs::write(bundle.join("trajectories").join("inst.traj.json"), traj_json).unwrap();
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo,
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: None,
+    };
+    let err = run_agent_apply(opts).unwrap_err();
+    assert!(
+        matches!(err, ApplyError::RedactedRefused),
+        "expected RedactedRefused from bundle trajectory, got {err:?}"
+    );
+}

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -1489,7 +1489,11 @@ fn apply_patch_bundle_layout_sibling_trajectory_refused() {
         },
         "messages": []
     }"#;
-    std::fs::write(bundle.join("trajectories").join("inst.traj.json"), traj_json).unwrap();
+    std::fs::write(
+        bundle.join("trajectories").join("inst.traj.json"),
+        traj_json,
+    )
+    .unwrap();
 
     let opts = AgentApplyOpts {
         selector: PatchSelector::PatchFile(patch_path),

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -1184,3 +1184,124 @@ fn apply_unwritable_report_path_fails_before_mutation() {
         "tree must not be mutated when report path is bad"
     );
 }
+
+#[test]
+fn apply_report_path_is_dir_fails_before_mutation() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    // Create a directory at the report path — preflight must reject this.
+    let report_as_dir = work.path().join("apply-report-dir");
+    std::fs::create_dir_all(&report_as_dir).unwrap();
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_as_dir),
+    };
+    let err = run_agent_apply(opts).unwrap_err();
+    assert!(
+        matches!(err, ApplyError::Io(_)),
+        "expected Io error when report path is a directory, got {err:?}"
+    );
+    // Tree must be unchanged.
+    let content = std::fs::read_to_string(repo.join("hello.txt")).unwrap();
+    assert_eq!(content, "before\n", "tree must not be mutated");
+}
+
+#[test]
+fn apply_report_missing_parent_not_created_before_apply() {
+    // Preflight must not create missing report parent directories before the
+    // apply; the parent should be created by write_report after the patch
+    // succeeds.
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    // Parent directory does not exist yet.
+    let missing_parent = work.path().join("new-dir");
+    let report_path = missing_parent.join("apply-report.json");
+    assert!(
+        !missing_parent.exists(),
+        "precondition: dir should not exist"
+    );
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path.clone()),
+    };
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied, "patch must be applied");
+    assert!(
+        report_path.exists(),
+        "write_report must create the parent dir and report"
+    );
+    // The parent dir must not have been created before the apply.
+    // We can only assert it now exists (post-apply); the key correctness
+    // property is that the apply succeeded — verified above.
+}
+
+#[test]
+fn apply_patch_with_sibling_trajectory_redaction_refused() {
+    // When --patch is used and the sibling .traj.json records patch_submission
+    // redaction, agent apply must refuse even though --trajectory was not used.
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    // Sibling trajectory records patch_submission redaction.
+    let traj_json = r#"{
+        "format": "mini-swe-agent-1.3",
+        "info": {
+            "redaction": {
+                "enabled": true,
+                "redacted": true,
+                "counts": [
+                    {"surface": "patch_submission", "kind": "configured_literal", "count": 1}
+                ]
+            }
+        },
+        "messages": []
+    }"#;
+    std::fs::write(work.path().join("task.traj.json"), traj_json).unwrap();
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo,
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: None,
+    };
+    let err = run_agent_apply(opts).unwrap_err();
+    assert!(
+        matches!(err, ApplyError::RedactedRefused),
+        "expected RedactedRefused when sibling traj records patch_submission redaction, got {err:?}"
+    );
+}

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -1453,6 +1453,93 @@ fn apply_report_overlap_fails_before_mutation() {
 }
 
 #[test]
+fn apply_dry_run_report_overlap_fails_before_write() {
+    // In dry-run mode, if --report points at a file the patch touches, the
+    // overlap check must fire BEFORE write_report writes anything to disk.
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    // Build a patch that adds new.txt (same as apply_report_overlap test).
+    std::fs::write(repo.join("new.txt"), "content\n").unwrap();
+    Command::new("git")
+        .args(["add", "new.txt"])
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    let out = Command::new("git")
+        .args(["diff", "--cached"])
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    let patch = String::from_utf8(out.stdout).unwrap();
+    Command::new("git")
+        .args(["reset", "HEAD", "new.txt"])
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    std::fs::remove_file(repo.join("new.txt")).unwrap();
+
+    let patch_path = work.path().join("add.patch");
+    std::fs::write(&patch_path, &patch).unwrap();
+
+    // dry_run: true — overlap check must still reject before writing report.
+    let report_path = repo.join("new.txt");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: true,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    let err = run_agent_apply(opts).unwrap_err();
+    assert!(
+        matches!(err, ApplyError::Io(_)),
+        "expected Io error for dry-run report/patch overlap, got {err:?}"
+    );
+    // new.txt must not have been created (neither the patch nor the report).
+    assert!(
+        !repo.join("new.txt").exists(),
+        "new.txt must not exist after a rejected dry-run overlap"
+    );
+}
+
+#[test]
+fn apply_plain_deletion_patch_records_deleted_file() {
+    // A plain unified-diff deletion (no `diff --git` header, +++ /dev/null)
+    // must record the deleted file in files_changed.
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    // Plain unified-diff deletion patch (no diff --git header).
+    let patch = "--- a/hello.txt\n+++ /dev/null\n@@ -1 +0,0 @@\n-before\n";
+    let patch_path = work.path().join("del.patch");
+    std::fs::write(&patch_path, patch).unwrap();
+
+    let report_path = work.path().join("report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo,
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    let report = run_agent_apply(opts).unwrap();
+    assert!(
+        report.files_changed.iter().any(|f| f == "hello.txt"),
+        "hello.txt must appear in files_changed for a plain-diff deletion; got {:?}",
+        report.files_changed
+    );
+}
+
+#[test]
 fn apply_patch_bundle_layout_sibling_trajectory_refused() {
     // When using --patch patches/inst.patch in a bundle layout, the sibling
     // trajectory at ../trajectories/inst.traj.json must be detected and its

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -829,3 +829,74 @@ fn apply_trajectory_with_patch_submission_redaction_allowed_with_flag() {
     let report = run_agent_apply(opts).unwrap();
     assert!(report.applied);
 }
+
+#[test]
+fn apply_report_missing_parent_dir_is_created() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    // Point report at a nested directory that does not exist yet.
+    let report_path = work
+        .path()
+        .join("artifacts")
+        .join("subdir")
+        .join("report.json");
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo,
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path.clone()),
+    };
+    // Should succeed: parent directories are created before the apply runs.
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied);
+    assert!(
+        report_path.exists(),
+        "report must be written even when parent did not exist"
+    );
+}
+
+#[test]
+fn apply_trajectory_file_inside_repo_not_dirty() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+
+    // Place both the trajectory and the patch *inside* the repo (untracked).
+    let traj_path = repo.join("task.traj.json");
+    let patch_path = repo.join("task.patch");
+    std::fs::write(
+        &traj_path,
+        r#"{"format":"mini-swe-agent-1.3","info":{},"messages":[]}"#,
+    )
+    .unwrap();
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::TrajectoryFile(traj_path),
+        target: repo,
+        allow_redacted: false,
+        allow_dirty: false, // strict — both artifacts must be excluded
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    // Should succeed: both the .traj.json and the sibling .patch are excluded
+    // from the dirty-tree gate.
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied);
+}

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -1407,12 +1407,6 @@ fn apply_report_overlap_fails_before_mutation() {
 
     // Build a patch that adds a new file "new.txt"
     std::fs::write(repo.join("new.txt"), "content\n").unwrap();
-    let out = Command::new("git")
-        .args(["diff", "--cached", "--"])
-        .current_dir(&repo)
-        .output()
-        .unwrap();
-    // Use git add + diff HEAD for new file
     Command::new("git")
         .args(["add", "new.txt"])
         .current_dir(&repo)

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -136,7 +136,11 @@ fn apply_to_non_git_target_returns_not_git_tree_error() {
 
     // Create a patch file (content doesn't matter for this test)
     let patch_path = work.path().join("task.patch");
-    std::fs::write(&patch_path, "--- a/foo\n+++ b/foo\n@@ -1 +1 @@\n-old\n+new\n").unwrap();
+    std::fs::write(
+        &patch_path,
+        "--- a/foo\n+++ b/foo\n@@ -1 +1 @@\n-old\n+new\n",
+    )
+    .unwrap();
 
     let opts = AgentApplyOpts {
         selector: PatchSelector::PatchFile(patch_path),
@@ -290,8 +294,7 @@ fn apply_check_failed_leaves_tree_unchanged() {
     std::fs::create_dir_all(&repo).unwrap();
     init_repo(&repo);
 
-    let original_content =
-        std::fs::read_to_string(repo.join("hello.txt")).unwrap();
+    let original_content = std::fs::read_to_string(repo.join("hello.txt")).unwrap();
 
     let bad_patch = concat!(
         "diff --git a/nonexistent.rs b/nonexistent.rs\n",
@@ -501,8 +504,11 @@ fn apply_selector_from_trajectory_resolves_sibling_patch() {
     // Write both sibling files: task.traj.json and task.patch
     let traj_path = work.path().join("task.traj.json");
     let patch_path = work.path().join("task.patch");
-    std::fs::write(&traj_path, r#"{"format":"mini-swe-agent-1.3","info":{},"messages":[]}"#)
-        .unwrap();
+    std::fs::write(
+        &traj_path,
+        r#"{"format":"mini-swe-agent-1.3","info":{},"messages":[]}"#,
+    )
+    .unwrap();
     std::fs::write(&patch_path, &patch_content).unwrap();
 
     let report_path = work.path().join("apply-report.json");

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -1243,7 +1243,7 @@ fn apply_report_missing_parent_not_created_before_apply() {
 
     let opts = AgentApplyOpts {
         selector: PatchSelector::PatchFile(patch_path),
-        target: repo.clone(),
+        target: repo,
         allow_redacted: false,
         allow_dirty: false,
         dry_run: false,
@@ -1303,5 +1303,95 @@ fn apply_patch_with_sibling_trajectory_redaction_refused() {
     assert!(
         matches!(err, ApplyError::RedactedRefused),
         "expected RedactedRefused when sibling traj records patch_submission redaction, got {err:?}"
+    );
+}
+
+#[test]
+fn apply_sweep_nested_traj_only_uses_fallback_patch() {
+    // If only the trajectory is in the nested layout but the patch is in the
+    // legacy flat location, the selector must pick the existing patch rather
+    // than failing with a missing-patch I/O error.
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let sweep_dir = work.path().join("sweep");
+    let instance_dir = sweep_dir.join("inst1");
+    std::fs::create_dir_all(&instance_dir).unwrap();
+
+    // Nested trajectory present, but patch is only in the legacy flat location.
+    std::fs::write(
+        instance_dir.join("run-1.traj.json"),
+        r#"{"format":"mini-swe-agent-1.3","info":{},"messages":[]}"#,
+    )
+    .unwrap();
+    std::fs::write(sweep_dir.join("inst1.patch"), &patch_content).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::SweepInstance {
+            sweep: sweep_dir,
+            instance: "inst1".into(),
+        },
+        target: repo,
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path.clone()),
+    };
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied, "patch must be applied");
+}
+
+#[test]
+fn apply_sweep_nested_legacy_trajectory_json_blocks_redacted_patch() {
+    // The nested layout should also check "trajectory.json" (the legacy nested
+    // trajectory name) when deciding whether redaction was recorded.
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let sweep_dir = work.path().join("sweep");
+    let instance_dir = sweep_dir.join("inst2");
+    std::fs::create_dir_all(&instance_dir).unwrap();
+
+    std::fs::write(instance_dir.join("run-1.patch"), &patch_content).unwrap();
+    // Use the legacy "trajectory.json" name (not "run-1.traj.json").
+    let traj_json = r#"{
+        "format": "mini-swe-agent-1.3",
+        "info": {
+            "redaction": {
+                "enabled": true,
+                "redacted": true,
+                "counts": [
+                    {"surface": "patch_submission", "kind": "configured_literal", "count": 1}
+                ]
+            }
+        },
+        "messages": []
+    }"#;
+    std::fs::write(instance_dir.join("trajectory.json"), traj_json).unwrap();
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::SweepInstance {
+            sweep: sweep_dir,
+            instance: "inst2".into(),
+        },
+        target: repo,
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: None,
+    };
+    let err = run_agent_apply(opts).unwrap_err();
+    assert!(
+        matches!(err, ApplyError::RedactedRefused),
+        "expected RedactedRefused from trajectory.json redaction, got {err:?}"
     );
 }

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -1,0 +1,734 @@
+//! Tests for `agent apply` — issue #473.
+//!
+//! RED phase: these tests reference the not-yet-implemented public API and
+//! will fail to compile until the implementation is in place.
+//! GREEN phase: implement src/run/apply.rs and wire the CLI.
+//! REFACTOR phase: clean up.
+
+#![allow(clippy::unwrap_used, clippy::too_many_lines)]
+
+use std::path::Path;
+use std::process::Command;
+
+use maxwells_daemon::exit_code::ExitCode;
+use maxwells_daemon::run::apply::{
+    AgentApplyOpts, ApplyError, ApplyReport, PatchSelector, run_agent_apply,
+};
+
+// ── Exit code unit tests ──────────────────────────────────────────────────────
+
+#[test]
+fn apply_check_failed_exit_code_is_28() {
+    assert_eq!(ExitCode::ApplyCheckFailed.as_i32(), 28);
+    assert_eq!(
+        ExitCode::ApplyCheckFailed.outcome_class(),
+        "apply_check_failed"
+    );
+}
+
+#[test]
+fn apply_redacted_refused_exit_code_is_29() {
+    assert_eq!(ExitCode::ApplyRedactedRefused.as_i32(), 29);
+    assert_eq!(
+        ExitCode::ApplyRedactedRefused.outcome_class(),
+        "apply_redacted_refused"
+    );
+}
+
+#[test]
+fn apply_dirty_tree_refused_exit_code_is_30() {
+    assert_eq!(ExitCode::ApplyDirtyTreeRefused.as_i32(), 30);
+    assert_eq!(
+        ExitCode::ApplyDirtyTreeRefused.outcome_class(),
+        "apply_dirty_tree_refused"
+    );
+}
+
+// ── Struct-field existence tests ──────────────────────────────────────────────
+
+#[test]
+fn apply_report_has_required_fields() {
+    use maxwells_daemon::artifact::{ArtifactKind, ArtifactSchemaVersion};
+
+    let report = ApplyReport {
+        schema_version: ArtifactSchemaVersion::CURRENT,
+        artifact_kind: ArtifactKind::ApplyReport,
+        source_patch_path: "/some/path/task.patch".into(),
+        target_git_sha: Some("abc123".into()),
+        files_changed: vec!["src/lib.rs".into()],
+        lines_added: 5,
+        lines_removed: 2,
+        check_result: "passed".into(),
+        applied: true,
+        dry_run: false,
+    };
+    assert_eq!(report.lines_added, 5);
+    assert_eq!(report.lines_removed, 2);
+    assert!(report.applied);
+    assert!(!report.dry_run);
+    assert_eq!(report.check_result, "passed");
+}
+
+#[test]
+fn artifact_kind_has_apply_report_variant() {
+    use maxwells_daemon::artifact::ArtifactKind;
+    assert_eq!(ArtifactKind::ApplyReport.label(), "apply_report");
+}
+
+// ── Helper: create a minimal git repo ─────────────────────────────────────────
+
+fn init_repo(dir: &Path) -> String {
+    fn git(dir: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    git(dir, &["init", "-q", "-b", "main"]);
+    git(dir, &["config", "user.email", "test@example.com"]);
+    git(dir, &["config", "user.name", "Test"]);
+    git(dir, &["config", "commit.gpgSign", "false"]);
+    git(dir, &["config", "tag.gpgSign", "false"]);
+    std::fs::write(dir.join("hello.txt"), "before\n").unwrap();
+    git(dir, &["add", "hello.txt"]);
+    git(dir, &["commit", "-q", "-m", "base"]);
+    let out = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+/// Write a well-formed patch for `hello.txt`: "before" → "after".
+fn make_valid_patch(repo: &Path) -> String {
+    // Create a patch by actually diffing a modification
+    std::fs::write(repo.join("hello.txt"), "after\n").unwrap();
+    let out = Command::new("git")
+        .args(["diff"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    let patch = String::from_utf8(out.stdout).unwrap();
+    // Restore the working tree
+    Command::new("git")
+        .args(["checkout", "hello.txt"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    patch
+}
+
+// ── Logic tests ───────────────────────────────────────────────────────────────
+
+#[test]
+fn apply_to_non_git_target_returns_not_git_tree_error() {
+    let work = tempfile::tempdir().unwrap();
+    let not_git = work.path().join("notgit");
+    std::fs::create_dir_all(&not_git).unwrap();
+
+    // Create a patch file (content doesn't matter for this test)
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, "--- a/foo\n+++ b/foo\n@@ -1 +1 @@\n-old\n+new\n").unwrap();
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: not_git.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: None,
+    };
+    let err = run_agent_apply(opts).unwrap_err();
+    assert!(
+        matches!(err, ApplyError::NotGitTree(_)),
+        "expected NotGitTree, got {err:?}"
+    );
+}
+
+#[test]
+fn apply_empty_patch_exits_0_with_no_changes() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_path = work.path().join("empty.patch");
+    std::fs::write(&patch_path, "").unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path.clone()),
+    };
+    let report = run_agent_apply(opts).unwrap();
+    assert_eq!(report.check_result, "empty");
+    assert!(!report.applied);
+    assert!(report.files_changed.is_empty());
+    // Report file must be written
+    assert!(report_path.exists());
+}
+
+#[test]
+fn apply_dirty_tree_refused_by_default() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    // Make tree dirty
+    std::fs::write(repo.join("dirty.txt"), "untracked\n").unwrap();
+
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, make_valid_patch(&repo)).unwrap();
+
+    // Re-dirty (make_valid_patch cleans the tracked file, but we added untracked)
+    std::fs::write(repo.join("dirty.txt"), "untracked\n").unwrap();
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: None,
+    };
+    let err = run_agent_apply(opts).unwrap_err();
+    assert!(
+        matches!(err, ApplyError::DirtyTree(_)),
+        "expected DirtyTree, got {err:?}"
+    );
+}
+
+#[test]
+fn apply_dirty_tree_allowed_with_allow_dirty() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+
+    // Make tree dirty (untracked file)
+    std::fs::write(repo.join("dirty.txt"), "untracked\n").unwrap();
+
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: true,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path.clone()),
+    };
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied);
+    // File was changed
+    let content = std::fs::read_to_string(repo.join("hello.txt")).unwrap();
+    assert_eq!(content, "after\n");
+}
+
+#[test]
+fn apply_check_failed_returns_check_failed_error() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    // A patch for a file that doesn't exist / has wrong context
+    let bad_patch = concat!(
+        "diff --git a/nonexistent.rs b/nonexistent.rs\n",
+        "--- a/nonexistent.rs\n",
+        "+++ b/nonexistent.rs\n",
+        "@@ -1,3 +1,3 @@\n",
+        " line1\n",
+        "-line2\n",
+        "+line2_modified\n",
+        " line3\n",
+    );
+    let patch_path = work.path().join("bad.patch");
+    std::fs::write(&patch_path, bad_patch).unwrap();
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: None,
+    };
+    let err = run_agent_apply(opts).unwrap_err();
+    assert!(
+        matches!(err, ApplyError::CheckFailed(_)),
+        "expected CheckFailed, got {err:?}"
+    );
+}
+
+#[test]
+fn apply_check_failed_leaves_tree_unchanged() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let original_content =
+        std::fs::read_to_string(repo.join("hello.txt")).unwrap();
+
+    let bad_patch = concat!(
+        "diff --git a/nonexistent.rs b/nonexistent.rs\n",
+        "--- a/nonexistent.rs\n",
+        "+++ b/nonexistent.rs\n",
+        "@@ -1,3 +1,3 @@\n",
+        " line1\n",
+        "-line2\n",
+        "+line2_modified\n",
+        " line3\n",
+    );
+    let patch_path = work.path().join("bad.patch");
+    std::fs::write(&patch_path, bad_patch).unwrap();
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: None,
+    };
+    let _err = run_agent_apply(opts).unwrap_err();
+
+    // Tree must be byte-for-byte unchanged
+    let after_content = std::fs::read_to_string(repo.join("hello.txt")).unwrap();
+    assert_eq!(original_content, after_content, "tree must be unchanged");
+}
+
+#[test]
+fn apply_dry_run_does_not_modify_tree() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: true,
+        three_way: false,
+        report_path: Some(report_path.clone()),
+    };
+    let report = run_agent_apply(opts).unwrap();
+
+    // Not applied in dry-run
+    assert!(!report.applied);
+    assert!(report.dry_run);
+    assert_eq!(report.check_result, "passed");
+
+    // Tree unchanged
+    let content = std::fs::read_to_string(repo.join("hello.txt")).unwrap();
+    assert_eq!(content, "before\n");
+
+    // Report still written
+    assert!(report_path.exists());
+}
+
+#[test]
+fn apply_success_modifies_tree_and_writes_report() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path.clone()),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path.clone()),
+    };
+    let report = run_agent_apply(opts).unwrap();
+
+    assert!(report.applied);
+    assert!(!report.dry_run);
+    assert_eq!(report.check_result, "passed");
+    assert!(report.target_git_sha.is_some());
+    assert!(!report.files_changed.is_empty());
+    assert_eq!(report.source_patch_path, patch_path.to_string_lossy());
+
+    // Tree was modified
+    let content = std::fs::read_to_string(repo.join("hello.txt")).unwrap();
+    assert_eq!(content, "after\n");
+
+    // Report file exists and is valid JSON
+    assert!(report_path.exists());
+    let report_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&report_path).unwrap()).unwrap();
+    assert_eq!(report_json["applied"], serde_json::json!(true));
+    assert_eq!(report_json["check_result"], serde_json::json!("passed"));
+}
+
+#[test]
+fn apply_success_report_contains_schema_version() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path.clone()),
+    };
+    run_agent_apply(opts).unwrap();
+
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&report_path).unwrap()).unwrap();
+    assert!(
+        json.get("schema_version").is_some(),
+        "report must contain schema_version"
+    );
+    assert!(
+        json.get("artifact_kind").is_some(),
+        "report must contain artifact_kind"
+    );
+}
+
+#[test]
+fn apply_report_written_to_custom_path() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    let custom_report = work.path().join("subdir").join("my-report.json");
+    std::fs::create_dir_all(custom_report.parent().unwrap()).unwrap();
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(custom_report.clone()),
+    };
+    run_agent_apply(opts).unwrap();
+    assert!(custom_report.exists());
+}
+
+#[test]
+fn apply_report_lines_added_removed_are_correct() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    let report = run_agent_apply(opts).unwrap();
+    // "before" → "after": 1 line removed, 1 line added
+    assert_eq!(report.lines_added, 1);
+    assert_eq!(report.lines_removed, 1);
+}
+
+#[test]
+fn apply_selector_from_trajectory_resolves_sibling_patch() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+
+    // Write both sibling files: task.traj.json and task.patch
+    let traj_path = work.path().join("task.traj.json");
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&traj_path, r#"{"format":"mini-swe-agent-1.3","info":{},"messages":[]}"#)
+        .unwrap();
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::TrajectoryFile(traj_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied);
+}
+
+#[test]
+fn apply_selector_from_sweep_instance_resolves_patch() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+
+    // Sweep directory structure: <sweep>/<instance>.patch
+    let sweep_dir = work.path().join("sweep_run");
+    std::fs::create_dir_all(&sweep_dir).unwrap();
+    std::fs::write(sweep_dir.join("my-instance.patch"), &patch_content).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::SweepInstance {
+            sweep: sweep_dir,
+            instance: "my-instance".into(),
+        },
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied);
+}
+
+#[test]
+fn apply_redacted_patch_content_refused_by_default() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    // A patch that contains a [REDACTED:...] marker in a line addition
+    let redacted_patch = concat!(
+        "diff --git a/hello.txt b/hello.txt\n",
+        "--- a/hello.txt\n",
+        "+++ b/hello.txt\n",
+        "@@ -1 +1 @@\n",
+        "-before\n",
+        "+[REDACTED:sha256:abcdef1234567890] was here\n",
+    );
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, redacted_patch).unwrap();
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: None,
+    };
+    let err = run_agent_apply(opts).unwrap_err();
+    assert!(
+        matches!(err, ApplyError::RedactedRefused),
+        "expected RedactedRefused, got {err:?}"
+    );
+}
+
+#[test]
+fn apply_redacted_patch_content_allowed_with_flag() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    // A patch with a [REDACTED:...] marker — but now we use --allow-redacted
+    // We also make the patch apply cleanly (context matches)
+    let redacted_patch = concat!(
+        "diff --git a/hello.txt b/hello.txt\n",
+        "--- a/hello.txt\n",
+        "+++ b/hello.txt\n",
+        "@@ -1 +1 @@\n",
+        "-before\n",
+        "+[REDACTED:sha256:abcdef1234567890] was here\n",
+    );
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, redacted_patch).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: true,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied);
+}
+
+#[test]
+fn apply_3way_flag_is_accepted() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: true,
+        report_path: Some(report_path),
+    };
+    // Should succeed with --3way
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied);
+}
+
+// ── Trajectory-based redaction detection ─────────────────────────────────────
+
+#[test]
+fn apply_trajectory_with_patch_submission_redaction_refused() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    // Write a trajectory that records patch_submission redaction
+    let traj_json = r#"{
+        "format": "mini-swe-agent-1.3",
+        "info": {
+            "redaction": {
+                "enabled": true,
+                "redacted": true,
+                "counts": [
+                    {"surface": "patch_submission", "kind": "configured_literal", "count": 1}
+                ]
+            }
+        },
+        "messages": []
+    }"#;
+    let traj_path = work.path().join("task.traj.json");
+    std::fs::write(&traj_path, traj_json).unwrap();
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::TrajectoryFile(traj_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: None,
+    };
+    let err = run_agent_apply(opts).unwrap_err();
+    assert!(
+        matches!(err, ApplyError::RedactedRefused),
+        "expected RedactedRefused when trajectory records patch_submission redaction, got {err:?}"
+    );
+}
+
+#[test]
+fn apply_trajectory_with_patch_submission_redaction_allowed_with_flag() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    let traj_json = r#"{
+        "format": "mini-swe-agent-1.3",
+        "info": {
+            "redaction": {
+                "enabled": true,
+                "redacted": true,
+                "counts": [
+                    {"surface": "patch_submission", "kind": "configured_literal", "count": 1}
+                ]
+            }
+        },
+        "messages": []
+    }"#;
+    let traj_path = work.path().join("task.traj.json");
+    std::fs::write(&traj_path, traj_json).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::TrajectoryFile(traj_path),
+        target: repo.clone(),
+        allow_redacted: true,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    // With --allow-redacted, should succeed despite trajectory redaction record
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied);
+}

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -589,6 +589,38 @@ fn apply_selector_from_sweep_instance_resolves_patch() {
 }
 
 #[test]
+fn apply_selector_sweep_bundle_patches_layout() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+
+    // Bundle layout: <sweep>/patches/<instance>.patch (from spec-bundle.md)
+    let sweep_dir = work.path().join("sweep_bundle");
+    let patches_dir = sweep_dir.join("patches");
+    std::fs::create_dir_all(&patches_dir).unwrap();
+    std::fs::write(patches_dir.join("my-instance.patch"), &patch_content).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::SweepInstance {
+            sweep: sweep_dir,
+            instance: "my-instance".into(),
+        },
+        target: repo,
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied);
+}
+
+#[test]
 fn apply_dry_run_without_report_flag_writes_default_report() {
     let work = tempfile::tempdir().unwrap();
     let repo = work.path().join("repo");

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -808,7 +808,97 @@ fn apply_3way_flag_is_accepted() {
     assert!(report.applied);
 }
 
-// ── Trajectory-based redaction detection ─────────────────────────────────────
+// ── Legacy redaction path (info/other/secret_leak_detected) ──────────────────
+
+#[test]
+fn apply_trajectory_with_legacy_other_redaction_refused() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    // Some older mini versions write the secret-leak marker under info/other
+    // rather than info/redaction/counts or info/secret_leak_detected.
+    let traj_json = r#"{
+        "format": "mini-swe-agent-1.3",
+        "info": {
+            "other": {
+                "secret_leak_detected": {
+                    "surface": "patch_submission"
+                }
+            }
+        },
+        "messages": []
+    }"#;
+    let traj_path = work.path().join("task.traj.json");
+    std::fs::write(&traj_path, traj_json).unwrap();
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::TrajectoryFile(traj_path),
+        target: repo,
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: None,
+    };
+    let err = run_agent_apply(opts).unwrap_err();
+    assert!(
+        matches!(err, ApplyError::RedactedRefused),
+        "expected RedactedRefused for info/other/secret_leak_detected, got {err:?}"
+    );
+}
+
+// ── /dev/null sentinel in new-file patches ────────────────────────────────────
+
+#[test]
+fn apply_new_file_patch_dev_null_not_in_files_changed() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    // A git-format patch that adds a brand-new file: old side is /dev/null.
+    let patch = concat!(
+        "diff --git a/new_file.txt b/new_file.txt\n",
+        "new file mode 100644\n",
+        "index 0000000..3b18e51\n",
+        "--- /dev/null\n",
+        "+++ b/new_file.txt\n",
+        "@@ -0,0 +1 @@\n",
+        "+hello world\n",
+    );
+    let patch_path = work.path().join("add_file.patch");
+    std::fs::write(&patch_path, patch).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied);
+    // Only the real new file should appear — not "dev/null".
+    assert!(
+        !report.files_changed.iter().any(|f| f.contains("dev/null")),
+        "dev/null must not appear in files_changed; got {:?}",
+        report.files_changed
+    );
+    assert!(
+        report.files_changed.contains(&"new_file.txt".to_owned()),
+        "new_file.txt must be in files_changed; got {:?}",
+        report.files_changed
+    );
+}
 
 #[test]
 fn apply_trajectory_with_patch_submission_redaction_refused() {

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -1056,3 +1056,50 @@ fn apply_trajectory_file_inside_repo_not_dirty() {
     let report = run_agent_apply(opts).unwrap();
     assert!(report.applied);
 }
+
+// ── Plain-diff timestamped /dev/null sentinel ─────────────────────────────────
+
+#[test]
+fn apply_plain_diff_new_file_with_timestamped_dev_null() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    // A plain unified-diff (`diff -u`) new-file patch. The old header is
+    // "/dev/null\t<timestamp>" — the tab+timestamp is the form plain `diff`
+    // produces, and must not appear in files_changed as "dev/null".
+    let patch = concat!(
+        "--- /dev/null\t2024-01-01 00:00:00.000000000 +0000\n",
+        "+++ new_plain.txt\t2024-01-01 00:00:01.000000000 +0000\n",
+        "@@ -0,0 +1 @@\n",
+        "+hello from plain diff\n",
+    );
+    let patch_path = work.path().join("plain_add.patch");
+    std::fs::write(&patch_path, patch).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo,
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied);
+    assert!(
+        !report.files_changed.iter().any(|f| f.contains("dev/null")),
+        "dev/null must not appear in files_changed; got {:?}",
+        report.files_changed
+    );
+    assert!(
+        report
+            .files_changed
+            .contains(&"new_plain.txt".to_owned()),
+        "new_plain.txt must be in files_changed; got {:?}",
+        report.files_changed
+    );
+}

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -1101,3 +1101,86 @@ fn apply_plain_diff_new_file_with_timestamped_dev_null() {
         report.files_changed
     );
 }
+
+// ── Bundle layout: --trajectory resolves ../patches/<id>.patch ────────────────
+
+#[test]
+fn apply_trajectory_resolves_bundle_patches_layout() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+
+    // Simulate bundle layout: trajectories/<id>.traj.json + patches/<id>.patch
+    let trajs_dir = work.path().join("trajectories");
+    let patches_dir = work.path().join("patches");
+    std::fs::create_dir_all(&trajs_dir).unwrap();
+    std::fs::create_dir_all(&patches_dir).unwrap();
+
+    let traj_path = trajs_dir.join("task-1.traj.json");
+    let patch_path = patches_dir.join("task-1.patch");
+    std::fs::write(
+        &traj_path,
+        r#"{"format":"mini-swe-agent-1.3","info":{},"messages":[]}"#,
+    )
+    .unwrap();
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::TrajectoryFile(traj_path),
+        target: repo,
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    // Should resolve trajectories/task-1.traj.json → ../patches/task-1.patch
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied);
+    assert_eq!(report.files_changed, vec!["hello.txt"]);
+}
+
+// ── Report path preflight before apply ────────────────────────────────────────
+
+#[test]
+fn apply_unwritable_report_path_fails_before_mutation() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    // Place a regular FILE where the report's parent directory should be so
+    // that create_dir_all fails before the apply runs.
+    let blocker = work.path().join("not-a-dir");
+    std::fs::write(&blocker, "blocker\n").unwrap();
+    let bad_report = blocker.join("apply-report.json");
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(bad_report),
+    };
+    let err = run_agent_apply(opts).unwrap_err();
+    assert!(
+        matches!(err, ApplyError::Io(_)),
+        "expected Io error for bad report path, got {err:?}"
+    );
+    // Tree must be unchanged — preflight must have fired before apply.
+    let content = std::fs::read_to_string(repo.join("hello.txt")).unwrap();
+    assert_eq!(
+        content, "before\n",
+        "tree must not be mutated when report path is bad"
+    );
+}

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -1540,6 +1540,116 @@ fn apply_plain_deletion_patch_records_deleted_file() {
 }
 
 #[test]
+fn apply_dirty_path_with_whitespace_not_excluded() {
+    // A patch artifact whose filename contains leading/trailing whitespace must
+    // be correctly excluded from the dirty-tree check (fix: no trim_ascii on
+    // the path bytes after stripping the "XY " status prefix).
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    // Create a patch file whose name has a trailing space.
+    let patch_content = make_valid_patch(&repo);
+    let patch_name = "task .patch"; // trailing space in name
+    let patch_path = repo.join(patch_name);
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    // The repo is "dirty" only because of the untracked patch file.
+    // With --patch pointing at that same file it must be excluded and apply.
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo,
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: None,
+    };
+    // Should succeed: the only dirty entry is the patch file itself.
+    run_agent_apply(opts).unwrap();
+}
+
+#[test]
+fn apply_report_symlink_to_patched_file_is_overlap() {
+    // When --report is a symlink pointing at a file the patch modifies, the
+    // overlap check must detect the conflict (fix: canonicalize report_dest
+    // when it already exists before comparing to patch file paths).
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("mod.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    // Create a symlink: work/report_link.json → repo/hello.txt (patched file)
+    let link = work.path().join("report_link.json");
+    std::os::unix::fs::symlink(repo.join("hello.txt"), &link).unwrap();
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(link),
+    };
+    let err = run_agent_apply(opts).unwrap_err();
+    assert!(
+        matches!(err, ApplyError::Io(_)),
+        "expected Io error when report symlink points at a patched file, got {err:?}"
+    );
+    // hello.txt must not have been modified.
+    assert_eq!(
+        std::fs::read_to_string(repo.join("hello.txt")).unwrap(),
+        "before\n",
+        "working tree must not be mutated when symlinked report overlaps patch"
+    );
+}
+
+#[test]
+fn apply_broken_report_symlink_rejected_before_apply() {
+    // When --report names a broken symlink, preflight must reject it before
+    // apply_patch runs (fix: detect symlink_metadata().is_ok() && !exists()).
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("mod.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    // Create a broken symlink: target does not exist.
+    let link = work.path().join("broken_link.json");
+    std::os::unix::fs::symlink(work.path().join("nonexistent.json"), &link).unwrap();
+
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(link),
+    };
+    let err = run_agent_apply(opts).unwrap_err();
+    assert!(
+        matches!(err, ApplyError::Io(_)),
+        "expected Io error for broken report symlink, got {err:?}"
+    );
+    // hello.txt must not have been modified.
+    assert_eq!(
+        std::fs::read_to_string(repo.join("hello.txt")).unwrap(),
+        "before\n",
+        "working tree must not be mutated when report path is a broken symlink"
+    );
+}
+
+#[test]
 fn apply_patch_bundle_layout_sibling_trajectory_refused() {
     // When using --patch patches/inst.patch in a bundle layout, the sibling
     // trajectory at ../trajectories/inst.traj.json must be detected and its

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -144,7 +144,7 @@ fn apply_to_non_git_target_returns_not_git_tree_error() {
 
     let opts = AgentApplyOpts {
         selector: PatchSelector::PatchFile(patch_path),
-        target: not_git.clone(),
+        target: not_git,
         allow_redacted: false,
         allow_dirty: false,
         dry_run: false,
@@ -171,7 +171,7 @@ fn apply_empty_patch_exits_0_with_no_changes() {
     let report_path = work.path().join("apply-report.json");
     let opts = AgentApplyOpts {
         selector: PatchSelector::PatchFile(patch_path),
-        target: repo.clone(),
+        target: repo,
         allow_redacted: false,
         allow_dirty: false,
         dry_run: false,
@@ -204,7 +204,7 @@ fn apply_dirty_tree_refused_by_default() {
 
     let opts = AgentApplyOpts {
         selector: PatchSelector::PatchFile(patch_path),
-        target: repo.clone(),
+        target: repo,
         allow_redacted: false,
         allow_dirty: false,
         dry_run: false,
@@ -241,7 +241,7 @@ fn apply_dirty_tree_allowed_with_allow_dirty() {
         allow_dirty: true,
         dry_run: false,
         three_way: false,
-        report_path: Some(report_path.clone()),
+        report_path: Some(report_path),
     };
     let report = run_agent_apply(opts).unwrap();
     assert!(report.applied);
@@ -273,7 +273,7 @@ fn apply_check_failed_returns_check_failed_error() {
 
     let opts = AgentApplyOpts {
         selector: PatchSelector::PatchFile(patch_path),
-        target: repo.clone(),
+        target: repo,
         allow_redacted: false,
         allow_dirty: false,
         dry_run: false,
@@ -417,7 +417,7 @@ fn apply_success_report_contains_schema_version() {
     let report_path = work.path().join("apply-report.json");
     let opts = AgentApplyOpts {
         selector: PatchSelector::PatchFile(patch_path),
-        target: repo.clone(),
+        target: repo,
         allow_redacted: false,
         allow_dirty: false,
         dry_run: false,
@@ -454,7 +454,7 @@ fn apply_report_written_to_custom_path() {
 
     let opts = AgentApplyOpts {
         selector: PatchSelector::PatchFile(patch_path),
-        target: repo.clone(),
+        target: repo,
         allow_redacted: false,
         allow_dirty: false,
         dry_run: false,
@@ -479,7 +479,7 @@ fn apply_report_lines_added_removed_are_correct() {
     let report_path = work.path().join("apply-report.json");
     let opts = AgentApplyOpts {
         selector: PatchSelector::PatchFile(patch_path),
-        target: repo.clone(),
+        target: repo,
         allow_redacted: false,
         allow_dirty: false,
         dry_run: false,
@@ -514,7 +514,7 @@ fn apply_selector_from_trajectory_resolves_sibling_patch() {
     let report_path = work.path().join("apply-report.json");
     let opts = AgentApplyOpts {
         selector: PatchSelector::TrajectoryFile(traj_path),
-        target: repo.clone(),
+        target: repo,
         allow_redacted: false,
         allow_dirty: false,
         dry_run: false,
@@ -546,7 +546,7 @@ fn apply_selector_sweep_instance_nested_layout() {
             sweep: sweep_dir,
             instance: "my-instance".into(),
         },
-        target: repo.clone(),
+        target: repo,
         allow_redacted: false,
         allow_dirty: false,
         dry_run: false,
@@ -577,7 +577,7 @@ fn apply_selector_from_sweep_instance_resolves_patch() {
             sweep: sweep_dir,
             instance: "my-instance".into(),
         },
-        target: repo.clone(),
+        target: repo,
         allow_redacted: false,
         allow_dirty: false,
         dry_run: false,
@@ -635,7 +635,7 @@ fn apply_patch_inside_repo_not_gitignored_does_not_trip_dirty_gate() {
     let report_path = work.path().join("apply-report.json");
     let opts = AgentApplyOpts {
         selector: PatchSelector::PatchFile(patch_path),
-        target: repo.clone(),
+        target: repo,
         allow_redacted: false,
         allow_dirty: false, // <-- strict; patch inside repo should be excluded
         dry_run: false,
@@ -668,7 +668,7 @@ fn apply_redacted_patch_content_refused_by_default() {
 
     let opts = AgentApplyOpts {
         selector: PatchSelector::PatchFile(patch_path),
-        target: repo.clone(),
+        target: repo,
         allow_redacted: false,
         allow_dirty: false,
         dry_run: false,
@@ -705,7 +705,7 @@ fn apply_redacted_patch_content_allowed_with_flag() {
     let report_path = work.path().join("apply-report.json");
     let opts = AgentApplyOpts {
         selector: PatchSelector::PatchFile(patch_path),
-        target: repo.clone(),
+        target: repo,
         allow_redacted: true,
         allow_dirty: false,
         dry_run: false,
@@ -730,7 +730,7 @@ fn apply_3way_flag_is_accepted() {
     let report_path = work.path().join("apply-report.json");
     let opts = AgentApplyOpts {
         selector: PatchSelector::PatchFile(patch_path),
-        target: repo.clone(),
+        target: repo,
         allow_redacted: false,
         allow_dirty: false,
         dry_run: false,
@@ -774,7 +774,7 @@ fn apply_trajectory_with_patch_submission_redaction_refused() {
 
     let opts = AgentApplyOpts {
         selector: PatchSelector::TrajectoryFile(traj_path),
-        target: repo.clone(),
+        target: repo,
         allow_redacted: false,
         allow_dirty: false,
         dry_run: false,
@@ -818,7 +818,7 @@ fn apply_trajectory_with_patch_submission_redaction_allowed_with_flag() {
     let report_path = work.path().join("apply-report.json");
     let opts = AgentApplyOpts {
         selector: PatchSelector::TrajectoryFile(traj_path),
-        target: repo.clone(),
+        target: repo,
         allow_redacted: true,
         allow_dirty: false,
         dry_run: false,

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -1096,9 +1096,7 @@ fn apply_plain_diff_new_file_with_timestamped_dev_null() {
         report.files_changed
     );
     assert!(
-        report
-            .files_changed
-            .contains(&"new_plain.txt".to_owned()),
+        report.files_changed.contains(&"new_plain.txt".to_owned()),
         "new_plain.txt must be in files_changed; got {:?}",
         report.files_changed
     );

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -878,7 +878,7 @@ fn apply_new_file_patch_dev_null_not_in_files_changed() {
     let report_path = work.path().join("apply-report.json");
     let opts = AgentApplyOpts {
         selector: PatchSelector::PatchFile(patch_path),
-        target: repo.clone(),
+        target: repo,
         allow_redacted: false,
         allow_dirty: false,
         dry_run: false,

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -680,6 +680,40 @@ fn apply_patch_inside_repo_not_gitignored_does_not_trip_dirty_gate() {
 }
 
 #[test]
+fn apply_patch_inside_untracked_subdir_does_not_trip_dirty_gate() {
+    // git status --porcelain (without --untracked-files=all) reports an
+    // untracked directory as "?? runs/" rather than "?? runs/task.patch".
+    // The dirty-gate exclusion must expand such entries.
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+
+    // Place the patch inside an untracked subdirectory inside the repo.
+    let runs_dir = repo.join("runs");
+    std::fs::create_dir_all(&runs_dir).unwrap();
+    let patch_path = runs_dir.join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo,
+        allow_redacted: false,
+        allow_dirty: false, // strict — the whole runs/ dir must be excluded
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    // Should succeed: git status --porcelain --untracked-files=all expands
+    // "?? runs/" to "?? runs/task.patch", which is then excluded.
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied);
+}
+
+#[test]
 fn apply_redacted_patch_content_refused_by_default() {
     let work = tempfile::tempdir().unwrap();
     let repo = work.path().join("repo");

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -1340,7 +1340,7 @@ fn apply_sweep_nested_traj_only_uses_fallback_patch() {
         allow_dirty: false,
         dry_run: false,
         three_way: false,
-        report_path: Some(report_path.clone()),
+        report_path: Some(report_path),
     };
     let report = run_agent_apply(opts).unwrap();
     assert!(report.applied, "patch must be applied");

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -526,6 +526,38 @@ fn apply_selector_from_trajectory_resolves_sibling_patch() {
 }
 
 #[test]
+fn apply_selector_sweep_instance_nested_layout() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+
+    // Canonical nested layout: <sweep>/<instance>/run-1.patch
+    let sweep_dir = work.path().join("sweep_run");
+    let instance_dir = sweep_dir.join("my-instance");
+    std::fs::create_dir_all(&instance_dir).unwrap();
+    std::fs::write(instance_dir.join("run-1.patch"), &patch_content).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::SweepInstance {
+            sweep: sweep_dir,
+            instance: "my-instance".into(),
+        },
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied);
+}
+
+#[test]
 fn apply_selector_from_sweep_instance_resolves_patch() {
     let work = tempfile::tempdir().unwrap();
     let repo = work.path().join("repo");
@@ -534,7 +566,7 @@ fn apply_selector_from_sweep_instance_resolves_patch() {
 
     let patch_content = make_valid_patch(&repo);
 
-    // Sweep directory structure: <sweep>/<instance>.patch
+    // Legacy flat layout: <sweep>/<instance>.patch (fallback when nested absent)
     let sweep_dir = work.path().join("sweep_run");
     std::fs::create_dir_all(&sweep_dir).unwrap();
     std::fs::write(sweep_dir.join("my-instance.patch"), &patch_content).unwrap();
@@ -552,6 +584,65 @@ fn apply_selector_from_sweep_instance_resolves_patch() {
         three_way: false,
         report_path: Some(report_path),
     };
+    let report = run_agent_apply(opts).unwrap();
+    assert!(report.applied);
+}
+
+#[test]
+fn apply_dry_run_without_report_flag_writes_default_report() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+    let patch_path = work.path().join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    // No report_path supplied — the default should be written next to target
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false,
+        dry_run: true,
+        three_way: false,
+        report_path: None,
+    };
+    run_agent_apply(opts).unwrap();
+
+    // Default report goes to target.parent() / apply-report.json
+    let default_report = repo.parent().unwrap().join("apply-report.json");
+    assert!(
+        default_report.exists(),
+        "default report must be written next to target"
+    );
+}
+
+#[test]
+fn apply_patch_inside_repo_not_gitignored_does_not_trip_dirty_gate() {
+    let work = tempfile::tempdir().unwrap();
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+
+    let patch_content = make_valid_patch(&repo);
+
+    // Write the patch *inside* the repo (untracked, not gitignored)
+    let patch_path = repo.join("task.patch");
+    std::fs::write(&patch_path, &patch_content).unwrap();
+
+    let report_path = work.path().join("apply-report.json");
+    let opts = AgentApplyOpts {
+        selector: PatchSelector::PatchFile(patch_path),
+        target: repo.clone(),
+        allow_redacted: false,
+        allow_dirty: false, // <-- strict; patch inside repo should be excluded
+        dry_run: false,
+        three_way: false,
+        report_path: Some(report_path),
+    };
+    // Should succeed: the patch file itself is excluded from the dirty check
     let report = run_agent_apply(opts).unwrap();
     assert!(report.applied);
 }


### PR DESCRIPTION
## Summary

Implements the `agent apply` command, which safely applies captured `.patch` artifacts to git working trees with a comprehensive safety-gate stack. This addresses issue #473 by providing a first-class operator interface for patch application with built-in protections against dirty trees, redaction-corrupted patches, and failed patch checks.

## Key Changes

- **New module `src/run/apply.rs`**: Core implementation of patch application logic with seven sequential safety gates:
  1. Patch selector resolution (PatchFile, TrajectoryFile, or SweepInstance)
  2. Git working tree validation
  3. Dirty-tree detection (skippable with `--allow-dirty`)
  4. Redaction-corruption detection via patch content and trajectory metadata (skippable with `--allow-redacted`)
  5. `git apply --check` validation
  6. Dry-run short-circuit (with `--dry-run`)
  7. Actual patch application and report generation

- **CLI integration** (`src/cli/args.rs` and `src/cli/mod.rs`):
  - New `AgentApplyCmd` struct with mutually-exclusive patch selectors (`--patch`, `--trajectory`, `--sweep`/`--instance`)
  - Options for `--target`, `--allow-redacted`, `--allow-dirty`, `--dry-run`, `--3way`, and `--report`
  - Command handler that validates selector exclusivity and invokes the apply logic

- **Exit codes** (`src/exit_code.rs`):
  - Exit 28 (`ApplyCheckFailed`): `git apply --check` rejected the patch
  - Exit 29 (`ApplyRedactedRefused`): Patch contains redaction markers or trajectory recorded patch-submission redaction
  - Exit 30 (`ApplyDirtyTreeRefused`): Working tree has uncommitted changes

- **Artifact types** (`src/artifact.rs`):
  - New `ArtifactKind::ApplyReport` variant for schema-versioned JSON reports

- **Comprehensive test suite** (`tests/agent_apply.rs`):
  - 734 lines of integration tests covering all safety gates, selector modes, error conditions, and report generation
  - Tests verify tree immutability on errors, correct diff stat parsing, trajectory-based redaction detection, and report JSON structure

- **Documentation** (`docs/spec-agent-apply.md`):
  - Complete specification of usage, selector rules, safety gates, and report schema

## Notable Implementation Details

- **Trajectory-based redaction detection**: Checks `info.redaction.counts[*].surface == "patch_submission"` in `.traj.json` files, with fallback to legacy `info.secret_leak_detected` marker
- **Automatic sibling resolution**: `.traj.json` → `.patch` and `<sweep>/<instance>.traj.json` → `<sweep>/<instance>.patch`
- **Diff stat parsing**: Extracts file names, lines added/removed directly from unified diff format without invoking additional git commands
- **Tree safety**: All gates before `git apply --check` are read-only; tree is only mutated after check passes and dry-run is not requested
- **Report generation**: Always written on success (including empty-patch and dry-run cases) with schema version and artifact kind for downstream tooling

https://claude.ai/code/session_01BEBcDpC9tGKMGGkCJyrFXH