### PR TITLE
🎨 Mosaic: UI Polish for agent skills-preview

### DIFF
--- a/src/run/skills_preview.rs
+++ b/src/run/skills_preview.rs
@@ -257,18 +257,27 @@ pub fn format_text(report: &SkillsPreviewReport, redactor: &Redactor) -> String 
         if task.active_skills.is_empty() {
             out.push_str("  (no skills activated)\n");
         } else {
+            let mut table = comfy_table::Table::new();
+            table
+                .load_preset(comfy_table::presets::UTF8_FULL)
+                .apply_modifier(comfy_table::modifiers::UTF8_ROUND_CORNERS)
+                .set_header(vec!["Skill", "Reason", "SHA256", "Bytes", "Path"]);
+
             for skill in &task.active_skills {
                 let reason_str = match skill.reason {
                     SkillActivationReason::ExplicitMention => "explicit",
                     SkillActivationReason::AutoMatch => "auto",
                 };
                 let path_str = skill.path.display().to_string();
-                let _ = writeln!(
-                    out,
-                    "  {} | {} | {} | {} bytes | {}",
-                    skill.name, reason_str, skill.sha256_prefix, skill.bytes, path_str,
-                );
+                table.add_row(vec![
+                    skill.name.as_str(),
+                    reason_str,
+                    &skill.sha256_prefix,
+                    &format!("{}", skill.bytes),
+                    &path_str,
+                ]);
             }
+            let _ = writeln!(out, "{table}");
         }
         let _ = writeln!(out, "  total_bytes_injected: {}", task.total_bytes_injected);
         let _ = writeln!(
@@ -283,20 +292,34 @@ pub fn format_text(report: &SkillsPreviewReport, redactor: &Redactor) -> String 
         );
     }
 
-    let _ = writeln!(
-        out,
-        "\n--- summary ---\n\
-         task_count: {}\n\
-         unique_skills_activated: {}\n\
-         p50_bytes_per_task: {}\n\
-         p95_bytes_per_task: {}\n\
-         tasks_hitting_max_active: {}",
-        report.summary.task_count,
-        report.summary.unique_skills_activated,
-        report.summary.p50_bytes_per_task,
-        report.summary.p95_bytes_per_task,
-        report.summary.tasks_hitting_max_active,
-    );
+    let mut summary_table = comfy_table::Table::new();
+    summary_table
+        .load_preset(comfy_table::presets::UTF8_FULL)
+        .apply_modifier(comfy_table::modifiers::UTF8_ROUND_CORNERS)
+        .set_header(vec!["Metric", "Value"]);
+
+    summary_table.add_row(vec![
+        "task_count",
+        &format!("{}", report.summary.task_count),
+    ]);
+    summary_table.add_row(vec![
+        "unique_skills_activated",
+        &format!("{}", report.summary.unique_skills_activated),
+    ]);
+    summary_table.add_row(vec![
+        "p50_bytes_per_task",
+        &format!("{}", report.summary.p50_bytes_per_task),
+    ]);
+    summary_table.add_row(vec![
+        "p95_bytes_per_task",
+        &format!("{}", report.summary.p95_bytes_per_task),
+    ]);
+    summary_table.add_row(vec![
+        "tasks_hitting_max_active",
+        &format!("{}", report.summary.tasks_hitting_max_active),
+    ]);
+
+    let _ = writeln!(out, "\n--- summary ---\n{summary_table}");
 
     redactor.redact_text(&out, surface::TRAJECTORY).text
 }


### PR DESCRIPTION
🖌️ **Before:** The output of `agent skills-preview` is a raw text block, which looks like a log file instead of a dashboard. 
✨ **After:** The Z-pattern scanning layout uses tables, `comfy_table` with `UTF8_FULL` preset, and `UTF8_ROUND_CORNERS` to easily visualize and understand the output of the CLI tool.
🖼️ **Visuals:** The `skills-preview` list is now shown inside a beautiful TUI-like ascii table. The summary values are also wrapped into an ascii table.

---
*PR created automatically by Jules for task [8822050939793645445](https://jules.google.com/task/8822050939793645445) started by @madmax983*