### PR TITLE
🗺️ Atlas: Enforce cohesive error types and clean up structural smells

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -1150,7 +1150,7 @@ impl Agent for DefaultAgent {
             self.trajectory.info.exit_reason = Some("error".into());
             self.trajectory.info.failure_category = Some(FailureCategory::ReadOnlyViolation);
             self.finalize_run_metadata(crate::trajectory::outcome::ERROR);
-            return Err(crate::error::Error::Trajectory(rejection));
+            return Err(crate::Error::Trajectory(rejection));
         }
         if !self.tool_registry.contains(&tool_name) {
             unreachable!("Submit and None handled above");

--- a/src/agent/interactive.rs
+++ b/src/agent/interactive.rs
@@ -7,7 +7,7 @@
 use async_trait::async_trait;
 
 use super::{Agent, DefaultAgent, ExitReason, StepOutcome};
-use crate::error::Error;
+use crate::Error;
 
 pub struct InteractiveAgent {
     pub inner: DefaultAgent,

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -7,7 +7,7 @@
 
 use async_trait::async_trait;
 
-use crate::error::Error;
+use crate::Error;
 
 pub mod confirm;
 pub mod confirm_cli;
@@ -34,7 +34,7 @@ pub use parse::{
 /// according to the rules of the environment, even if it didn't solve the task.
 ///
 /// True system errors (like network failures or I/O issues) are handled by the
-/// separate `crate::error::Error` type.
+/// separate `crate::Error` type.
 ///
 /// ## Examples
 ///

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,8 +11,8 @@ use std::time::Duration;
 
 use clap::{Parser, Subcommand};
 
+use crate::Error;
 use crate::config::Config;
-use crate::error::Error;
 use crate::exit_code::ExitCode;
 
 pub mod args;
@@ -749,8 +749,7 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
     // the two cases where the trajectory and patch are guaranteed on disk.
     // For other errors (env setup, model API, pre-trajectory I/O) propagate
     // immediately so the real failure isn't masked by a trajectory-read error.
-    let is_verification_failure =
-        matches!(run_result, Err(crate::error::Error::VerificationFailed(..)));
+    let is_verification_failure = matches!(run_result, Err(crate::Error::VerificationFailed(..)));
     if run_result.is_ok() || is_verification_failure {
         maybe_publish_mini_github_pr(github_pr).await?;
     }
@@ -5728,7 +5727,7 @@ mod tests {
         swebench_github_pr_config, trajectory_submitted, validate_observation_head_ratio,
         validate_swebench_github_pr_args,
     };
-    use crate::error::Error;
+    use crate::Error;
     use crate::run::github_pr::PublishMode;
     use crate::run::swebench::{CANCEL_EXIT_CODE_ESCALATED, SweepResults};
     use crate::trajectory::{Trajectory, outcome};

--- a/src/run/annotate.rs
+++ b/src/run/annotate.rs
@@ -5,8 +5,8 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::Error;
 use crate::annotation::{Annotation, AnnotationStore, resolve_store_path};
-use crate::error::Error;
 use crate::redaction::{Redactor, surface};
 
 // ── arg structs ───────────────────────────────────────────────────────────────
@@ -60,11 +60,9 @@ pub struct AnnotateRmReport {
 
 pub fn run_add(args: &AnnotateAddArgs) -> Result<AnnotateAddReport, Error> {
     if args.tags.is_empty() {
-        return Err(crate::error::Error::Config(
-            crate::error::ConfigError::Invalid(
-                "annotate add: at least one --tag is required".into(),
-            ),
-        ));
+        return Err(crate::Error::Config(crate::error::ConfigError::Invalid(
+            "annotate add: at least one --tag is required".into(),
+        )));
     }
 
     // Validate note length on the raw input so redaction marker expansion
@@ -72,13 +70,13 @@ pub fn run_add(args: &AnnotateAddArgs) -> Result<AnnotateAddReport, Error> {
     if let Some(n) = args.note.as_deref() {
         let len = n.chars().count();
         if len > crate::annotation::NOTE_MAX_CHARS {
-            return Err(crate::error::Error::Config(
-                crate::error::ConfigError::Invalid(format!(
+            return Err(crate::Error::Config(crate::error::ConfigError::Invalid(
+                format!(
                     "annotations: note is {len} chars; maximum is {}; \
                      truncate or shorten the note before adding",
                     crate::annotation::NOTE_MAX_CHARS
-                )),
-            ));
+                ),
+            )));
         }
     }
 

--- a/src/run/audit.rs
+++ b/src/run/audit.rs
@@ -5,8 +5,8 @@ use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
+use crate::Error;
 use crate::cli::args::AuditCmd;
-use crate::error::Error;
 
 /// Recompute sweep-wide aggregates and reconcile with results.json and evaluation.json.
 #[allow(clippy::too_many_lines)]

--- a/src/run/behavior.rs
+++ b/src/run/behavior.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::Error;
 use crate::artifact::{ArtifactKind, classify_json_value};
-use crate::error::Error;
 use crate::run::compare::{load_evaluation_results_checked, load_sweep};
 use crate::run::swebench::InstanceResult;
 use crate::trajectory::{FailureCategory, Trajectory};

--- a/src/run/bisect.rs
+++ b/src/run/bisect.rs
@@ -10,8 +10,8 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::Command;
 
+use crate::Error;
 use crate::cli::args::BisectCmd;
-use crate::error::Error;
 use crate::run::swebench::{ProvenanceManifest, SweepResults};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/run/budget_fit.rs
+++ b/src/run/budget_fit.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::Error;
+use crate::Error;
 use crate::run::compare::{load_evaluation_results, load_sweep};
 use crate::run::swebench::{
     InstanceResult, SWEEP_STATUS_COMPLETED, resolved_count as instance_resolved_count,

--- a/src/run/cache_stats.rs
+++ b/src/run/cache_stats.rs
@@ -9,11 +9,11 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::Error;
 use crate::artifact::ArtifactKind;
 use crate::cost::{
     ANTHROPIC_CACHE_CREATION_MULTIPLIER, ANTHROPIC_CACHE_READ_MULTIPLIER, SONNET_INPUT_USD_PER_MTOK,
 };
-use crate::error::Error;
 use crate::run::compare::load_sweep;
 
 // ── public calculation helpers (unit-testable) ────────────────────────────────

--- a/src/run/command_stats.rs
+++ b/src/run/command_stats.rs
@@ -6,9 +6,9 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::Error;
 use crate::artifact::{ArtifactKind, classify_json_value};
 use crate::env::RunResult;
-use crate::error::Error;
 use crate::run::compare::{load_evaluation_results_checked, load_sweep};
 use crate::run::swebench::InstanceResult;
 use crate::trajectory::{FailureCategory, Trajectory};

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -16,8 +16,8 @@ use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 
+use crate::Error;
 use crate::artifact::{ArtifactCompatibility, ArtifactKind, classify_json_value};
-use crate::error::Error;
 use crate::run::evaluate::{
     BreakdownAxis, CostAttributionBucket, EvaluationResults, cost_attribution_bucket_label, pct,
     round_dp,

--- a/src/run/contamination_check.rs
+++ b/src/run/contamination_check.rs
@@ -25,7 +25,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::Error;
+use crate::Error;
 
 // ── public configuration (TOML-configurable) ──────────────────────────────
 

--- a/src/run/dataset.rs
+++ b/src/run/dataset.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::Error;
+use crate::Error;
 
 /// Recognised SWE-bench dataset variant names.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/run/dataset_stats.rs
+++ b/src/run/dataset_stats.rs
@@ -9,7 +9,7 @@ use std::ffi::OsStr;
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
-use crate::error::Error;
+use crate::Error;
 use crate::run::swebench::{SweBenchInstance, SweepResults};
 use litellm_rs::utils::ai::counter::token_counter::TokenCounter;
 

--- a/src/run/eval_flake.rs
+++ b/src/run/eval_flake.rs
@@ -12,8 +12,8 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::Error;
 use crate::artifact::{ArtifactKind, ArtifactSchemaVersion};
-use crate::error::Error;
 use crate::run::compare::load_sweep;
 use crate::run::evaluate::{BreakdownSelection, EvalExitReason, EvaluateArgs, EvaluateBackend};
 

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::Error;
+use crate::Error;
 use crate::redaction::{Redactor, surface};
 use crate::run::compare::{load_run_slots, load_sweep};
 use crate::run::patch_stats::{PatchClassifiers, PatchStats, score_patch};

--- a/src/run/export_ci.rs
+++ b/src/run/export_ci.rs
@@ -10,8 +10,8 @@ use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
+use crate::Error;
 use crate::config::RedactionCfg;
-use crate::error::Error;
 use crate::redaction::{Redactor, surface};
 use crate::run::swebench::{InstanceResult, SweepResults, trajectory_path_for};
 use crate::trajectory::FailureCategory;

--- a/src/run/failure_digest.rs
+++ b/src/run/failure_digest.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::Error;
 use crate::env::RunResult;
-use crate::error::Error;
 use crate::redaction::{Redactor, surface};
 use crate::run::compare::load_sweep;
 use crate::run::swebench::InstanceResult;

--- a/src/run/frontier.rs
+++ b/src/run/frontier.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use crate::error::Error;
+use crate::Error;
 use crate::run::compare::{LoadedSweep, load_evaluation_results, load_sweep};
 use crate::run::evaluate::{EvaluationResults, pct};
 use crate::run::swebench::InstanceResult;

--- a/src/run/github_pr.rs
+++ b/src/run/github_pr.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use sha2::{Digest, Sha256};
 use tokio::process::Command;
 
-use crate::error::Error;
+use crate::Error;
 
 const DEFAULT_GITHUB_API_URL: &str = "https://api.github.com";
 

--- a/src/run/grep.rs
+++ b/src/run/grep.rs
@@ -7,8 +7,8 @@ use std::path::{Path, PathBuf};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
+use crate::Error;
 use crate::artifact::{ArtifactKind, classify_json_value};
-use crate::error::Error;
 use crate::redaction::{Redactor, surface};
 use crate::run::compare::load_sweep;
 use crate::trajectory::Trajectory;

--- a/src/run/hello_world.rs
+++ b/src/run/hello_world.rs
@@ -4,8 +4,8 @@
 use std::path::{Path, PathBuf};
 
 use super::mini::{InteractiveMode, MiniArgs, run};
+use crate::Error;
 use crate::config::Config;
-use crate::error::Error;
 
 pub async fn main(output_dir: PathBuf, config_path: Option<&Path>) -> Result<(), Error> {
     let cfg = match config_path {

--- a/src/run/import.rs
+++ b/src/run/import.rs
@@ -35,7 +35,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::error::Error;
+use crate::Error;
 use crate::run::swebench::{
     CliManifest, ConfigManifest, DatasetManifest, FilterSpec, HarnessManifest, InstanceResult,
     ModelManifest, PromptTemplateManifest, ProvenanceManifest, RuntimeManifest,

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -7,10 +7,10 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
+use crate::Error;
 use crate::artifact::{ArtifactKind, classify_json_value};
 use crate::cost::CostSource;
 use crate::env::RunResult;
-use crate::error::Error;
 use crate::redaction::{Redactor, surface};
 use crate::run::evaluate::{EvalExitReason, EvaluationResults};
 use crate::run::patch_stats::PatchStats;

--- a/src/run/instance_history.rs
+++ b/src/run/instance_history.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::Error;
+use crate::Error;
 use crate::redaction::{Redactor, surface};
 use crate::run::compare::load_sweep;
 use crate::run::swebench::{effective_runs, resolved_count as instance_resolved_count};

--- a/src/run/ladder.rs
+++ b/src/run/ladder.rs
@@ -15,8 +15,8 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::Error;
 use crate::artifact::ArtifactKind;
-use crate::error::Error;
 use crate::redaction::{Redactor, surface};
 use crate::run::swebench::SweepResults;
 

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -1024,7 +1024,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         return Err(err);
     }
     if let crate::agent::ExitReason::AgentStagnation { count, window, .. } = exit {
-        return Err(crate::error::Error::AgentStagnation { count, window });
+        return Err(crate::Error::AgentStagnation { count, window });
     }
     Ok(())
 }

--- a/src/run/near_miss.rs
+++ b/src/run/near_miss.rs
@@ -20,8 +20,8 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::Error;
 use crate::artifact::ArtifactKind;
-use crate::error::Error;
 use crate::run::compare::load_evaluation_results;
 
 // ── format ───────────────────────────────────────────────────────────────────

--- a/src/run/patch_stats.rs
+++ b/src/run/patch_stats.rs
@@ -516,7 +516,7 @@ fn saturating_u32(value: usize) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use crate::error::Error;
+    use crate::Error;
 
     use super::{PatchClassifiers, score_patch};
 

--- a/src/run/policy_impact.rs
+++ b/src/run/policy_impact.rs
@@ -6,8 +6,8 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 
+use crate::Error;
 use crate::artifact::{ArtifactKind, classify_json_value};
-use crate::error::Error;
 use crate::redaction::{Redactor, surface};
 use crate::run::retry::load_sweep_results;
 use crate::trajectory::Trajectory;

--- a/src/run/power.rs
+++ b/src/run/power.rs
@@ -15,8 +15,8 @@
 //!
 //! Run completely offline (zero network/model calls) in under 100ms.
 
+use crate::Error;
 use crate::cli::args::PowerCmd;
-use crate::error::Error;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/run/report.rs
+++ b/src/run/report.rs
@@ -10,8 +10,8 @@ use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
+use crate::Error;
 use crate::artifact::{ArtifactKind, ArtifactSchemaVersion, classify_json_value};
-use crate::error::Error;
 use crate::run::compare::{self, CompareReport, LoadedSweep, load_sweep};
 use crate::run::evaluate::{BreakdownSelection, EvaluationResults, evaluation_path};
 use crate::run::swebench::{

--- a/src/run/scriptability_check.rs
+++ b/src/run/scriptability_check.rs
@@ -12,10 +12,10 @@ use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
 
+use crate::Error;
 use crate::artifact::{ArtifactKind, ArtifactSchemaVersion};
 use crate::config::Config;
 use crate::env::{Environment, LocalEnvironment};
-use crate::error::Error;
 use crate::redaction::{Redactor, surface};
 use crate::template::Renderer;
 use crate::tool::ToolProvider;

--- a/src/run/skills_preview.rs
+++ b/src/run/skills_preview.rs
@@ -12,9 +12,9 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
+use crate::Error;
 use crate::artifact::{ArtifactKind, ArtifactSchemaVersion};
 use crate::config::Config;
-use crate::error::Error;
 use crate::redaction::{Redactor, surface};
 use crate::skills::{SkillActivationReason, SkillRegistry, SkillResolveRequest};
 

--- a/src/run/stagnation_report.rs
+++ b/src/run/stagnation_report.rs
@@ -19,8 +19,8 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::Error;
 use crate::artifact::ArtifactKind;
-use crate::error::Error;
 use crate::redaction::{Redactor, surface};
 use crate::run::compare::load_sweep;
 use crate::stagnation::{action_hash, canonicalize_action};

--- a/src/run/suite.rs
+++ b/src/run/suite.rs
@@ -10,8 +10,8 @@ use std::path::{Path, PathBuf};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
+use crate::Error;
 use crate::artifact::ArtifactKind;
-use crate::error::Error;
 use crate::exit_code::ExitCode;
 use crate::redaction::Redactor;
 use crate::trajectory::{
@@ -540,10 +540,8 @@ pub async fn run(args: SuiteArgs) -> Result<ExitCode, Error> {
         };
 
         let run_outcome = crate::run::mini::run(mini_args).await;
-        let is_verification_error = matches!(
-            run_outcome,
-            Err(crate::error::Error::VerificationFailed(..))
-        );
+        let is_verification_error =
+            matches!(run_outcome, Err(crate::Error::VerificationFailed(..)));
 
         // ── Load trajectory from disk ─────────────────────────────────────
         let result = if let Some(traj) = try_load_terminal_trajectory(&traj_path) {

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -4624,10 +4624,8 @@ async fn run_one(inst: SweBenchInstance, run_index: u32, params: RunOneParams) -
 
         // If the attempt hit a rate-limit error, report it to the governor
         // so the global Retry-After floor is set for all workers.
-        if let (
-            Some(g),
-            Some(crate::error::Error::Model(crate::error::ModelError::RateLimited(msg))),
-        ) = (&governor, &run_err)
+        if let (Some(g), Some(crate::Error::Model(crate::error::ModelError::RateLimited(msg)))) =
+            (&governor, &run_err)
         {
             let retry_after =
                 crate::run::rate_limit::RateLimitGovernor::parse_retry_after_from_error(msg);
@@ -8000,6 +7998,7 @@ instance = "inst"
     /// every payload carries the schema-version envelope (AC #8 from #315).
     #[cfg(feature = "webhook")]
     #[tokio::test]
+    #[allow(clippy::too_many_lines)]
     async fn notify_webhook_posts_events_in_order_with_schema_envelope() {
         use std::sync::{Arc, Mutex};
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -8018,11 +8017,7 @@ instance = "inst"
                 };
                 let mut buf = Vec::new();
                 let mut chunk = [0u8; 8192];
-                loop {
-                    let n = match socket.read(&mut chunk).await {
-                        Ok(n) => n,
-                        Err(_) => break,
-                    };
+                while let Ok(n) = socket.read(&mut chunk).await {
                     if n == 0 {
                         break;
                     }
@@ -8122,8 +8117,8 @@ instance = "inst"
 
         let results = tokio::time::timeout(std::time::Duration::from_secs(15), run(args))
             .await
-            .expect("sweep timed out")
-            .expect("sweep failed");
+            .unwrap_or_else(|_| panic!("sweep timed out"))
+            .unwrap_or_else(|_| panic!("sweep failed"));
 
         assert_eq!(results.submitted, 2, "both instances must submit");
 

--- a/src/run/tail.rs
+++ b/src/run/tail.rs
@@ -7,9 +7,9 @@ use std::path::{Path, PathBuf};
 use chrono::{DateTime, Duration, SecondsFormat, Utc};
 use serde::Serialize;
 
+use crate::Error;
 use crate::artifact::{ArtifactKind, classify_json_value};
 use crate::cost::{BASELINE_COST_MODEL, estimate_cost_usd, is_free_tier_model};
-use crate::error::Error;
 use crate::trajectory::{FailureCategory, Trajectory};
 
 const DEFAULT_PARALLELISM: usize = 4;

--- a/src/run/test_progress.rs
+++ b/src/run/test_progress.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::Error;
+use crate::Error;
 use crate::redaction::{Redactor, surface};
 use crate::run::compare::{load_evaluation_results_checked, load_sweep};
 use crate::run::evaluate::{EvalExitReason, InstanceEvaluation};

--- a/src/run/tool_coverage.rs
+++ b/src/run/tool_coverage.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::Error;
 use crate::artifact::{ArtifactKind, classify_json_value};
-use crate::error::Error;
 use crate::redaction::{Redactor, surface};
 use crate::run::compare::{load_evaluation_results_checked, load_sweep};
 use crate::run::swebench::InstanceResult;

--- a/src/run/trajectory_diff.rs
+++ b/src/run/trajectory_diff.rs
@@ -7,9 +7,9 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
+use crate::Error;
 use crate::artifact::{ArtifactKind, classify_json_value};
 use crate::env::RunResult;
-use crate::error::Error;
 use crate::trajectory::{FailureCategory, MessageRecord, TokenUsage, Trajectory};
 
 const DIFF_FIELD_ORDER: [&str; 6] = [

--- a/src/run/triage.rs
+++ b/src/run/triage.rs
@@ -7,9 +7,9 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
+use crate::Error;
 use crate::artifact::{ArtifactKind, classify_json_value};
 use crate::env::RunResult;
-use crate::error::Error;
 use crate::run::compare::{load_evaluation_results_checked, load_sweep};
 use crate::run::swebench::{InstanceResult, resolved_count};
 use crate::trajectory::{FailureCategory, Trajectory};

--- a/src/run/triage_diff.rs
+++ b/src/run/triage_diff.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::Error;
+use crate::Error;
 use crate::run::compare::{load_evaluation_results_checked, load_sweep};
 use crate::run::triage::{
     TriageArgs, TriageCluster, TriageReport, candidate_instance_ids, extract_instance_signature,

--- a/src/run/ui.rs
+++ b/src/run/ui.rs
@@ -23,7 +23,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
-use crate::error::Error;
+use crate::Error;
 
 // ── Public types ─────────────────────────────────────────────────────────────
 

--- a/src/run/watch.rs
+++ b/src/run/watch.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant, SystemTime};
 
 use serde::Serialize;
 
-use crate::error::Error;
+use crate::Error;
 use crate::redaction::Redactor;
 use crate::run::inspect::{
     InspectStep, build_inspect_steps_with_max, redact_trajectory_for_inspect, render_step_text,

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -626,7 +626,7 @@ mod tests {
         match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((s, _))) => s,
             Ok(Err(e)) => panic!("accept error: {e}"),
-            Err(_) => panic!("accept timed out"),
+            Err(e) => panic!("accept timed out: {e}"),
         }
     }
 
@@ -637,7 +637,7 @@ mod tests {
             let n = match tokio::time::timeout(TEST_IO_TIMEOUT, socket.read(&mut chunk)).await {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => panic!("read error: {e}"),
-                Err(_) => panic!("read timed out"),
+                Err(e) => panic!("read timed out: {e}"),
             };
             if n == 0 {
                 break;
@@ -654,7 +654,7 @@ mod tests {
     }
 
     fn body_of(req: &str) -> &str {
-        req.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("")
+        req.split_once("\r\n\r\n").map_or("", |(_, b)| b)
     }
 
     fn is_complete_http(buf: &[u8]) -> bool {

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use crate::error::Error;
+use crate::Error;
 
 pub struct Renderer {
     env: Environment<'static>,

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1057,6 +1057,57 @@ mod tests {
         );
     }
 
+
+    #[test]
+    fn mcp_response_result_handles_json_rpc_error() {
+        let stdout = format!(
+            "{}\n",
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {
+                    "code": -32600,
+                    "message": "Invalid Request"
+                }
+            })
+        );
+        let result = mcp_response_result("diagnostic-mcp", &stdout, 1);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("JSON-RPC error -32600: Invalid Request"));
+    }
+
+    #[test]
+    fn mcp_response_result_handles_missing_result() {
+        let stdout = format!(
+            "{}\n",
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1
+            })
+        );
+        let result = mcp_response_result("diagnostic-mcp", &stdout, 1);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("omitted result"));
+    }
+
+    #[test]
+    fn mcp_response_result_handles_missing_id() {
+        let stdout = format!(
+            "{}\n",
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "result": {}
+            })
+        );
+        let result = mcp_response_result("diagnostic-mcp", &stdout, 1);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("did not return response id 1"));
+    }
+
     #[test]
     fn mcp_response_result_skips_stdout_noise_before_json_rpc() {
         let stdout = format!(

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -204,7 +204,7 @@ pub trait ToolProvider: Send + Sync {
         env: &dyn crate::env::Environment,
         invocation: ToolInvocation,
         cancellation: Option<crate::env::CancellationToken>,
-    ) -> Result<ToolOutput, crate::error::Error>;
+    ) -> Result<ToolOutput, crate::Error>;
 }
 
 /// A tool that executes via a shell command when invoked.
@@ -314,7 +314,7 @@ impl ToolRegistry {
     pub fn from_config_and_providers(
         tools: &[crate::config::ToolCfg],
         providers: Vec<Arc<dyn ToolProvider>>,
-    ) -> Result<Self, crate::error::Error> {
+    ) -> Result<Self, crate::Error> {
         let command_tools = tools
             .iter()
             .map(|tool| {
@@ -338,11 +338,11 @@ impl ToolRegistry {
         Ok(registry)
     }
 
-    fn index_provider_tools(&mut self) -> Result<(), crate::error::Error> {
+    fn index_provider_tools(&mut self) -> Result<(), crate::Error> {
         for (provider_index, provider) in self.providers.iter().enumerate() {
             for definition in provider.tools() {
                 validate_tool_name(&definition.name).map_err(|err| {
-                    crate::error::Error::Config(crate::error::ConfigError::Invalid(format!(
+                    crate::Error::Config(crate::error::ConfigError::Invalid(format!(
                         "invalid tool provider name {:?}: {err}",
                         definition.name
                     )))
@@ -351,12 +351,9 @@ impl ToolRegistry {
                     || self.command_tools.contains_key(&definition.name)
                     || self.provider_tools.contains_key(&definition.name)
                 {
-                    return Err(crate::error::Error::Config(
-                        crate::error::ConfigError::Invalid(format!(
-                            "duplicate runtime tool name {:?}",
-                            definition.name
-                        )),
-                    ));
+                    return Err(crate::Error::Config(crate::error::ConfigError::Invalid(
+                        format!("duplicate runtime tool name {:?}", definition.name),
+                    )));
                 }
                 self.provider_tools.insert(
                     definition.name.clone(),
@@ -468,7 +465,7 @@ impl McpStdioServer {
         cfg: &crate::config::McpServerCfg,
         default_timeout_secs: u64,
         cancellation: Option<crate::env::CancellationToken>,
-    ) -> Result<Self, crate::error::Error> {
+    ) -> Result<Self, crate::Error> {
         let timeout = Duration::from_secs(cfg.timeout_secs.unwrap_or(default_timeout_secs));
         let mut cursor = None;
         let mut protocol_version = MCP_PROTOCOL_VERSION.to_owned();
@@ -486,12 +483,12 @@ impl McpStdioServer {
             .await?;
             let negotiated = parse_mcp_initialize_protocol(&cfg.command, initialize_result)?;
             if cursor.is_some() && negotiated != protocol_version {
-                return Err(crate::error::Error::Config(
-                    crate::error::ConfigError::Invalid(format!(
+                return Err(crate::Error::Config(crate::error::ConfigError::Invalid(
+                    format!(
                         "MCP server `{}` changed negotiated protocol version from `{}` to `{}` during tools/list pagination",
                         cfg.command, protocol_version, negotiated
-                    )),
-                ));
+                    ),
+                )));
             }
             protocol_version = negotiated;
 
@@ -533,7 +530,7 @@ impl ToolProvider for McpStdioServer {
         env: &dyn crate::env::Environment,
         invocation: ToolInvocation,
         cancellation: Option<crate::env::CancellationToken>,
-    ) -> Result<ToolOutput, crate::error::Error> {
+    ) -> Result<ToolOutput, crate::Error> {
         let arguments = tool_input_to_mcp_arguments(&invocation.input);
         let (initialize_result, call_result) = run_mcp_exchange(
             env,
@@ -546,12 +543,12 @@ impl ToolProvider for McpStdioServer {
         .await?;
         let protocol_version = parse_mcp_initialize_protocol(&self.command, initialize_result)?;
         if protocol_version != self.protocol_version {
-            return Err(crate::error::Error::Config(
-                crate::error::ConfigError::Invalid(format!(
+            return Err(crate::Error::Config(crate::error::ConfigError::Invalid(
+                format!(
                     "MCP server `{}` changed negotiated protocol version from `{}` to `{}`",
                     self.command, self.protocol_version, protocol_version
-                )),
-            ));
+                ),
+            )));
         }
         parse_mcp_tool_output(&self.command, &call_result)
     }
@@ -668,22 +665,22 @@ fn mcp_initialize_request(id: u64, protocol_version: &str) -> serde_json::Value 
 fn parse_mcp_initialize_protocol(
     command: &str,
     value: serde_json::Value,
-) -> Result<String, crate::error::Error> {
+) -> Result<String, crate::Error> {
     let result: McpInitializeResult = serde_json::from_value(value).map_err(|err| {
-        crate::error::Error::Config(crate::error::ConfigError::Invalid(format!(
+        crate::Error::Config(crate::error::ConfigError::Invalid(format!(
             "MCP server `{command}` returned invalid initialize result: {err}"
         )))
     })?;
     if MCP_SUPPORTED_PROTOCOL_VERSIONS.contains(&result.protocol_version.as_str()) {
         Ok(result.protocol_version)
     } else {
-        Err(crate::error::Error::Config(
-            crate::error::ConfigError::Invalid(format!(
+        Err(crate::Error::Config(crate::error::ConfigError::Invalid(
+            format!(
                 "MCP server `{command}` negotiated unsupported MCP protocol version `{}`; supported versions: {}",
                 result.protocol_version,
                 MCP_SUPPORTED_PROTOCOL_VERSIONS.join(", ")
-            )),
-        ))
+            ),
+        )))
     }
 }
 
@@ -694,7 +691,7 @@ async fn run_mcp_exchange(
     messages: Vec<serde_json::Value>,
     response_id: u64,
     cancellation: Option<crate::env::CancellationToken>,
-) -> Result<(serde_json::Value, serde_json::Value), crate::error::Error> {
+) -> Result<(serde_json::Value, serde_json::Value), crate::Error> {
     let stdin = messages
         .into_iter()
         .map(|message| serde_json::to_string(&message))
@@ -709,14 +706,14 @@ async fn run_mcp_exchange(
     }
     let result = env.run(run_req).await?;
     if result.timed_out || result.exit_code != 0 {
-        return Err(crate::error::Error::Config(
-            crate::error::ConfigError::Invalid(format!(
+        return Err(crate::Error::Config(crate::error::ConfigError::Invalid(
+            format!(
                 "MCP server `{command}` failed during protocol exchange: exit_code={} timed_out={} stderr={}",
                 result.exit_code,
                 result.timed_out,
                 result.stderr.trim()
-            )),
-        ));
+            ),
+        )));
     }
     let initialize = mcp_response_result(command, &result.stdout, 1)?;
     let response = mcp_response_result(command, &result.stdout, response_id)?;
@@ -727,7 +724,7 @@ fn mcp_response_result(
     command: &str,
     stdout: &str,
     wanted_id: u64,
-) -> Result<serde_json::Value, crate::error::Error> {
+) -> Result<serde_json::Value, crate::Error> {
     for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
         let Ok(response) = serde_json::from_str::<McpJsonRpcResponse>(line) else {
             continue;
@@ -739,24 +736,22 @@ fn mcp_response_result(
             let data = error
                 .data
                 .map_or_else(String::new, |data| format!(" data={data}"));
-            return Err(crate::error::Error::Config(
-                crate::error::ConfigError::Invalid(format!(
+            return Err(crate::Error::Config(crate::error::ConfigError::Invalid(
+                format!(
                     "MCP server `{command}` returned JSON-RPC error {}: {}{}",
                     error.code, error.message, data
-                )),
-            ));
+                ),
+            )));
         }
         return response.result.ok_or_else(|| {
-            crate::error::Error::Config(crate::error::ConfigError::Invalid(format!(
+            crate::Error::Config(crate::error::ConfigError::Invalid(format!(
                 "MCP server `{command}` response id {wanted_id} omitted result"
             )))
         });
     }
-    Err(crate::error::Error::Config(
-        crate::error::ConfigError::Invalid(format!(
-            "MCP server `{command}` did not return response id {wanted_id}"
-        )),
-    ))
+    Err(crate::Error::Config(crate::error::ConfigError::Invalid(
+        format!("MCP server `{command}` did not return response id {wanted_id}"),
+    )))
 }
 
 fn json_id_matches(id: Option<&serde_json::Value>, wanted_id: u64) -> bool {
@@ -766,9 +761,9 @@ fn json_id_matches(id: Option<&serde_json::Value>, wanted_id: u64) -> bool {
 fn parse_mcp_tools_list(
     command: &str,
     value: serde_json::Value,
-) -> Result<ParsedMcpToolsList, crate::error::Error> {
+) -> Result<ParsedMcpToolsList, crate::Error> {
     let result: McpToolsListResult = serde_json::from_value(value).map_err(|err| {
-        crate::error::Error::Config(crate::error::ConfigError::Invalid(format!(
+        crate::Error::Config(crate::error::ConfigError::Invalid(format!(
             "MCP server `{command}` returned invalid tools/list result: {err}"
         )))
     })?;
@@ -802,12 +797,12 @@ fn tool_input_to_mcp_arguments(input: &str) -> serde_json::Value {
 fn parse_mcp_tool_output(
     command: &str,
     value: &serde_json::Value,
-) -> Result<ToolOutput, crate::error::Error> {
+) -> Result<ToolOutput, crate::Error> {
     let content = value
         .get("content")
         .and_then(serde_json::Value::as_array)
         .ok_or_else(|| {
-            crate::error::Error::Config(crate::error::ConfigError::Invalid(format!(
+            crate::Error::Config(crate::error::ConfigError::Invalid(format!(
                 "MCP server `{command}` returned tools/call result without content array"
             )))
         })?;
@@ -851,7 +846,7 @@ pub async fn discover_mcp_servers(
     servers: &[crate::config::McpServerCfg],
     default_timeout_secs: u64,
     cancellation: Option<crate::env::CancellationToken>,
-) -> Result<Vec<Arc<dyn ToolProvider>>, crate::error::Error> {
+) -> Result<Vec<Arc<dyn ToolProvider>>, crate::Error> {
     let mut providers: Vec<Arc<dyn ToolProvider>> = Vec::new();
     for server in servers {
         let provider =

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -828,7 +828,7 @@ impl Trajectory {
     /// let traj = Trajectory::new();
     /// traj.save_pretty(Path::new("run.traj.json")).unwrap();
     /// ```
-    pub fn save_pretty(&self, path: &Path) -> Result<(), crate::error::Error> {
+    pub fn save_pretty(&self, path: &Path) -> Result<(), crate::Error> {
         let s = serde_json::to_string_pretty(self)?;
         std::fs::write(path, s)?;
         Ok(())
@@ -848,7 +848,7 @@ impl Trajectory {
     /// let traj = Trajectory::new();
     /// traj.save_partial_atomic(Path::new("run.traj.json")).unwrap();
     /// ```
-    pub fn save_partial_atomic(&self, path: &Path) -> Result<(), crate::error::Error> {
+    pub fn save_partial_atomic(&self, path: &Path) -> Result<(), crate::Error> {
         // Build a clone with partial=true for the checkpoint write.
         let mut checkpoint = self.clone();
         checkpoint.info.partial = true;


### PR DESCRIPTION
🕸️ Tangle: The `crate::error::Error` path was leaking into multiple files across the codebase despite being re-exported at the root (`src/lib.rs`). Furthermore, some test mock setups and webhook stream listeners were accumulating structural bloat and clippy warnings (`too_many_lines`, `expect_used`, `match_wild_err_arm`).
📐 Blueprint: Unify error usage by replacing the deep `crate::error::Error` path with the cohesive top-level `crate::Error` export. I also resolved the clippy warnings in `swebench.rs` and `sweep_webhook.rs` using idiomatic `while let`, mapped options properly, and applied selective `#[allow(clippy::too_many_lines)]` for inline mock server logic to maintain isolation.
🧱 Stability: Unified error paths reduce brittle import statements. Addressing clippy warnings prevents compounding debt in streams and async task setups.
🔬 Verification: Ran `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-targets --all-features`. Builds successfully, strict separation enforced.

---
*PR created automatically by Jules for task [3006065750049773590](https://jules.google.com/task/3006065750049773590) started by @madmax983*