### PR TITLE
🗺️ Atlas: Extract ModelError and remove FailedAttempt duplication

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -22,7 +22,8 @@ use super::{
 use crate::config::{Config, ToolHookCfg};
 use crate::cost::{BASELINE_COST_MODEL, CostSource, estimate_cost_usd, is_free_tier_model};
 use crate::env::{CancellationToken, Environment, RunRequest, RunResult};
-use crate::error::{Error, ModelError};
+use crate::error::Error;
+use crate::model::ModelError;
 use crate::model::{
     CacheHint, FallbackAttemptRecord, Message, MessageExtra, Model, ModelResponse, QueryOpts, Role,
 };
@@ -678,7 +679,7 @@ async fn query_model_until_cancelled(
     history: &[Message],
     opts: &QueryOpts,
     cancellation: Option<CancellationToken>,
-) -> Result<Option<ModelResponse>, crate::error::ModelError> {
+) -> Result<Option<ModelResponse>, crate::model::ModelError> {
     let Some(mut cancellation) = cancellation else {
         return model.query(history, opts).await.map(Some);
     };
@@ -895,11 +896,7 @@ impl Agent for DefaultAgent {
         // propagating so finalize_run_metadata can still emit a summary.
         if let Err(ModelError::AllCandidatesFailed(_, ref attempts)) = query_result {
             self.fallback_failed_attempts
-                .extend(attempts.iter().map(|a| FallbackAttemptRecord {
-                    model: a.model.clone(),
-                    failure_reason: a.reason.clone(),
-                    retry_after_secs: a.retry_after_secs,
-                }));
+                .extend(attempts.iter().cloned());
         }
         let Some(resp) = query_result? else {
             self.finalize_cancelled();
@@ -2473,7 +2470,7 @@ mod tests {
             &self,
             _messages: &[Message],
             _opts: &QueryOpts,
-        ) -> Result<ModelResponse, crate::error::ModelError> {
+        ) -> Result<ModelResponse, crate::model::ModelError> {
             let _ = self.cancel_tx.send(true);
             Ok(ModelResponse {
                 content: "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nlate submit\n```".into(),
@@ -2506,7 +2503,7 @@ mod tests {
             &self,
             _messages: &[Message],
             _opts: &QueryOpts,
-        ) -> Result<ModelResponse, crate::error::ModelError> {
+        ) -> Result<ModelResponse, crate::model::ModelError> {
             let _ = self.query_started_tx.send(true);
             tokio::time::sleep(Duration::from_secs(30)).await;
             self.query_returned.store(true, Ordering::SeqCst);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 //! Error types. One top-level `Error` composed of focused subsystem enums,
 //! so call sites can match on the specific failure mode without a catch-all.
 
+use crate::model::ModelError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -58,137 +59,6 @@ pub enum Error {
     /// bench audit failure
     #[error("audit: {0}")]
     Audit(String),
-}
-
-#[derive(Debug, Error)]
-pub enum ModelError {
-    #[error("model request failed: {0}")]
-    Request(String),
-
-    #[error("model returned malformed response: {0}")]
-    Malformed(String),
-
-    #[error("model refused request: {0}")]
-    Refused(String),
-
-    #[error("missing credentials: {0}")]
-    MissingCredentials(String),
-
-    #[error("rate limited: {0}")]
-    RateLimited(String),
-
-    /// All models in the fallback chain failed with transient errors.
-    /// The message names every attempted model and its coarse failure reason.
-    /// The structured attempt records are preserved for trajectory telemetry.
-    #[error("all fallback candidates failed: {0}")]
-    AllCandidatesFailed(String, Vec<FailedAttempt>),
-
-    /// Replay only: prompt fingerprint drift detected at step {0}.
-    /// Recorded fingerprint and actual fingerprint differ.
-    #[error("replay prompt drift at step {0}: fingerprints do not match")]
-    ReplayDrift(usize),
-
-    /// Generic scripted model exhaustion: the response queue ran out at step {0}.
-    /// Used by `DeterministicModel` in any context (tests, sweeps, replay).
-    /// Replay code translates this into `ScriptedResponsesExhausted` so that
-    /// exit-code routing can distinguish replay-structural failures from ordinary
-    /// test/sweep failures.
-    #[error("scripted responses exhausted at step {0}")]
-    ResponsesExhausted(u32),
-
-    /// Replay only: the scripted-response queue is exhausted at step {0},
-    /// meaning the cassette trajectory is structurally incompatible with the
-    /// current agent (e.g. the agent issued more model calls than were recorded).
-    #[error("replay response exhausted: no scripted response for step {0}")]
-    ScriptedResponsesExhausted(u32),
-
-    /// Replay only: the trajectory has no fingerprint at step {0} and
-    /// `--allow-unfingerprinted` was not passed.
-    #[error(
-        "trajectory has no fingerprint at step {0}; \
-         use --allow-unfingerprinted to permit replaying legacy trajectories"
-    )]
-    ReplayUnfingerprintedLegacy(usize),
-}
-
-/// A single failed attempt record carried inside `AllCandidatesFailed`.
-/// Mirrors `model::FallbackAttemptRecord` without creating a cross-layer
-/// import cycle between `error` and `model`.
-#[derive(Debug, Clone)]
-pub struct FailedAttempt {
-    pub model: String,
-    pub reason: String,
-    pub retry_after_secs: Option<u64>,
-}
-
-impl ModelError {
-    /// Returns `true` for errors that are worth retrying with a fallback model.
-    ///
-    /// Transient: rate limits, network/timeout failures, provider 5xx.
-    /// Non-transient: bad credentials, bad model name, malformed request,
-    /// context-window overflow, content policy, all-candidates-failed.
-    #[must_use]
-    pub fn is_transient(&self) -> bool {
-        matches!(self, Self::RateLimited(_) | Self::Request(_))
-    }
-
-    /// Parse a Retry-After duration in seconds from a `RateLimited` error
-    /// message. Returns `None` for all other variants or when no numeric
-    /// Retry-After value is present in the message text.
-    #[must_use]
-    pub fn retry_after_secs(&self) -> Option<u64> {
-        let Self::RateLimited(msg) = self else {
-            return None;
-        };
-        let msg_lower = msg.to_ascii_lowercase();
-        for prefix in ["retry-after: ", "retry_after: ", "retry after: "] {
-            if let Some(pos) = msg_lower.find(prefix) {
-                let digits: &str = msg[pos + prefix.len()..]
-                    .split(|c: char| !c.is_ascii_digit())
-                    .next()
-                    .unwrap_or("");
-                if let Ok(n) = digits.parse::<u64>() {
-                    return Some(n);
-                }
-            }
-        }
-        None
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn retry_after_secs_parses_numeric_value_from_rate_limited() {
-        let e = ModelError::RateLimited("rate limited retry-after: 30 please wait".into());
-        assert_eq!(e.retry_after_secs(), Some(30));
-    }
-
-    #[test]
-    fn retry_after_secs_returns_none_when_not_present() {
-        let e = ModelError::RateLimited("too many requests".into());
-        assert_eq!(e.retry_after_secs(), None);
-    }
-
-    #[test]
-    fn retry_after_secs_returns_none_for_non_rate_limited_variants() {
-        assert_eq!(ModelError::Malformed("bad".into()).retry_after_secs(), None);
-        assert_eq!(ModelError::Request("err".into()).retry_after_secs(), None);
-    }
-
-    #[test]
-    fn retry_after_secs_handles_underscore_variant() {
-        let e = ModelError::RateLimited("retry_after: 60".into());
-        assert_eq!(e.retry_after_secs(), Some(60));
-    }
-
-    #[test]
-    fn retry_after_secs_handles_space_variant() {
-        let e = ModelError::RateLimited("retry after: 90".into());
-        assert_eq!(e.retry_after_secs(), Some(90));
-    }
 }
 
 #[derive(Debug, Error)]

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -203,11 +203,11 @@ impl ExitCode {
             Error::VerificationFailed(..) => Self::VerificationFailure,
             Error::Env(env_e) => Self::from_env_error(env_e),
             Error::Model(model_e) => match model_e {
-                crate::error::ModelError::ReplayDrift(_) => Self::ReplayPromptDrift,
-                crate::error::ModelError::ScriptedResponsesExhausted(_) => {
+                crate::model::ModelError::ReplayDrift(_) => Self::ReplayPromptDrift,
+                crate::model::ModelError::ScriptedResponsesExhausted(_) => {
                     Self::ReplayResponseExhausted
                 }
-                crate::error::ModelError::ReplayUnfingerprintedLegacy(_) => Self::UsageError,
+                crate::model::ModelError::ReplayUnfingerprintedLegacy(_) => Self::UsageError,
                 // ResponsesExhausted (generic DeterministicModel exhaustion used in
                 // non-replay contexts) and all other model errors → task unsuccessful.
                 // Replay translates ResponsesExhausted → ScriptedResponsesExhausted
@@ -242,7 +242,8 @@ impl ExitCode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::{ConfigError, EnvError, ModelError};
+    use crate::error::{ConfigError, EnvError};
+    use crate::model::ModelError;
 
     #[test]
     fn from_error_config_is_usage_error() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,9 @@ pub use config::{
 #[cfg(feature = "docker")]
 pub use env::DockerEnvironment;
 pub use env::{Environment, LocalEnvironment, RunRequest, RunResult};
-pub use error::{ConfigError, EnvError, Error, ModelError};
+pub use error::{ConfigError, EnvError, Error};
 pub use exit_code::ExitCode;
+pub use model::ModelError;
 pub use model::{
     AnthropicBackend, CacheHint, DeterministicModel, FallbackAttemptRecord, FallbackModel,
     LitellmBackend, Message, MessageExtra, Model, ModelResponse, ModelUsage, QueryOpts, Role,

--- a/src/model/deterministic.rs
+++ b/src/model/deterministic.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use std::sync::Mutex;
 
 use super::{Message, Model, ModelResponse, ModelUsage, QueryOpts};
-use crate::error::ModelError;
+use crate::model::ModelError;
 
 pub struct DeterministicModel {
     name: String,

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -1,0 +1,123 @@
+use super::FallbackAttemptRecord;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ModelError {
+    #[error("model request failed: {0}")]
+    Request(String),
+
+    #[error("model returned malformed response: {0}")]
+    Malformed(String),
+
+    #[error("model refused request: {0}")]
+    Refused(String),
+
+    #[error("missing credentials: {0}")]
+    MissingCredentials(String),
+
+    #[error("rate limited: {0}")]
+    RateLimited(String),
+
+    /// All models in the fallback chain failed with transient errors.
+    /// The message names every attempted model and its coarse failure reason.
+    /// The structured attempt records are preserved for trajectory telemetry.
+    #[error("all fallback candidates failed: {0}")]
+    AllCandidatesFailed(String, Vec<FallbackAttemptRecord>),
+
+    /// Replay only: prompt fingerprint drift detected at step {0}.
+    /// Recorded fingerprint and actual fingerprint differ.
+    #[error("replay prompt drift at step {0}: fingerprints do not match")]
+    ReplayDrift(usize),
+
+    /// Generic scripted model exhaustion: the response queue ran out at step {0}.
+    /// Used by `DeterministicModel` in any context (tests, sweeps, replay).
+    /// Replay code translates this into `ScriptedResponsesExhausted` so that
+    /// exit-code routing can distinguish replay-structural failures from ordinary
+    /// test/sweep failures.
+    #[error("scripted responses exhausted at step {0}")]
+    ResponsesExhausted(u32),
+
+    /// Replay only: the scripted-response queue is exhausted at step {0},
+    /// meaning the cassette trajectory is structurally incompatible with the
+    /// current agent (e.g. the agent issued more model calls than were recorded).
+    #[error("replay response exhausted: no scripted response for step {0}")]
+    ScriptedResponsesExhausted(u32),
+
+    /// Replay only: the trajectory has no fingerprint at step {0} and
+    /// `--allow-unfingerprinted` was not passed.
+    #[error(
+        "trajectory has no fingerprint at step {0}; \
+         use --allow-unfingerprinted to permit replaying legacy trajectories"
+    )]
+    ReplayUnfingerprintedLegacy(usize),
+}
+
+impl ModelError {
+    /// Returns `true` for errors that are worth retrying with a fallback model.
+    ///
+    /// Transient: rate limits, network/timeout failures, provider 5xx.
+    /// Non-transient: bad credentials, bad model name, malformed request,
+    /// context-window overflow, content policy, all-candidates-failed.
+    #[must_use]
+    pub fn is_transient(&self) -> bool {
+        matches!(self, Self::RateLimited(_) | Self::Request(_))
+    }
+
+    /// Parse a Retry-After duration in seconds from a `RateLimited` error
+    /// message. Returns `None` for all other variants or when no numeric
+    /// Retry-After value is present in the message text.
+    #[must_use]
+    pub fn retry_after_secs(&self) -> Option<u64> {
+        let Self::RateLimited(msg) = self else {
+            return None;
+        };
+        let msg_lower = msg.to_ascii_lowercase();
+        for prefix in ["retry-after: ", "retry_after: ", "retry after: "] {
+            if let Some(pos) = msg_lower.find(prefix) {
+                let digits: &str = msg[pos + prefix.len()..]
+                    .split(|c: char| !c.is_ascii_digit())
+                    .next()
+                    .unwrap_or("");
+                if let Ok(n) = digits.parse::<u64>() {
+                    return Some(n);
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_after_secs_parses_numeric_value_from_rate_limited() {
+        let e = ModelError::RateLimited("rate limited retry-after: 30 please wait".into());
+        assert_eq!(e.retry_after_secs(), Some(30));
+    }
+
+    #[test]
+    fn retry_after_secs_returns_none_when_not_present() {
+        let e = ModelError::RateLimited("too many requests".into());
+        assert_eq!(e.retry_after_secs(), None);
+    }
+
+    #[test]
+    fn retry_after_secs_returns_none_for_non_rate_limited_variants() {
+        assert_eq!(ModelError::Malformed("bad".into()).retry_after_secs(), None);
+        assert_eq!(ModelError::Request("err".into()).retry_after_secs(), None);
+    }
+
+    #[test]
+    fn retry_after_secs_handles_underscore_variant() {
+        let e = ModelError::RateLimited("retry_after: 60".into());
+        assert_eq!(e.retry_after_secs(), Some(60));
+    }
+
+    #[test]
+    fn retry_after_secs_handles_space_variant() {
+        let e = ModelError::RateLimited("retry after: 90".into());
+        assert_eq!(e.retry_after_secs(), Some(90));
+    }
+}

--- a/src/model/fallback.rs
+++ b/src/model/fallback.rs
@@ -14,7 +14,7 @@
 use async_trait::async_trait;
 
 use super::{FallbackAttemptRecord, Message, Model, ModelResponse, QueryOpts};
-use crate::error::{FailedAttempt, ModelError};
+use crate::model::ModelError;
 
 pub struct FallbackModel {
     /// Ordered chain: index 0 is primary, the rest are fallback candidates.
@@ -100,14 +100,7 @@ impl Model for FallbackModel {
                         failure_reason: coarse_reason(&e),
                         retry_after_secs: e.retry_after_secs(),
                     });
-                    let error_attempts: Vec<FailedAttempt> = failed_attempts
-                        .iter()
-                        .map(|a| FailedAttempt {
-                            model: a.model.clone(),
-                            reason: a.failure_reason.clone(),
-                            retry_after_secs: a.retry_after_secs,
-                        })
-                        .collect();
+                    let error_attempts = failed_attempts.clone();
                     let summary = failed_attempts
                         .iter()
                         .map(|a| format!("{}: {}", a.model, a.failure_reason))
@@ -120,14 +113,7 @@ impl Model for FallbackModel {
 
         // Every candidate exhausted via transient failures. Preserve structured
         // attempt records so DefaultAgent can write telemetry even on all-fail.
-        let error_attempts: Vec<FailedAttempt> = failed_attempts
-            .iter()
-            .map(|a| FailedAttempt {
-                model: a.model.clone(),
-                reason: a.failure_reason.clone(),
-                retry_after_secs: a.retry_after_secs,
-            })
-            .collect();
+        let error_attempts = failed_attempts.clone();
         let summary = failed_attempts
             .iter()
             .map(|a| format!("{}: {}", a.model, a.failure_reason))
@@ -237,9 +223,9 @@ mod tests {
         assert!(msg.contains("m2"));
         assert_eq!(attempts.len(), 2);
         assert_eq!(attempts[0].model, "m1");
-        assert_eq!(attempts[0].reason, "rate_limited");
+        assert_eq!(attempts[0].failure_reason, "rate_limited");
         assert_eq!(attempts[1].model, "m2");
-        assert_eq!(attempts[1].reason, "rate_limited");
+        assert_eq!(attempts[1].failure_reason, "rate_limited");
     }
 
     #[tokio::test]
@@ -259,7 +245,7 @@ mod tests {
         assert!(msg.contains("m2"), "summary must mention secondary: {msg}");
         assert_eq!(attempts.len(), 2, "both attempts must be preserved");
         assert_eq!(attempts[0].model, "m1");
-        assert_eq!(attempts[0].reason, "rate_limited");
+        assert_eq!(attempts[0].failure_reason, "rate_limited");
         assert_eq!(attempts[1].model, "m2");
     }
 

--- a/src/model/litellm.rs
+++ b/src/model/litellm.rs
@@ -30,7 +30,7 @@ use litellm_rs::{
 };
 
 use super::{Message, Model, ModelResponse, ModelUsage, QueryOpts, Role, cap_breakpoints};
-use crate::error::ModelError;
+use crate::model::ModelError;
 
 const BREAKPOINT_CAP: usize = 4;
 
@@ -455,13 +455,13 @@ mod tests {
             tpm_limit: None,
         });
         match e {
-            crate::error::ModelError::RateLimited(msg) => {
+            crate::model::ModelError::RateLimited(msg) => {
                 assert!(
                     msg.contains("retry-after: 45"),
                     "structured retry_after should be embedded in message: {msg}"
                 );
                 assert_eq!(
-                    crate::error::ModelError::RateLimited(msg).retry_after_secs(),
+                    crate::model::ModelError::RateLimited(msg).retry_after_secs(),
                     Some(45),
                     "retry_after_secs should parse back the embedded value"
                 );
@@ -479,7 +479,7 @@ mod tests {
             tpm_limit: None,
         });
         match e {
-            crate::error::ModelError::RateLimited(msg) => {
+            crate::model::ModelError::RateLimited(msg) => {
                 assert_eq!(msg, "quota exceeded");
             }
             other => panic!("expected RateLimited, got {other:?}"),

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -11,13 +11,13 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-use crate::error::ModelError;
-
 pub mod deterministic;
+pub mod error;
 pub mod fallback;
 pub mod litellm;
 
 pub use deterministic::DeterministicModel;
+pub use error::ModelError;
 pub use fallback::FallbackModel;
 pub use litellm::{AnthropicBackend, LitellmBackend};
 

--- a/src/run/fork.rs
+++ b/src/run/fork.rs
@@ -14,8 +14,9 @@ use crate::config::{Config, EnvKind, McpServerCfg};
 #[cfg(feature = "docker")]
 use crate::env::DockerEnvironment;
 use crate::env::{Environment, LocalEnvironment};
-use crate::error::{Error, ModelError};
+use crate::error::Error;
 use crate::fingerprint::{canonical_json, cap_canonical, compute_input_fingerprint};
+use crate::model::ModelError;
 use crate::model::litellm::LitellmBackend;
 use crate::model::{
     DeterministicModel, FallbackModel, Message, Model, ModelResponse, ModelUsage, QueryOpts,

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -1179,7 +1179,7 @@ async fn run_agent_with_timeout(
 fn classify_error(err: &Error) -> FailureCategory {
     match err {
         Error::Env(_) => FailureCategory::EnvSetup,
-        Error::Model(crate::error::ModelError::Malformed(_)) => FailureCategory::ModelParse,
+        Error::Model(crate::model::ModelError::Malformed(_)) => FailureCategory::ModelParse,
         Error::Model(_) => FailureCategory::ModelApi,
         _ => FailureCategory::AgentInternal,
     }

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -26,8 +26,9 @@ use crate::config::{Config, EnvKind};
 #[cfg(feature = "docker")]
 use crate::env::DockerEnvironment;
 use crate::env::{Environment, LocalEnvironment};
-use crate::error::{Error, ModelError};
+use crate::error::Error;
 use crate::fingerprint::{canonical_json, cap_canonical, compute_input_fingerprint};
+use crate::model::ModelError;
 use crate::model::{DeterministicModel, Message, Model, ModelResponse, QueryOpts};
 use crate::redaction::Redactor;
 use crate::trajectory::Trajectory;

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -4626,7 +4626,7 @@ async fn run_one(inst: SweBenchInstance, run_index: u32, params: RunOneParams) -
         // so the global Retry-After floor is set for all workers.
         if let (
             Some(g),
-            Some(crate::error::Error::Model(crate::error::ModelError::RateLimited(msg))),
+            Some(crate::error::Error::Model(crate::model::ModelError::RateLimited(msg))),
         ) = (&governor, &run_err)
         {
             let retry_after =
@@ -4901,14 +4901,14 @@ fn classify_error(err: &Error) -> FailureCategory {
         // Docker build/start/exec or local command execution plumbing.
         Error::Env(_) => FailureCategory::EnvSetup,
         // Model transport/auth/rate-limit/5xx style failures.
-        Error::Model(crate::error::ModelError::Malformed(_)) => FailureCategory::ModelParse,
+        Error::Model(crate::model::ModelError::Malformed(_)) => FailureCategory::ModelParse,
         // When transient failures precede a terminal non-transient one, the error
         // is wrapped in AllCandidatesFailed to preserve attempt telemetry. Peek at
         // the last attempt's coarse reason so classification matches the terminal
         // error type rather than always falling through to ModelApi.
-        Error::Model(crate::error::ModelError::AllCandidatesFailed(_, attempts)) => {
+        Error::Model(crate::model::ModelError::AllCandidatesFailed(_, attempts)) => {
             // `coarse_reason(Malformed)` in fallback.rs returns "malformed_response".
-            if attempts.last().map(|a| a.reason.as_str()) == Some("malformed_response") {
+            if attempts.last().map(|a| a.failure_reason.as_str()) == Some("malformed_response") {
                 FailureCategory::ModelParse
             } else {
                 FailureCategory::ModelApi
@@ -7566,7 +7566,7 @@ instance = "inst"
         let model = DeterministicModel::new(vec!["__rate_limited__:2".to_owned()]);
         let result = model.query(&[], &QueryOpts::default()).await;
         match result {
-            Err(crate::error::ModelError::RateLimited(msg)) => {
+            Err(crate::model::ModelError::RateLimited(msg)) => {
                 assert!(
                     msg.contains("retry-after: 2"),
                     "error should include retry-after seconds, got: {msg}"
@@ -7846,18 +7846,19 @@ instance = "inst"
 
     #[test]
     fn classify_error_all_candidates_failed_malformed_terminal_is_model_parse() {
-        use crate::error::{FailedAttempt, ModelError};
+        use crate::model::FallbackAttemptRecord;
+        use crate::model::ModelError;
         // Transient attempt followed by a Malformed terminal: the terminal
         // coarse_reason is "malformed_response" → ModelParse.
         let attempts = vec![
-            FailedAttempt {
+            FallbackAttemptRecord {
                 model: "m1".into(),
-                reason: "rate_limited".into(),
+                failure_reason: "rate_limited".into(),
                 retry_after_secs: None,
             },
-            FailedAttempt {
+            FallbackAttemptRecord {
                 model: "m2".into(),
-                reason: "malformed_response".into(),
+                failure_reason: "malformed_response".into(),
                 retry_after_secs: None,
             },
         ];
@@ -7874,17 +7875,18 @@ instance = "inst"
 
     #[test]
     fn classify_error_all_candidates_failed_transient_terminal_is_model_api() {
-        use crate::error::{FailedAttempt, ModelError};
+        use crate::model::FallbackAttemptRecord;
+        use crate::model::ModelError;
         // All transient failures: terminal reason is "rate_limited" → ModelApi.
         let attempts = vec![
-            FailedAttempt {
+            FallbackAttemptRecord {
                 model: "m1".into(),
-                reason: "rate_limited".into(),
+                failure_reason: "rate_limited".into(),
                 retry_after_secs: None,
             },
-            FailedAttempt {
+            FallbackAttemptRecord {
                 model: "m2".into(),
-                reason: "rate_limited".into(),
+                failure_reason: "rate_limited".into(),
                 retry_after_secs: None,
             },
         ];
@@ -7901,7 +7903,7 @@ instance = "inst"
 
     #[test]
     fn classify_error_all_candidates_failed_empty_attempts_is_model_api() {
-        use crate::error::ModelError;
+        use crate::model::ModelError;
         // Edge case: no attempts recorded → fallback to ModelApi.
         let err = Error::Model(ModelError::AllCandidatesFailed("all failed".into(), vec![]));
         assert_eq!(classify_error(&err), FailureCategory::ModelApi);
@@ -7909,14 +7911,14 @@ instance = "inst"
 
     #[test]
     fn classify_error_plain_malformed_is_model_parse() {
-        use crate::error::ModelError;
+        use crate::model::ModelError;
         let err = Error::Model(ModelError::Malformed("bad json".into()));
         assert_eq!(classify_error(&err), FailureCategory::ModelParse);
     }
 
     #[test]
     fn classify_error_rate_limited_is_model_api() {
-        use crate::error::ModelError;
+        use crate::model::ModelError;
         let err = Error::Model(ModelError::RateLimited("429".into()));
         assert_eq!(classify_error(&err), FailureCategory::ModelApi);
     }
@@ -8000,6 +8002,7 @@ instance = "inst"
     /// every payload carries the schema-version envelope (AC #8 from #315).
     #[cfg(feature = "webhook")]
     #[tokio::test]
+    #[allow(clippy::too_many_lines)]
     async fn notify_webhook_posts_events_in_order_with_schema_envelope() {
         use std::sync::{Arc, Mutex};
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -8018,11 +8021,7 @@ instance = "inst"
                 };
                 let mut buf = Vec::new();
                 let mut chunk = [0u8; 8192];
-                loop {
-                    let n = match socket.read(&mut chunk).await {
-                        Ok(n) => n,
-                        Err(_) => break,
-                    };
+                while let Ok(n) = socket.read(&mut chunk).await {
                     if n == 0 {
                         break;
                     }
@@ -8122,8 +8121,8 @@ instance = "inst"
 
         let results = tokio::time::timeout(std::time::Duration::from_secs(15), run(args))
             .await
-            .expect("sweep timed out")
-            .expect("sweep failed");
+            .unwrap_or_else(|_| panic!("sweep timed out"))
+            .unwrap_or_else(|_| panic!("sweep failed"));
 
         assert_eq!(results.submitted, 2, "both instances must submit");
 

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -626,7 +626,7 @@ mod tests {
         match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((s, _))) => s,
             Ok(Err(e)) => panic!("accept error: {e}"),
-            Err(_) => panic!("accept timed out"),
+            Err(e) => panic!("accept timed out: {e}"),
         }
     }
 
@@ -637,7 +637,7 @@ mod tests {
             let n = match tokio::time::timeout(TEST_IO_TIMEOUT, socket.read(&mut chunk)).await {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => panic!("read error: {e}"),
-                Err(_) => panic!("read timed out"),
+                Err(e) => panic!("read timed out: {e}"),
             };
             if n == 0 {
                 break;
@@ -654,7 +654,7 @@ mod tests {
     }
 
     fn body_of(req: &str) -> &str {
-        req.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("")
+        req.split_once("\r\n\r\n").map_or("", |(_, b)| b)
     }
 
     fn is_complete_http(buf: &[u8]) -> bool {

--- a/tests/exit_code_contract.rs
+++ b/tests/exit_code_contract.rs
@@ -6,8 +6,9 @@
 
 #![allow(clippy::unwrap_used)]
 
-use maxwells_daemon::error::{ConfigError, EnvError, Error, ModelError};
+use maxwells_daemon::error::{ConfigError, EnvError, Error};
 use maxwells_daemon::exit_code::ExitCode;
+use maxwells_daemon::model::ModelError;
 
 // ── integer code values ───────────────────────────────────────────────────────
 

--- a/tests/fallback_model.rs
+++ b/tests/fallback_model.rs
@@ -12,7 +12,7 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use maxwells_daemon::error::ModelError;
+use maxwells_daemon::model::ModelError;
 use maxwells_daemon::model::{
     FallbackAttemptRecord, FallbackModel, Message, Model, ModelResponse, ModelUsage, QueryOpts,
 };
@@ -227,7 +227,7 @@ async fn all_candidates_failed_returns_compound_error() {
         "both failed attempts should be preserved"
     );
     let _ = attempts[0].model.as_str(); // FailedAttempt::model
-    let _ = attempts[0].reason.as_str(); // FailedAttempt::reason
+    let _ = attempts[0].failure_reason.as_str(); // FailedAttempt::reason
 }
 
 // ── FallbackSummary: all_failed is not fabricated as primary ──────────────────

--- a/tests/sampling_params.rs
+++ b/tests/sampling_params.rs
@@ -16,7 +16,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use maxwells_daemon::agent::default::DefaultAgentBuilder;
 use maxwells_daemon::env::RunRequest;
-use maxwells_daemon::error::{EnvError, ModelError};
+use maxwells_daemon::error::EnvError;
+use maxwells_daemon::model::ModelError;
 use maxwells_daemon::model::{
     Message, MessageExtra, Model, ModelResponse, ModelUsage, QueryOpts, SamplingParams,
 };
@@ -314,7 +315,7 @@ impl Model for AlwaysFail {
         &self,
         _messages: &[Message],
         _opts: &QueryOpts,
-    ) -> Result<ModelResponse, maxwells_daemon::error::ModelError> {
+    ) -> Result<ModelResponse, maxwells_daemon::model::ModelError> {
         Err(ModelError::RateLimited(
             "scripted rate limit for test".into(),
         ))


### PR DESCRIPTION
* 🕸️ Tangle: The `FailedAttempt` struct was duplicated in `src/error.rs` because `ModelError` was defined there, creating a circular dependency if it imported `FallbackAttemptRecord` from `src/model`.
* 📐 Blueprint: Extracted `ModelError` into `src/model/error.rs`, allowing it to cleanly use `FallbackAttemptRecord` directly and eliminating the duplicate `FailedAttempt` type.
* 🧱 Stability: Removed code duplication and enforced tighter module cohesion by keeping model-specific errors inside the `model` module boundary.
* 🔬 Verification: Builds successfully, all tests pass, and strict separation is enforced without circular dependencies.

---
*PR created automatically by Jules for task [4899769682316661814](https://jules.google.com/task/4899769682316661814) started by @madmax983*