### PR TITLE
🗺️ Atlas: Encapsulate Newtype inner values

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -8,7 +8,7 @@ macro_rules! string_id {
     ($name:ident) => {
         #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
         #[serde(transparent)]
-        pub struct $name(pub String);
+        pub struct $name(String);
 
         impl $name {
             pub fn new(s: impl Into<String>) -> Self {
@@ -44,9 +44,12 @@ string_id!(TaskId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct StepIdx(pub u32);
+pub struct StepIdx(u32);
 
 impl StepIdx {
+    pub const fn new(val: u32) -> Self {
+        Self(val)
+    }
     pub const fn zero() -> Self {
         Self(0)
     }

--- a/tests/fuzz_step_idx.rs
+++ b/tests/fuzz_step_idx.rs
@@ -4,7 +4,7 @@ use proptest::prelude::*;
 proptest! {
     #[test]
     fn step_idx_next_never_panics(x in 0u32..=u32::MAX) {
-        let step = StepIdx(x);
+        let step = StepIdx::new(x);
         let _ = step.next();
     }
 }

--- a/tests/fuzz_step_idx_overflow.rs
+++ b/tests/fuzz_step_idx_overflow.rs
@@ -1,6 +1,6 @@
 #[test]
 fn step_idx_next_saturates_on_max() {
-    let mut step = maxwells_daemon::ids::StepIdx(u32::MAX);
+    let mut step = maxwells_daemon::ids::StepIdx::new(u32::MAX);
     step = step.next();
     assert_eq!(step.get(), u32::MAX);
 }


### PR DESCRIPTION
🕸️ Tangle: Newtype wrappers `ContainerId`, `TaskId` and `StepIdx` in `src/ids.rs` had public inner fields (e.g. `pub String` and `pub u32`), breaking domain boundaries and allowing external modification or bypass of encapsulation.
📐 Blueprint: Changed the inner fields to private (e.g. `String` and `u32`). Added a public constructor `pub const fn new(val: u32) -> Self` for `StepIdx` to allow instantiation.
🧱 Stability: Enforces strict separation of concerns and reduces coupling by preventing direct access to the underlying primitive values.
🔬 Verification: `cargo test` and `cargo check` pass successfully.

---
*PR created automatically by Jules for task [2808928951241382256](https://jules.google.com/task/2808928951241382256) started by @madmax983*