### PR TITLE
🌟 Nova: JSON Export for Trajectories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ live-anthropic = []
 markdown-export = []
 html-export = []
 webhook = []
+json-export = []
 csv-export = []
 mermaid-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2285,14 +2285,14 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`, and `json-export`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `json-export` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3352,13 +3352,16 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "json-export"
+    ) {
         return bench_inspect_export(i);
     }
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/json-export), not `{}`",
             i.format
         ))));
     }
@@ -3432,6 +3435,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "json-export" => inspect_export_json(&traj)?,
         _ => unreachable!("dispatch guarded by caller"),
     };
 
@@ -3517,6 +3521,22 @@ fn inspect_export_mermaid(_traj: &crate::trajectory::Trajectory) -> Result<Strin
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "format_unavailable: --format mermaid requires the `mermaid-export` Cargo feature; \
          rebuild with `--features mermaid-export`"
+            .into(),
+    )))
+}
+
+#[cfg(feature = "json-export")]
+#[allow(clippy::unnecessary_wraps)]
+fn inspect_export_json(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    use crate::trajectory::export::{JsonExporter, TrajectoryExporter};
+    Ok(JsonExporter::export(traj))
+}
+
+#[cfg(not(feature = "json-export"))]
+fn inspect_export_json(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "format_unavailable: --format json-export requires the `json-export` Cargo feature; \
+         rebuild with `--features json-export`"
             .into(),
     )))
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -47,6 +47,9 @@ pub struct MarkdownExporter;
 #[cfg(feature = "csv-export")]
 pub struct CsvExporter;
 
+#[cfg(feature = "json-export")]
+pub struct JsonExporter;
+
 #[cfg(feature = "mermaid-export")]
 pub struct MermaidExporter;
 
@@ -54,6 +57,30 @@ pub struct MermaidExporter;
 pub struct HtmlExporter;
 
 use std::fmt::Write;
+
+#[cfg(feature = "json-export")]
+impl TrajectoryExporter for JsonExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        // Manually clone the fields because Trajectory does not implement Clone.
+        let mut t_clone = Trajectory {
+            trajectory_format: trajectory.trajectory_format.clone(),
+            info: trajectory.info.clone(),
+            messages: trajectory.messages.clone(),
+            fork_lineage: trajectory.fork_lineage.clone(),
+        };
+        if let Some(task) = &mut t_clone.info.task {
+            *task = redactor.redact_text(task, surface::EXPORT).text;
+        }
+        if let Some(outcome) = &mut t_clone.info.outcome {
+            *outcome = redactor.redact_text(outcome, surface::EXPORT).text;
+        }
+        for msg in &mut t_clone.messages {
+            msg.content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+        }
+        serde_json::to_string_pretty(&t_clone).unwrap_or_else(|_| "{}".to_string())
+    }
+}
 
 #[cfg(feature = "csv-export")]
 impl TrajectoryExporter for CsvExporter {
@@ -319,6 +346,27 @@ mod tests {
         assert!(mermaid.contains("U->>A: Hello \"user\""));
 
         assert!(mermaid.contains("Note over S,T: Outcome: submitted"));
+    }
+
+    #[cfg(feature = "json-export")]
+    #[test]
+    fn test_json_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some("submitted".to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::assistant("Hello user"));
+
+        let json = JsonExporter::export(&t);
+        #[allow(clippy::expect_used)]
+        let parsed: Trajectory = serde_json::from_str(&json).expect("failed to parse json");
+
+        assert_eq!(parsed.info.task.as_deref(), Some("Add a feature"));
+        assert_eq!(parsed.info.outcome.as_deref(), Some("submitted"));
+        assert_eq!(parsed.messages.len(), 3);
+        assert_eq!(parsed.messages[0].content, "System prompt");
     }
 
     #[cfg(feature = "html-export")]


### PR DESCRIPTION
💡 **The Spark:** We have multiple ways to export and share agent trajectories (Markdown, HTML, Mermaid, CSV) for human readability, but if a user wanted to programmatically ingest the exported (and critically, *redacted*) output, they would have to parse CSV or parse the raw `traj.json` themselves (and risk leaking un-redacted secrets). 
 
🚀 **The Feature:** I've added a `json-export` feature flag and integrated `JsonExporter` into the `max inspect` command. It takes the trajectory, recursively applies the existing `Redactor` rules to the task, outcome, and all message text, and then serializes the pristine artifact as a formatted JSON string.
 
🔮 **The Potential:** This enables safe, programmatic data ingestion of sweeps. Teams can now pipe `max inspect --format json-export` directly into downstream analytical tools, dashboards, or fine-tuning datasets, confident that all configured secrets have been correctly sanitized.
 
⚠️ **Risk:** Extremely low. The feature is completely isolated behind the new `json-export` compilation flag and is purely additive. It adheres to the established `TrajectoryExporter` trait and relies entirely on the battle-tested `Redactor` logic already utilized by the other exporters.

---
*PR created automatically by Jules for task [6588989493931783703](https://jules.google.com/task/6588989493931783703) started by @madmax983*