### PR TITLE
Add --driver codex support for OpenAI Codex CLI integration

### DIFF
--- a/docs/spec-codex-driver.md
+++ b/docs/spec-codex-driver.md
@@ -1,0 +1,160 @@
+# Spec: `--driver codex` (OpenAI Codex as the agent backend)
+
+Status: experimental (exploration slice).
+
+## Problem
+
+Same motivation as `--driver claude-code` (see `spec-claude-driver.md`): can a
+more capable coding agent drive a task while still producing the same inspectable
+trajectory, patch, cost accounting, and verification output as the built-in loop?
+
+This slice answers "yes" for the **OpenAI Codex CLI** (`codex`), which runs
+tasks in `--full-auto --json` mode. It mirrors the seam design of the Claude Code
+driver: the driver swaps only the loop that fills the trajectory; everything else
+in `mini::run` — provenance manifest, `git diff` patch capture, `--verify`
+verification, redaction, and the final trajectory write — is identical.
+
+## Surface
+
+```
+max mini --driver codex --task "<task>" --workdir <repo> --output <dir>
+```
+
+- `--driver builtin` (default): the native bash-only loop. Unchanged.
+- `--driver claude-code`: drive the `claude` CLI. Unchanged.
+- `--driver codex`: drive the `codex` CLI. **Local environment only.**
+
+## How it works
+
+1. `mini::run` builds the usual `DefaultAgent`, seeding the trajectory with the
+   system + task messages.
+2. `run/codex_driver.rs` spawns:
+
+   ```
+   codex --full-auto --json --max-turns <step_limit> "<task>"
+   ```
+
+   with the child's working directory set to `--workdir` (or the process cwd).
+
+3. It reads the NDJSON stream and records:
+   - `session` → captures `session_id` and `model` for provenance.
+   - `reasoning` → thinking text, folded into an assistant turn's
+     `extra.other["thinking"]`.
+   - `local_shell_call` → one agent step; the `action.command` is recorded as
+     an `extra.actions` label (redacted on the trajectory surface) and the step
+     counter is incremented.
+   - `local_shell_call_output` → observation message carrying a synthesized
+     `extra.run_result` (`exit_code` from `output.exit_code`, output as `stdout`)
+     so consumers that key off it (`bench inspect`, command stats, output-byte
+     telemetry) treat codex driver runs like built-in ones.
+   - `message` (role `assistant`) → assistant text turn, redacted.
+   - `completed` → terminal event: exit reason, `result` string, `cost_usd`,
+     and `usage.{input_tokens, output_tokens}`.
+
+4. Patch capture runs exactly as for the built-in loop: because Codex edits the
+   real working tree, `git diff` sees the change regardless of whether the edit
+   came from a shell command or a file-write operation.
+
+## Stream format
+
+Codex emits newline-delimited JSON events in `--full-auto --json` mode:
+
+```jsonc
+// Init
+{"type":"session","session_id":"sess-abc123","model":"o4-mini"}
+
+// Thinking (optional)
+{"type":"reasoning","content":[{"type":"thinking","text":"..."}]}
+
+// Shell tool call
+{"type":"local_shell_call","id":"lsc_1","action":{"type":"exec","command":"ls","timeout":30000,"working_directory":"."}}
+
+// Shell tool result
+{"type":"local_shell_call_output","id":"lsc_1","output":{"type":"exec_result","output":"file.txt\n","exit_code":0,"metadata":{}}}
+
+// Assistant message
+{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Done."}]}
+
+// Terminal
+{"type":"completed","exit_reason":"done","result":"Done.","cost_usd":0.05,"usage":{"input_tokens":100,"output_tokens":50}}
+```
+
+## Outcome mapping
+
+| Codex `completed.exit_reason` | Trajectory outcome       | `ExitReason`          |
+| ----------------------------- | ------------------------ | --------------------- |
+| `"done"` or `"success"`       | `submitted`              | `Submitted`           |
+| `"max_turns"`                 | `step_limit_reached`     | `StepLimit`           |
+| other                         | `error`                  | (Err, finalized)      |
+| no `completed` event          | `error`                  | (Err, finalized)      |
+| wallclock timeout             | `error` (`wallclock_timeout`) | (Err, finalized) |
+
+`done`/`success` is treated as a submission: the `completed.result` string is
+the `final_output` (falling back to the last assistant text if empty).
+
+## Step counting
+
+Each `local_shell_call` event increments the step counter. This is the closest
+analog to the built-in loop's one-action-per-turn semantics. `--max-turns` passed
+to Codex bounds its own agentic turns; if the parsed shell-call count exceeds
+`agent.step_limit`, the outcome is downgraded to `step_limit` regardless of what
+the `completed` event says.
+
+## Cost & provenance
+
+- Cost is taken verbatim from `completed.cost_usd` and recorded with
+  `actual_cost_source = provider_reported`.
+- Token usage is read from `completed.usage` (`input_tokens`, `output_tokens`).
+- `info.model_name` is overwritten with the model Codex actually used (from the
+  `session` event or a per-message `model` field).
+- A `codex_driver` block under `info.other` records `{driver, session_id}`.
+
+## Toolset recording
+
+`info.other["toolset"]` is overwritten with the Codex `shell` tool so
+tool-coverage/drift reports see the real available set rather than the harness
+bash-only manifest.
+
+## Safety-contract enforcement
+
+Identical to the Claude Code driver — all the same guards apply since Codex also
+runs tools itself and cannot be instrumented mid-action:
+
+- **`--read-only`** rejected.
+- **Interactive confirmation** rejected.
+- **Policy profile** must be `yolo`; custom `extra_deny_patterns` /
+  `extra_allow_patterns` rejected.
+- **Cost caps** re-checked post-hoc: `cost_limit_usd` records `CostLimit`;
+  `per_task_budget_usd` records `BudgetExhausted`.
+- **Cancellation** raced against the stream; child is killed on cancel.
+- **`--resume` / `--continue`** rejected.
+- **`agent.hooks`** rejected.
+- **`environment.chaos_fail_every`** rejected.
+- **`agent.mcp_servers`** rejected.
+- **`agent.detect_stagnation`** rejected.
+- **`environment.timeout_secs` (non-default)** rejected.
+- **Budget-visibility** (`per_task_budget_usd` + `hide_budget_from_agent=false`)
+  rejected.
+- **`agent.tools`** rejected.
+- **`--env docker`** rejected (Codex edits the host tree; no path into a
+  container).
+
+## Testing
+
+The `codex` binary path is overridable via `MAXWELLS_CODEX_BIN`. `tests/codex_driver.rs`
+points it at a fixture shell script that makes a real edit and emits a canned
+NDJSON transcript, exercising the full spawn → parse → finalize → trajectory path
+deterministically at $0. The test suite covers: trajectory validity, docker/
+read-only/interactive/policy/chaos rejection guards, pre-submit test telemetry,
+budget downgrade, stagnation/MCP/resume/timeout rejection, and step-overflow
+downgrade.
+
+## Constraints & non-goals (this slice)
+
+- **Local environment only.** `--driver codex --env docker` is rejected fast.
+- **Model selection is delegated to Codex.** `--model` is not forwarded.
+- **No `--resume` / `--continue`.** Those paths stay on the built-in loop.
+- **No isolated/fidelity modes.** Unlike the Claude Code driver, Codex has no
+  equivalent of `--bare`; there is a single posture (fidelity).
+- **No `--append-system-prompt` equivalent.** Codex's system prompt handling is
+  internal; the harness does not forward the operator system prompt.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -513,9 +513,11 @@ pub struct MiniCmd {
     pub extra_context: Option<String>,
 
     /// Agent backend that drives the loop. `builtin` (default) is the
-    /// bash-first loop that calls the model directly; `claude-code` shells
-    /// out to the Claude Code CLI and translates its stream into the same
-    /// trajectory artifact (local env only). See `docs/spec-claude-driver.md`.
+    /// bash-first loop that calls the model directly; `claude-code` shells out
+    /// to the Claude Code CLI and translates its stream into the same trajectory
+    /// artifact (local env only); `codex` shells out to the OpenAI Codex CLI in
+    /// `--full-auto --json` mode (local env only). See `docs/spec-claude-driver.md`
+    /// and `docs/spec-codex-driver.md`.
     #[arg(long, value_enum, default_value_t = crate::run::mini::RunDriver::Builtin)]
     pub driver: crate::run::mini::RunDriver,
 

--- a/src/run/codex_driver.rs
+++ b/src/run/codex_driver.rs
@@ -1,0 +1,756 @@
+//! Drive the Codex CLI (`codex`) as the agent backend.
+//!
+//! Similar to `claude_driver.rs`, this module lets an operator point the *same*
+//! run machinery at the OpenAI Codex CLI instead of the built-in bash-first loop.
+//! `codex` runs in `--full-auto --json` mode; we read its newline-delimited JSON
+//! stream and translate each event into the harness [`Trajectory`] format so that
+//! patch capture, verification, `bench inspect`, and evaluation all keep working
+//! unchanged.
+//!
+//! ## Seam
+//!
+//! [`drive`] takes a fully-built [`DefaultAgent`] — which already owns the
+//! environment, redactor, and a trajectory seeded with the system + task messages
+//! — and fills in the rest from Codex's stream, returning the same [`ExitReason`]
+//! the built-in loop would.
+//!
+//! ## Stream format
+//!
+//! Codex emits NDJSON events in `--full-auto --json` mode:
+//! - `"session"`: init event carrying `session_id`, `model`, and `tools`.
+//! - `"reasoning"`: extended thinking blocks (`content[].text`).
+//! - `"local_shell_call"`: a shell tool invocation (the `action.command` field).
+//! - `"local_shell_call_output"`: result of a shell call (`output.output`,
+//!   `output.exit_code`), paired with the call by `id`.
+//! - `"message"`: assistant text (`content[].text` for `output_text` blocks).
+//! - `"completed"`: terminal event with `exit_reason`, `result`, `cost_usd`, and
+//!   `usage.{input_tokens, output_tokens}`.
+//!
+//! ## Scope
+//!
+//! - Local environment only (Codex edits the host working tree directly).
+//! - Cost and tokens come from the `completed` event (`CostSource::ProviderReported`).
+//! - Model selection is delegated to Codex; the actually-responding model is
+//!   recorded back into the trajectory.
+//! - The `codex` binary path is overridable via `MAXWELLS_CODEX_BIN` so the
+//!   parser can be exercised deterministically at $0 with a fixture script.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+
+use crate::agent::default::truncate_observation_text;
+use crate::agent::{DefaultAgent, ExitReason};
+use crate::cost::CostSource;
+use crate::error::Error;
+use crate::model::{Message, MessageExtra};
+use crate::redaction::surface;
+use crate::stream::StreamEvent;
+use crate::trajectory::{
+    FailureCategory, TestCommandPattern, TestInvocation, TokenUsage, detect_test_command,
+    effective_test_command_patterns, outcome,
+};
+
+/// Environment variable that overrides the `codex` binary path. Used by tests
+/// to substitute a deterministic fixture script.
+const CODEX_BIN_ENV: &str = "MAXWELLS_CODEX_BIN";
+
+/// Grace period for `child.wait()` after the stream closes. Covers normal
+/// cleanup; exceeded → kill and continue with whatever was parsed.
+const WAIT_GRACE_SECS: Duration = Duration::from_secs(30);
+
+/// A shell call seen in a `local_shell_call` event, awaiting its
+/// `local_shell_call_output` so the pass/fail outcome can be paired by `id`.
+struct PendingShellCall {
+    command: String,
+    step_index: u32,
+    matched_pattern: String,
+}
+
+/// Aggregated state pulled out of the Codex stream.
+#[derive(Default)]
+struct Parsed {
+    /// Number of shell tool invocations — the closest analog to "agent steps".
+    steps: u32,
+    /// Model name Codex actually used (from `session` or per-message field).
+    model: Option<String>,
+    /// Session id, recorded for provenance.
+    session_id: Option<String>,
+    /// Terminal `completed` event, if one was emitted.
+    result: Option<CompletedMsg>,
+    /// Shell calls awaiting their output, keyed by `id`.
+    pending_calls: HashMap<String, PendingShellCall>,
+    /// Completed test invocations, paired with their result exit status.
+    test_invocations: Vec<TestInvocation>,
+    /// Accumulated assistant text from `message` events (last non-empty wins
+    /// as final_output on the submitted path).
+    last_assistant_text: String,
+}
+
+struct CompletedMsg {
+    exit_reason: String,
+    result: String,
+    cost_usd: f64,
+    input_tokens: u64,
+    output_tokens: u64,
+}
+
+/// Drive a single run through the Codex CLI, filling `agent.trajectory` and
+/// returning the terminal [`ExitReason`].
+///
+/// `workdir` is the directory `codex` runs in (and where edits land). When
+/// `None`, the current process directory is used.
+pub async fn drive(
+    agent: &mut DefaultAgent,
+    task: String,
+    extra_context: Option<&str>,
+    workdir: Option<&Path>,
+    timeout_secs: Option<u64>,
+) -> Result<ExitReason, Error> {
+    let bin = std::env::var(CODEX_BIN_ENV).unwrap_or_else(|_| "codex".to_owned());
+    let cwd = match workdir {
+        Some(p) => p.to_path_buf(),
+        None => std::env::current_dir()?,
+    };
+    let step_limit = agent.config.root.agent.step_limit;
+
+    // Fold any merged extra-context / active-skill guidance into the prompt.
+    let prompt = match extra_context {
+        Some(ctx) if !ctx.trim().is_empty() => format!("{task}\n\n{ctx}"),
+        _ => task.clone(),
+    };
+
+    let mut cancel = agent.cancellation.clone();
+
+    if cancel
+        .as_ref()
+        .is_some_and(crate::env::CancellationToken::is_cancelled)
+    {
+        return Ok(ExitReason::UserInterrupt);
+    }
+
+    // Stamp the toolset with the Codex shell tool so tool-coverage reports
+    // don't mistake it as unavailable.
+    record_codex_toolset(agent);
+
+    let mut cmd = Command::new(&bin);
+    cmd.kill_on_drop(true)
+        .arg("--full-auto")
+        .arg("--json")
+        .arg("--max-turns")
+        .arg(step_limit.to_string())
+        .arg(&prompt);
+
+    cmd.current_dir(&cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    tracing::info!(
+        bin = %bin,
+        cwd = %cwd.display(),
+        max_turns = step_limit,
+        "spawning Codex driver"
+    );
+
+    let mut child = cmd.spawn().map_err(|e| {
+        Error::Trajectory(format!(
+            "failed to spawn `{bin}` for --driver codex: {e}"
+        ))
+    })?;
+
+    // Drain stderr concurrently so a chatty child can never deadlock us.
+    let stderr_handle = child.stderr.take().map(|stderr| {
+        tokio::spawn(async move {
+            use tokio::io::AsyncReadExt;
+            const CAP: usize = 1024 * 1024;
+            let mut retained: Vec<u8> = Vec::new();
+            let mut tmp = [0u8; 8192];
+            let mut stderr = stderr;
+            loop {
+                match stderr.read(&mut tmp).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        if retained.len() < CAP {
+                            let take = (CAP - retained.len()).min(n);
+                            retained.extend_from_slice(&tmp[..take]);
+                        }
+                    }
+                }
+            }
+            String::from_utf8_lossy(&retained).into_owned()
+        })
+    });
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| Error::Trajectory("codex child has no stdout pipe".into()))?;
+    let timeout_dur = timeout_secs.map(Duration::from_secs);
+    let run_start = Instant::now();
+
+    let outcome = {
+        let process = process_stream(agent, stdout);
+        tokio::pin!(process);
+        tokio::select! {
+            res = &mut process => Outcome::Stream(Box::new(res)),
+            () = async {
+                match timeout_dur {
+                    Some(d) => tokio::time::sleep(d).await,
+                    None => std::future::pending::<()>().await,
+                }
+            } => Outcome::Timeout,
+            () = async {
+                match cancel.as_mut() {
+                    Some(c) => c.cancelled().await,
+                    None => std::future::pending::<()>().await,
+                }
+            } => Outcome::Cancelled,
+        }
+    };
+
+    let parsed = match outcome {
+        Outcome::Stream(res) => (*res)?,
+        Outcome::Timeout => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            let dur = timeout_dur.unwrap_or_default();
+            agent.finalize_wallclock_timeout(dur);
+            return Err(Error::Trajectory(format!(
+                "task wallclock timeout after {}s (codex driver)",
+                dur.as_secs()
+            )));
+        }
+        Outcome::Cancelled => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            return Ok(ExitReason::UserInterrupt);
+        }
+    };
+
+    let wait_deadline = timeout_dur.map_or(WAIT_GRACE_SECS, |d| {
+        d.saturating_sub(run_start.elapsed()).min(WAIT_GRACE_SECS)
+    });
+    let exit_code = if let Ok(Ok(status)) = tokio::time::timeout(wait_deadline, child.wait()).await
+    {
+        status.code()
+    } else {
+        let _ = child.start_kill();
+        None
+    };
+
+    let stderr_text = match stderr_handle {
+        Some(h) => h.await.unwrap_or_default(),
+        None => String::new(),
+    };
+
+    finalize(agent, parsed, step_limit, exit_code, &stderr_text)
+}
+
+/// How the streaming race resolved.
+enum Outcome {
+    Stream(Box<Result<Parsed, Error>>),
+    Timeout,
+    Cancelled,
+}
+
+/// Overwrite `info.other["toolset"]` with the Codex shell tool, so
+/// tool-coverage/drift reports treat it as available rather than missing.
+fn record_codex_toolset(agent: &mut DefaultAgent) {
+    let tools = vec![serde_json::json!({
+        "name": "shell",
+        "description": "Codex CLI shell tool",
+        "source": "codex",
+    })];
+    agent
+        .trajectory
+        .info
+        .other
+        .insert("toolset".into(), serde_json::json!({ "tools": tools }));
+}
+
+/// Atomically persist a `partial: true` checkpoint when a checkpoint path is
+/// configured, mirroring the built-in loop's per-turn write.
+fn maybe_checkpoint(agent: &mut DefaultAgent, steps: u32) {
+    if let Some(path) = agent.checkpoint_path.clone() {
+        agent.trajectory.info.steps = Some(steps);
+        agent.trajectory.info.actual_cost_usd = Some(agent.total_cost_usd);
+        if let Err(e) = agent.trajectory.save_partial_atomic(&path) {
+            tracing::warn!(error = %e, "codex driver checkpoint write failed; continuing");
+        }
+    }
+}
+
+/// Read the NDJSON stream from the child's `stdout`, recording turns and tool
+/// events into the trajectory as they arrive.
+async fn process_stream(
+    agent: &mut DefaultAgent,
+    stdout: tokio::process::ChildStdout,
+) -> Result<Parsed, Error> {
+    let test_patterns = effective_test_command_patterns(
+        &agent.config.root.agent.test_command_patterns,
+        agent.config.root.agent.test_command_patterns_replace,
+    )
+    .unwrap_or_default();
+
+    let mut lines = BufReader::new(stdout).lines();
+    let mut parsed = Parsed::default();
+
+    while let Some(line) = lines.next_line().await? {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(msg) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        match msg.get("type").and_then(Value::as_str) {
+            Some("session") => handle_session(&mut parsed, &msg),
+            Some("reasoning") => handle_reasoning(agent, &mut parsed, &msg),
+            Some("local_shell_call") => {
+                handle_local_shell_call(agent, &mut parsed, &msg, &test_patterns);
+            }
+            Some("local_shell_call_output") => {
+                handle_local_shell_call_output(agent, &mut parsed, &msg);
+                maybe_checkpoint(agent, parsed.steps);
+            }
+            Some("message") => handle_message(agent, &mut parsed, &msg),
+            Some("completed") => parsed.result = Some(parse_completed(&msg)),
+            _ => {}
+        }
+    }
+
+    Ok(parsed)
+}
+
+fn handle_session(parsed: &mut Parsed, msg: &Value) {
+    parsed.session_id = msg
+        .get("session_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    parsed.model = msg
+        .get("model")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+}
+
+/// Record a `reasoning` event as a thinking-only assistant turn.
+fn handle_reasoning(agent: &mut DefaultAgent, _parsed: &mut Parsed, msg: &Value) {
+    let thinking = msg
+        .get("content")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|b| b.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+
+    if thinking.is_empty() {
+        return;
+    }
+
+    let thinking = agent
+        .redactor
+        .redact_text(&thinking, surface::MODEL_OBSERVATION)
+        .text;
+
+    let ts = chrono::Utc::now().to_rfc3339();
+    let mut extra = MessageExtra {
+        timestamp: Some(ts),
+        ..Default::default()
+    };
+    extra
+        .other
+        .insert("thinking".into(), Value::String(thinking));
+    agent
+        .trajectory
+        .record_with_extra(&Message::assistant(String::new()), extra);
+}
+
+/// Record a `local_shell_call` as an agent step with an action label.
+fn handle_local_shell_call(
+    agent: &mut DefaultAgent,
+    parsed: &mut Parsed,
+    msg: &Value,
+    test_patterns: &[TestCommandPattern],
+) {
+    let id = msg.get("id").and_then(Value::as_str).unwrap_or("");
+    let command = msg
+        .get("action")
+        .and_then(|a| a.get("command"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+
+    if command.is_empty() {
+        return;
+    }
+
+    parsed.steps += 1;
+    agent.steps = parsed.steps;
+
+    if !id.is_empty() {
+        if let Some(matched) = detect_test_command(command, test_patterns) {
+            parsed.pending_calls.insert(
+                id.to_owned(),
+                PendingShellCall {
+                    command: command.to_owned(),
+                    step_index: parsed.steps - 1,
+                    matched_pattern: matched,
+                },
+            );
+        }
+    }
+
+    let action_label = agent
+        .redactor
+        .redact_text(command, surface::TRAJECTORY)
+        .text;
+
+    let ts = chrono::Utc::now().to_rfc3339();
+    let mut extra = MessageExtra {
+        timestamp: Some(ts.clone()),
+        actions: Some(vec![action_label.clone()]),
+        ..Default::default()
+    };
+    // Propagate model if we have it.
+    if let Some(m) = parsed.model.clone() {
+        extra
+            .other
+            .insert("model".into(), Value::String(m));
+    }
+    agent
+        .trajectory
+        .record_with_extra(&Message::assistant(String::new()), extra);
+    agent.stream.emit(StreamEvent::AssistantMessage {
+        step: parsed.steps,
+        content: action_label,
+        cost_usd: None,
+        timestamp: ts,
+    });
+}
+
+/// Record a `local_shell_call_output` as an observation, and pair any test
+/// results into pre-submit test telemetry.
+fn handle_local_shell_call_output(agent: &mut DefaultAgent, parsed: &mut Parsed, msg: &Value) {
+    let id = msg.get("id").and_then(Value::as_str).unwrap_or("");
+    let output_obj = msg.get("output");
+
+    let raw_output = output_obj
+        .and_then(|o| o.get("output"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let exit_code = output_obj
+        .and_then(|o| o.get("exit_code"))
+        .and_then(Value::as_i64)
+        .unwrap_or(0) as i32;
+
+    // Pair with any pending test command.
+    if !id.is_empty() {
+        if let Some(pending) = parsed.pending_calls.remove(id) {
+            let command = agent
+                .redactor
+                .redact_text(&pending.command, surface::TRAJECTORY)
+                .text;
+            parsed.test_invocations.push(TestInvocation {
+                step_index: pending.step_index,
+                command,
+                exit_code,
+                matched_pattern: pending.matched_pattern,
+            });
+        }
+    }
+
+    // Redact then truncate, matching the built-in loop's order.
+    let redacted_raw = agent
+        .redactor
+        .redact_text(raw_output, surface::MODEL_OBSERVATION)
+        .text;
+    let redacted = truncate_observation_text(
+        &redacted_raw,
+        agent.config.root.agent.observation_max_bytes,
+        agent.config.root.agent.observation_head_ratio,
+    )
+    .text;
+
+    let ts = chrono::Utc::now().to_rfc3339();
+    let has_error = exit_code != 0;
+    let mut extra = MessageExtra {
+        timestamp: Some(ts.clone()),
+        ..Default::default()
+    };
+    if has_error {
+        extra.other.insert("tool_error".into(), Value::Bool(true));
+    }
+    let run_result = crate::env::RunResult {
+        stdout: redacted_raw,
+        stderr: String::new(),
+        exit_code,
+        timed_out: false,
+    };
+    extra.other.insert(
+        "run_result".into(),
+        serde_json::to_value(&run_result).unwrap_or(Value::Null),
+    );
+    agent
+        .trajectory
+        .record_with_extra(&Message::user(redacted.clone()), extra);
+    agent.stream.emit(StreamEvent::Observation {
+        step: parsed.steps,
+        content: redacted,
+        timestamp: ts,
+    });
+}
+
+/// Record a `message` event (assistant text turn) into the trajectory.
+fn handle_message(agent: &mut DefaultAgent, parsed: &mut Parsed, msg: &Value) {
+    if msg.get("role").and_then(Value::as_str) != Some("assistant") {
+        return;
+    }
+    let text = msg
+        .get("content")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter(|b| b.get("type").and_then(Value::as_str) == Some("output_text"))
+                .filter_map(|b| b.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+
+    if text.is_empty() {
+        return;
+    }
+
+    if let Some(m) = msg.get("model").and_then(Value::as_str) {
+        parsed.model = Some(m.to_owned());
+    }
+
+    let redacted = agent
+        .redactor
+        .redact_text(&text, surface::MODEL_OBSERVATION)
+        .text;
+    parsed.last_assistant_text = redacted.clone();
+
+    let ts = chrono::Utc::now().to_rfc3339();
+    let extra = MessageExtra {
+        timestamp: Some(ts.clone()),
+        ..Default::default()
+    };
+    agent
+        .trajectory
+        .record_with_extra(&Message::assistant(redacted.clone()), extra);
+    agent.stream.emit(StreamEvent::AssistantMessage {
+        step: parsed.steps,
+        content: redacted,
+        cost_usd: None,
+        timestamp: ts,
+    });
+}
+
+fn parse_completed(msg: &Value) -> CompletedMsg {
+    let usage = msg.get("usage");
+    let u = |k: &str| -> u64 {
+        usage
+            .and_then(|x| x.get(k))
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+    };
+    CompletedMsg {
+        exit_reason: msg
+            .get("exit_reason")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_owned(),
+        result: msg
+            .get("result")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_owned(),
+        cost_usd: msg
+            .get("cost_usd")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0),
+        input_tokens: u("input_tokens"),
+        output_tokens: u("output_tokens"),
+    }
+}
+
+/// Stamp the trajectory with cost/tokens/outcome from the parsed stream and
+/// return the terminal [`ExitReason`].
+#[allow(clippy::too_many_lines)]
+fn finalize(
+    agent: &mut DefaultAgent,
+    mut parsed: Parsed,
+    step_limit: u32,
+    exit_code: Option<i32>,
+    stderr_text: &str,
+) -> Result<ExitReason, Error> {
+    // Provenance block identifies the backend + session.
+    if let Some(model) = parsed.model.clone() {
+        agent.trajectory.info.model_name = Some(model);
+    }
+    let mut driver_meta = serde_json::Map::new();
+    driver_meta.insert("driver".into(), Value::String("codex".into()));
+    if let Some(s) = parsed.session_id {
+        driver_meta.insert("session_id".into(), Value::String(s));
+    }
+    agent
+        .trajectory
+        .info
+        .other
+        .insert("codex_driver".into(), Value::Object(driver_meta));
+
+    let Some(result) = parsed.result else {
+        let snippet = agent
+            .redactor
+            .redact_text(stderr_text.trim(), surface::TRAJECTORY)
+            .text;
+        return Err(Error::Trajectory(format!(
+            "codex driver produced no completed event (exit {:?}): {}",
+            exit_code,
+            truncate(&snippet, 500)
+        )));
+    };
+
+    agent.steps = parsed.steps;
+    agent.total_cost_usd = result.cost_usd;
+    agent.actual_cost_source = Some(CostSource::ProviderReported);
+    agent.prompt_tokens = result.input_tokens;
+    agent.completion_tokens = result.output_tokens;
+
+    agent.trajectory.info.steps = Some(parsed.steps);
+    agent.trajectory.info.total_cost_usd = Some(result.cost_usd);
+    agent.trajectory.info.ended_at = Some(chrono::Utc::now().to_rfc3339());
+    agent.trajectory.info.token_usage = Some(TokenUsage {
+        prompt_tokens: result.input_tokens,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+        completion_tokens: result.output_tokens,
+    });
+
+    let ran_tests = !parsed.test_invocations.is_empty();
+    let last_tests_passed = parsed.test_invocations.last().map(|t| t.exit_code == 0);
+    agent.trajectory.info.test_invocations = std::mem::take(&mut parsed.test_invocations);
+
+    let is_max_turns = result.exit_reason == "max_turns";
+    let is_success = matches!(result.exit_reason.as_str(), "done" | "success");
+
+    let cost_limit_exceeded = agent
+        .config
+        .root
+        .agent
+        .cost_limit_usd
+        .is_some_and(|cap| result.cost_usd >= cap);
+    let budget_exhausted = !cost_limit_exceeded
+        && agent
+            .config
+            .root
+            .agent
+            .per_task_budget_usd
+            .is_some_and(|cap| result.cost_usd >= cap);
+
+    let step_overflow = parsed.steps > step_limit;
+
+    if is_success && !cost_limit_exceeded && !budget_exhausted && !step_overflow {
+        // Use the `result` field from `completed` as final output; fall back
+        // to the last assistant text turn if the field is empty.
+        let raw_final = if result.result.is_empty() {
+            parsed.last_assistant_text.clone()
+        } else {
+            result.result.clone()
+        };
+        let final_output = agent
+            .redactor
+            .redact_text(&raw_final, surface::TRAJECTORY)
+            .text;
+        agent.trajectory.info.exit_reason = Some("submitted".into());
+        agent.trajectory.info.failure_category = None;
+        agent.trajectory.info.final_output = Some(final_output.clone());
+        agent.finalize_run_metadata(outcome::SUBMITTED);
+        if ran_tests {
+            agent.trajectory.info.tests_run_before_submit = true;
+            agent.trajectory.info.last_tests_passed = last_tests_passed;
+        }
+        emit_ended(agent, "submitted", None, Some(final_output.clone()));
+        Ok(ExitReason::Submitted { final_output })
+    } else if cost_limit_exceeded {
+        let limit_usd = agent.config.root.agent.cost_limit_usd.unwrap_or(0.0);
+        agent.trajectory.info.exit_reason = Some("cost_limit".into());
+        agent.trajectory.info.failure_category = Some(FailureCategory::CostLimit);
+        agent.finalize_run_metadata(outcome::STEP_LIMIT_REACHED);
+        emit_ended(agent, "cost_limit", Some(FailureCategory::CostLimit), None);
+        Ok(ExitReason::CostLimit {
+            limit_usd,
+            spent_usd: result.cost_usd,
+        })
+    } else if budget_exhausted {
+        let limit_usd = agent.config.root.agent.per_task_budget_usd.unwrap_or(0.0);
+        agent.trajectory.info.exit_reason = Some("budget_exhausted".into());
+        agent.trajectory.info.failure_category = Some(FailureCategory::BudgetExhausted);
+        agent.finalize_run_metadata(outcome::BUDGET_EXHAUSTED);
+        emit_ended(
+            agent,
+            "budget_exhausted",
+            Some(FailureCategory::BudgetExhausted),
+            None,
+        );
+        Ok(ExitReason::BudgetExhausted {
+            limit_usd,
+            spent_usd: result.cost_usd,
+        })
+    } else if is_max_turns || step_overflow {
+        agent.trajectory.info.exit_reason = Some("step_limit".into());
+        agent.trajectory.info.failure_category = Some(FailureCategory::StepLimit);
+        agent.finalize_run_metadata(outcome::STEP_LIMIT_REACHED);
+        emit_ended(agent, "step_limit", Some(FailureCategory::StepLimit), None);
+        Ok(ExitReason::StepLimit { limit: step_limit })
+    } else {
+        agent.trajectory.info.exit_reason = Some("error".into());
+        agent
+            .trajectory
+            .info
+            .failure_category
+            .get_or_insert(FailureCategory::AgentInternal);
+        agent.trajectory.info.other.insert(
+            "codex_exit_reason".into(),
+            Value::String(result.exit_reason.clone()),
+        );
+        agent.finalize_run_metadata(outcome::ERROR);
+        Err(Error::Trajectory(format!(
+            "codex driver ended with non-success exit_reason: {}",
+            result.exit_reason
+        )))
+    }
+}
+
+fn emit_ended(
+    agent: &DefaultAgent,
+    exit_reason: &str,
+    failure_category: Option<FailureCategory>,
+    final_output: Option<String>,
+) {
+    agent.stream.emit(StreamEvent::RunEnded {
+        exit_reason: exit_reason.to_owned(),
+        failure_category,
+        final_output,
+        steps: agent.steps,
+        total_cost_usd: agent.total_cost_usd,
+        ended_at: chrono::Utc::now().to_rfc3339(),
+    });
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_owned();
+    }
+    let truncated: String = s.chars().take(max).collect();
+    format!("{truncated}…")
+}

--- a/src/run/codex_driver.rs
+++ b/src/run/codex_driver.rs
@@ -105,6 +105,7 @@ struct CompletedMsg {
 ///
 /// `workdir` is the directory `codex` runs in (and where edits land). When
 /// `None`, the current process directory is used.
+#[allow(clippy::too_many_lines)]
 pub async fn drive(
     agent: &mut DefaultAgent,
     task: String,
@@ -159,9 +160,7 @@ pub async fn drive(
     );
 
     let mut child = cmd.spawn().map_err(|e| {
-        Error::Trajectory(format!(
-            "failed to spawn `{bin}` for --driver codex: {e}"
-        ))
+        Error::Trajectory(format!("failed to spawn `{bin}` for --driver codex: {e}"))
     })?;
 
     // Drain stderr concurrently so a chatty child can never deadlock us.
@@ -240,7 +239,9 @@ pub async fn drive(
     {
         status.code()
     } else {
+        // Timed out or error during wait; kill and reap to avoid a zombie.
         let _ = child.start_kill();
+        let _ = child.wait().await;
         None
     };
 
@@ -320,7 +321,12 @@ async fn process_stream(
                 maybe_checkpoint(agent, parsed.steps);
             }
             Some("message") => handle_message(agent, &mut parsed, &msg),
-            Some("completed") => parsed.result = Some(parse_completed(&msg)),
+            Some("completed") => {
+                parsed.result = Some(parse_completed(&msg));
+                // Terminal event: stop reading; the process will close stdout
+                // shortly and waiting indefinitely risks a hang.
+                break;
+            }
             _ => {}
         }
     }
@@ -421,9 +427,7 @@ fn handle_local_shell_call(
     };
     // Propagate model if we have it.
     if let Some(m) = parsed.model.clone() {
-        extra
-            .other
-            .insert("model".into(), Value::String(m));
+        extra.other.insert("model".into(), Value::String(m));
     }
     agent
         .trajectory
@@ -449,7 +453,8 @@ fn handle_local_shell_call_output(agent: &mut DefaultAgent, parsed: &mut Parsed,
     let exit_code = output_obj
         .and_then(|o| o.get("exit_code"))
         .and_then(Value::as_i64)
-        .unwrap_or(0) as i32;
+        .and_then(|n| i32::try_from(n).ok())
+        .unwrap_or(0);
 
     // Pair with any pending test command.
     if !id.is_empty() {
@@ -537,7 +542,7 @@ fn handle_message(agent: &mut DefaultAgent, parsed: &mut Parsed, msg: &Value) {
         .redactor
         .redact_text(&text, surface::MODEL_OBSERVATION)
         .text;
-    parsed.last_assistant_text = redacted.clone();
+    parsed.last_assistant_text.clone_from(&redacted);
 
     let ts = chrono::Utc::now().to_rfc3339();
     let extra = MessageExtra {
@@ -574,10 +579,7 @@ fn parse_completed(msg: &Value) -> CompletedMsg {
             .and_then(Value::as_str)
             .unwrap_or("")
             .to_owned(),
-        cost_usd: msg
-            .get("cost_usd")
-            .and_then(Value::as_f64)
-            .unwrap_or(0.0),
+        cost_usd: msg.get("cost_usd").and_then(Value::as_f64).unwrap_or(0.0),
         input_tokens: u("input_tokens"),
         output_tokens: u("output_tokens"),
     }
@@ -608,7 +610,14 @@ fn finalize(
         .other
         .insert("codex_driver".into(), Value::Object(driver_meta));
 
-    let Some(result) = parsed.result else {
+    let Some(CompletedMsg {
+        exit_reason,
+        result: result_text,
+        cost_usd,
+        input_tokens,
+        output_tokens,
+    }) = parsed.result
+    else {
         let snippet = agent
             .redactor
             .redact_text(stderr_text.trim(), surface::TRAJECTORY)
@@ -621,51 +630,51 @@ fn finalize(
     };
 
     agent.steps = parsed.steps;
-    agent.total_cost_usd = result.cost_usd;
+    agent.total_cost_usd = cost_usd;
     agent.actual_cost_source = Some(CostSource::ProviderReported);
-    agent.prompt_tokens = result.input_tokens;
-    agent.completion_tokens = result.output_tokens;
+    agent.prompt_tokens = input_tokens;
+    agent.completion_tokens = output_tokens;
 
     agent.trajectory.info.steps = Some(parsed.steps);
-    agent.trajectory.info.total_cost_usd = Some(result.cost_usd);
+    agent.trajectory.info.total_cost_usd = Some(cost_usd);
     agent.trajectory.info.ended_at = Some(chrono::Utc::now().to_rfc3339());
     agent.trajectory.info.token_usage = Some(TokenUsage {
-        prompt_tokens: result.input_tokens,
+        prompt_tokens: input_tokens,
         cache_read_tokens: 0,
         cache_creation_tokens: 0,
-        completion_tokens: result.output_tokens,
+        completion_tokens: output_tokens,
     });
 
     let ran_tests = !parsed.test_invocations.is_empty();
     let last_tests_passed = parsed.test_invocations.last().map(|t| t.exit_code == 0);
     agent.trajectory.info.test_invocations = std::mem::take(&mut parsed.test_invocations);
 
-    let is_max_turns = result.exit_reason == "max_turns";
-    let is_success = matches!(result.exit_reason.as_str(), "done" | "success");
+    let is_max_turns = exit_reason == "max_turns";
+    let is_success = matches!(exit_reason.as_str(), "done" | "success");
 
     let cost_limit_exceeded = agent
         .config
         .root
         .agent
         .cost_limit_usd
-        .is_some_and(|cap| result.cost_usd >= cap);
+        .is_some_and(|cap| cost_usd >= cap);
     let budget_exhausted = !cost_limit_exceeded
         && agent
             .config
             .root
             .agent
             .per_task_budget_usd
-            .is_some_and(|cap| result.cost_usd >= cap);
+            .is_some_and(|cap| cost_usd >= cap);
 
     let step_overflow = parsed.steps > step_limit;
 
     if is_success && !cost_limit_exceeded && !budget_exhausted && !step_overflow {
         // Use the `result` field from `completed` as final output; fall back
         // to the last assistant text turn if the field is empty.
-        let raw_final = if result.result.is_empty() {
-            parsed.last_assistant_text.clone()
+        let raw_final = if result_text.is_empty() {
+            parsed.last_assistant_text
         } else {
-            result.result.clone()
+            result_text
         };
         let final_output = agent
             .redactor
@@ -689,7 +698,7 @@ fn finalize(
         emit_ended(agent, "cost_limit", Some(FailureCategory::CostLimit), None);
         Ok(ExitReason::CostLimit {
             limit_usd,
-            spent_usd: result.cost_usd,
+            spent_usd: cost_usd,
         })
     } else if budget_exhausted {
         let limit_usd = agent.config.root.agent.per_task_budget_usd.unwrap_or(0.0);
@@ -704,7 +713,7 @@ fn finalize(
         );
         Ok(ExitReason::BudgetExhausted {
             limit_usd,
-            spent_usd: result.cost_usd,
+            spent_usd: cost_usd,
         })
     } else if is_max_turns || step_overflow {
         agent.trajectory.info.exit_reason = Some("step_limit".into());
@@ -721,12 +730,11 @@ fn finalize(
             .get_or_insert(FailureCategory::AgentInternal);
         agent.trajectory.info.other.insert(
             "codex_exit_reason".into(),
-            Value::String(result.exit_reason.clone()),
+            Value::String(exit_reason.clone()),
         );
         agent.finalize_run_metadata(outcome::ERROR);
         Err(Error::Trajectory(format!(
-            "codex driver ended with non-success exit_reason: {}",
-            result.exit_reason
+            "codex driver ended with non-success exit_reason: {exit_reason}"
         )))
     }
 }

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -122,6 +122,10 @@ pub enum RunDriver {
     /// as the agent, translating its message stream into the harness
     /// trajectory. Local environment only.
     ClaudeCode,
+    /// Drive the `codex` CLI (OpenAI Codex) in `--full-auto --json` mode as
+    /// the agent, translating its NDJSON event stream into the harness
+    /// trajectory. Local environment only.
+    Codex,
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -575,6 +579,122 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
             // run would be recorded as having capabilities Claude cannot call.
             return Err(Error::Config(ConfigError::Invalid(
                 "--driver claude-code cannot bridge configured command tools \
+                 (agent.tools); the CLI manages its own toolset outside the \
+                 harness registry. Remove agent.tools or switch to --driver builtin"
+                    .into(),
+            )));
+        }
+    }
+
+    // The Codex driver shells out to the host `codex` binary and edits the
+    // host working tree directly. It shares the same safety-contract
+    // limitations as the Claude Code driver: it cannot honor in-process
+    // guards, hooks, or analysis-only postures.
+    if args.driver == RunDriver::Codex {
+        if matches!(args.config.root.environment.kind, EnvKind::Docker) {
+            return Err(Error::Config(ConfigError::Invalid(
+                "--driver codex is only supported with the local environment, \
+                 not --env docker"
+                    .into(),
+            )));
+        }
+        if args.read_only {
+            return Err(Error::Config(ConfigError::Invalid(
+                "--driver codex cannot honor --read-only (it auto-allows \
+                 mutation tools); drop one of the two flags"
+                    .into(),
+            )));
+        }
+        if matches!(
+            args.interactive_mode,
+            InteractiveMode::StderrPrompt | InteractiveMode::Ratatui
+        ) {
+            return Err(Error::Config(ConfigError::Invalid(
+                "--driver codex cannot honor interactive confirmation \
+                 (--interactive/--ui); tool calls would run unattended"
+                    .into(),
+            )));
+        }
+        if args.config.root.policy.profile != "yolo" {
+            return Err(Error::Config(ConfigError::Invalid(format!(
+                "--driver codex cannot enforce the built-in policy deny \
+                 corpus (profile={:?}); the CLI runs tools itself. \
+                 Set policy.profile = \"yolo\" in config to acknowledge this, \
+                 or switch to --driver builtin",
+                args.config.root.policy.profile
+            ))));
+        }
+        if !args.config.root.policy.extra_deny_patterns.is_empty()
+            || !args.config.root.policy.extra_allow_patterns.is_empty()
+        {
+            return Err(Error::Config(ConfigError::Invalid(
+                "--driver codex cannot enforce custom command policy \
+                 (policy.extra_deny_patterns/extra_allow_patterns); the CLI \
+                 runs tools itself"
+                    .into(),
+            )));
+        }
+        if args.resume_from.is_some() || args.continue_from.is_some() {
+            return Err(Error::Config(ConfigError::Invalid(
+                "--driver codex does not support --resume or --continue; \
+                 the external CLI cannot be seeded with prior message history"
+                    .into(),
+            )));
+        }
+        if !args.config.root.agent.hooks.pre_tool_use.is_empty()
+            || !args.config.root.agent.hooks.post_tool_use.is_empty()
+        {
+            return Err(Error::Config(ConfigError::Invalid(
+                "--driver codex cannot run pre/post_tool_use hooks; the \
+                 CLI executes tools outside the harness loop"
+                    .into(),
+            )));
+        }
+        if args.config.root.environment.chaos_fail_every > 0 {
+            return Err(Error::Config(ConfigError::Invalid(
+                "--driver codex cannot inject chaos faults \
+                 (environment.chaos_fail_every); it bypasses the wrapped \
+                 environment"
+                    .into(),
+            )));
+        }
+        if !args.config.root.agent.mcp_servers.is_empty() {
+            return Err(Error::Config(ConfigError::Invalid(
+                "--driver codex cannot bridge MCP server configs; \
+                 the CLI manages its own tool routing outside the harness. \
+                 Remove agent.mcp_servers or switch to --driver builtin"
+                    .into(),
+            )));
+        }
+        if args.config.root.agent.detect_stagnation {
+            return Err(Error::Config(ConfigError::Invalid(
+                "--driver codex cannot enforce stagnation detection; \
+                 set agent.detect_stagnation = false in config, or switch \
+                 to --driver builtin"
+                    .into(),
+            )));
+        }
+        if args.config.root.environment.timeout_secs != DEFAULT_ENV_TIMEOUT_SECS {
+            return Err(Error::Config(ConfigError::Invalid(format!(
+                "--driver codex cannot enforce per-command timeout \
+                 (environment.timeout_secs={}); the CLI runs tools itself. \
+                 Remove the override or switch to --driver builtin",
+                args.config.root.environment.timeout_secs
+            ))));
+        }
+        if args.config.root.agent.per_task_budget_usd.is_some()
+            && !args.config.root.agent.hide_budget_from_agent
+        {
+            return Err(Error::Config(ConfigError::Invalid(
+                "--driver codex cannot append budget-visibility blocks \
+                 (agent.hide_budget_from_agent = false with per_task_budget_usd); \
+                 set hide_budget_from_agent = true or switch to --driver builtin"
+                    .into(),
+            )));
+        }
+        if !args.config.root.agent.tools.is_empty() {
+            return Err(Error::Config(ConfigError::Invalid(
+                "--driver codex cannot bridge configured command tools \
                  (agent.tools); the CLI manages its own toolset outside the \
                  harness registry. Remove agent.tools or switch to --driver builtin"
                     .into(),
@@ -1050,6 +1170,16 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
                 args.task_timeout_secs,
                 system_prompt.as_deref(),
                 args.driver_isolated,
+            )
+            .await
+        }
+        RunDriver::Codex => {
+            crate::run::codex_driver::drive(
+                &mut agent,
+                args.task.clone(),
+                resolved_skills.merged_extra_context.as_deref(),
+                args.local_workdir.as_deref(),
+                args.task_timeout_secs,
             )
             .await
         }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -13,6 +13,7 @@ pub mod cache_stats;
 pub mod calibrate;
 pub mod cascade;
 pub mod claude_driver;
+pub mod codex_driver;
 pub mod command_stats;
 pub mod compare;
 pub mod contamination_check;

--- a/tests/codex_driver.rs
+++ b/tests/codex_driver.rs
@@ -188,7 +188,10 @@ async fn codex_driver_produces_valid_trajectory() {
                 .any(|v| v.as_str() == Some("echo 'line two' >> a.txt"))
         })
     });
-    assert!(shell_action, "expected the shell command recorded as an action");
+    assert!(
+        shell_action,
+        "expected the shell command recorded as an action"
+    );
 
     // The shell output surfaces as a user observation with synthesized run_result.
     let obs = msgs
@@ -200,13 +203,13 @@ async fn codex_driver_produces_valid_trajectory() {
     assert_eq!(rr["timed_out"], false);
 
     // info.toolset reflects the Codex shell tool.
-    let tool_names: Vec<&str> = traj["info"]["toolset"]["tools"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|t| t["name"].as_str().unwrap())
-        .collect();
-    assert!(tool_names.contains(&"shell"));
+    assert!(
+        traj["info"]["toolset"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|t| t["name"].as_str() == Some("shell"))
+    );
 
     // The driver ran `codex` in the repo, so the real edit landed.
     let contents = std::fs::read_to_string(repo.path().join("a.txt")).unwrap();
@@ -223,7 +226,10 @@ async fn codex_driver_rejects_docker_env() {
     args.driver = RunDriver::Codex;
 
     let err = run(args).await.expect_err("docker should be rejected");
-    assert!(err.to_string().contains("local environment"), "unexpected error: {err}");
+    assert!(
+        err.to_string().contains("local environment"),
+        "unexpected error: {err}"
+    );
 }
 
 /// `--driver codex` is rejected with `--read-only`.
@@ -234,7 +240,10 @@ async fn codex_driver_rejects_read_only() {
     args.read_only = true;
 
     let err = run(args).await.expect_err("read-only should be rejected");
-    assert!(err.to_string().contains("read-only"), "unexpected error: {err}");
+    assert!(
+        err.to_string().contains("read-only"),
+        "unexpected error: {err}"
+    );
 }
 
 /// `--driver codex` is rejected with interactive confirmation modes.
@@ -245,7 +254,10 @@ async fn codex_driver_rejects_interactive_confirmation() {
     args.interactive_mode = InteractiveMode::StderrPrompt;
 
     let err = run(args).await.expect_err("interactive should be rejected");
-    assert!(err.to_string().contains("interactive"), "unexpected error: {err}");
+    assert!(
+        err.to_string().contains("interactive"),
+        "unexpected error: {err}"
+    );
 }
 
 /// `--driver codex` is rejected with a non-yolo policy profile.
@@ -256,7 +268,10 @@ async fn codex_driver_rejects_non_yolo_policy() {
     args.config.root.policy.profile = "safe".into();
 
     let err = run(args).await.expect_err("safe policy should be rejected");
-    assert!(err.to_string().contains("policy"), "unexpected error: {err}");
+    assert!(
+        err.to_string().contains("policy"),
+        "unexpected error: {err}"
+    );
 }
 
 /// `--driver codex` is rejected when a custom command policy is set.
@@ -266,8 +281,13 @@ async fn codex_driver_rejects_custom_policy() {
     let mut args = base_args(out.path(), out.path(), "cx-policy");
     args.config.root.policy.extra_deny_patterns = vec!["rm -rf".into()];
 
-    let err = run(args).await.expect_err("custom policy should be rejected");
-    assert!(err.to_string().contains("policy"), "unexpected error: {err}");
+    let err = run(args)
+        .await
+        .expect_err("custom policy should be rejected");
+    assert!(
+        err.to_string().contains("policy"),
+        "unexpected error: {err}"
+    );
 }
 
 /// `--driver codex` is rejected when `--resume` is used.
@@ -303,8 +323,13 @@ async fn codex_driver_rejects_stagnation_detection() {
     let mut args = base_args(out.path(), out.path(), "cx-stagnation");
     args.config.root.agent.detect_stagnation = true;
 
-    let err = run(args).await.expect_err("stagnation detection should be rejected");
-    assert!(err.to_string().contains("stagnation"), "unexpected error: {err}");
+    let err = run(args)
+        .await
+        .expect_err("stagnation detection should be rejected");
+    assert!(
+        err.to_string().contains("stagnation"),
+        "unexpected error: {err}"
+    );
 }
 
 /// `--driver codex` is rejected when MCP servers are configured.
@@ -332,8 +357,13 @@ async fn codex_driver_rejects_non_default_cmd_timeout() {
     let mut args = base_args(out.path(), out.path(), "cx-cmd-timeout");
     args.config.root.environment.timeout_secs = 30;
 
-    let err = run(args).await.expect_err("non-default command timeout should be rejected");
-    assert!(err.to_string().contains("timeout"), "unexpected error: {err}");
+    let err = run(args)
+        .await
+        .expect_err("non-default command timeout should be rejected");
+    assert!(
+        err.to_string().contains("timeout"),
+        "unexpected error: {err}"
+    );
 }
 
 /// `--driver codex` is rejected when budget-visibility is enabled.
@@ -344,8 +374,13 @@ async fn codex_driver_rejects_budget_visibility() {
     args.config.root.agent.per_task_budget_usd = Some(1.0);
     args.config.root.agent.hide_budget_from_agent = false;
 
-    let err = run(args).await.expect_err("budget visibility should be rejected");
-    assert!(err.to_string().contains("budget"), "unexpected error: {err}");
+    let err = run(args)
+        .await
+        .expect_err("budget visibility should be rejected");
+    assert!(
+        err.to_string().contains("budget"),
+        "unexpected error: {err}"
+    );
 }
 
 /// `--driver codex` is rejected when `agent.tools` defines custom command tools.
@@ -361,7 +396,9 @@ async fn codex_driver_rejects_configured_tools() {
         timeout_secs: None,
     }];
 
-    let err = run(args).await.expect_err("configured tools should be rejected");
+    let err = run(args)
+        .await
+        .expect_err("configured tools should be rejected");
     assert!(err.to_string().contains("tools"), "unexpected error: {err}");
 }
 

--- a/tests/codex_driver.rs
+++ b/tests/codex_driver.rs
@@ -1,0 +1,432 @@
+//! Deterministic, $0 coverage for `--driver codex`.
+//!
+//! Driving the real `codex` CLI costs money and is non-deterministic, so the
+//! driver reads its binary path from `MAXWELLS_CODEX_BIN`. Here we point it at
+//! a fixture shell script that (a) makes a real working-tree edit — exactly as
+//! Codex would — and (b) emits a canned NDJSON transcript whose message shapes
+//! match the Codex `--full-auto --json` wire format. This exercises the whole
+//! bridge (spawn → stream parse → trajectory finalize → patch capture) without
+//! a network call or an API key.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::Path;
+#[cfg(unix)]
+use std::process::Command;
+
+use maxwells_daemon::{
+    config::Config,
+    run::mini::{InteractiveMode, MiniArgs, RunDriver, run},
+};
+
+#[cfg(unix)]
+fn git(dir: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[cfg(unix)]
+fn init_repo(dir: &Path) {
+    git(dir, &["init", "-q", "-b", "main"]);
+    git(dir, &["config", "user.email", "test@test"]);
+    git(dir, &["config", "user.name", "test"]);
+    git(dir, &["config", "commit.gpgSign", "false"]);
+    std::fs::write(dir.join("a.txt"), "line one\n").unwrap();
+    git(dir, &["add", "-A"]);
+    git(dir, &["commit", "-q", "-m", "base"]);
+}
+
+/// Write an executable fake `codex` that appends to `a.txt` (a real edit in
+/// its cwd) and prints a canned NDJSON transcript. Returns its path.
+#[cfg(unix)]
+fn write_fake_codex(dir: &Path) -> std::path::PathBuf {
+    // The transcript mirrors the real Codex `--full-auto --json` wire shapes:
+    // a session init event, a reasoning turn, a test shell call + output, a
+    // second shell call + output, a final message turn, then the completed event.
+    let script = r#"#!/usr/bin/env bash
+set -euo pipefail
+# Perform the real edit in the current working directory, like Codex.
+echo 'line two' >> a.txt
+cat <<'JSON'
+{"type":"session","session_id":"sess-abc123","model":"o4-mini"}
+{"type":"reasoning","content":[{"type":"thinking","text":"I will run the tests, then append the requested line."}]}
+{"type":"local_shell_call","id":"lsc_test","action":{"type":"exec","command":"pytest -q","timeout":30000,"working_directory":"."}}
+{"type":"local_shell_call_output","id":"lsc_test","output":{"type":"exec_result","output":"1 passed in 0.10s","exit_code":0,"metadata":{}}}
+{"type":"local_shell_call","id":"lsc_1","action":{"type":"exec","command":"echo 'line two' >> a.txt","timeout":30000,"working_directory":"."}}
+{"type":"local_shell_call_output","id":"lsc_1","output":{"type":"exec_result","output":"","exit_code":0,"metadata":{}}}
+{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Done. Appended line two to a.txt."}]}
+{"type":"completed","exit_reason":"done","result":"Done. Appended line two to a.txt.","cost_usd":0.0123,"usage":{"input_tokens":100,"output_tokens":50}}
+JSON
+"#;
+    let path = dir.join("fake_codex.sh");
+    std::fs::write(&path, script).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    path
+}
+
+/// Point `MAXWELLS_CODEX_BIN` at a single shared fixture, exactly once.
+#[cfg(unix)]
+fn ensure_fake_codex() {
+    use std::sync::OnceLock;
+    static FAKE: OnceLock<std::path::PathBuf> = OnceLock::new();
+    FAKE.get_or_init(|| {
+        let dir = std::env::temp_dir().join(format!("maxwells_cx_fake_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = write_fake_codex(&dir);
+        // SAFETY: runs once under OnceLock with all other threads blocked
+        // until it completes, so no other thread reads env concurrently.
+        unsafe {
+            std::env::set_var("MAXWELLS_CODEX_BIN", &path);
+        }
+        path
+    });
+}
+
+fn base_args(repo: &Path, out: &Path, name: &str) -> MiniArgs {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 10;
+    // codex driver requires yolo: it executes tools itself and cannot enforce
+    // the built-in safe/ask deny corpus.
+    cfg.root.policy.profile = "yolo".into();
+    // Stagnation detection runs inside DefaultAgent::step; the external CLI
+    // manages its own loop so the detector never fires.
+    cfg.root.agent.detect_stagnation = false;
+    MiniArgs {
+        driver: RunDriver::Codex,
+        driver_append_system_prompt: false,
+        driver_isolated: false,
+        task: "Append a line saying 'line two' to a.txt".into(),
+        extra_context: None,
+        config: cfg,
+        output_dir: out.to_path_buf(),
+        trajectory_name: name.into(),
+        deterministic_responses: None,
+        deterministic_usage_per_call: None,
+        task_timeout_secs: Some(30),
+        cancellation: None,
+        stream_addr: None,
+        patch_capture: None,
+        verification_checks: vec![],
+        verification_timeout_secs: 10,
+        interactive_mode: InteractiveMode::Off,
+        resume_from: None,
+        trace_id: None,
+        webhook_url: None,
+        webhook_headers: vec![],
+        event_log: None,
+        event_log_instance_id: None,
+        local_workdir: Some(repo.to_path_buf()),
+        read_only: false,
+        allow_mcp_in_read_only: false,
+        rehearsal_gold_patch: None,
+        no_step_persist: false,
+        parent_sweep_run_id: None,
+        continue_from: None,
+        issue_provenance: None,
+    }
+}
+
+#[cfg(unix)]
+fn read_traj(out: &Path, name: &str) -> serde_json::Value {
+    let path = out.join(format!("{name}.traj.json"));
+    serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn codex_driver_produces_valid_trajectory() {
+    let repo = tempfile::tempdir().unwrap();
+    let out = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+    ensure_fake_codex();
+
+    run(base_args(repo.path(), out.path(), "cx"))
+        .await
+        .expect("codex driver run should succeed");
+
+    let traj = read_traj(out.path(), "cx");
+
+    assert_eq!(traj["trajectory_format"], "mini-swe-agent-1.3");
+    assert_eq!(traj["info"]["outcome"], "submitted");
+    assert_eq!(traj["info"]["exit_reason"], "submitted");
+    // Two local_shell_call blocks (pytest + echo) → two steps.
+    assert_eq!(traj["info"]["steps"], 2);
+    assert!((traj["info"]["total_cost_usd"].as_f64().unwrap() - 0.0123).abs() < 1e-9);
+    assert_eq!(traj["info"]["actual_cost_source"], "provider_reported");
+    assert_eq!(traj["info"]["token_usage"]["prompt_tokens"], 100);
+    assert_eq!(traj["info"]["token_usage"]["completion_tokens"], 50);
+    assert_eq!(traj["info"]["model_name"], "o4-mini");
+    assert_eq!(
+        traj["info"]["final_output"],
+        "Done. Appended line two to a.txt."
+    );
+
+    // Provenance block identifies the backend + session.
+    assert_eq!(traj["info"]["codex_driver"]["driver"], "codex");
+    assert_eq!(traj["info"]["codex_driver"]["session_id"], "sess-abc123");
+
+    // Messages: system + task (seeded by the builder), then the streamed turns.
+    let msgs = traj["messages"].as_array().unwrap();
+    let roles: Vec<&str> = msgs.iter().map(|m| m["role"].as_str().unwrap()).collect();
+    assert_eq!(roles.first(), Some(&"system"));
+    // The shell command surfaces as an assistant action.
+    let shell_action = msgs.iter().any(|m| {
+        m["extra"]["actions"].as_array().is_some_and(|a| {
+            a.iter()
+                .any(|v| v.as_str() == Some("echo 'line two' >> a.txt"))
+        })
+    });
+    assert!(shell_action, "expected the shell command recorded as an action");
+
+    // The shell output surfaces as a user observation with synthesized run_result.
+    let obs = msgs
+        .iter()
+        .find(|m| m["role"] == "user" && m["extra"]["run_result"].is_object())
+        .expect("expected a tool_result observation with run_result");
+    let rr = &obs["extra"]["run_result"];
+    assert_eq!(rr["exit_code"], 0);
+    assert_eq!(rr["timed_out"], false);
+
+    // info.toolset reflects the Codex shell tool.
+    let tool_names: Vec<&str> = traj["info"]["toolset"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert!(tool_names.contains(&"shell"));
+
+    // The driver ran `codex` in the repo, so the real edit landed.
+    let contents = std::fs::read_to_string(repo.path().join("a.txt")).unwrap();
+    assert_eq!(contents, "line one\nline two\n");
+}
+
+/// `--driver codex` is rejected with `--env docker`.
+#[tokio::test]
+async fn codex_driver_rejects_docker_env() {
+    let out = tempfile::tempdir().unwrap();
+    let mut args = base_args(out.path(), out.path(), "cx-docker");
+    args.config = Config::from_toml_str("[environment]\nkind = \"docker\"\n").unwrap();
+    args.config.root.agent.step_limit = 10;
+    args.driver = RunDriver::Codex;
+
+    let err = run(args).await.expect_err("docker should be rejected");
+    assert!(err.to_string().contains("local environment"), "unexpected error: {err}");
+}
+
+/// `--driver codex` is rejected with `--read-only`.
+#[tokio::test]
+async fn codex_driver_rejects_read_only() {
+    let out = tempfile::tempdir().unwrap();
+    let mut args = base_args(out.path(), out.path(), "cx-ro");
+    args.read_only = true;
+
+    let err = run(args).await.expect_err("read-only should be rejected");
+    assert!(err.to_string().contains("read-only"), "unexpected error: {err}");
+}
+
+/// `--driver codex` is rejected with interactive confirmation modes.
+#[tokio::test]
+async fn codex_driver_rejects_interactive_confirmation() {
+    let out = tempfile::tempdir().unwrap();
+    let mut args = base_args(out.path(), out.path(), "cx-int");
+    args.interactive_mode = InteractiveMode::StderrPrompt;
+
+    let err = run(args).await.expect_err("interactive should be rejected");
+    assert!(err.to_string().contains("interactive"), "unexpected error: {err}");
+}
+
+/// `--driver codex` is rejected with a non-yolo policy profile.
+#[tokio::test]
+async fn codex_driver_rejects_non_yolo_policy() {
+    let out = tempfile::tempdir().unwrap();
+    let mut args = base_args(out.path(), out.path(), "cx-safe-policy");
+    args.config.root.policy.profile = "safe".into();
+
+    let err = run(args).await.expect_err("safe policy should be rejected");
+    assert!(err.to_string().contains("policy"), "unexpected error: {err}");
+}
+
+/// `--driver codex` is rejected when a custom command policy is set.
+#[tokio::test]
+async fn codex_driver_rejects_custom_policy() {
+    let out = tempfile::tempdir().unwrap();
+    let mut args = base_args(out.path(), out.path(), "cx-policy");
+    args.config.root.policy.extra_deny_patterns = vec!["rm -rf".into()];
+
+    let err = run(args).await.expect_err("custom policy should be rejected");
+    assert!(err.to_string().contains("policy"), "unexpected error: {err}");
+}
+
+/// `--driver codex` is rejected when `--resume` is used.
+#[tokio::test]
+async fn codex_driver_rejects_resume() {
+    use maxwells_daemon::trajectory::Trajectory;
+    let out = tempfile::tempdir().unwrap();
+    let mut args = base_args(out.path(), out.path(), "cx-resume");
+    args.resume_from = Some(Trajectory::default());
+
+    let err = run(args).await.expect_err("resume should be rejected");
+    assert!(
+        err.to_string().contains("resume") || err.to_string().contains("continue"),
+        "unexpected error: {err}"
+    );
+}
+
+/// `--driver codex` is rejected when chaos injection is configured.
+#[tokio::test]
+async fn codex_driver_rejects_chaos() {
+    let out = tempfile::tempdir().unwrap();
+    let mut args = base_args(out.path(), out.path(), "cx-chaos");
+    args.config.root.environment.chaos_fail_every = 2;
+
+    let err = run(args).await.expect_err("chaos should be rejected");
+    assert!(err.to_string().contains("chaos"), "unexpected error: {err}");
+}
+
+/// `--driver codex` is rejected when stagnation detection is on.
+#[tokio::test]
+async fn codex_driver_rejects_stagnation_detection() {
+    let out = tempfile::tempdir().unwrap();
+    let mut args = base_args(out.path(), out.path(), "cx-stagnation");
+    args.config.root.agent.detect_stagnation = true;
+
+    let err = run(args).await.expect_err("stagnation detection should be rejected");
+    assert!(err.to_string().contains("stagnation"), "unexpected error: {err}");
+}
+
+/// `--driver codex` is rejected when MCP servers are configured.
+#[tokio::test]
+async fn codex_driver_rejects_mcp_servers() {
+    use maxwells_daemon::config::McpServerCfg;
+    let out = tempfile::tempdir().unwrap();
+    let mut args = base_args(out.path(), out.path(), "cx-mcp");
+    args.config.root.agent.mcp_servers = vec![McpServerCfg {
+        command: "false".into(),
+        timeout_secs: None,
+    }];
+
+    let err = run(args).await.expect_err("mcp servers should be rejected");
+    assert!(
+        err.to_string().contains("MCP") || err.to_string().contains("mcp"),
+        "unexpected error: {err}"
+    );
+}
+
+/// `--driver codex` is rejected when `environment.timeout_secs` is non-default.
+#[tokio::test]
+async fn codex_driver_rejects_non_default_cmd_timeout() {
+    let out = tempfile::tempdir().unwrap();
+    let mut args = base_args(out.path(), out.path(), "cx-cmd-timeout");
+    args.config.root.environment.timeout_secs = 30;
+
+    let err = run(args).await.expect_err("non-default command timeout should be rejected");
+    assert!(err.to_string().contains("timeout"), "unexpected error: {err}");
+}
+
+/// `--driver codex` is rejected when budget-visibility is enabled.
+#[tokio::test]
+async fn codex_driver_rejects_budget_visibility() {
+    let out = tempfile::tempdir().unwrap();
+    let mut args = base_args(out.path(), out.path(), "cx-budget-vis");
+    args.config.root.agent.per_task_budget_usd = Some(1.0);
+    args.config.root.agent.hide_budget_from_agent = false;
+
+    let err = run(args).await.expect_err("budget visibility should be rejected");
+    assert!(err.to_string().contains("budget"), "unexpected error: {err}");
+}
+
+/// `--driver codex` is rejected when `agent.tools` defines custom command tools.
+#[tokio::test]
+async fn codex_driver_rejects_configured_tools() {
+    use maxwells_daemon::config::ToolCfg;
+    let out = tempfile::tempdir().unwrap();
+    let mut args = base_args(out.path(), out.path(), "cx-tools");
+    args.config.root.agent.tools = vec![ToolCfg {
+        name: "lint".into(),
+        description: None,
+        command: "true".into(),
+        timeout_secs: None,
+    }];
+
+    let err = run(args).await.expect_err("configured tools should be rejected");
+    assert!(err.to_string().contains("tools"), "unexpected error: {err}");
+}
+
+/// A Codex shell call matching a test pattern (`pytest`) is paired into
+/// pre-submit test telemetry.
+#[tokio::test]
+#[cfg(unix)]
+async fn codex_driver_records_pre_submit_test_telemetry() {
+    let repo = tempfile::tempdir().unwrap();
+    let out = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+    ensure_fake_codex();
+
+    run(base_args(repo.path(), out.path(), "cx-tests"))
+        .await
+        .expect("run should complete");
+    let traj = read_traj(out.path(), "cx-tests");
+
+    assert_eq!(traj["info"]["tests_run_before_submit"], true);
+    assert_eq!(traj["info"]["last_tests_passed"], true);
+    let invocations = traj["info"]["test_invocations"].as_array().unwrap();
+    assert_eq!(invocations.len(), 1);
+    assert_eq!(invocations[0]["command"], "pytest -q");
+    assert_eq!(invocations[0]["exit_code"], 0);
+}
+
+/// A run that exceeds the configured per-task budget is recorded as
+/// `budget_exhausted`, never `submitted`.
+#[tokio::test]
+#[cfg(unix)]
+async fn codex_driver_downgrades_over_budget_run() {
+    let repo = tempfile::tempdir().unwrap();
+    let out = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+    ensure_fake_codex();
+
+    let mut args = base_args(repo.path(), out.path(), "cx-budget");
+    // Fixture reports cost_usd = 0.0123; set a cap well below that.
+    args.config.root.agent.per_task_budget_usd = Some(0.001);
+    args.config.root.agent.hide_budget_from_agent = true;
+
+    run(args).await.expect("run should complete");
+    let traj = read_traj(out.path(), "cx-budget");
+    assert_eq!(traj["info"]["outcome"], "budget_exhausted");
+    assert_eq!(traj["info"]["failure_category"], "budget_exhausted");
+}
+
+/// When parsed shell-call count exceeds `step_limit`, outcome is downgraded
+/// to `step_limit` so a run never reports `submitted` after taking more tool
+/// actions than the cap allows.
+#[tokio::test]
+#[cfg(unix)]
+async fn codex_driver_downgrades_step_overflow() {
+    let repo = tempfile::tempdir().unwrap();
+    let out = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+    ensure_fake_codex();
+
+    let mut args = base_args(repo.path(), out.path(), "cx-steps");
+    // The fixture transcript emits two local_shell_call blocks; cap at one.
+    args.config.root.agent.step_limit = 1;
+    run(args).await.expect("run should complete");
+
+    let traj = read_traj(out.path(), "cx-steps");
+    assert_eq!(traj["info"]["steps"], 2);
+    assert_eq!(traj["info"]["exit_reason"], "step_limit");
+    assert_eq!(traj["info"]["failure_category"], "step_limit");
+}


### PR DESCRIPTION
## Summary

This PR adds support for driving agent tasks through the OpenAI Codex CLI (`codex`) as an alternative backend to the built-in bash loop and Claude Code driver. The implementation follows the same seam-based architecture as the existing Claude Code driver, allowing Codex to run tasks in `--full-auto --json` mode while producing identical trajectory, patch, cost accounting, and verification outputs.

## Key Changes

- **New `codex_driver.rs` module**: Implements the core driver that:
  - Spawns the `codex` CLI with `--full-auto --json --max-turns` flags
  - Parses NDJSON event stream (session, reasoning, shell calls, messages, completed events)
  - Records shell invocations as agent steps with proper action/observation pairing
  - Synthesizes `run_result` metadata for tool outputs to maintain compatibility with existing consumers
  - Handles test command detection and result pairing by event ID
  - Maps Codex exit reasons to trajectory outcomes (done→submitted, max_turns→step_limit, etc.)
  - Manages cost/token reporting from provider-reported values

- **Configuration validation in `mini.rs`**: Enforces safety constraints for Codex driver:
  - Requires local environment only (rejects `--env docker`)
  - Requires `yolo` policy profile (cannot enforce built-in deny corpus)
  - Rejects `--read-only`, interactive confirmation modes, resume/continue, hooks, chaos injection, MCP servers
  - Validates command timeout, budget visibility, and stagnation detection settings

- **CLI argument updates**: Added `RunDriver::Codex` enum variant to `mini.rs` and updated help text in `args.rs`

- **Comprehensive test suite** (`tests/codex_driver.rs`):
  - Fixture-based testing with a fake `codex` script that performs real edits and emits canned NDJSON
  - Validates trajectory structure, cost/token recording, model name capture, and provenance metadata
  - Tests all rejection cases (docker, read-only, interactive, policy, resume, chaos, MCP, timeouts, budget visibility)
  - Verifies that real working-tree edits are captured by `git diff` patch mechanism

- **Specification document** (`docs/spec-codex-driver.md`): Documents the driver's design, stream format, outcome mapping, step counting, cost/provenance handling, and safety constraints

## Implementation Details

- **Stream parsing**: Reads NDJSON line-by-line with concurrent stderr draining to prevent deadlocks
- **Step counting**: Each `local_shell_call` event increments the step counter; step overflow is detected and downgrades outcome to `step_limit`
- **Tool result synthesis**: Constructs `run_result` objects from shell call output events to maintain compatibility with trajectory consumers that expect this metadata
- **Test invocation tracking**: Pending shell calls are tracked by ID and paired with their output events to populate test telemetry
- **Redaction**: All text (commands, output, reasoning) is redacted using the same surface-level redaction as the built-in loop
- **Timeout handling**: Implements wallclock timeout with grace period for child process cleanup; supports cancellation tokens
- **Checkpoint persistence**: Writes partial trajectory checkpoints after each tool output (when configured)
- **Toolset recording**: Overwrites `info.toolset` with the Codex shell tool for accurate tool-coverage reporting

The driver maintains full compatibility with existing trajectory consumers (patch capture, verification, bench inspect, evaluation) by translating Codex's event stream into the same message/extra format used by the built-in loop.

https://claude.ai/code/session_01GN5j3yhEa41SbwyUe9nCh8