### PR TITLE
feat: implement dataset content drift detection in bench compare

### DIFF
--- a/docs/evaluator-provenance.md
+++ b/docs/evaluator-provenance.md
@@ -17,6 +17,8 @@ Every `evaluation.json` contains a top-level `provenance` object:
     "backend_version": "sb-cli 0.5.2",
     "dataset_subset": "swe-bench-m",
     "dataset_split": "dev",
+    "dataset_sha256": "aaaaaaaaaaaabbbbbbbbbbbbccccccccccccddddddddddddeeeeeeeeeeeeffff",
+    "dataset_instance_count": 17,
     "run_id": "my-sweep-2026-01-15",
     "prediction_path": "/sweeps/run-a/all_preds.jsonl",
     "prediction_sha256": "e3b0c44298fc1c149afb...",
@@ -50,15 +52,16 @@ field; they deserialize successfully with `provenance: null`.
 
 | Status | Meaning |
 |---|---|
-| `matching` | Both evaluations used the same backend, version, dataset subset, and split |
+| `matching` | Both evaluations used the same backend, version, dataset subset, split, and dataset content (SHA-256) |
 | `mismatched` | A scoring-affecting field differs; comparison may be unreliable |
-| `unavailable` | One or both sides lack provenance (legacy artifacts) |
+| `unavailable` | One or both sides lack provenance (legacy artifacts or missing `dataset_sha256`) |
 
 Fields checked for comparability:
 - `backend` — evaluator name (`"sb-cli"` vs `"none"`)
 - `backend_version` — version string when both sides recorded one
 - `dataset_subset` — e.g. `"swe-bench-m"` vs `"swe-bench_lite"`
 - `dataset_split` — e.g. `"dev"` vs `"test"`
+- `dataset_sha256` — SWE-bench dataset SHA-256 content hash (catches upstream re-publishes, partial downloads, or local edits)
 - `sb_cli.timeout_per_instance_secs` — when both used `sb-cli`
 - `sb_cli.parallel` — when both used `sb-cli`
 
@@ -80,8 +83,22 @@ Evaluator provenance: mismatched
   ! evaluator provenance: backend_version differs (baseline="sb-cli 0.5.0", candidate="sb-cli 0.6.1")
 ```
 
-and in the compare JSON report as `evaluator_provenance_status` and
-`evaluator_provenance_warnings`.
+and in the compare JSON report inside the `comparability` block as `dataset_sha256_a`, `dataset_sha256_b`, and `dataset_content_matches`.
+
+### Dataset Content Drift Detection
+
+If `bench compare` detects that the `dataset_sha256` content hash differs between the baseline and candidate (even if they share the same subset name and split), the overview table prints the mismatch with prefix-truncated hashes and instance counts before resolved-rate or regression numbers:
+
+```text
+Dataset mismatch:
+  Baseline:  aaaaaaaaaaaa (n=17)
+  Candidate: 111111111111 (n=23)
+```
+
+This prevents silent data drift from corrupting evaluation results due to:
+- Upstream republishes of the dataset
+- Interrupted or partial downloads into the local cache
+- Local file edits or different instance filtering
 
 ## Reproducible evaluation example
 

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -2851,18 +2851,14 @@ fn compare_evaluator_provenance(
 
     let mut warnings = Vec::new();
 
-    match (&b.dataset_sha256, &c.dataset_sha256) {
-        (Some(b_sha), Some(c_sha)) => {
-            if b_sha != c_sha {
-                warnings.push("evaluator provenance: dataset content (sha256) differs".to_owned());
-            }
+    let mut has_legacy_missing_hash = false;
+    if let (Some(b_sha), Some(c_sha)) = (&b.dataset_sha256, &c.dataset_sha256) {
+        if b_sha != c_sha {
+            warnings.push("evaluator provenance: dataset content (sha256) differs".to_owned());
         }
-        _ => {
-            return (
-                EvaluatorProvenanceStatus::Unavailable,
-                vec!["evaluator provenance: legacy artifact missing dataset_sha256".to_owned()],
-            );
-        }
+    } else {
+        has_legacy_missing_hash = true;
+        warnings.push("evaluator provenance: legacy artifact missing dataset_sha256".to_owned());
     }
 
     if b.backend != c.backend {
@@ -2925,6 +2921,8 @@ fn compare_evaluator_provenance(
 
     if warnings.is_empty() {
         (EvaluatorProvenanceStatus::Matching, Vec::new())
+    } else if has_legacy_missing_hash && warnings.len() == 1 {
+        (EvaluatorProvenanceStatus::Unavailable, warnings)
     } else {
         (EvaluatorProvenanceStatus::Mismatched, warnings)
     }

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -239,6 +239,22 @@ pub struct CompareReport {
     /// was loaded or when no flaky instances were found in the paired overlap.
     #[serde(default)]
     pub flaky_instances_excluded: usize,
+    /// Comparability metadata block
+    pub comparability: ComparabilityBlock,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ComparabilityBlock {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset_sha256_a: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset_sha256_b: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset_instance_count_a: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset_instance_count_b: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset_content_matches: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -477,6 +493,28 @@ fn write_compare_overview(s: &mut String, report: &CompareReport) {
         &report.artifact_version_mismatches,
         &report.artifact_warnings,
     );
+    if report.evaluator_provenance_status == EvaluatorProvenanceStatus::Mismatched {
+        if let (Some(sha_a), Some(sha_b)) = (
+            &report.comparability.dataset_sha256_a,
+            &report.comparability.dataset_sha256_b,
+        ) {
+            if sha_a != sha_b {
+                let prefix_a = &sha_a[..12.min(sha_a.len())];
+                let prefix_b = &sha_b[..12.min(sha_b.len())];
+                let count_a = report
+                    .comparability
+                    .dataset_instance_count_a
+                    .map_or_else(|| "?".to_string(), |c| format!("n={c}"));
+                let count_b = report
+                    .comparability
+                    .dataset_instance_count_b
+                    .map_or_else(|| "?".to_string(), |c| format!("n={c}"));
+                let _ = writeln!(s, "Dataset mismatch:");
+                let _ = writeln!(s, "  Baseline:  {prefix_a} ({count_a})");
+                let _ = writeln!(s, "  Candidate: {prefix_b} ({count_b})");
+            }
+        }
+    }
     let _ = writeln!(
         s,
         "Resolved:           {} -> {} ({:+})",
@@ -1631,6 +1669,33 @@ pub fn compute(args: &CompareArgs) -> Result<CompareReport, Error> {
         },
     );
     apply_evaluator_provenance(&mut report, baseline_eval.as_ref(), candidate_eval.as_ref());
+    let dataset_sha256_a = baseline_eval
+        .as_ref()
+        .and_then(|e| e.results.provenance.as_ref())
+        .and_then(|p| p.dataset_sha256.clone());
+    let dataset_sha256_b = candidate_eval
+        .as_ref()
+        .and_then(|e| e.results.provenance.as_ref())
+        .and_then(|p| p.dataset_sha256.clone());
+    let dataset_instance_count_a = baseline_eval
+        .as_ref()
+        .and_then(|e| e.results.provenance.as_ref())
+        .and_then(|p| p.dataset_instance_count);
+    let dataset_instance_count_b = candidate_eval
+        .as_ref()
+        .and_then(|e| e.results.provenance.as_ref())
+        .and_then(|p| p.dataset_instance_count);
+    let dataset_content_matches = match (&dataset_sha256_a, &dataset_sha256_b) {
+        (Some(a), Some(b)) => Some(a == b),
+        _ => None,
+    };
+    report.comparability = ComparabilityBlock {
+        dataset_sha256_a,
+        dataset_sha256_b,
+        dataset_instance_count_a,
+        dataset_instance_count_b,
+        dataset_content_matches,
+    };
     // Sampling drift: scan trajectory files for both sweeps.
     let common_ids: Vec<String> = baseline
         .instances
@@ -1931,6 +1996,13 @@ fn diff_with_overrides<S: std::hash::BuildHasher>(
         candidate_test_only_resolved_rate: None,
         test_only_resolved_rate_delta: None,
         flaky_instances_excluded: 0,
+        comparability: ComparabilityBlock {
+            dataset_sha256_a: None,
+            dataset_sha256_b: None,
+            dataset_instance_count_a: None,
+            dataset_instance_count_b: None,
+            dataset_content_matches: None,
+        },
     }
 }
 
@@ -2778,6 +2850,20 @@ fn compare_evaluator_provenance(
     };
 
     let mut warnings = Vec::new();
+
+    match (&b.dataset_sha256, &c.dataset_sha256) {
+        (Some(b_sha), Some(c_sha)) => {
+            if b_sha != c_sha {
+                warnings.push("evaluator provenance: dataset content (sha256) differs".to_owned());
+            }
+        }
+        _ => {
+            return (
+                EvaluatorProvenanceStatus::Unavailable,
+                vec!["evaluator provenance: legacy artifact missing dataset_sha256".to_owned()],
+            );
+        }
+    }
 
     if b.backend != c.backend {
         warnings.push(format!(
@@ -4862,6 +4948,8 @@ mod tests {
             backend_version: None,
             dataset_subset: Some("swe-bench-m".into()),
             dataset_split: Some("dev".into()),
+            dataset_sha256: Some("default_sha256_value".into()),
+            dataset_instance_count: Some(10),
             run_id: None,
             prediction_path: None,
             prediction_sha256: None,

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -28,6 +28,12 @@ pub struct EvaluatorProvenance {
     /// SWE-bench dataset split (e.g. `"dev"`, `"test"`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dataset_split: Option<String>,
+    /// SWE-bench dataset SHA-256 hash.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset_sha256: Option<String>,
+    /// Optional SWE-bench dataset instance count.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset_instance_count: Option<usize>,
     /// Run ID supplied to the evaluator.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub run_id: Option<String>,
@@ -415,11 +421,21 @@ pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
         resolved_by_run,
         effective_run_id,
     } = run_output;
+    let (dataset_sha256, dataset_instance_count) = if let Some(ref manifest) = loaded.manifest {
+        (
+            Some(manifest.dataset.sha256.clone()),
+            Some(manifest.dataset.instance_count),
+        )
+    } else {
+        (None, None)
+    };
     let provenance = build_provenance(
         args,
         &resolved_by_run,
         effective_run_id.as_deref(),
         eval_started_at,
+        dataset_sha256,
+        dataset_instance_count,
     );
     attach_patch_stats(&mut eval, args, &resolved_by_run)?;
     let (rollup, test_only_resolved_rate) = build_submission_class_rollup(&eval.instances);
@@ -470,6 +486,8 @@ fn build_provenance(
     resolved_by_run: &HashMap<RunSlotKey, bool>,
     effective_run_id: Option<&str>,
     started_at: String,
+    dataset_sha256: Option<String>,
+    dataset_instance_count: Option<usize>,
 ) -> EvaluatorProvenance {
     let run_id_str = effective_run_id
         .or(args.run_id.as_deref())
@@ -532,6 +550,8 @@ fn build_provenance(
             EvaluateBackend::SbCli => Some(args.sb_split.clone()),
             EvaluateBackend::None | EvaluateBackend::Rehearsal => None,
         },
+        dataset_sha256,
+        dataset_instance_count,
         run_id: recorded_run_id,
         prediction_path,
         prediction_sha256,
@@ -3048,7 +3068,14 @@ mod tests {
             breakdown: BreakdownSelection::none(),
             cost_attribution: false,
         };
-        let prov = build_provenance(&args, &HashMap::new(), None, "2026-01-01T00:00:00Z".into());
+        let prov = build_provenance(
+            &args,
+            &HashMap::new(),
+            None,
+            "2026-01-01T00:00:00Z".into(),
+            None,
+            None,
+        );
         assert_eq!(prov.backend, "none");
         assert!(prov.backend_version.is_none());
         assert!(prov.prediction_path.is_none());
@@ -3084,6 +3111,8 @@ mod tests {
             &HashMap::new(),
             Some("generated-123"),
             "2026-01-01T00:00:00Z".into(),
+            None,
+            None,
         );
         assert_eq!(prov.run_id.as_deref(), Some("generated-123"));
     }

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -421,7 +421,12 @@ pub fn run(args: &EvaluateArgs) -> Result<EvaluationResults, Error> {
         resolved_by_run,
         effective_run_id,
     } = run_output;
-    let (dataset_sha256, dataset_instance_count) = if let Some(ref manifest) = loaded.manifest {
+    let (dataset_sha256, dataset_instance_count) = if let Some(ref dataset_path) = args.dataset_path
+    {
+        let sha = sha256_file(dataset_path).ok();
+        let count = swebench::load_dataset(dataset_path).ok().map(|v| v.len());
+        (sha, count)
+    } else if let Some(ref manifest) = loaded.manifest {
         (
             Some(manifest.dataset.sha256.clone()),
             Some(manifest.dataset.instance_count),

--- a/tests/evaluator_provenance.rs
+++ b/tests/evaluator_provenance.rs
@@ -1528,3 +1528,77 @@ fn evaluate_custom_dataset_override_stamps_its_hash_and_count() {
     // Instance count should be Some(3)
     assert_eq!(prov.dataset_instance_count, Some(3));
 }
+
+// ---------------------------------------------------------------------------
+// 31. Legacy fixture + current with differing known fields -> Mismatched
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compare_legacy_and_current_with_mismatched_known_fields_gives_mismatched() {
+    let dir_b = tempfile::tempdir().unwrap();
+    let dir_c = tempfile::tempdir().unwrap();
+
+    write_results(dir_b.path(), vec![minimal_instance_result("task-a")]);
+    write_results(dir_c.path(), vec![minimal_instance_result("task-a")]);
+
+    // Legacy evaluation.json without dataset_sha256, split = dev
+    let eval_b = serde_json::json!({
+        "artifact_kind": "evaluation_results",
+        "schema_version": {"major": 1, "minor": 1},
+        "instances": [],
+        "provenance": {
+            "backend": "none",
+            "backend_version": "1.0",
+            "dataset_subset": "swe-bench-m",
+            "dataset_split": "dev"
+        }
+    });
+
+    // Current evaluation.json with dataset_sha256, but split = test (differs from dev!)
+    let eval_c = serde_json::json!({
+        "artifact_kind": "evaluation_results",
+        "schema_version": {"major": 1, "minor": 1},
+        "instances": [],
+        "provenance": {
+            "backend": "none",
+            "backend_version": "1.0",
+            "dataset_subset": "swe-bench-m",
+            "dataset_split": "test",
+            "dataset_sha256": "1111111111112222222222223333333333334444444444445555555555556666",
+            "dataset_instance_count": 23
+        }
+    });
+
+    std::fs::write(
+        dir_b.path().join("evaluation.json"),
+        serde_json::to_string_pretty(&eval_b).unwrap(),
+    )
+    .unwrap();
+    std::fs::write(
+        dir_c.path().join("evaluation.json"),
+        serde_json::to_string_pretty(&eval_c).unwrap(),
+    )
+    .unwrap();
+
+    let report =
+        maxwells_daemon::run::compare::compute(&compare_args(dir_b.path(), dir_c.path())).unwrap();
+
+    // Since dataset_split differs, status MUST be Mismatched, not Unavailable!
+    assert_eq!(
+        report.evaluator_provenance_status,
+        EvaluatorProvenanceStatus::Mismatched
+    );
+
+    // It should have both the split mismatch and the legacy missing dataset_sha256 warnings
+    let warnings = &report.evaluator_provenance_warnings;
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.contains("legacy artifact missing dataset_sha256")),
+        "expected legacy artifact warning, got: {warnings:?}"
+    );
+    assert!(
+        warnings.iter().any(|w| w.contains("dataset split differs")),
+        "expected dataset split differs warning, got: {warnings:?}"
+    );
+}

--- a/tests/evaluator_provenance.rs
+++ b/tests/evaluator_provenance.rs
@@ -1481,3 +1481,50 @@ fn compare_json_contains_comparability_block() {
     );
     assert!(!comp["dataset_content_matches"].as_bool().unwrap());
 }
+
+// ---------------------------------------------------------------------------
+// 30. evaluate with custom dataset_path override stamps its hash and instance count in provenance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn evaluate_custom_dataset_override_stamps_its_hash_and_count() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results(dir.path(), vec![minimal_instance_result("task-a")]);
+
+    // Create a custom dataset jsonl file with 3 rows
+    let dataset_path = dir.path().join("custom_dataset.jsonl");
+    let dataset_content = "{\"instance_id\":\"task-a\",\"problem_statement\":\"foo\"}\n\
+                           {\"instance_id\":\"task-b\",\"problem_statement\":\"bar\"}\n\
+                           {\"instance_id\":\"task-c\",\"problem_statement\":\"baz\"}\n";
+    std::fs::write(&dataset_path, dataset_content).unwrap();
+
+    // Call evaluate::run with the dataset_path override
+    let eval = maxwells_daemon::run::evaluate::run(&maxwells_daemon::run::evaluate::EvaluateArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        dataset_path: Some(dataset_path),
+        backend: maxwells_daemon::run::evaluate::EvaluateBackend::None,
+        timeout_per_instance_secs: 1,
+        parallel: 1,
+        sb_subset: "verified".into(),
+        sb_split: "test".into(),
+        run_id: None,
+        breakdown: maxwells_daemon::run::evaluate::BreakdownSelection::none(),
+        cost_attribution: false,
+    })
+    .unwrap();
+
+    assert!(eval.provenance.is_some());
+    let prov = eval.provenance.unwrap();
+
+    // Hash should match custom dataset file hash
+    let expected_sha = {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(dataset_content.as_bytes());
+        format!("{:x}", hasher.finalize())
+    };
+    assert_eq!(prov.dataset_sha256.as_deref(), Some(expected_sha.as_str()));
+
+    // Instance count should be Some(3)
+    assert_eq!(prov.dataset_instance_count, Some(3));
+}

--- a/tests/evaluator_provenance.rs
+++ b/tests/evaluator_provenance.rs
@@ -172,6 +172,8 @@ fn evaluator_provenance_struct_exists_and_serializes() {
         backend_version: None,
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: Some("test-run-001".into()),
         prediction_path: Some("/tmp/preds.jsonl".into()),
         prediction_sha256: Some("abc123".into()),
@@ -199,6 +201,8 @@ fn evaluation_results_roundtrip_with_provenance() {
         backend_version: None,
         dataset_subset: None,
         dataset_split: None,
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: None,
         prediction_path: None,
         prediction_sha256: None,
@@ -342,6 +346,8 @@ fn compare_matching_provenance_gives_matching_status() {
         backend_version: None,
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: Some("run-001".into()),
         prediction_path: Some("/tmp/preds.jsonl".into()),
         prediction_sha256: Some("abc".into()),
@@ -399,6 +405,8 @@ fn compare_backend_mismatch_gives_mismatched_status() {
         backend_version: None,
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: None,
         prediction_path: None,
         prediction_sha256: None,
@@ -416,6 +424,8 @@ fn compare_backend_mismatch_gives_mismatched_status() {
         backend_version: None,
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: None,
         prediction_path: None,
         prediction_sha256: None,
@@ -462,6 +472,8 @@ fn compare_dataset_subset_mismatch_gives_mismatched_status() {
         backend_version: None,
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: None,
         prediction_path: None,
         prediction_sha256: None,
@@ -479,6 +491,8 @@ fn compare_dataset_subset_mismatch_gives_mismatched_status() {
         backend_version: None,
         dataset_subset: Some("swe-bench_lite".into()), // DIFFERENT
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: None,
         prediction_path: None,
         prediction_sha256: None,
@@ -524,6 +538,8 @@ fn compare_dataset_split_mismatch_gives_mismatched_status() {
         backend_version: None,
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some(split.into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: None,
         prediction_path: None,
         prediction_sha256: None,
@@ -578,6 +594,8 @@ fn compare_one_side_missing_provenance_gives_unavailable() {
         backend_version: None,
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: None,
         prediction_path: None,
         prediction_sha256: None,
@@ -639,6 +657,8 @@ fn summary_report_has_evaluator_provenance_field() {
         backend_version: None,
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: None,
         prediction_path: None,
         prediction_sha256: None,
@@ -715,6 +735,8 @@ fn inspect_summary_loads_provenance_from_evaluation_json() {
         backend_version: None,
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: Some("my-run-id".into()),
         prediction_path: None,
         prediction_sha256: None,
@@ -763,6 +785,8 @@ fn inspect_text_renders_provenance_summary() {
         backend_version: Some("1.2.3".into()),
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: Some("run-42".into()),
         prediction_path: Some("/tmp/preds.jsonl".into()),
         prediction_sha256: None,
@@ -828,6 +852,8 @@ fn evaluator_provenance_backend_version_optional() {
         backend_version: None, // None is valid for backend=none
         dataset_subset: None,
         dataset_split: None,
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: None,
         prediction_path: None,
         prediction_sha256: None,
@@ -861,6 +887,8 @@ fn compare_backend_version_mismatch_gives_mismatched_status() {
         backend_version: Some("1.0.0".into()),
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: None,
         prediction_path: None,
         prediction_sha256: None,
@@ -878,6 +906,8 @@ fn compare_backend_version_mismatch_gives_mismatched_status() {
         backend_version: Some("2.0.0".into()), // DIFFERENT VERSION
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: None,
         prediction_path: None,
         prediction_sha256: None,
@@ -946,6 +976,8 @@ fn compare_run_id_diff_does_not_warn() {
         backend_version: None,
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: Some("run-AAAA".into()),
         prediction_path: Some("/sweeps/run-a/predictions.jsonl".into()),
         prediction_sha256: Some("aaaa".into()),
@@ -1012,6 +1044,8 @@ fn compare_timeout_mismatch_gives_mismatched_status() {
         backend_version: None,
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: None,
         prediction_path: None,
         prediction_sha256: None,
@@ -1076,6 +1110,8 @@ fn compare_parallel_mismatch_gives_mismatched_status() {
         backend_version: None,
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: None,
         prediction_path: None,
         prediction_sha256: None,
@@ -1157,6 +1193,8 @@ fn compare_human_table_shows_provenance_warnings() {
         backend_version: None,
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: None,
         prediction_path: None,
         prediction_sha256: None,
@@ -1174,6 +1212,8 @@ fn compare_human_table_shows_provenance_warnings() {
         backend_version: None,
         dataset_subset: Some("swe-bench-m".into()),
         dataset_split: Some("dev".into()),
+        dataset_sha256: Some("default_sha256_value".into()),
+        dataset_instance_count: Some(10),
         run_id: None,
         prediction_path: None,
         prediction_sha256: None,
@@ -1197,4 +1237,247 @@ fn compare_human_table_shows_provenance_warnings() {
         text.contains("backend"),
         "human_table() should show provenance warning text; got:\n{text}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// 27. dataset_sha256 mismatch -> Mismatched + warning + prefix/count rendering
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compare_dataset_sha256_mismatch_gives_mismatched_status() {
+    let dir_b = tempfile::tempdir().unwrap();
+    let dir_c = tempfile::tempdir().unwrap();
+
+    write_results(dir_b.path(), vec![minimal_instance_result("task-a")]);
+    write_results(dir_c.path(), vec![minimal_instance_result("task-a")]);
+
+    // Baseline evaluation.json with dataset_sha256 A
+    let eval_b = serde_json::json!({
+        "artifact_kind": "evaluation_results",
+        "schema_version": {"major": 1, "minor": 1},
+        "instances": [
+            {
+                "instance_id": "task-a",
+                "resolved": true,
+                "runs": 1,
+                "resolved_count": 1,
+                "pass_at_1": true,
+                "tests_passed": [],
+                "tests_failed": [],
+                "eval_exit_reason": "resolved"
+            }
+        ],
+        "provenance": {
+            "backend": "none",
+            "backend_version": "1.0",
+            "dataset_subset": "swe-bench-m",
+            "dataset_split": "dev",
+            "dataset_sha256": "aaaaaaaaaaaabbbbbbbbbbbbccccccccccccddddddddddddeeeeeeeeeeeeffff",
+            "dataset_instance_count": 17
+        }
+    });
+
+    // Candidate evaluation.json with DIFFERENT dataset_sha256 B
+    let eval_c = serde_json::json!({
+        "artifact_kind": "evaluation_results",
+        "schema_version": {"major": 1, "minor": 1},
+        "instances": [
+            {
+                "instance_id": "task-a",
+                "resolved": true,
+                "runs": 1,
+                "resolved_count": 1,
+                "pass_at_1": true,
+                "tests_passed": [],
+                "tests_failed": [],
+                "eval_exit_reason": "resolved"
+            }
+        ],
+        "provenance": {
+            "backend": "none",
+            "backend_version": "1.0",
+            "dataset_subset": "swe-bench-m",
+            "dataset_split": "dev",
+            "dataset_sha256": "1111111111112222222222223333333333334444444444445555555555556666",
+            "dataset_instance_count": 23
+        }
+    });
+
+    std::fs::write(
+        dir_b.path().join("evaluation.json"),
+        serde_json::to_string_pretty(&eval_b).unwrap(),
+    )
+    .unwrap();
+    std::fs::write(
+        dir_c.path().join("evaluation.json"),
+        serde_json::to_string_pretty(&eval_c).unwrap(),
+    )
+    .unwrap();
+
+    let report =
+        maxwells_daemon::run::compare::compute(&compare_args(dir_b.path(), dir_c.path())).unwrap();
+
+    assert_eq!(
+        report.evaluator_provenance_status,
+        EvaluatorProvenanceStatus::Mismatched
+    );
+    assert!(
+        report
+            .evaluator_provenance_warnings
+            .iter()
+            .any(|w| w.contains("dataset content (sha256) differs")),
+        "expected dataset content mismatch warning, got: {:?}",
+        report.evaluator_provenance_warnings
+    );
+
+    let text = report.human_table();
+    assert!(
+        text.contains("aaaaaaaaaaaa"),
+        "human_table() should show baseline prefix: {text}"
+    );
+    assert!(
+        text.contains("111111111111"),
+        "human_table() should show candidate prefix: {text}"
+    );
+    assert!(
+        text.contains("n=17"),
+        "human_table() should show baseline instance count: {text}"
+    );
+    assert!(
+        text.contains("n=23"),
+        "human_table() should show candidate instance count: {text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 28. Legacy fixture (no dataset_sha256) + current -> Unavailable, not mismatched
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compare_legacy_and_current_gives_unavailable() {
+    let dir_b = tempfile::tempdir().unwrap();
+    let dir_c = tempfile::tempdir().unwrap();
+
+    write_results(dir_b.path(), vec![minimal_instance_result("task-a")]);
+    write_results(dir_c.path(), vec![minimal_instance_result("task-a")]);
+
+    // Legacy evaluation.json without dataset_sha256
+    let eval_b = serde_json::json!({
+        "artifact_kind": "evaluation_results",
+        "schema_version": {"major": 1, "minor": 1},
+        "instances": [],
+        "provenance": {
+            "backend": "none",
+            "backend_version": "1.0",
+            "dataset_subset": "swe-bench-m",
+            "dataset_split": "dev"
+        }
+    });
+
+    // Current evaluation.json with dataset_sha256
+    let eval_c = serde_json::json!({
+        "artifact_kind": "evaluation_results",
+        "schema_version": {"major": 1, "minor": 1},
+        "instances": [],
+        "provenance": {
+            "backend": "none",
+            "backend_version": "1.0",
+            "dataset_subset": "swe-bench-m",
+            "dataset_split": "dev",
+            "dataset_sha256": "1111111111112222222222223333333333334444444444445555555555556666",
+            "dataset_instance_count": 23
+        }
+    });
+
+    std::fs::write(
+        dir_b.path().join("evaluation.json"),
+        serde_json::to_string_pretty(&eval_b).unwrap(),
+    )
+    .unwrap();
+    std::fs::write(
+        dir_c.path().join("evaluation.json"),
+        serde_json::to_string_pretty(&eval_c).unwrap(),
+    )
+    .unwrap();
+
+    let report =
+        maxwells_daemon::run::compare::compute(&compare_args(dir_b.path(), dir_c.path())).unwrap();
+
+    assert_eq!(
+        report.evaluator_provenance_status,
+        EvaluatorProvenanceStatus::Unavailable
+    );
+    assert!(
+        report
+            .evaluator_provenance_warnings
+            .iter()
+            .any(|w| w.contains("legacy artifact missing dataset_sha256")),
+        "expected legacy artifact warning, got: {:?}",
+        report.evaluator_provenance_warnings
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 29. Compare report JSON contains dataset_sha256_a, dataset_sha256_b, and dataset_content_matches
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compare_json_contains_comparability_block() {
+    let dir_b = tempfile::tempdir().unwrap();
+    let dir_c = tempfile::tempdir().unwrap();
+
+    write_results(dir_b.path(), vec![minimal_instance_result("task-a")]);
+    write_results(dir_c.path(), vec![minimal_instance_result("task-a")]);
+
+    let eval_b = serde_json::json!({
+        "artifact_kind": "evaluation_results",
+        "schema_version": {"major": 1, "minor": 1},
+        "instances": [],
+        "provenance": {
+            "backend": "none",
+            "dataset_sha256": "aaaaaaaaaaaabbbbbbbbbbbbccccccccccccddddddddddddeeeeeeeeeeeeffff"
+        }
+    });
+
+    let eval_c = serde_json::json!({
+        "artifact_kind": "evaluation_results",
+        "schema_version": {"major": 1, "minor": 1},
+        "instances": [],
+        "provenance": {
+            "backend": "none",
+            "dataset_sha256": "1111111111112222222222223333333333334444444444445555555555556666"
+        }
+    });
+
+    std::fs::write(
+        dir_b.path().join("evaluation.json"),
+        serde_json::to_string_pretty(&eval_b).unwrap(),
+    )
+    .unwrap();
+    std::fs::write(
+        dir_c.path().join("evaluation.json"),
+        serde_json::to_string_pretty(&eval_c).unwrap(),
+    )
+    .unwrap();
+
+    let report =
+        maxwells_daemon::run::compare::compute(&compare_args(dir_b.path(), dir_c.path())).unwrap();
+
+    let json = report.to_json_pretty().unwrap();
+    let val: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    let comp = &val["comparability"];
+    assert!(
+        comp.is_object(),
+        "comparability should be a nested object in JSON"
+    );
+    assert_eq!(
+        comp["dataset_sha256_a"].as_str().unwrap(),
+        "aaaaaaaaaaaabbbbbbbbbbbbccccccccccccddddddddddddeeeeeeeeeeeeffff"
+    );
+    assert_eq!(
+        comp["dataset_sha256_b"].as_str().unwrap(),
+        "1111111111112222222222223333333333334444444444445555555555556666"
+    );
+    assert!(!comp["dataset_content_matches"].as_bool().unwrap());
 }

--- a/tests/fixtures/artifact_schema/current/evaluation.json
+++ b/tests/fixtures/artifact_schema/current/evaluation.json
@@ -34,6 +34,8 @@
   },
   "provenance": {
     "backend": "none",
+    "dataset_sha256": "aaaaaaaaaaaabbbbbbbbbbbbccccccccccccddddddddddddeeeeeeeeeeeeffff",
+    "dataset_instance_count": 1,
     "eval_started_at": "2026-01-01T00:00:00Z",
     "eval_ended_at": "2026-01-01T00:00:01Z"
   },


### PR DESCRIPTION
## Problem
`bench compare` classifies two evaluations as `matching` whenever their evaluator provenance agrees on `backend`, `backend_version`, `dataset_subset`, and `dataset_split`. Dataset *content* is not part of that decision. Two sweeps run weeks apart against the same alias (`verified` / `test`) can be reported `matching` even when the underlying JSONL changed.

## Solution
- Plumbed `dataset_sha256` and optional `dataset_instance_count` from sweep manifests (`results.json`) into `evaluation.json` provenance.
- Updated `bench compare` comparability checking: a differing `dataset_sha256` sets status to `Mismatched` with warning `"dataset content (sha256) differs"`. Legacy artifacts lacking `dataset_sha256` deserialize cleanly and return `Unavailable` status.
- Added explicit detailed mismatch warnings with prefix-truncated hashes (first 12 characters) and instance counts under `"Dataset mismatch:"` in `bench compare` output prior to metrics breakdown.
- Updated JSON outputs of `CompareReport` to include `dataset_sha256_a`, `dataset_sha256_b`, and `dataset_content_matches` in the `comparability` block.
- Updated `docs/evaluator-provenance.md` and added robust integration tests.