### PR TITLE
👺 Havoc: [remove thread-unsafe std::env mutations]

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -716,6 +716,7 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
     let verification_checks = parse_verify_checks(&m.verify)?;
     let interactive_mode = resolve_interactive_mode(m.interactive, m.yolo, m.ui);
     let args = crate::run::mini::MiniArgs {
+        test_env: None,
         task,
         extra_context: m.extra_context,
         config: cfg,
@@ -1119,6 +1120,7 @@ async fn mini_resume_cmd(
     );
 
     let args = crate::run::mini::MiniArgs {
+        test_env: None,
         task,
         extra_context: m.extra_context,
         config: cfg,
@@ -1384,6 +1386,7 @@ async fn mini_continue_cmd(
     let interactive_mode = resolve_interactive_mode(m.interactive, m.yolo, m.ui);
 
     let args = crate::run::mini::MiniArgs {
+        test_env: None,
         task: follow_up_task,
         extra_context: m.extra_context,
         config: cfg,

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -146,6 +146,13 @@ struct RedactionMatch {
 
 impl Redactor {
     pub fn from_config(cfg: &RedactionCfg) -> Result<Self, regex::Error> {
+        Self::from_config_with_env(cfg, std::env::vars_os())
+    }
+
+    pub fn from_config_with_env(
+        cfg: &RedactionCfg,
+        env_vars: impl IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
+    ) -> Result<Self, regex::Error> {
         let mut rules = Vec::new();
         let mut blocking_literals = Vec::new();
         let mut seen_literals = BTreeSet::new();
@@ -193,7 +200,7 @@ impl Redactor {
                 blocking_literals.push(literal);
             }
 
-            for (name_os, value_os) in std::env::vars_os() {
+            for (name_os, value_os) in env_vars {
                 let name = name_os.to_string_lossy();
                 let value = value_os.to_string_lossy().into_owned();
                 if let Some(kind) = env_literal_kind(&name, &value) {
@@ -241,6 +248,13 @@ impl Redactor {
 
     pub fn from_config_lossy(cfg: &RedactionCfg) -> Self {
         Self::from_config(cfg).unwrap_or_else(|_| Self::disabled())
+    }
+
+    pub fn from_config_lossy_with_env(
+        cfg: &RedactionCfg,
+        env_vars: impl IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
+    ) -> Self {
+        Self::from_config_with_env(cfg, env_vars).unwrap_or_else(|_| Self::disabled())
     }
 
     pub fn default_enabled() -> Self {

--- a/src/run/hello_world.rs
+++ b/src/run/hello_world.rs
@@ -15,6 +15,7 @@ pub async fn main(output_dir: PathBuf, config_path: Option<&Path>) -> Result<(),
     let traj_path = output_dir.join("hello-world.traj.json");
     let out_path = output_dir.join("hello-world.output.txt");
     let args = MiniArgs {
+        test_env: None,
         task: "Say hello".to_owned(),
         extra_context: None,
         config: cfg,

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -109,6 +109,7 @@ pub struct MiniArgs {
     pub config: Config,
     pub output_dir: PathBuf,
     pub trajectory_name: String,
+    pub test_env: Option<Vec<(std::ffi::OsString, std::ffi::OsString)>>,
     pub deterministic_responses: Option<Vec<String>>,
     /// Optional fixed `ModelUsage` reported by the deterministic backend
     /// on every call. Only meaningful when `deterministic_responses` is
@@ -2478,6 +2479,7 @@ index 8a1218a..24c5735 100644\n\
             no_step_persist: false,
             parent_sweep_run_id: None,
             continue_from: None,
+            test_env: None,
         };
 
         run(args).await.unwrap();
@@ -2635,6 +2637,7 @@ index 8a1218a..24c5735 100644\n\
             verification_timeout_secs: 60,
             resume_from: None,
             continue_from: None,
+            test_env: None,
             interactive_mode: InteractiveMode::Off,
             trace_id: None,
             webhook_url: None,
@@ -2692,6 +2695,7 @@ index 8a1218a..24c5735 100644\n\
             verification_timeout_secs: 60,
             resume_from: None,
             continue_from: Some(continue_state),
+            test_env: None,
             interactive_mode: InteractiveMode::Off,
             trace_id: None,
             webhook_url: None,
@@ -2821,6 +2825,7 @@ index 8a1218a..24c5735 100644\n\
             no_step_persist: false,
             parent_sweep_run_id: None,
             continue_from: None,
+            test_env: None,
         };
 
         run(args).await.unwrap();
@@ -2919,6 +2924,7 @@ index 8a1218a..24c5735 100644\n\
             no_step_persist: false,
             parent_sweep_run_id: None,
             continue_from: None,
+            test_env: None,
         };
 
         run(args).await.unwrap();
@@ -3008,6 +3014,7 @@ index 8a1218a..24c5735 100644\n\
             no_step_persist: true,
             parent_sweep_run_id: None,
             continue_from: None,
+            test_env: None,
         };
         run(args).await.unwrap();
 
@@ -3076,6 +3083,7 @@ index 8a1218a..24c5735 100644\n\
             no_step_persist: false,
             parent_sweep_run_id: None,
             continue_from: None,
+            test_env: None,
         };
         run(args).await.unwrap();
 
@@ -3146,6 +3154,7 @@ index 8a1218a..24c5735 100644\n\
             no_step_persist: false,
             parent_sweep_run_id: None,
             continue_from: None,
+            test_env: None,
         };
 
         run(args).await.unwrap();
@@ -3262,6 +3271,7 @@ index 8a1218a..24c5735 100644\n\
             no_step_persist: false,
             parent_sweep_run_id: None,
             continue_from: None,
+            test_env: None,
         }
     }
 

--- a/src/run/suite.rs
+++ b/src/run/suite.rs
@@ -510,6 +510,7 @@ pub async fn run(args: SuiteArgs) -> Result<ExitCode, Error> {
 
         let trajectory_name = task.id.clone();
         let mini_args = crate::run::mini::MiniArgs {
+            test_env: None,
             task: task.task.clone(),
             extra_context: task.extra_context.clone(),
             config: task_cfg,

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -4587,6 +4587,7 @@ async fn run_one(inst: SweBenchInstance, run_index: u32, params: RunOneParams) -
         };
 
         let args = crate::run::mini::MiniArgs {
+            test_env: None,
             task: task.clone(),
             extra_context: None,
             config: cfg.clone(),
@@ -7999,6 +8000,7 @@ instance = "inst"
     /// (sweep_started → 2 × instance_completed → sweep_completed) and that
     /// every payload carries the schema-version envelope (AC #8 from #315).
     #[cfg(feature = "webhook")]
+    #[allow(clippy::too_many_lines)]
     #[tokio::test]
     async fn notify_webhook_posts_events_in_order_with_schema_envelope() {
         use std::sync::{Arc, Mutex};
@@ -8018,11 +8020,7 @@ instance = "inst"
                 };
                 let mut buf = Vec::new();
                 let mut chunk = [0u8; 8192];
-                loop {
-                    let n = match socket.read(&mut chunk).await {
-                        Ok(n) => n,
-                        Err(_) => break,
-                    };
+                while let Ok(n) = socket.read(&mut chunk).await {
                     if n == 0 {
                         break;
                     }
@@ -8122,8 +8120,8 @@ instance = "inst"
 
         let results = tokio::time::timeout(std::time::Duration::from_secs(15), run(args))
             .await
-            .expect("sweep timed out")
-            .expect("sweep failed");
+            .unwrap_or_else(|e| panic!("sweep timed out: {e}"))
+            .unwrap_or_else(|e| panic!("sweep failed: {e}"));
 
         assert_eq!(results.submitted, 2, "both instances must submit");
 

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -455,9 +455,10 @@ mod tests {
         // Synthetic env var picked up automatically by from_config_lossy.
         let unique_val = format!("sk-deadbeef-sweep-wh-{}", addr.port());
         let env_name = format!("FAKE_API_KEY_SWH_{}", addr.port());
-        // SAFETY: single-threaded test context; no concurrent env reads.
-        unsafe { std::env::set_var(&env_name, &unique_val) };
-        let redactor = Redactor::default_enabled();
+        let redactor = Redactor::from_config_lossy_with_env(
+            &crate::config::RedactionCfg::default(),
+            vec![(env_name.clone().into(), unique_val.clone().into())],
+        );
 
         let sink = SweepWebhookSink::new(url, &[], redactor, "sweep-redact".to_owned()).unwrap();
         sink.emit(SweepNotificationEvent::InstanceCompleted {
@@ -470,8 +471,6 @@ mod tests {
 
         let socket = accept(&listener).await;
         let req = read_http(socket).await;
-        // SAFETY: single-threaded test context; no concurrent env reads.
-        unsafe { std::env::remove_var(&env_name) };
 
         assert!(
             !req.contains(&unique_val),
@@ -626,7 +625,7 @@ mod tests {
         match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((s, _))) => s,
             Ok(Err(e)) => panic!("accept error: {e}"),
-            Err(_) => panic!("accept timed out"),
+            Err(e) => panic!("accept timed out: {e}"),
         }
     }
 
@@ -637,7 +636,7 @@ mod tests {
             let n = match tokio::time::timeout(TEST_IO_TIMEOUT, socket.read(&mut chunk)).await {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => panic!("read error: {e}"),
-                Err(_) => panic!("read timed out"),
+                Err(e) => panic!("read timed out: {e}"),
             };
             if n == 0 {
                 break;
@@ -654,7 +653,7 @@ mod tests {
     }
 
     fn body_of(req: &str) -> &str {
-        req.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("")
+        req.split_once("\r\n\r\n").map_or("", |(_, b)| b)
     }
 
     fn is_complete_http(buf: &[u8]) -> bool {

--- a/tests/chaos.rs
+++ b/tests/chaos.rs
@@ -49,6 +49,7 @@ fn chaos_args(cfg: Config, output: std::path::PathBuf, name: &str) -> MiniArgs {
         no_step_persist: false,
         parent_sweep_run_id: None,
         continue_from: None,
+        test_env: None,
     }
 }
 

--- a/tests/checkpointing.rs
+++ b/tests/checkpointing.rs
@@ -578,6 +578,7 @@ async fn mini_run_writes_partial_checkpoint_after_each_step() {
         no_step_persist: false,
         parent_sweep_run_id: None,
         continue_from: None,
+        test_env: None,
     };
 
     mini_run(args).await.unwrap();

--- a/tests/read_only.rs
+++ b/tests/read_only.rs
@@ -77,6 +77,7 @@ async fn read_only_blocks_bash_and_preserves_git_status() {
         no_step_persist: false,
         parent_sweep_run_id: None,
         continue_from: None,
+        test_env: None,
     })
     .await;
     assert!(

--- a/tests/skills.rs
+++ b/tests/skills.rs
@@ -464,6 +464,7 @@ paths = ["{skill_path}"]
         no_step_persist: false,
         parent_sweep_run_id: None,
         continue_from: None,
+        test_env: None,
     })
     .await
     .unwrap();
@@ -546,6 +547,7 @@ secret_literals = ["TOP_SECRET_VALUE", "TOP_SECRET_ROOT"]
         no_step_persist: false,
         parent_sweep_run_id: None,
         continue_from: None,
+        test_env: None,
     })
     .await
     .unwrap();

--- a/tests/verification.rs
+++ b/tests/verification.rs
@@ -49,6 +49,7 @@ fn mini_args(work: &tempfile::TempDir, name: &str, checks: Vec<VerificationCheck
         no_step_persist: false,
         parent_sweep_run_id: None,
         continue_from: None,
+        test_env: None,
     }
 }
 

--- a/tests/webhook.rs
+++ b/tests/webhook.rs
@@ -149,6 +149,7 @@ fn make_mini_args(
         no_step_persist: false,
         parent_sweep_run_id: None,
         continue_from: None,
+        test_env: None,
     }
 }
 
@@ -543,6 +544,7 @@ async fn webhook_redacts_secrets_before_post() {
         no_step_persist: false,
         parent_sweep_run_id: None,
         continue_from: None,
+        test_env: None,
     };
 
     let (run_result, bodies) =


### PR DESCRIPTION
* 🧨 **The Trigger:** "Concurrent tests using `unsafe { std::env::set_var }` cause data races and UB in Rust 1.80+."
* 📉 **The Stack Trace:** "Data Race / Crash during `cargo test`."
* 🧪 **Reproduction:** "Run `cargo test` with high concurrency."
* 😈 **Comment:** "Global mutable state is a lie. Tests must not mutate `std::env`."

---
*PR created automatically by Jules for task [14248545018652848613](https://jules.google.com/task/14248545018652848613) started by @madmax983*