### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -449,7 +449,7 @@ impl Redactor {
 
     /// Run redaction and return per-match annotations for operator verification.
     ///
-    /// Unlike [`redact_text`], this method does not update surface-level telemetry
+    /// Unlike [`Redactor::redact_text`], this method does not update surface-level telemetry
     /// counts and does not require a surface label. It is designed for the
     /// `agent redact-check` preflight command.
     #[must_use]

--- a/src/run/contamination_check.rs
+++ b/src/run/contamination_check.rs
@@ -6,10 +6,10 @@
 //!
 //! | Signal | Description | Range |
 //! |--------|-------------|-------|
-//! | `edit_before_read_ratio` | Fraction of edited files never read before patching | [0,1] |
-//! | `patch_similarity_to_gold` | Normalised similarity between agent patch and gold patch | [0,1] |
-//! | `time_to_first_edit` | Suspicion from early first edit (step 0 → 1.0, last step → 0.0) | [0,1] |
-//! | `verbatim_recall` | Whether agent message contains ≥ N tokens from gold patch surface | {0,1} |
+//! | `edit_before_read_ratio` | Fraction of edited files never read before patching | `[0,1]` |
+//! | `patch_similarity_to_gold` | Normalised similarity between agent patch and gold patch | `[0,1]` |
+//! | `time_to_first_edit` | Suspicion from early first edit (step 0 → 1.0, last step → 0.0) | `[0,1]` |
+//! | `verbatim_recall` | Whether agent message contains ≥ N tokens from gold patch surface | `{0,1}` |
 //!
 //! # Risk tiers
 //!

--- a/src/run/ui.rs
+++ b/src/run/ui.rs
@@ -39,7 +39,7 @@ pub struct InstanceEntry {
     pub traj_path: PathBuf,
 }
 
-/// Arguments forwarded from the CLI to [`run`].
+/// Arguments forwarded from the CLI to `run`.
 pub struct UiArgs {
     pub sweep: PathBuf,
     pub port: u16,


### PR DESCRIPTION
📖 Chapter: Documentation link fixes across codebase.
🔦 Insight: Fixed unresolved intra-doc links in `src/redaction.rs`, `src/run/contamination_check.rs`, and `src/run/ui.rs` caused by missing module scopes or unescaped brackets.
🧪 Example: `cargo doc` now compiles without warnings.

---
*PR created automatically by Jules for task [13207053177227677235](https://jules.google.com/task/13207053177227677235) started by @madmax983*