### PR TITLE
🎸 Bard: [documentation update]

### DIFF
--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -1,8 +1,33 @@
 //! Run-scoped secret redaction.
 //!
-//! This is deliberately not a full DLP engine. It masks configured literals,
-//! common structured secret shapes, and current-process environment values
-//! with sensitive names before text reaches persisted or shareable surfaces.
+//! Why this exists: When autonomous agents operate in environments containing sensitive
+//! credentials (like `GITHUB_TOKEN` or `OPENAI_API_KEY`), there is a risk that these
+//! secrets will be leaked into trajectories, logs, or model inputs. This module
+//! acts as a safety net, actively intercepting strings before they hit persisted
+//! or shareable surfaces to mask secrets.
+//!
+//! This is deliberately not a full DLP engine. It uses a lightweight, rule-based
+//! approach to mask:
+//! - Explicitly configured literals.
+//! - Common structured secret shapes (e.g., typical Bearer tokens, GitHub keys).
+//! - Current-process environment variables whose names imply sensitive material
+//!   (e.g., `*SECRET*`, `*TOKEN*`).
+//!
+//! # Examples
+//!
+//! ```
+//! use maxwells_daemon::redaction::Redactor;
+//! use maxwells_daemon::config::RedactionCfg;
+//!
+//! // 1. Create a default-enabled redactor
+//! let redactor = Redactor::default_enabled();
+//!
+//! // 2. Redact potentially sensitive text before it reaches a surface
+//! let text = "My API key is sk-ant-1234567890abcdef1234567890abcdef";
+//! let safe_text = redactor.redact_text(text, "trajectory").text;
+//!
+//! assert!(safe_text.contains("[REDACTED:api_key:"));
+//! ```
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex, PoisonError};
@@ -89,6 +114,14 @@ pub struct RedactionOutcome {
 }
 
 #[derive(Clone)]
+/// The central engine for masking secrets in text and structured data.
+///
+/// `Redactor` wraps an immutable core of compiled rules (configured literals,
+/// regex patterns, and active environment variables). It uses interior mutability
+/// to track telemetry (how many secrets of what kind were intercepted on which
+/// surface) and to assign stable, hashed replacement markers (so the same secret
+/// string gets the same marker throughout the run, allowing correlation without
+/// revealing the secret).
 pub struct Redactor {
     inner: Arc<RedactorInner>,
 }
@@ -243,6 +276,15 @@ impl Redactor {
         Self::from_config(cfg).unwrap_or_else(|_| Self::disabled())
     }
 
+    /// Creates a new `Redactor` enabled by default, using standard built-in rules
+    /// and scanning the current process environment for variables with sensitive names.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use maxwells_daemon::redaction::Redactor;
+    /// let redactor = Redactor::default_enabled();
+    /// ```
     pub fn default_enabled() -> Self {
         Self::from_config_lossy(&RedactionCfg::default())
     }
@@ -263,6 +305,21 @@ impl Redactor {
         }
     }
 
+    /// Scans the `input` string and replaces any detected secrets with stable markers.
+    ///
+    /// This method updates internal telemetry, recording that a secret was intercepted
+    /// on the specified `surface` (e.g., `"trajectory"`, `"model_observation"`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use maxwells_daemon::redaction::Redactor;
+    /// let redactor = Redactor::default_enabled();
+    ///
+    /// let outcome = redactor.redact_text("Here is my secret sk-ant-1234567890abcdef1234567890abcdef", "log");
+    /// assert!(outcome.redacted);
+    /// assert!(outcome.text.contains("[REDACTED:api_key:"));
+    /// ```
     #[must_use]
     pub fn redact_text(&self, input: &str, surface: &str) -> RedactionOutcome {
         let (text, redacted) = self.apply_redaction(input, Some(surface));
@@ -449,7 +506,7 @@ impl Redactor {
 
     /// Run redaction and return per-match annotations for operator verification.
     ///
-    /// Unlike [`redact_text`], this method does not update surface-level telemetry
+    /// Unlike [`Redactor::redact_text`], this method does not update surface-level telemetry
     /// counts and does not require a surface label. It is designed for the
     /// `agent redact-check` preflight command.
     #[must_use]

--- a/src/run/contamination_check.rs
+++ b/src/run/contamination_check.rs
@@ -6,10 +6,10 @@
 //!
 //! | Signal | Description | Range |
 //! |--------|-------------|-------|
-//! | `edit_before_read_ratio` | Fraction of edited files never read before patching | [0,1] |
-//! | `patch_similarity_to_gold` | Normalised similarity between agent patch and gold patch | [0,1] |
-//! | `time_to_first_edit` | Suspicion from early first edit (step 0 → 1.0, last step → 0.0) | [0,1] |
-//! | `verbatim_recall` | Whether agent message contains ≥ N tokens from gold patch surface | {0,1} |
+//! | `edit_before_read_ratio` | Fraction of edited files never read before patching | `[0,1]` |
+//! | `patch_similarity_to_gold` | Normalised similarity between agent patch and gold patch | `[0,1]` |
+//! | `time_to_first_edit` | Suspicion from early first edit (step 0 → 1.0, last step → 0.0) | `[0,1]` |
+//! | `verbatim_recall` | Whether agent message contains ≥ N tokens from gold patch surface | `{0,1}` |
 //!
 //! # Risk tiers
 //!

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -8000,6 +8000,7 @@ instance = "inst"
     /// every payload carries the schema-version envelope (AC #8 from #315).
     #[cfg(feature = "webhook")]
     #[tokio::test]
+    #[allow(clippy::too_many_lines)]
     async fn notify_webhook_posts_events_in_order_with_schema_envelope() {
         use std::sync::{Arc, Mutex};
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -8018,11 +8019,7 @@ instance = "inst"
                 };
                 let mut buf = Vec::new();
                 let mut chunk = [0u8; 8192];
-                loop {
-                    let n = match socket.read(&mut chunk).await {
-                        Ok(n) => n,
-                        Err(_) => break,
-                    };
+                while let Ok(n) = socket.read(&mut chunk).await {
                     if n == 0 {
                         break;
                     }
@@ -8122,8 +8119,8 @@ instance = "inst"
 
         let results = tokio::time::timeout(std::time::Duration::from_secs(15), run(args))
             .await
-            .expect("sweep timed out")
-            .expect("sweep failed");
+            .unwrap_or_else(|e| panic!("sweep timed out: {e:?}"))
+            .unwrap_or_else(|e| panic!("sweep failed: {e:?}"));
 
         assert_eq!(results.submitted, 2, "both instances must submit");
 

--- a/src/run/ui.rs
+++ b/src/run/ui.rs
@@ -39,7 +39,7 @@ pub struct InstanceEntry {
     pub traj_path: PathBuf,
 }
 
-/// Arguments forwarded from the CLI to [`run`].
+/// Arguments forwarded from the CLI to `run`.
 pub struct UiArgs {
     pub sweep: PathBuf,
     pub port: u16,

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -626,7 +626,7 @@ mod tests {
         match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((s, _))) => s,
             Ok(Err(e)) => panic!("accept error: {e}"),
-            Err(_) => panic!("accept timed out"),
+            Err(e) => panic!("accept timed out: {e}"),
         }
     }
 
@@ -637,7 +637,7 @@ mod tests {
             let n = match tokio::time::timeout(TEST_IO_TIMEOUT, socket.read(&mut chunk)).await {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => panic!("read error: {e}"),
-                Err(_) => panic!("read timed out"),
+                Err(e) => panic!("read timed out: {e}"),
             };
             if n == 0 {
                 break;
@@ -654,7 +654,7 @@ mod tests {
     }
 
     fn body_of(req: &str) -> &str {
-        req.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("")
+        req.split_once("\r\n\r\n").map_or("", |(_, b)| b)
     }
 
     fn is_complete_http(buf: &[u8]) -> bool {


### PR DESCRIPTION
📖 Chapter: The `redaction` module
🔦 Insight: Replaced missing documentation with clear, story-driven explanation of secret redaction and added executable doctests.
🧪 Example: Added `## Examples` block for `Redactor`.
🖼️ Preview: Ensured clean `cargo doc` output.

---
*PR created automatically by Jules for task [7362395573776525717](https://jules.google.com/task/7362395573776525717) started by @madmax983*