### PR TITLE
🎨 Mosaic: UI Polish for Policy Check

### DIFF
--- a/src/run/policy_check.rs
+++ b/src/run/policy_check.rs
@@ -237,6 +237,7 @@ fn parse_corpus(raw: &str) -> Vec<String> {
 /// Format the policy-check output as a human-readable table (one row per command).
 #[must_use]
 pub fn format_text(output: &PolicyCheckOutput) -> String {
+    use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
     use std::fmt::Write as _;
 
     if output.verdicts.is_empty() {
@@ -258,55 +259,25 @@ pub fn format_text(output: &PolicyCheckOutput) -> String {
         return out;
     }
 
-    let cmd_width = output
-        .verdicts
-        .iter()
-        .map(|v| v.command.len())
-        .max()
-        .unwrap_or(7)
-        .max(7); // min width: "command"
-    let rule_width = output
-        .verdicts
-        .iter()
-        .map(|v| v.matching_rule.len())
-        .max()
-        .unwrap_or(12)
-        .max(12); // min width: "matching_rule"
-
-    let mut out = String::new();
-    let _ = writeln!(
-        out,
-        "{:<width$}  {:<8}  {:<rule_w$}  profile",
-        "command",
-        "verdict",
-        "matching_rule",
-        width = cmd_width,
-        rule_w = rule_width,
-    );
-    let _ = writeln!(
-        out,
-        "{:-<width$}  {:-<8}  {:-<rule_w$}  -------",
-        "",
-        "",
-        "",
-        width = cmd_width,
-        rule_w = rule_width,
-    );
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec!["command", "verdict", "matching_rule", "profile"]);
 
     for v in &output.verdicts {
-        let _ = writeln!(
-            out,
-            "{:<width$}  {:<8}  {:<rule_w$}  {}",
-            v.command,
-            v.verdict.as_str(),
-            v.matching_rule,
-            v.profile,
-            width = cmd_width,
-            rule_w = rule_width,
-        );
+        table.add_row(vec![
+            v.command.clone(),
+            v.verdict.as_str().to_string(),
+            v.matching_rule.clone(),
+            v.profile.clone(),
+        ]);
     }
 
+    let mut out = table.to_string();
+
     if !output.mismatches.is_empty() {
+        out.push('\n');
         out.push('\n');
         out.push_str("EXPECT FAILURES:\n");
         for m in &output.mismatches {
@@ -321,6 +292,7 @@ pub fn format_text(output: &PolicyCheckOutput) -> String {
         }
     }
 
+    out.push('\n');
     out
 }
 


### PR DESCRIPTION
🖌️ **Before:** The output of `cargo run -- agent policy-check` used manual ASCII table layout to report verdicts.
✨ **After:** The CLI now correctly renders verdicts inside a structured table.
🖼️ **Visuals:** Replaced manually padded strings with a `comfy-table` layout using UTF-8 round corners.

---
*PR created automatically by Jules for task [9158988350438622988](https://jules.google.com/task/9158988350438622988) started by @madmax983*