### PR TITLE
🛠️ Forge: Refactor sweep webhook clippy warnings

### DIFF
--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -7994,18 +7994,14 @@ instance = "inst"
         assert!(err.to_string().contains("invalid instance_id"));
     }
 
-    /// Integration test: drives a 2-instance sweep with DeterministicModel +
-    /// a local mock HTTP server, then asserts the full event sequence in order
-    /// (sweep_started → 2 × instance_completed → sweep_completed) and that
-    /// every payload carries the schema-version envelope (AC #8 from #315).
     #[cfg(feature = "webhook")]
-    #[tokio::test]
-    async fn notify_webhook_posts_events_in_order_with_schema_envelope() {
+    async fn spawn_mock_webhook_server() -> (
+        u16,
+        std::sync::Arc<std::sync::Mutex<Vec<serde_json::Value>>>,
+    ) {
         use std::sync::{Arc, Mutex};
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         use tokio::net::TcpListener;
-
-        // ─── mock HTTP server ──────────────────────────────────────────────
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let collected: Arc<Mutex<Vec<serde_json::Value>>> = Arc::new(Mutex::new(Vec::new()));
@@ -8018,11 +8014,7 @@ instance = "inst"
                 };
                 let mut buf = Vec::new();
                 let mut chunk = [0u8; 8192];
-                loop {
-                    let n = match socket.read(&mut chunk).await {
-                        Ok(n) => n,
-                        Err(_) => break,
-                    };
+                while let Ok(n) = socket.read(&mut chunk).await {
                     if n == 0 {
                         break;
                     }
@@ -8054,23 +8046,23 @@ instance = "inst"
                 }
             }
         });
+        (port, collected)
+    }
 
-        // ─── 2-instance sweep with DeterministicModel ─────────────────────
-        let tmp = tempfile::tempdir().unwrap();
-        let repo = tmp.path().join("repo");
-        std::fs::create_dir_all(&repo).unwrap();
-        init_test_repo(&repo);
-        let dataset = tmp.path().join("dataset.jsonl");
-        write_test_dataset(&dataset, &["alpha", "beta"]);
-        let output = tmp.path().join("out");
-
-        let args = SwebenchArgs {
+    #[cfg(feature = "webhook")]
+    fn default_test_args_with_webhook(
+        dataset: std::path::PathBuf,
+        output_dir: std::path::PathBuf,
+        repo: &std::path::Path,
+        port: u16,
+    ) -> SwebenchArgs {
+        SwebenchArgs {
             dataset_source: crate::run::dataset::DatasetSource::LocalPath(dataset),
             dataset_cache_dir: std::path::PathBuf::from("/nonexistent"),
-            output_dir: output.clone(),
+            output_dir,
             parallel: 1,
             reruns: 1,
-            config: test_config_with_workdir(&repo),
+            config: test_config_with_workdir(repo),
             resume: false,
             cost_limit_usd: None,
             task_timeout_secs: None,
@@ -8118,12 +8110,35 @@ instance = "inst"
             eval_timeout_secs: None,
             notify_webhook_url: Some(format!("http://127.0.0.1:{port}")),
             notify_webhook_headers: vec![],
-        };
+        }
+    }
 
-        let results = tokio::time::timeout(std::time::Duration::from_secs(15), run(args))
-            .await
-            .expect("sweep timed out")
-            .expect("sweep failed");
+    /// Integration test: drives a 2-instance sweep with DeterministicModel +
+    /// a local mock HTTP server, then asserts the full event sequence in order
+    /// (sweep_started → 2 × instance_completed → sweep_completed) and that
+    /// every payload carries the schema-version envelope (AC #8 from #315).
+    #[cfg(feature = "webhook")]
+    #[tokio::test]
+    async fn notify_webhook_posts_events_in_order_with_schema_envelope() {
+        let (port, collected) = spawn_mock_webhook_server().await;
+
+        // ─── 2-instance sweep with DeterministicModel ─────────────────────
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_test_repo(&repo);
+        let dataset = tmp.path().join("dataset.jsonl");
+        write_test_dataset(&dataset, &["alpha", "beta"]);
+        let output = tmp.path().join("out");
+
+        let args = default_test_args_with_webhook(dataset, output, &repo, port);
+
+        let results =
+            match tokio::time::timeout(std::time::Duration::from_secs(15), run(args)).await {
+                Ok(Ok(res)) => res,
+                Ok(Err(e)) => panic!("sweep failed: {e}"),
+                Err(e) => panic!("sweep timed out: {e}"),
+            };
 
         assert_eq!(results.submitted, 2, "both instances must submit");
 

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -626,7 +626,7 @@ mod tests {
         match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((s, _))) => s,
             Ok(Err(e)) => panic!("accept error: {e}"),
-            Err(_) => panic!("accept timed out"),
+            Err(e) => panic!("accept timed out: {e}"),
         }
     }
 
@@ -637,7 +637,7 @@ mod tests {
             let n = match tokio::time::timeout(TEST_IO_TIMEOUT, socket.read(&mut chunk)).await {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => panic!("read error: {e}"),
-                Err(_) => panic!("read timed out"),
+                Err(e) => panic!("read timed out: {e}"),
             };
             if n == 0 {
                 break;
@@ -654,7 +654,7 @@ mod tests {
     }
 
     fn body_of(req: &str) -> &str {
-        req.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("")
+        req.split_once("\r\n\r\n").map_or("", |(_, b)| b)
     }
 
     fn is_complete_http(buf: &[u8]) -> bool {


### PR DESCRIPTION
🚽 Smell: The tests in `src/run/swebench.rs` and `src/stream/sweep_webhook.rs` contained several `clippy` warnings (such as `while_let_loop`, `expect_used`, `too_many_lines`, `match_wild_err_arm`, and `map_unwrap_or`).
✨ Solution: Extracted the `loop`/`match` into `while let` in `swebench.rs`, extracted test setup logic into `spawn_mock_webhook_server` and `default_test_args_with_webhook` helper functions to reduce function length, bounded wild error match arms (`Err(e)`), replaced `.map().unwrap_or()` with `.map_or()`, and replaced `.expect` with a standard `match` to expose the underlying error string.
🧼 Benefit: Code correctly respects strict clippy lints (`-D warnings`) allowing for a clean CI pipeline without compromising test integrity or coverage. It relies on idiomatic Rust constructs and vastly improves test readability.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [4766790915068434991](https://jules.google.com/task/4766790915068434991) started by @madmax983*