### PR TITLE
⚡ Bolt: Remove intermediate allocations in normalize_search_text

### DIFF
--- a/src/skills.rs
+++ b/src/skills.rs
@@ -540,16 +540,27 @@ fn searchable_tokens(name: &str, description: &str) -> BTreeSet<String> {
         .collect()
 }
 
+/// Normalizes search text by converting to lowercase, keeping specific punctuation,
+/// and collapsing all other characters into single spaces.
+///
+/// ⚡ Bolt: This avoids intermediate Vec and String allocations by properly
+/// spacing elements during the initial pass over `text.chars()`.
 fn normalize_search_text(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
+    let mut in_whitespace = true;
+
     for ch in text.chars() {
         if ch.is_ascii_alphanumeric() || ch == '$' || ch == '@' || ch == '/' {
+            if in_whitespace && !out.is_empty() {
+                out.push(' ');
+            }
             out.push(ch.to_ascii_lowercase());
+            in_whitespace = false;
         } else {
-            out.push(' ');
+            in_whitespace = true;
         }
     }
-    out.split_whitespace().collect::<Vec<_>>().join(" ")
+    out
 }
 
 fn is_stopword(token: &str) -> bool {


### PR DESCRIPTION
💡 What: Removed intermediate `.split_whitespace().collect::<Vec<_>>().join(" ")` in `normalize_search_text` by formatting spaces in the initial loop.
🎯 Why: The previous approach unnecessarily allocated an intermediate string to be split, collected into a vector, and then joined into another string, causing excessive heap allocations.
📊 Impact: Reduces heap allocations by creating the result directly in a single pass.
🔬 Measurement: Run `cargo test` and `cargo bench` to verify.

---
*PR created automatically by Jules for task [7429259611280076695](https://jules.google.com/task/7429259611280076695) started by @madmax983*