### PR TITLE
Implement self-describing command catalog subcommand 'max catalog'

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -3050,7 +3050,7 @@ pub struct NearMissCmd {
 #[derive(Debug, Args, Clone)]
 pub struct CatalogCmd {
     /// Filter entries by stage: preflight, run, inspect, analyze, publish.
-    #[arg(long)]
+    #[arg(long, value_parser = ["preflight", "run", "inspect", "analyze", "publish"])]
     pub stage: Option<String>,
 
     /// Filter to free-only (no model calls) commands.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -3046,6 +3046,21 @@ pub struct NearMissCmd {
     #[arg(long, default_value = "text", value_parser = ["text", "json"])]
     pub format: String,
 }
+/// `catalog` — self-describing command catalog for operator discoverability.
+#[derive(Debug, Args, Clone)]
+pub struct CatalogCmd {
+    /// Filter entries by stage: preflight, run, inspect, analyze, publish.
+    #[arg(long)]
+    pub stage: Option<String>,
+
+    /// Filter to free-only (no model calls) commands.
+    #[arg(long = "free-only", default_value_t = false)]
+    pub free_only: bool,
+
+    /// Output format: `text` or `json`.
+    #[arg(long, default_value = "text", value_parser = ["text", "json"])]
+    pub format: String,
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -73,6 +73,12 @@ pub fn entries() -> &'static [CatalogEntry] {
             stage: "preflight",
         },
         CatalogEntry {
+            path: "agent injection-audit",
+            summary: "Audit sweep trajectories for prompt-injection signals",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
             path: "agent policy-check",
             summary: "Check a command corpus against the policy config",
             cost_tier: "free",

--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -1,0 +1,468 @@
+use super::args::CatalogCmd;
+use crate::error::Error;
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+use serde::Serialize;
+
+#[derive(Clone, Serialize)]
+pub struct CatalogEntry {
+    pub path: &'static str,
+    pub summary: &'static str,
+    pub cost_tier: &'static str, // "free" or "paid"
+    pub stage: &'static str,     // "preflight", "run", "inspect", "analyze", "publish"
+}
+
+#[derive(Serialize)]
+struct JsonCatalogResponse {
+    schema_version: &'static str,
+    commands: Vec<CatalogEntry>,
+}
+
+#[allow(clippy::too_many_lines)]
+pub fn entries() -> &'static [CatalogEntry] {
+    &[
+        // Top-level subcommands
+        CatalogEntry {
+            path: "catalog",
+            summary: "Display the daemon's subcommand catalog with metadata",
+            cost_tier: "free",
+            stage: "preflight",
+        },
+        CatalogEntry {
+            path: "cleanup",
+            summary: "Reap leftover Maxwell's Daemon containers, including legacy labels",
+            cost_tier: "free",
+            stage: "preflight",
+        },
+        CatalogEntry {
+            path: "hello-world",
+            summary: "Smoke-test: scripted model + local env writes a trajectory",
+            cost_tier: "free",
+            stage: "preflight",
+        },
+        CatalogEntry {
+            path: "mini",
+            summary: "Run one task end-to-end and write a trajectory",
+            cost_tier: "paid",
+            stage: "run",
+        },
+        CatalogEntry {
+            path: "replay",
+            summary: "Replay an existing trajectory using a deterministic model",
+            cost_tier: "free",
+            stage: "inspect",
+        },
+        CatalogEntry {
+            path: "ui",
+            summary: "Serve a read-only local sweep browser",
+            cost_tier: "free",
+            stage: "publish",
+        },
+        // Agent subcommands
+        CatalogEntry {
+            path: "agent apply",
+            summary: "Apply a captured patch artifact to a working tree",
+            cost_tier: "free",
+            stage: "run",
+        },
+        CatalogEntry {
+            path: "agent env preview",
+            summary: "Preview environment configuration for a task without running anything",
+            cost_tier: "free",
+            stage: "preflight",
+        },
+        CatalogEntry {
+            path: "agent policy-check",
+            summary: "Check a command corpus against the policy config",
+            cost_tier: "free",
+            stage: "preflight",
+        },
+        CatalogEntry {
+            path: "agent redact-audit",
+            summary: "Audit a finished sweep tree for secret leaks in stored artifacts",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "agent redact-check",
+            summary: "Verify the secret-redaction config against sample input",
+            cost_tier: "free",
+            stage: "preflight",
+        },
+        CatalogEntry {
+            path: "agent skills-preview",
+            summary: "Preview which skills will activate for one or more tasks",
+            cost_tier: "free",
+            stage: "preflight",
+        },
+        CatalogEntry {
+            path: "agent suite",
+            summary: "Run an operator-defined personal eval task pack",
+            cost_tier: "paid",
+            stage: "run",
+        },
+        // Bench subcommands
+        CatalogEntry {
+            path: "bench annotate add",
+            summary: "Attach persistent operator triage tags and notes to a SWE-bench instance",
+            cost_tier: "free",
+            stage: "inspect",
+        },
+        CatalogEntry {
+            path: "bench annotate list",
+            summary: "List persistent operator triage tags and notes",
+            cost_tier: "free",
+            stage: "inspect",
+        },
+        CatalogEntry {
+            path: "bench annotate rm",
+            summary: "Remove persistent operator triage tags and notes from a SWE-bench instance",
+            cost_tier: "free",
+            stage: "inspect",
+        },
+        CatalogEntry {
+            path: "bench assert",
+            summary: "Evaluate operator-declared SLO rules against completed sweep artifacts and gate CI",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench audit",
+            summary: "Re-derive and verify sweep aggregates against trajectories",
+            cost_tier: "free",
+            stage: "inspect",
+        },
+        CatalogEntry {
+            path: "bench behavior",
+            summary: "Surface agent action-class mix by outcome bucket",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench bisect",
+            summary: "Identify the commit that introduced a resolved-rate regression",
+            cost_tier: "paid",
+            stage: "run",
+        },
+        CatalogEntry {
+            path: "bench budget-fit",
+            summary: "Right-size step, cost, and wallclock caps from completed sweep distributions",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench bundle",
+            summary: "Export or verify a portable, redacted sweep archive",
+            cost_tier: "free",
+            stage: "publish",
+        },
+        CatalogEntry {
+            path: "bench cache-stats",
+            summary: "Surface prompt-cache hit rate, savings, and spend for a completed sweep",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench calibrate",
+            summary: "Compare a forecast artifact against completed sweep results",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench cascade",
+            summary: "Cost-optimized model-tier routing per instance",
+            cost_tier: "paid",
+            stage: "run",
+        },
+        CatalogEntry {
+            path: "bench command-stats",
+            summary: "Aggregate shell-command frequency and cost by outcome bucket",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench compare",
+            summary: "Diff two completed sweep runs by instance id",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench contamination-check",
+            summary: "Score each resolved instance for training-leakage risk using deterministic trajectory signals",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench dataset-stats",
+            summary: "Preview SWE-bench dataset composition offline and zero-cost before running a sweep",
+            cost_tier: "free",
+            stage: "preflight",
+        },
+        CatalogEntry {
+            path: "bench diff-config",
+            summary: "Diff two completed sweep manifests to analyze configuration drift",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench doctor",
+            summary: "Validate sweep inputs without launching tasks",
+            cost_tier: "free",
+            stage: "preflight",
+        },
+        CatalogEntry {
+            path: "bench eval-flake",
+            summary: "Quantify evaluator-side verdict noise by replaying the evaluator N times per patch",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench evaluate",
+            summary: "Evaluate a completed sweep with an evaluation backend",
+            cost_tier: "free",
+            stage: "run",
+        },
+        CatalogEntry {
+            path: "bench evaluator-selftest",
+            summary: "Verify the evaluator pipeline using gold patches as a zero-cost preflight",
+            cost_tier: "free",
+            stage: "preflight",
+        },
+        CatalogEntry {
+            path: "bench export-ci",
+            summary: "Export a completed sweep as JUnit XML and/or GitHub Actions annotations",
+            cost_tier: "free",
+            stage: "publish",
+        },
+        CatalogEntry {
+            path: "bench failure-digest",
+            summary: "Emit a self-contained failure summary for one instance in a completed sweep",
+            cost_tier: "free",
+            stage: "inspect",
+        },
+        CatalogEntry {
+            path: "bench forecast",
+            summary: "Forecast sweep cost from a reproducible calibration slice",
+            cost_tier: "paid",
+            stage: "preflight",
+        },
+        CatalogEntry {
+            path: "bench fork",
+            summary: "Fork a trajectory at step N and continue with config overrides",
+            cost_tier: "paid",
+            stage: "run",
+        },
+        CatalogEntry {
+            path: "bench frontier",
+            summary: "Pareto frontier across multiple sweep runs: ASCII chart + JSON dataset",
+            cost_tier: "free",
+            stage: "publish",
+        },
+        CatalogEntry {
+            path: "bench grep",
+            summary: "Search every trajectory in a sweep for a regex pattern",
+            cost_tier: "free",
+            stage: "inspect",
+        },
+        CatalogEntry {
+            path: "bench import",
+            summary: "Ingest an external predictions file and materialise it as a normalised sweep directory",
+            cost_tier: "free",
+            stage: "inspect",
+        },
+        CatalogEntry {
+            path: "bench inspect",
+            summary: "Inspect a single trajectory or list filtered instance summaries",
+            cost_tier: "free",
+            stage: "inspect",
+        },
+        CatalogEntry {
+            path: "bench instance-history",
+            summary: "Join historical sweeps on instance_id and report resolution history",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench ladder",
+            summary: "Resolved-rate and cost trend across sweeps in a root directory",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench matrix",
+            summary: "Run multiple sweep arms against the same instance set",
+            cost_tier: "paid",
+            stage: "run",
+        },
+        CatalogEntry {
+            path: "bench near-miss",
+            summary: "Rank unresolved sweep instances by gold-patch proximity",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench policy-impact",
+            summary: "Measure sweep policy impact on outcomes",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench power",
+            summary: "Calculate statistical power or required sample size",
+            cost_tier: "free",
+            stage: "preflight",
+        },
+        CatalogEntry {
+            path: "bench rehearsal",
+            summary: "Walk the full sweep pipeline end-to-end at zero cost using gold-patch shadow submissions",
+            cost_tier: "free",
+            stage: "preflight",
+        },
+        CatalogEntry {
+            path: "bench report",
+            summary: "Produce a shareable markdown or HTML sweep summary",
+            cost_tier: "free",
+            stage: "publish",
+        },
+        CatalogEntry {
+            path: "bench reproduce",
+            summary: "Replay a saved sweep from its manifest and report reproducibility",
+            cost_tier: "paid",
+            stage: "run",
+        },
+        CatalogEntry {
+            path: "bench retry",
+            summary: "Re-run only the failed instances of a completed sweep and merge results",
+            cost_tier: "paid",
+            stage: "run",
+        },
+        CatalogEntry {
+            path: "bench scriptability-check",
+            summary: "Probe every configured MCP server and dry-run every configured hook before any model call",
+            cost_tier: "free",
+            stage: "preflight",
+        },
+        CatalogEntry {
+            path: "bench self-check",
+            summary: "Score agent self-verdict against the evaluator",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench stagnation-report",
+            summary: "Surface looped-action signatures across a sweep",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench swebench",
+            summary: "Run a SWE-bench sweep over a local JSONL dataset",
+            cost_tier: "paid",
+            stage: "run",
+        },
+        CatalogEntry {
+            path: "bench tail",
+            summary: "Tail live aggregate progress for a running sweep directory",
+            cost_tier: "free",
+            stage: "inspect",
+        },
+        CatalogEntry {
+            path: "bench test-progress",
+            summary: "Compute per-test partial-credit scores across a completed sweep",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench tool-ablation",
+            summary: "Systematic per-tool removal ablation: baseline plus one arm per removed tool",
+            cost_tier: "paid",
+            stage: "run",
+        },
+        CatalogEntry {
+            path: "bench tool-coverage",
+            summary: "Measure MCP tool usage and correlate with outcome across a sweep",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench triage",
+            summary: "Cluster unresolved sweep failures into ranked actionable groups",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench triage-diff",
+            summary: "Diff failure-cluster composition between two sweeps",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
+            path: "bench watch",
+            summary: "Attach to a single in-flight instance and stream its turns live",
+            cost_tier: "free",
+            stage: "inspect",
+        },
+    ]
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub fn run_catalog(cmd: CatalogCmd) -> Result<(), Error> {
+    // 1. Filter entries
+    let mut filtered: Vec<CatalogEntry> = entries()
+        .iter()
+        .filter(|e| {
+            if cmd.free_only && e.cost_tier != "free" {
+                return false;
+            }
+            if let Some(ref s) = cmd.stage {
+                if e.stage != s {
+                    return false;
+                }
+            }
+            true
+        })
+        .cloned()
+        .collect();
+
+    // Sort by path for stable output
+    filtered.sort_by_key(|e| e.path);
+
+    if cmd.format == "json" {
+        let resp = JsonCatalogResponse {
+            schema_version: "1.0",
+            commands: filtered,
+        };
+        let json_str = serde_json::to_string_pretty(&resp)
+            .map_err(|e| Error::Config(crate::error::ConfigError::Invalid(e.to_string())))?;
+        println!("{json_str}");
+    } else {
+        // Text grouped by stage
+        let stages_in_order = ["preflight", "run", "inspect", "analyze", "publish"];
+        let mut first = true;
+        for stage in stages_in_order {
+            let stage_entries: Vec<&CatalogEntry> =
+                filtered.iter().filter(|e| e.stage == stage).collect();
+            if stage_entries.is_empty() {
+                continue;
+            }
+
+            if !first {
+                println!();
+            }
+            first = false;
+
+            println!("Stage: {stage}");
+            let mut table = Table::new();
+            table
+                .load_preset(UTF8_FULL)
+                .apply_modifier(UTF8_ROUND_CORNERS)
+                .set_header(vec!["Command Path", "Job-to-be-Done Summary", "Cost Tier"]);
+
+            for e in stage_entries {
+                table.add_row(vec![e.path, e.summary, e.cost_tier]);
+            }
+            println!("{table}");
+        }
+    }
+
+    Ok(())
+}

--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -3,12 +3,14 @@ use crate::error::Error;
 use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 use serde::Serialize;
 
+pub const STAGES: &[&str] = &["preflight", "run", "inspect", "analyze", "publish"];
+
 #[derive(Clone, Serialize)]
 pub struct CatalogEntry {
     pub path: &'static str,
     pub summary: &'static str,
     pub cost_tier: &'static str, // "free" or "paid"
-    pub stage: &'static str,     // "preflight", "run", "inspect", "analyze", "publish"
+    pub stage: &'static str,
 }
 
 #[derive(Serialize)]
@@ -436,11 +438,10 @@ pub fn run_catalog(cmd: CatalogCmd) -> Result<(), Error> {
         println!("{json_str}");
     } else {
         // Text grouped by stage
-        let stages_in_order = ["preflight", "run", "inspect", "analyze", "publish"];
         let mut first = true;
-        for stage in stages_in_order {
+        for stage in STAGES {
             let stage_entries: Vec<&CatalogEntry> =
-                filtered.iter().filter(|e| e.stage == stage).collect();
+                filtered.iter().filter(|e| e.stage == *stage).collect();
             if stage_entries.is_empty() {
                 continue;
             }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,6 +16,7 @@ use crate::error::Error;
 use crate::exit_code::ExitCode;
 
 pub mod args;
+pub mod catalog;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -53,6 +54,8 @@ pub enum Command {
     },
     /// Serve a read-only local sweep browser (requires the `ui-server` feature).
     Ui(args::UiCmd),
+    /// Self-describing command catalog for operator discoverability.
+    Catalog(args::CatalogCmd),
     /// Reap leftover Maxwell's Daemon containers, including legacy labels.
     Cleanup,
 }
@@ -143,6 +146,7 @@ pub async fn run() -> Result<(), Error> {
             args::AgentCmd::PolicyCheck(p) => agent_policy_check_cmd(&p),
             args::AgentCmd::Apply(a) => agent_apply_cmd(&a),
         },
+        Command::Catalog(c) => catalog::run_catalog(c),
         Command::Ui(u) => ui_cmd(u).await,
         #[cfg(feature = "docker")]
         Command::Cleanup => cleanup_cmd().await,

--- a/tests/catalog_coverage.rs
+++ b/tests/catalog_coverage.rs
@@ -51,10 +51,8 @@ fn test_catalog_subcommand_coverage() {
 fn test_catalog_entry_metadata_validity() {
     let entries = catalog::entries();
     for entry in entries {
-        // Valid stages: preflight, run, inspect, analyze, publish
-        let valid_stages = ["preflight", "run", "inspect", "analyze", "publish"];
         assert!(
-            valid_stages.contains(&entry.stage),
+            catalog::STAGES.contains(&entry.stage),
             "Invalid stage '{}' for command '{}'",
             entry.stage,
             entry.path
@@ -94,8 +92,8 @@ fn test_catalog_filtering() {
     assert!(has_paid, "Catalog must contain at least one paid command");
 
     // Verify we have all stages represented
-    for stage in ["preflight", "run", "inspect", "analyze", "publish"] {
-        let has_stage = entries.iter().any(|e| e.stage == stage);
+    for stage in catalog::STAGES {
+        let has_stage = entries.iter().any(|e| e.stage == *stage);
         assert!(
             has_stage,
             "Catalog must contain at least one command in stage '{stage}'"
@@ -108,6 +106,9 @@ fn collect_executable_paths(
     current_path: &[String],
     paths: &mut Vec<String>,
 ) {
+    if cmd.is_hide_set() {
+        return;
+    }
     // If this command is not the root and has no subcommands, it is a leaf executable command.
     // If it HAS subcommands, it acts as a namespace (e.g. `bench`, `agent`, `agent env`).
     // In our CLI, the namespaces themselves are not directly runnable (they require a subcommand).

--- a/tests/catalog_coverage.rs
+++ b/tests/catalog_coverage.rs
@@ -101,11 +101,7 @@ fn test_catalog_filtering() {
     }
 }
 
-fn collect_executable_paths(
-    cmd: &clap::Command,
-    current_path: &[String],
-    paths: &mut Vec<String>,
-) {
+fn collect_executable_paths(cmd: &clap::Command, current_path: &[String], paths: &mut Vec<String>) {
     if cmd.is_hide_set() {
         return;
     }

--- a/tests/catalog_coverage.rs
+++ b/tests/catalog_coverage.rs
@@ -1,0 +1,124 @@
+#![allow(clippy::unwrap_used)]
+
+use clap::CommandFactory as _;
+use maxwells_daemon::cli::{Cli, catalog};
+
+#[test]
+fn test_catalog_subcommand_coverage() {
+    let root = Cli::command();
+
+    // 1. Traverse clap command tree recursively to find all executable paths.
+    let mut executable_paths = Vec::new();
+    collect_executable_paths(&root, &[], &mut executable_paths);
+
+    // Sort for stable comparison
+    executable_paths.sort();
+
+    // 2. Get all entries in the catalog registry
+    let catalog_entries = catalog::entries();
+    let mut catalog_paths: Vec<String> =
+        catalog_entries.iter().map(|e| e.path.to_string()).collect();
+    catalog_paths.sort();
+
+    // Check for orphans: subcommands compiled but missing from catalog
+    let mut orphans = Vec::new();
+    for path in &executable_paths {
+        if !catalog_paths.contains(path) {
+            orphans.push(path.clone());
+        }
+    }
+
+    // Check for stale entries: in catalog but missing from compiled CLI
+    let mut stale = Vec::new();
+    for path in &catalog_paths {
+        if !executable_paths.contains(path) {
+            stale.push(path.clone());
+        }
+    }
+
+    assert!(
+        orphans.is_empty(),
+        "Orphan subcommands found (compiled in CLI but missing from catalog): {orphans:#?}"
+    );
+
+    assert!(
+        stale.is_empty(),
+        "Stale catalog entries found (referenced in catalog but missing/renamed in CLI): {stale:#?}"
+    );
+}
+
+#[test]
+fn test_catalog_entry_metadata_validity() {
+    let entries = catalog::entries();
+    for entry in entries {
+        // Valid stages: preflight, run, inspect, analyze, publish
+        let valid_stages = ["preflight", "run", "inspect", "analyze", "publish"];
+        assert!(
+            valid_stages.contains(&entry.stage),
+            "Invalid stage '{}' for command '{}'",
+            entry.stage,
+            entry.path
+        );
+
+        // Valid cost tiers: free, paid
+        let valid_costs = ["free", "paid"];
+        assert!(
+            valid_costs.contains(&entry.cost_tier),
+            "Invalid cost tier '{}' for command '{}'",
+            entry.cost_tier,
+            entry.path
+        );
+
+        // One-line summary should be non-empty and not end with a newline or be overly long
+        assert!(
+            !entry.summary.is_empty(),
+            "Summary for '{}' is empty",
+            entry.path
+        );
+        assert!(
+            !entry.summary.contains('\n'),
+            "Summary for '{}' contains newlines",
+            entry.path
+        );
+    }
+}
+
+#[test]
+fn test_catalog_filtering() {
+    let entries = catalog::entries();
+
+    // Verify we have both free and paid commands
+    let has_free = entries.iter().any(|e| e.cost_tier == "free");
+    let has_paid = entries.iter().any(|e| e.cost_tier == "paid");
+    assert!(has_free, "Catalog must contain at least one free command");
+    assert!(has_paid, "Catalog must contain at least one paid command");
+
+    // Verify we have all stages represented
+    for stage in ["preflight", "run", "inspect", "analyze", "publish"] {
+        let has_stage = entries.iter().any(|e| e.stage == stage);
+        assert!(
+            has_stage,
+            "Catalog must contain at least one command in stage '{stage}'"
+        );
+    }
+}
+
+fn collect_executable_paths(
+    cmd: &clap::Command,
+    current_path: &[String],
+    paths: &mut Vec<String>,
+) {
+    // If this command is not the root and has no subcommands, it is a leaf executable command.
+    // If it HAS subcommands, it acts as a namespace (e.g. `bench`, `agent`, `agent env`).
+    // In our CLI, the namespaces themselves are not directly runnable (they require a subcommand).
+    // Let's verify this by checking if the command requires a subcommand.
+    if cmd.get_name() != "max" && cmd.get_subcommands().count() == 0 {
+        paths.push(current_path.join(" "));
+    } else {
+        for sub in cmd.get_subcommands() {
+            let mut next_path = current_path.to_owned();
+            next_path.push(sub.get_name().to_string());
+            collect_executable_paths(sub, &next_path, paths);
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the self-describing command catalog subcommand `max catalog` as specified in issue #495.

### Changes
- Implemented `CatalogCmd` arguments and wired the new subcommand to `mod.rs`.
- Created `catalog.rs` containing a registry of all 63 subcommands (along with their Job-to-be-Done summaries, cost tiers, and stages).
- Added `--format text` using `comfy-table` (grouped by stage in execution sequence) and `--format json` (schema-versioned "1.0", sorted by path for stability).
- Implemented stage and cost-tier filtering.
- Added comprehensive integration tests in `catalog_coverage.rs` programmatically validating CLI subcommand parity against the catalog (enforcing 0 orphans and 0 stale entries as an anti-rot gate).
