### PR TITLE
Implement `agent best-of` command for sampling N runs and selecting best patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,31 @@ to stdout for CI capture.
 See `docs/spec-agent-stability.md` for the full flag reference, schema,
 exit-code matrix, and pass-predicate semantics.
 
-### 8. Optional Preflight Before SWE-bench
+### 8. Get the Best of N Tries on a Real Task
+
+LLM outputs are stochastic — the same task run twice may succeed or fail
+depending on sampling. Use `agent best-of` to run a task N times and keep only
+the patch that passes the most of your `--verify` checks:
+
+```bash
+cargo run --quiet -- --log error agent best-of \
+    --task "Fix the null dereference in src/foo.rs" \
+    --runs 3 \
+    --verify "tests:cargo test" \
+    --verify "lint:cargo clippy -- -D warnings" \
+    --model claude-opus-4-7 \
+    --output ./runs
+```
+
+The winner is selected by a deterministic policy: most checks passed → lowest
+cost → fewest steps → smallest patch → lexicographically smallest SHA-256.
+Results land in `runs/<task-slug>/best-of-results.json` and the winning patch in
+`runs/<task-slug>/best.patch`, ready for `agent apply`.
+
+See `docs/spec-agent-best-of.md` for the full flag reference, selection policy,
+JSON schema, and exit-code matrix.
+
+### 9. Optional Preflight Before SWE-bench
 
 Use `bench dataset-stats` to preview the composition, token distributions (computed completely offline using `litellm-rs`'s `TokenCounter`), expected tests count, languages present, representative slice skewness (warns if unique repos < 50% or median token length difference > 25% compared to the full dataset), and historical resolved rates matching current dataset hash before running a sweep:
 
@@ -273,7 +297,7 @@ budget, run `forecast` before a full sweep:
 cargo run --quiet -- --log info bench forecast --dataset-path ./data/swebench.jsonl --output runs/forecast --limit 5 --calibration-n 2 --sweep-cost-limit-usd 1.00 --format json > runs/forecast.json
 ```
 
-### 9. Close The Calibration Loop
+### 10. Close The Calibration Loop
 
 For paid sweeps, treat the operator loop as `doctor` -> `forecast` ->
 `swebench` -> `calibrate`. The forecast keeps the first spend bounded; the

--- a/docs/spec-agent-best-of.md
+++ b/docs/spec-agent-best-of.md
@@ -1,0 +1,225 @@
+# `agent best-of` — Sample N Runs and Emit the Best Patch
+
+**Issue:** #485  
+**Complexity tier:** M
+
+## Overview
+
+`agent best-of` runs one task N times through the existing `mini` execution
+path with identical configuration, scores each candidate patch using the
+operator's own `--verify` checks, and emits the single best patch using a
+documented, deterministic selection policy.
+
+This command turns LLM stochasticity into a quality win: instead of running
+`mini` once and hoping, you run it N times and keep the best result.
+
+## Usage
+
+```
+max agent best-of \
+  --task "Fix the null dereference in src/foo.rs" \
+  --runs 3 \
+  --model claude-opus-4-7 \
+  --verify "tests:cargo test" \
+  --verify "lint:cargo clippy -- -D warnings" \
+  [--output ./runs] \
+  [--output-patch best.patch] \
+  [--allow-no-pass] \
+  [--cost-limit-usd 2.00] \
+  [--format json]
+```
+
+Or read the task from a file (or stdin with `-`):
+
+```
+max agent best-of \
+  --task-file task.txt \
+  --runs 5 \
+  --verify "tests:make test"
+```
+
+## Flag Reference
+
+| Flag | Required | Default | Description |
+|---|---|---|---|
+| `--task TASK` | one of `--task`/`--task-file` | — | Task description |
+| `--task-file PATH` | one of `--task`/`--task-file` | — | Path to task file (`-` for stdin) |
+| `--runs N` | yes | — | Number of runs, 2–10 |
+| `--model NAME` | no | `claude-opus-4-7` | Model identifier |
+| `--verify NAME:COMMAND` | **yes** | — | Verify check (repeatable) |
+| `--verify-timeout-secs N` | no | 60 | Per-check timeout |
+| `--output DIR` | no | `./runs` | Root output directory |
+| `--output-patch PATH` | no | `<output>/<name>/best.patch` | Winner patch path |
+| `--allow-no-pass` | no | false | Exit 0 even when all runs fail |
+| `--cost-limit-usd F` | no | — | Total USD cap across all runs |
+| `--per-task-budget-usd F` | no | — | Per-run USD cap |
+| `--step-limit N` | no | — | Max steps per run |
+| `--task-timeout-secs N` | no | — | Per-run wallclock timeout |
+| `--best-of-name NAME` | no | slug of task | Subdirectory name |
+| `--format text\|json` | no | `text` | Output format |
+| `--config PATH` | no | — | TOML config overlay |
+| `--env local\|docker` | no | — | Environment |
+| `--docker-image IMG` | no | — | Docker image |
+| `--mcp-server CMD` | no | — | MCP server command (repeatable) |
+| `--detect-stagnation` | no | — | Enable/disable stagnation detection |
+| `--history-max-input-tokens N` | no | — | Token budget for prompt |
+| `--history-keep-last-observations N` | no | — | Keep last N observations |
+
+## `--verify` Requirement
+
+`--verify` is **required**. Without an oracle there is no basis for comparing
+runs. If you just want to run a task once, use `mini`. Exit 2 (`usage_error`)
+when `--verify` is omitted.
+
+## Selection / Tie-Break Policy
+
+The winner is chosen by the following fully deterministic chain:
+
+1. **Most `verify_checks_passed`** (skipped runs excluded).
+2. **Lowest `total_cost_usd`** (tie-break).
+3. **Fewest `step_count`** (tie-break).
+4. **Smallest patch byte length** (tie-break).
+5. **Lexicographically smallest `patch_sha256`** (tie-break).
+
+`tie_break_applied: true` is set in the artifact whenever any tie-break beyond
+rule 1 was used. The `selection_rationale` string names the decisive rule.
+
+## Artifacts
+
+All artifacts land in `<output>/<best-of-name>/`:
+
+| File | Description |
+|---|---|
+| `run_NN.traj.json` | Per-run trajectory (same as `mini`) |
+| `run_NN.patch` | Per-run captured patch |
+| `best-of-results.json` | Schema-versioned selection report |
+| `best.patch` (or `--output-patch`) | Winner's patch file |
+
+### `best-of-results.json` Schema
+
+```json
+{
+  "schema_version": {"major": 1, "minor": 10},
+  "artifact_kind": "best_of_results",
+  "task": "Fix the null dereference",
+  "runs": 3,
+  "winner_run_index": 1,
+  "passing_run_count": 2,
+  "all_failed": false,
+  "tie_break_applied": false,
+  "selection_rationale": "most_verify_checks_passed",
+  "started_at": "2026-01-01T00:00:00Z",
+  "finished_at": "2026-01-01T00:00:30Z",
+  "runs_detail": [
+    {
+      "run_index": 0,
+      "outcome": "submitted",
+      "verify_checks_passed": 1,
+      "verify_checks_total": 2,
+      "passed": false,
+      "total_cost_usd": 0.0042,
+      "step_count": 12,
+      "patch_byte_len": 384,
+      "patch_sha256": "a3f9..."
+    },
+    {
+      "run_index": 1,
+      "outcome": "submitted",
+      "verify_checks_passed": 2,
+      "verify_checks_total": 2,
+      "passed": true,
+      "total_cost_usd": 0.0038,
+      "step_count": 10,
+      "patch_byte_len": 412,
+      "patch_sha256": "b7c2..."
+    }
+  ]
+}
+```
+
+**Top-level fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `schema_version` | object | `{major, minor}` |
+| `artifact_kind` | string | Always `"best_of_results"` |
+| `task` | string | The task description |
+| `runs` | u32 | Configured number of runs |
+| `winner_run_index` | u32 \| null | 0-based index of selected winner |
+| `passing_run_count` | u32 | Non-skipped runs that passed all checks |
+| `all_failed` | bool | True when no run passed all checks |
+| `tie_break_applied` | bool | True when any tie-break beyond rule 1 was used |
+| `selection_rationale` | string | Name of the decisive selection rule |
+| `started_at` / `finished_at` | RFC 3339 | Timestamps |
+| `runs_detail` | array | Per-run records |
+
+**Per-run fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `run_index` | u32 | 0-based index |
+| `outcome` | string | Terminal outcome from trajectory |
+| `verify_checks_passed` | u32 | Checks that passed |
+| `verify_checks_total` | u32 | Total checks configured |
+| `passed` | bool | `verify_checks_passed == verify_checks_total` |
+| `total_cost_usd` | f64 \| null | Run cost |
+| `step_count` | u32 \| null | Agent steps executed |
+| `patch_byte_len` | u64 \| null | Patch file size in bytes |
+| `patch_sha256` | string \| null | SHA-256 of the captured patch |
+| `skipped` | bool | Run was skipped (budget cap) |
+| `skip_reason` | string \| null | Reason for skipping |
+
+## Exit Code Matrix
+
+| Exit code | Label | Condition |
+|---|---|---|
+| 0 | `success` | At least one run passed all verify checks |
+| 0 | `success` | `--allow-no-pass` given, even when all runs failed |
+| 2 | `usage_error` | `--verify` omitted; `--runs` outside 2–10; bad flags |
+| 5 | `budget_halt` | At least one run was skipped due to `--cost-limit-usd` |
+| 40 | `best_of_all_failed` | No run passed all verify checks (no `--allow-no-pass`) |
+
+## `--runs` Range
+
+`--runs` must be 2–10 (inclusive). Best-of-1 is identical to `mini` — exit 2
+with a message pointing at `mini` when `--runs 1` is passed.
+
+## Cost Limiting
+
+`--cost-limit-usd F` caps total spend across all runs. When the cumulative cost
+reaches the limit, remaining runs are recorded with `skipped: true` and
+`skip_reason: "cost_limit_usd"`. The command still selects a winner from the
+completed runs and exits with exit code 5 (`budget_halt`).
+
+## All-Failed Behaviour
+
+When no run passes all verify checks:
+
+- `all_failed: true` is set in `best-of-results.json`
+- The best-scoring run (most checks passed, then tie-breaks) is still selected
+  and its patch is written to `--output-patch`
+- Exit code 40 (`best_of_all_failed`) unless `--allow-no-pass` is given
+
+## Determinism on the Scripted-Model Path
+
+On the no-key scripted-model path (used in testing), two invocations with
+identical inputs produce byte-identical `best-of-results.json` and
+byte-identical `best.patch`. This property is verified by the integration
+test suite.
+
+## Composability
+
+The emitted `best.patch` is identical to that run's own captured patch and can
+be applied with `agent apply`:
+
+```
+max agent best-of --task "..." --runs 3 --verify "tests:cargo test"
+max agent apply --patch runs/my-task/best.patch
+```
+
+## Related Commands
+
+- `mini` — single task run
+- `agent stability` (#475) — measures run-to-run variance without selecting
+- `bench cascade` — exploits capability differences across model tiers
+- `agent apply` (#473) — applies the emitted patch to a working tree

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -70,6 +70,7 @@ pub enum ArtifactKind {
     NearMissReport,
     ApplyReport,
     StabilityResults,
+    BestOfResults,
 }
 
 impl ArtifactKind {
@@ -97,6 +98,7 @@ impl ArtifactKind {
             Self::NearMissReport => "near_miss_report",
             Self::ApplyReport => "apply_report",
             Self::StabilityResults => "stability_results",
+            Self::BestOfResults => "best_of_results",
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -457,6 +457,112 @@ pub struct InjectionAuditCmd {
     pub output: Option<PathBuf>,
 }
 
+/// Output-format selector for `agent best-of`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum BestOfFormatArg {
+    Text,
+    Json,
+}
+
+/// `agent best-of` — sample N runs and emit the best patch (issue #485).
+#[derive(Debug, Args)]
+pub struct BestOfCmd {
+    /// Task description to run N times. Mutually exclusive with `--task-file`.
+    #[arg(long, value_name = "TASK", conflicts_with = "task_file")]
+    pub task: Option<String>,
+
+    /// Path to a file containing the task description (use `-` for stdin).
+    /// Mutually exclusive with `--task`.
+    #[arg(long = "task-file", value_name = "PATH", conflicts_with = "task")]
+    pub task_file: Option<PathBuf>,
+
+    /// Number of times to run the task (2..=10). Best-of-1 is equivalent to `mini`.
+    #[arg(long, value_name = "N")]
+    pub runs: u32,
+
+    /// Model name (e.g. `claude-opus-4-7`).
+    #[arg(long, default_value = "claude-opus-4-7")]
+    pub model: String,
+
+    /// Optional path to a TOML config file (overlays defaults).
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+
+    /// Verify check in `NAME:COMMAND` format (repeatable, required).
+    /// Without `--verify`, there is no oracle to drive selection.
+    #[arg(long = "verify", value_name = "NAME:COMMAND")]
+    pub verify: Vec<String>,
+
+    /// Per-check timeout in seconds for `--verify` checks. Default: 60.
+    #[arg(long = "verify-timeout-secs", default_value_t = 60)]
+    pub verify_timeout_secs: u64,
+
+    /// Root output directory. Artifacts land in `<output>/<best-of-name>/`.
+    #[arg(long, default_value = "./runs")]
+    pub output: PathBuf,
+
+    /// Where to write the winner's patch file.
+    /// Default: `<output>/<best-of-name>/best.patch`.
+    #[arg(long = "output-patch", value_name = "PATH")]
+    pub output_patch: Option<PathBuf>,
+
+    /// When all runs fail verify checks, exit 0 instead of exit 40.
+    /// `all_failed: true` is still set in `best-of-results.json`.
+    #[arg(long, default_value_t = false)]
+    pub allow_no_pass: bool,
+
+    /// Total USD ceiling across all runs. Remaining runs are recorded as
+    /// `skipped` rather than overrunning the budget.
+    #[arg(long = "cost-limit-usd")]
+    pub cost_limit_usd: Option<f64>,
+
+    /// Per-run USD ceiling enforced inside the agent loop.
+    #[arg(long)]
+    pub per_task_budget_usd: Option<f64>,
+
+    /// Max agent steps per run.
+    #[arg(long)]
+    pub step_limit: Option<u32>,
+
+    /// Per-run wallclock timeout in seconds.
+    #[arg(long)]
+    pub task_timeout_secs: Option<u64>,
+
+    /// Environment: `local` or `docker`.
+    #[arg(long)]
+    pub env: Option<String>,
+
+    /// Docker image, if `--env docker`.
+    #[arg(long)]
+    pub docker_image: Option<String>,
+
+    /// Register an invocation-time MCP stdio server command (repeatable).
+    #[arg(long = "mcp-server", value_name = "COMMAND")]
+    pub mcp_servers: Vec<String>,
+
+    /// Enable or disable in-loop stagnation detection.
+    #[arg(long = "detect-stagnation", num_args = 0..=1, default_missing_value = "true")]
+    pub detect_stagnation: Option<bool>,
+
+    /// Token budget for the model-visible prompt.
+    #[arg(long)]
+    pub history_max_input_tokens: Option<u64>,
+
+    /// Keep only the last N tool observations in the model-visible prompt.
+    #[arg(long)]
+    pub history_keep_last_observations: Option<usize>,
+
+    /// Name for this best-of run (used as the output subdirectory name and in
+    /// `best-of-results.json`). Defaults to a slug of the task text.
+    #[arg(long = "best-of-name", value_name = "NAME")]
+    pub best_of_name: Option<String>,
+
+    /// Output format: `text` (default, human-readable) or `json` (prints
+    /// `best-of-results.json` to stdout for CI capture).
+    #[arg(long, value_enum)]
+    pub format: Option<BestOfFormatArg>,
+}
+
 /// `agent` subcommands.
 #[derive(Debug, Subcommand)]
 pub enum AgentCmd {
@@ -481,6 +587,8 @@ pub enum AgentCmd {
     PolicyCheck(PolicyCheckCmd),
     /// Apply a captured patch artifact to a working tree (issue #473).
     Apply(AgentApplyCmd),
+    /// Sample N runs and emit the best patch by --verify oracle (issue #485).
+    BestOf(Box<BestOfCmd>),
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -61,6 +61,12 @@ pub fn entries() -> &'static [CatalogEntry] {
         },
         // Agent subcommands
         CatalogEntry {
+            path: "agent best-of",
+            summary: "Sample N runs and emit the best patch by --verify oracle",
+            cost_tier: "paid",
+            stage: "run",
+        },
+        CatalogEntry {
             path: "agent apply",
             summary: "Apply a captured patch artifact to a working tree",
             cost_tier: "free",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -146,6 +146,7 @@ pub async fn run() -> Result<(), Error> {
             args::AgentCmd::Suite(s) => Box::pin(agent_suite_cmd(*s)).await,
             args::AgentCmd::PolicyCheck(p) => agent_policy_check_cmd(&p),
             args::AgentCmd::Apply(a) => agent_apply_cmd(&a),
+            args::AgentCmd::BestOf(b) => Box::pin(agent_best_of_cmd(*b)).await,
         },
         Command::Catalog(c) => catalog::run_catalog(c),
         Command::Ui(u) => ui_cmd(u).await,
@@ -6031,6 +6032,145 @@ async fn agent_stability_cmd(s: args::StabilityCmd) -> Result<(), Error> {
     if s.format == Some(args::StabilityFormatArg::Json) {
         let result_dir = s.output.join(&stability_name_for_json);
         let result_path = result_dir.join("stability-results.json");
+        if let Ok(json_text) = std::fs::read_to_string(&result_path) {
+            println!("{json_text}");
+        }
+    }
+
+    if exit_code != ExitCode::Success {
+        exit_with_outcome(exit_code, exit_code.outcome_class());
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_lines)]
+async fn agent_best_of_cmd(b: args::BestOfCmd) -> Result<(), Error> {
+    // ── Validate --runs ───────────────────────────────────────────────────────
+    if let Err(msg) = crate::run::best_of::validate_runs(b.runs) {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(msg)));
+    }
+
+    // ── Require --verify ──────────────────────────────────────────────────────
+    if b.verify.is_empty() {
+        return Err(Error::Config(crate::error::ConfigError::Usage(
+            "--verify is required for `agent best-of`; it is the oracle that drives \
+             selection. Without it there is no way to score runs against each other. \
+             Use `mini` if you just want to run a single task."
+                .into(),
+        )));
+    }
+
+    // ── Resolve task text ─────────────────────────────────────────────────────
+    let task = match (&b.task, &b.task_file) {
+        (Some(t), _) => t.clone(),
+        (None, Some(path)) => {
+            if path == std::path::Path::new("-") {
+                use std::io::Read as _;
+                let mut buf = String::new();
+                std::io::stdin()
+                    .read_to_string(&mut buf)
+                    .map_err(Error::Io)?;
+                buf.trim().to_owned()
+            } else {
+                std::fs::read_to_string(path)
+                    .map_err(|e| {
+                        Error::Config(crate::error::ConfigError::Invalid(format!(
+                            "cannot read task file '{}': {e}",
+                            path.display()
+                        )))
+                    })?
+                    .trim()
+                    .to_owned()
+            }
+        }
+        (None, None) => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(
+                "one of --task or --task-file is required".into(),
+            )));
+        }
+    };
+
+    if task.is_empty() {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(
+            "task must not be empty".into(),
+        )));
+    }
+
+    // ── Load config and apply CLI overrides ───────────────────────────────────
+    let mut cfg = match &b.config {
+        Some(p) => Config::load(p)?,
+        None => Config::defaults()?,
+    };
+
+    cfg.root.model.name.clone_from(&b.model);
+
+    if let Some(v) = b.step_limit {
+        cfg.root.agent.step_limit = v;
+    }
+    if let Some(v) = b.per_task_budget_usd {
+        cfg.root.agent.per_task_budget_usd = Some(v);
+    }
+    if let Some(kind) = &b.env {
+        cfg.root.environment.kind = parse_env_kind(kind.as_str())?;
+    }
+    if let Some(img) = b.docker_image.clone() {
+        cfg.root.environment.docker_image = Some(img);
+    }
+    if let Some(v) = b.detect_stagnation {
+        cfg.root.agent.detect_stagnation = v;
+    }
+    if let Some(v) = b.history_max_input_tokens {
+        cfg.root.agent.history_max_input_tokens = Some(v);
+    }
+    if let Some(v) = b.history_keep_last_observations {
+        cfg.root.agent.history_keep_last_observations = Some(v);
+    }
+    apply_mcp_server_overrides(&mut cfg, &b.mcp_servers)?;
+
+    // ── Derive best-of name from task slug when not supplied ──────────────────
+    let best_of_name = b.best_of_name.clone().unwrap_or_else(|| {
+        let slug: String = task
+            .chars()
+            .take(40)
+            .map(|c| if c.is_alphanumeric() { c } else { '-' })
+            .collect::<String>()
+            .trim_matches('-')
+            .to_owned();
+        if slug.is_empty() {
+            "best-of".to_owned()
+        } else {
+            slug
+        }
+    });
+
+    let output_dir = b.output.clone();
+    let best_of_name_for_json = best_of_name.clone();
+
+    let best_of_args = crate::run::best_of::BestOfArgs {
+        task,
+        runs: b.runs,
+        config: cfg,
+        output_dir,
+        best_of_name,
+        verify: b.verify,
+        verify_timeout_secs: b.verify_timeout_secs,
+        cost_limit_usd: b.cost_limit_usd,
+        task_timeout_secs: b.task_timeout_secs,
+        step_limit: b.step_limit,
+        per_task_budget_usd: b.per_task_budget_usd,
+        output_patch: b.output_patch,
+        allow_no_pass: b.allow_no_pass,
+        deterministic_responses: None,
+        deterministic_usage_per_call: None,
+        print_summary: b.format != Some(args::BestOfFormatArg::Json),
+    };
+
+    let exit_code = crate::run::best_of::run(best_of_args).await?;
+
+    // ── --format json: print artifact to stdout ───────────────────────────────
+    if b.format == Some(args::BestOfFormatArg::Json) {
+        let result_dir = b.output.join(&best_of_name_for_json);
+        let result_path = result_dir.join("best-of-results.json");
         if let Ok(json_text) = std::fs::read_to_string(&result_path) {
             println!("{json_text}");
         }

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -163,6 +163,11 @@ pub enum ExitCode {
     /// runs completed; the gate is wired correctly but the measured pass rate
     /// did not meet the declared threshold.
     StabilityGateFailure = 39,
+    /// 40 — `agent best-of` completed all runs and no run passed all verify
+    /// checks. The best-scoring run was still selected and its patch emitted;
+    /// `all_failed: true` is set in `best-of-results.json`. Pass
+    /// `--allow-no-pass` to downgrade to exit 0 while keeping `all_failed: true`.
+    BestOfAllFailed = 40,
     /// 130 — user interruption (graceful SIGINT / Ctrl-C; 128 + SIGINT(2)).
     Interrupted = 130,
     /// 137 — forced kill (SIGKILL escalation after graceful-cancel deadline; 128 + SIGKILL(9)).
@@ -223,6 +228,7 @@ impl ExitCode {
             Self::InjectionAuditHits => "injection_audit_hits",
             Self::InjectionAuditScanError => "injection_audit_scan_error",
             Self::StabilityGateFailure => "stability_gate_failure",
+            Self::BestOfAllFailed => "best_of_all_failed",
             Self::Interrupted => "interrupted",
             Self::Killed => "killed",
         }

--- a/src/run/best_of.rs
+++ b/src/run/best_of.rs
@@ -431,7 +431,10 @@ pub async fn run(args: BestOfArgs) -> Result<ExitCode, Error> {
                 base_commit,
                 workdir: patch_workdir,
                 patch_path: run_patch_path,
-                skip_patch_validation: false,
+                // best-of's oracle is --verify, not patch non-emptiness; skipping
+                // the SWE-bench "empty diff = error" rule prevents the outcome from
+                // being downgraded when the scripted model or a no-op agent submits.
+                skip_patch_validation: true,
             }),
             verification_checks: verification_checks.clone(),
             verification_timeout_secs: args.verify_timeout_secs,

--- a/src/run/best_of.rs
+++ b/src/run/best_of.rs
@@ -1,0 +1,672 @@
+//! `agent best-of` — sample N runs and emit the best patch (issue #485).
+//!
+//! Runs one task N times through the existing `mini` path with identical config,
+//! scores each candidate patch by the operator's `--verify` oracle, and emits the
+//! single best patch using a deterministic selection policy.
+
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::artifact::{ArtifactKind, ArtifactSchemaVersion};
+use crate::error::Error;
+use crate::exit_code::ExitCode;
+
+// ── Result schema ─────────────────────────────────────────────────────────────
+
+/// Per-run record stored in `best-of-results.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BestOfRunDetail {
+    /// 0-based run index.
+    pub run_index: u32,
+    /// Terminal outcome string from the trajectory (or `skipped_budget_exhausted`).
+    pub outcome: String,
+    /// Number of `--verify` checks that passed for this run.
+    pub verify_checks_passed: u32,
+    /// Total number of `--verify` checks configured.
+    pub verify_checks_total: u32,
+    /// True iff all verify checks passed.
+    pub passed: bool,
+    /// Billed cost for this run in USD.
+    pub total_cost_usd: Option<f64>,
+    /// Agent steps executed.
+    pub step_count: Option<u32>,
+    /// Byte length of the captured patch. `None` when no patch was captured.
+    pub patch_byte_len: Option<u64>,
+    /// SHA-256 hex digest of the captured patch bytes. `None` when no patch was captured.
+    pub patch_sha256: Option<String>,
+    /// Whether this run was skipped (cost cap exceeded before it started).
+    pub skipped: bool,
+    /// Human-readable reason for skipping, when `skipped == true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skip_reason: Option<String>,
+}
+
+/// Top-level `best-of-results.json` artifact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BestOfResults {
+    pub schema_version: ArtifactSchemaVersion,
+    pub artifact_kind: ArtifactKind,
+    /// The task description that was run.
+    pub task: String,
+    /// Total number of runs configured (including skipped).
+    pub runs: u32,
+    /// 0-based index of the selected winner run. `None` if all runs were skipped.
+    pub winner_run_index: Option<u32>,
+    /// Number of non-skipped runs that passed all verify checks.
+    pub passing_run_count: u32,
+    /// True when no run passed all verify checks.
+    pub all_failed: bool,
+    /// True when the tie-break chain beyond "most checks passed" was used.
+    pub tie_break_applied: bool,
+    /// Human-readable rationale for the winner selection.
+    pub selection_rationale: String,
+    pub started_at: String,
+    pub finished_at: String,
+    pub runs_detail: Vec<BestOfRunDetail>,
+}
+
+impl BestOfResults {
+    /// Render a human-readable multi-line summary.
+    pub fn summary_text(&self) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::new();
+
+        let non_skipped = self
+            .runs_detail
+            .iter()
+            .filter(|d| !d.skipped)
+            .count();
+
+        let _ = writeln!(
+            &mut out,
+            "agent best-of: \"{}\" — {}/{} runs passed all verify checks",
+            truncate(&self.task, 60),
+            self.passing_run_count,
+            non_skipped,
+        );
+
+        if self.all_failed {
+            let _ = writeln!(
+                &mut out,
+                "  WARNING: all runs failed verify checks — best-scoring run selected"
+            );
+        }
+
+        if let Some(winner) = self.winner_run_index {
+            let _ = writeln!(&mut out, "  WINNER: run {winner} (0-based index)");
+        }
+        if self.tie_break_applied {
+            let _ = writeln!(&mut out, "  tie_break_applied: true");
+        }
+        let _ = writeln!(
+            &mut out,
+            "  selection_rationale: {}",
+            self.selection_rationale
+        );
+        let _ = writeln!(&mut out);
+        let _ = writeln!(
+            &mut out,
+            "  {:<4}  {:<22}  {:<5}  {:>6}/{:<6}  {:>8}  {:>6}",
+            "RUN", "OUTCOME", "PASS", "PASS", "TOTAL", "COST($)", "STEPS"
+        );
+        let _ = writeln!(&mut out, "  {}", "-".repeat(62));
+        for d in &self.runs_detail {
+            let cost = d
+                .total_cost_usd
+                .map_or_else(|| "-".to_owned(), |c| format!("{c:.4}"));
+            let steps = d
+                .step_count
+                .map_or_else(|| "-".to_owned(), |s| s.to_string());
+            let winner_marker = self
+                .winner_run_index
+                .is_some_and(|w| w == d.run_index);
+            let pass_label = if d.skipped {
+                "skip"
+            } else if d.passed {
+                "yes"
+            } else {
+                "no"
+            };
+            let winner_str = if winner_marker { "*" } else { " " };
+            let _ = writeln!(
+                &mut out,
+                "{} {:<4}  {:<22}  {:<5}  {:>6}/{:<6}  {:>8}  {:>6}",
+                winner_str,
+                d.run_index,
+                truncate(&d.outcome, 22),
+                pass_label,
+                d.verify_checks_passed,
+                d.verify_checks_total,
+                cost,
+                steps,
+            );
+        }
+        out
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_owned()
+    } else {
+        let t: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{t}…")
+    }
+}
+
+// ── Selection policy ──────────────────────────────────────────────────────────
+
+/// Deterministically select the best run from the completed runs.
+///
+/// Selection policy (all tie-breaks are deterministic):
+/// 1. Most `verify_checks_passed` (skipped runs excluded).
+/// 2. Lowest `total_cost_usd`.
+/// 3. Fewest `step_count`.
+/// 4. Smallest patch byte length (approximated by SHA-256 presence and string
+///    length of the stored patch — callers store the patch content, not SHA).
+/// 5. Lexicographically smallest `patch_sha256`.
+///
+/// Returns `(winner_run_index, rationale_string, tie_break_applied)`.
+pub fn select_winner(runs: &[BestOfRunDetail]) -> (u32, String, bool) {
+    let candidates: Vec<&BestOfRunDetail> = runs.iter().filter(|d| !d.skipped).collect();
+
+    if candidates.is_empty() {
+        // All skipped; pick run index 0 as a fallback (should not happen in practice)
+        return (0, "all_skipped_fallback".into(), false);
+    }
+
+    // Primary sort: most checks passed (descending)
+    let max_checks = candidates
+        .iter()
+        .map(|d| d.verify_checks_passed)
+        .max()
+        .unwrap_or(0);
+
+    let tier1: Vec<&BestOfRunDetail> = candidates
+        .iter()
+        .copied()
+        .filter(|d| d.verify_checks_passed == max_checks)
+        .collect();
+
+    if tier1.len() == 1 {
+        return (tier1[0].run_index, "most_verify_checks_passed".into(), false);
+    }
+
+    // Tie-break 1: lowest cost
+    let min_cost = tier1
+        .iter()
+        .map(|d| ordered_f64(d.total_cost_usd.unwrap_or(f64::MAX)))
+        .min()
+        .unwrap_or_else(|| ordered_f64(0.0));
+
+    let tier2: Vec<&BestOfRunDetail> = tier1
+        .iter()
+        .copied()
+        .filter(|d| ordered_f64(d.total_cost_usd.unwrap_or(f64::MAX)) == min_cost)
+        .collect();
+
+    if tier2.len() == 1 {
+        return (
+            tier2[0].run_index,
+            "tie_break:lowest_cost_usd".into(),
+            true,
+        );
+    }
+
+    // Tie-break 2: fewest steps
+    let min_steps = tier2
+        .iter()
+        .map(|d| d.step_count.unwrap_or(u32::MAX))
+        .min()
+        .unwrap_or(0);
+
+    let tier3: Vec<&BestOfRunDetail> = tier2
+        .iter()
+        .copied()
+        .filter(|d| d.step_count.unwrap_or(u32::MAX) == min_steps)
+        .collect();
+
+    if tier3.len() == 1 {
+        return (
+            tier3[0].run_index,
+            "tie_break:fewest_steps".into(),
+            true,
+        );
+    }
+
+    // Tie-break 3: smallest patch byte length
+    let min_patch_len = tier3
+        .iter()
+        .map(|d| d.patch_byte_len.unwrap_or(u64::MAX))
+        .min()
+        .unwrap_or(0);
+
+    let tier4: Vec<&BestOfRunDetail> = tier3
+        .iter()
+        .copied()
+        .filter(|d| d.patch_byte_len.unwrap_or(u64::MAX) == min_patch_len)
+        .collect();
+
+    if tier4.len() == 1 {
+        return (
+            tier4[0].run_index,
+            "tie_break:smallest_patch_bytes".into(),
+            true,
+        );
+    }
+
+    // Tie-break 4: lexicographically smallest patch SHA-256
+    let best = tier4
+        .iter()
+        .copied()
+        .min_by(|a, b| {
+            // No sha (no patch) is treated as lexicographically largest
+            let sha_a = a.patch_sha256.as_deref().unwrap_or("\u{FF}");
+            let sha_b = b.patch_sha256.as_deref().unwrap_or("\u{FF}");
+            sha_a.cmp(sha_b)
+        })
+        .unwrap_or(tier4[0]);
+
+    (
+        best.run_index,
+        "tie_break:patch_sha256_lex".into(),
+        true,
+    )
+}
+
+/// Total ordering wrapper for f64 (NaN treated as MAX).
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct OrderedF64(u64);
+
+fn ordered_f64(v: f64) -> OrderedF64 {
+    if v.is_nan() {
+        OrderedF64(u64::MAX)
+    } else {
+        OrderedF64(v.to_bits())
+    }
+}
+
+// ── Runner arguments ──────────────────────────────────────────────────────────
+
+/// Arguments for `agent best-of`.
+pub struct BestOfArgs {
+    /// The task to run N times.
+    pub task: String,
+    /// How many times to run the task (validated 2..=10 before calling `run`).
+    pub runs: u32,
+    pub config: crate::config::Config,
+    /// Root output directory; artifacts land in `<output_dir>/<best_of_name>/`.
+    pub output_dir: PathBuf,
+    /// Subdirectory name for this best-of run.
+    pub best_of_name: String,
+    /// Verify checks in `NAME:COMMAND` format. Empty → fallback to outcome_submitted.
+    pub verify: Vec<String>,
+    pub verify_timeout_secs: u64,
+    /// Total USD ceiling. Remaining runs are recorded as skipped when exceeded.
+    pub cost_limit_usd: Option<f64>,
+    pub task_timeout_secs: Option<u64>,
+    pub step_limit: Option<u32>,
+    /// Per-run USD ceiling enforced inside the agent loop.
+    pub per_task_budget_usd: Option<f64>,
+    /// Where to write the winner's patch file. Defaults to `<best_of_dir>/best.patch`.
+    pub output_patch: Option<PathBuf>,
+    /// When true, exit 0 even when all runs fail verify checks.
+    pub allow_no_pass: bool,
+    /// Scripted model responses (test-only).
+    pub deterministic_responses: Option<Vec<String>>,
+    /// Fixed per-call usage for scripted backend (test-only).
+    pub deterministic_usage_per_call: Option<crate::model::ModelUsage>,
+    /// When false, suppress the human-readable summary (--format json).
+    pub print_summary: bool,
+}
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+/// Validate that `n` is in the range 2..=10. Returns an error message on failure.
+pub fn validate_runs(n: u32) -> Result<(), String> {
+    match n {
+        0 | 1 => Err(format!(
+            "--runs must be between 2 and 10 (inclusive), got {n}; \
+             best-of-1 is equivalent to `mini` — use that command instead"
+        )),
+        2..=10 => Ok(()),
+        _ => Err(format!(
+            "--runs must be between 2 and 10 (inclusive), got {n}"
+        )),
+    }
+}
+
+// ── Main runner ───────────────────────────────────────────────────────────────
+
+/// Run best-of selection and return the final exit code.
+///
+/// Writes `<output_dir>/<best_of_name>/best-of-results.json` and, when a
+/// winner has a captured patch, writes the patch to `--output` (or
+/// `<best_of_dir>/best.patch`).
+#[allow(clippy::too_many_lines)]
+pub async fn run(args: BestOfArgs) -> Result<ExitCode, Error> {
+    // ── Validate name (no path traversal) ────────────────────────────────────
+    if args.best_of_name.contains('/')
+        || args.best_of_name.contains('\\')
+        || args.best_of_name.contains("..")
+    {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "best-of name '{}' must not contain path separators or '..'",
+            args.best_of_name
+        ))));
+    }
+
+    // ── Prepare output directory ──────────────────────────────────────────────
+    let best_of_dir = args.output_dir.join(&args.best_of_name);
+    std::fs::create_dir_all(&best_of_dir).map_err(Error::Io)?;
+
+    // ── Parse verify checks ───────────────────────────────────────────────────
+    let verification_checks = parse_verify_checks(&args.verify)?;
+
+    let started_at = Utc::now().to_rfc3339();
+    let mut runs_detail: Vec<BestOfRunDetail> = Vec::with_capacity(args.runs as usize);
+    let mut cumulative_cost = 0.0_f64;
+    let mut run_patch_texts: Vec<Option<String>> = Vec::new();
+
+    for run_index in 0..args.runs {
+        // ── Cost-cap check: skip remaining runs ───────────────────────────────
+        if let Some(limit) = args.cost_limit_usd {
+            if cumulative_cost >= limit {
+                runs_detail.push(BestOfRunDetail {
+                    run_index,
+                    outcome: "skipped_budget_exhausted".into(),
+                    verify_checks_passed: 0,
+                    verify_checks_total: u32::try_from(verification_checks.len()).unwrap_or(0),
+                    passed: false,
+                    total_cost_usd: None,
+                    step_count: None,
+                    patch_byte_len: None,
+                    patch_sha256: None,
+                    skipped: true,
+                    skip_reason: Some("cost_limit_usd".into()),
+                });
+                run_patch_texts.push(None);
+                continue;
+            }
+        }
+
+        let trajectory_name = format!("run_{run_index:02}");
+        let traj_path = best_of_dir.join(format!("{trajectory_name}.traj.json"));
+        let _ = std::fs::remove_file(&traj_path);
+
+        // ── Build and execute mini run ────────────────────────────────────────
+        let mut run_cfg = args.config.clone();
+        if let Some(v) = args.step_limit {
+            run_cfg.root.agent.step_limit = v;
+        }
+        if let Some(v) = args.per_task_budget_usd {
+            run_cfg.root.agent.per_task_budget_usd = Some(v);
+        }
+
+        let mini_args = crate::run::mini::MiniArgs {
+            task: args.task.clone(),
+            extra_context: None,
+            config: run_cfg,
+            driver: crate::run::mini::RunDriver::Builtin,
+            driver_append_system_prompt: false,
+            driver_isolated: false,
+            output_dir: best_of_dir.clone(),
+            trajectory_name: trajectory_name.clone(),
+            deterministic_responses: args.deterministic_responses.clone(),
+            deterministic_usage_per_call: args.deterministic_usage_per_call.clone(),
+            task_timeout_secs: args.task_timeout_secs,
+            cancellation: None,
+            stream_addr: None,
+            patch_capture: None,
+            verification_checks: verification_checks.clone(),
+            verification_timeout_secs: args.verify_timeout_secs,
+            resume_from: None,
+            interactive_mode: crate::run::mini::InteractiveMode::Off,
+            trace_id: None,
+            webhook_url: None,
+            webhook_headers: vec![],
+            event_log: None,
+            event_log_instance_id: None,
+            local_workdir: std::env::current_dir().ok(),
+            read_only: false,
+            allow_mcp_in_read_only: false,
+            rehearsal_gold_patch: None,
+            no_step_persist: false,
+            parent_sweep_run_id: None,
+            continue_from: None,
+            issue_provenance: None,
+        };
+
+        if let Err(e) = crate::run::mini::run(mini_args).await {
+            if !traj_path.exists() {
+                return Err(e);
+            }
+        }
+
+        // ── Read trajectory and score run ─────────────────────────────────────
+        let patch_text = read_sibling_patch(&best_of_dir, &trajectory_name);
+
+        let detail = if let Some(traj) = try_load_trajectory(&traj_path) {
+            let outcome = traj
+                .info
+                .outcome
+                .clone()
+                .unwrap_or_else(|| "error".to_owned());
+            let cost = traj.info.total_cost_usd;
+            let steps = traj.info.steps;
+
+            cumulative_cost += cost.unwrap_or(0.0);
+
+            let (checks_passed, checks_total) =
+                count_verify_results(&traj, &verification_checks);
+
+            let passed = checks_total > 0 && checks_passed == checks_total;
+            let patch_byte_len = patch_text
+                .as_deref()
+                .map(|p| p.len() as u64);
+            let patch_sha = patch_text.as_deref().map(sha256_hex);
+
+            BestOfRunDetail {
+                run_index,
+                outcome,
+                verify_checks_passed: checks_passed,
+                verify_checks_total: checks_total,
+                passed,
+                total_cost_usd: cost,
+                step_count: steps,
+                patch_byte_len,
+                patch_sha256: patch_sha,
+                skipped: false,
+                skip_reason: None,
+            }
+        } else {
+            run_patch_texts.push(None);
+            BestOfRunDetail {
+                run_index,
+                outcome: "error".into(),
+                verify_checks_passed: 0,
+                verify_checks_total: u32::try_from(verification_checks.len()).unwrap_or(0),
+                passed: false,
+                total_cost_usd: None,
+                step_count: None,
+                patch_byte_len: None,
+                patch_sha256: None,
+                skipped: false,
+                skip_reason: None,
+            }
+        };
+
+        run_patch_texts.push(patch_text);
+        runs_detail.push(detail);
+    }
+
+    let finished_at = Utc::now().to_rfc3339();
+
+    // ── Select winner ─────────────────────────────────────────────────────────
+    let passing_run_count = u32::try_from(
+        runs_detail.iter().filter(|d| d.passed).count(),
+    )
+    .unwrap_or(u32::MAX);
+
+    let all_failed = passing_run_count == 0
+        && runs_detail.iter().any(|d| !d.skipped);
+
+    let (winner_run_index, selection_rationale, tie_break_applied) =
+        if runs_detail.iter().any(|d| !d.skipped) {
+            let (idx, rat, tb) = select_winner(&runs_detail);
+            (Some(idx), rat, tb)
+        } else {
+            (None, "all_skipped".into(), false)
+        };
+
+    // ── Write winner patch ────────────────────────────────────────────────────
+    let patch_out_path = args
+        .output_patch
+        .clone()
+        .unwrap_or_else(|| best_of_dir.join("best.patch"));
+
+    if let Some(winner_idx) = winner_run_index {
+        let winner_patch = run_patch_texts
+            .get(winner_idx as usize)
+            .and_then(|p| p.as_deref());
+
+        let patch_bytes = winner_patch.unwrap_or("").as_bytes();
+        if let Some(parent) = patch_out_path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent).map_err(Error::Io)?;
+            }
+        }
+        std::fs::write(&patch_out_path, patch_bytes).map_err(Error::Io)?;
+    }
+
+    // ── Build results artifact ────────────────────────────────────────────────
+    let results = BestOfResults {
+        schema_version: ArtifactSchemaVersion::CURRENT,
+        artifact_kind: ArtifactKind::BestOfResults,
+        task: args.task.clone(),
+        runs: args.runs,
+        winner_run_index,
+        passing_run_count,
+        all_failed,
+        tie_break_applied,
+        selection_rationale,
+        started_at,
+        finished_at,
+        runs_detail,
+    };
+
+    // ── Write best-of-results.json ────────────────────────────────────────────
+    let results_path = best_of_dir.join("best-of-results.json");
+    write_results(&results, &results_path)?;
+
+    // ── Print summary ─────────────────────────────────────────────────────────
+    if args.print_summary {
+        print!("{}", results.summary_text());
+        if winner_run_index.is_some() {
+            eprintln!("best patch written to: {}", patch_out_path.display());
+        }
+    }
+
+    // ── Exit code resolution ──────────────────────────────────────────────────
+    // Budget halt if any runs were skipped
+    if results.runs_detail.iter().any(|d| d.skipped) {
+        return Ok(ExitCode::BudgetHalt);
+    }
+
+    if all_failed {
+        if args.allow_no_pass {
+            return Ok(ExitCode::Success);
+        }
+        return Ok(ExitCode::BestOfAllFailed);
+    }
+
+    Ok(ExitCode::Success)
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+fn parse_verify_checks(
+    specs: &[String],
+) -> Result<Vec<crate::trajectory::VerificationCheck>, Error> {
+    specs
+        .iter()
+        .map(|s| {
+            let colon = s.find(':').ok_or_else(|| {
+                Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "--verify must be in NAME:COMMAND format, got `{s}`"
+                )))
+            })?;
+            let name = s[..colon].trim();
+            let command = s[colon + 1..].trim();
+            if name.is_empty() || command.is_empty() {
+                return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "--verify NAME:COMMAND requires non-empty name and command, got `{s}`"
+                ))));
+            }
+            Ok(crate::trajectory::VerificationCheck {
+                name: name.to_owned(),
+                command: command.to_owned(),
+            })
+        })
+        .collect()
+}
+
+fn try_load_trajectory(path: &Path) -> Option<crate::trajectory::Trajectory> {
+    let text = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn read_sibling_patch(dir: &Path, trajectory_name: &str) -> Option<String> {
+    let patch_path = dir.join(format!("{trajectory_name}.patch"));
+    std::fs::read_to_string(patch_path).ok()
+}
+
+/// Count the number of verify checks that passed vs total.
+///
+/// With verify checks present: counts individual check results from the
+/// trajectory's `verification_results`. Without checks: falls back to
+/// outcome-based scoring (submitted = 1/1).
+fn count_verify_results(
+    traj: &crate::trajectory::Trajectory,
+    checks: &[crate::trajectory::VerificationCheck],
+) -> (u32, u32) {
+    if checks.is_empty() {
+        // Fallback: treat outcome==submitted as 1/1
+        let passed = traj.info.outcome.as_deref()
+            == Some(crate::trajectory::outcome::SUBMITTED);
+        return (u32::from(passed), 1);
+    }
+
+    let total = u32::try_from(checks.len()).unwrap_or(0);
+
+    // Count passed checks from verification_results if available
+    if !traj.info.verification_results.is_empty() {
+        let passed = u32::try_from(
+            traj.info.verification_results
+                .iter()
+                .filter(|r| r.passed)
+                .count(),
+        )
+        .unwrap_or(0);
+        return (passed, total);
+    }
+
+    // Fall back to binary: all passed or none
+    let all_passed = traj.info.verification_status.as_deref()
+        == Some(crate::trajectory::verification_status::VERIFIED);
+    (if all_passed { total } else { 0 }, total)
+}
+
+fn sha256_hex(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn write_results(results: &BestOfResults, path: &Path) -> Result<(), Error> {
+    let json = serde_json::to_string_pretty(results).map_err(Error::Json)?;
+    std::fs::write(path, json).map_err(Error::Io)
+}

--- a/src/run/best_of.rs
+++ b/src/run/best_of.rs
@@ -74,11 +74,7 @@ impl BestOfResults {
         use std::fmt::Write as _;
         let mut out = String::new();
 
-        let non_skipped = self
-            .runs_detail
-            .iter()
-            .filter(|d| !d.skipped)
-            .count();
+        let non_skipped = self.runs_detail.iter().filter(|d| !d.skipped).count();
 
         let _ = writeln!(
             &mut out,
@@ -120,9 +116,7 @@ impl BestOfResults {
             let steps = d
                 .step_count
                 .map_or_else(|| "-".to_owned(), |s| s.to_string());
-            let winner_marker = self
-                .winner_run_index
-                .is_some_and(|w| w == d.run_index);
+            let winner_marker = self.winner_run_index.is_some_and(|w| w == d.run_index);
             let pass_label = if d.skipped {
                 "skip"
             } else if d.passed {
@@ -192,7 +186,11 @@ pub fn select_winner(runs: &[BestOfRunDetail]) -> (u32, String, bool) {
         .collect();
 
     if tier1.len() == 1 {
-        return (tier1[0].run_index, "most_verify_checks_passed".into(), false);
+        return (
+            tier1[0].run_index,
+            "most_verify_checks_passed".into(),
+            false,
+        );
     }
 
     // Tie-break 1: lowest cost
@@ -205,15 +203,13 @@ pub fn select_winner(runs: &[BestOfRunDetail]) -> (u32, String, bool) {
     let tier2: Vec<&BestOfRunDetail> = tier1
         .iter()
         .copied()
-        .filter(|d| d.total_cost_usd.unwrap_or(f64::MAX).total_cmp(&min_cost) == std::cmp::Ordering::Equal)
+        .filter(|d| {
+            d.total_cost_usd.unwrap_or(f64::MAX).total_cmp(&min_cost) == std::cmp::Ordering::Equal
+        })
         .collect();
 
     if tier2.len() == 1 {
-        return (
-            tier2[0].run_index,
-            "tie_break:lowest_cost_usd".into(),
-            true,
-        );
+        return (tier2[0].run_index, "tie_break:lowest_cost_usd".into(), true);
     }
 
     // Tie-break 2: fewest steps
@@ -230,11 +226,7 @@ pub fn select_winner(runs: &[BestOfRunDetail]) -> (u32, String, bool) {
         .collect();
 
     if tier3.len() == 1 {
-        return (
-            tier3[0].run_index,
-            "tie_break:fewest_steps".into(),
-            true,
-        );
+        return (tier3[0].run_index, "tie_break:fewest_steps".into(), true);
     }
 
     // Tie-break 3: smallest patch byte length
@@ -270,11 +262,7 @@ pub fn select_winner(runs: &[BestOfRunDetail]) -> (u32, String, bool) {
         })
         .unwrap_or(tier4[0]);
 
-    (
-        best.run_index,
-        "tie_break:patch_sha256_lex".into(),
-        true,
-    )
+    (best.run_index, "tie_break:patch_sha256_lex".into(), true)
 }
 
 // ── Runner arguments ──────────────────────────────────────────────────────────
@@ -411,8 +399,7 @@ pub async fn run(args: BestOfArgs) -> Result<ExitCode, Error> {
             stream_addr: None,
             patch_capture: Some(crate::run::mini::PatchCaptureSpec {
                 base_commit: None,
-                workdir: std::env::current_dir()
-                    .unwrap_or_else(|_| std::path::PathBuf::from(".")),
+                workdir: std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
                 patch_path: best_of_dir.join(format!("{trajectory_name}.patch")),
                 skip_patch_validation: false,
             }),
@@ -455,13 +442,10 @@ pub async fn run(args: BestOfArgs) -> Result<ExitCode, Error> {
 
             cumulative_cost += cost.unwrap_or(0.0);
 
-            let (checks_passed, checks_total) =
-                count_verify_results(&traj, &verification_checks);
+            let (checks_passed, checks_total) = count_verify_results(&traj, &verification_checks);
 
             let passed = checks_total > 0 && checks_passed == checks_total;
-            let patch_byte_len = patch_text
-                .as_deref()
-                .map(|p| p.len() as u64);
+            let patch_byte_len = patch_text.as_deref().map(|p| p.len() as u64);
             let patch_sha = patch_text.as_deref().map(sha256_hex);
 
             BestOfRunDetail {
@@ -500,13 +484,10 @@ pub async fn run(args: BestOfArgs) -> Result<ExitCode, Error> {
     let finished_at = Utc::now().to_rfc3339();
 
     // ── Select winner ─────────────────────────────────────────────────────────
-    let passing_run_count = u32::try_from(
-        runs_detail.iter().filter(|d| d.passed).count(),
-    )
-    .unwrap_or(u32::MAX);
+    let passing_run_count =
+        u32::try_from(runs_detail.iter().filter(|d| d.passed).count()).unwrap_or(u32::MAX);
 
-    let all_failed = passing_run_count == 0
-        && runs_detail.iter().any(|d| !d.skipped);
+    let all_failed = passing_run_count == 0 && runs_detail.iter().any(|d| !d.skipped);
 
     let (winner_run_index, selection_rationale, tie_break_applied) =
         if runs_detail.iter().any(|d| !d.skipped) {
@@ -629,8 +610,7 @@ fn count_verify_results(
 ) -> (u32, u32) {
     if checks.is_empty() {
         // Fallback: treat outcome==submitted as 1/1
-        let passed = traj.info.outcome.as_deref()
-            == Some(crate::trajectory::outcome::SUBMITTED);
+        let passed = traj.info.outcome.as_deref() == Some(crate::trajectory::outcome::SUBMITTED);
         return (u32::from(passed), 1);
     }
 
@@ -639,7 +619,8 @@ fn count_verify_results(
     // Count passed checks from verification_results if available
     if !traj.info.verification_results.is_empty() {
         let passed = u32::try_from(
-            traj.info.verification_results
+            traj.info
+                .verification_results
                 .iter()
                 .filter(|r| r.passed)
                 .count(),

--- a/src/run/best_of.rs
+++ b/src/run/best_of.rs
@@ -372,7 +372,9 @@ pub async fn run(args: BestOfArgs) -> Result<ExitCode, Error> {
 
         let trajectory_name = format!("run_{run_index:02}");
         let traj_path = best_of_dir.join(format!("{trajectory_name}.traj.json"));
+        let run_patch_path = best_of_dir.join(format!("{trajectory_name}.patch"));
         let _ = std::fs::remove_file(&traj_path);
+        let _ = std::fs::remove_file(&run_patch_path);
 
         // ── Build and execute mini run ────────────────────────────────────────
         let mut run_cfg = args.config.clone();
@@ -382,6 +384,34 @@ pub async fn run(args: BestOfArgs) -> Result<ExitCode, Error> {
         if let Some(v) = args.per_task_budget_usd {
             run_cfg.root.agent.per_task_budget_usd = Some(v);
         }
+
+        let is_docker = matches!(
+            run_cfg.root.environment.kind,
+            crate::config::EnvKind::Docker
+        );
+
+        // For Docker, `git diff` runs inside the container so the workdir must
+        // be the container path. For local, use the host CWD.
+        let patch_workdir = if is_docker {
+            PathBuf::from(&run_cfg.root.environment.workdir)
+        } else {
+            std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+        };
+
+        // Snapshot HEAD before the run so agents that commit don't produce an
+        // empty diff (local env only; Docker HEAD is snapshotted inside the
+        // container where we can't reach it cheaply here).
+        let base_commit = if is_docker {
+            None
+        } else {
+            std::process::Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(&patch_workdir)
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
+        };
 
         let mini_args = crate::run::mini::MiniArgs {
             task: args.task.clone(),
@@ -398,9 +428,9 @@ pub async fn run(args: BestOfArgs) -> Result<ExitCode, Error> {
             cancellation: None,
             stream_addr: None,
             patch_capture: Some(crate::run::mini::PatchCaptureSpec {
-                base_commit: None,
-                workdir: std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
-                patch_path: best_of_dir.join(format!("{trajectory_name}.patch")),
+                base_commit,
+                workdir: patch_workdir,
+                patch_path: run_patch_path,
                 skip_patch_validation: false,
             }),
             verification_checks: verification_checks.clone(),

--- a/src/run/best_of.rs
+++ b/src/run/best_of.rs
@@ -384,6 +384,17 @@ pub async fn run(args: BestOfArgs) -> Result<ExitCode, Error> {
         if let Some(v) = args.per_task_budget_usd {
             run_cfg.root.agent.per_task_budget_usd = Some(v);
         }
+        // Clamp per-run budget to the remaining global budget so the last
+        // allowed run cannot overrun the total ceiling by a full candidate.
+        if let Some(limit) = args.cost_limit_usd {
+            let remaining = (limit - cumulative_cost).max(0.0);
+            let clamped = run_cfg
+                .root
+                .agent
+                .per_task_budget_usd
+                .map_or(remaining, |p| p.min(remaining));
+            run_cfg.root.agent.per_task_budget_usd = Some(clamped);
+        }
 
         let is_docker = matches!(
             run_cfg.root.environment.kind,

--- a/src/run/best_of.rs
+++ b/src/run/best_of.rs
@@ -198,14 +198,14 @@ pub fn select_winner(runs: &[BestOfRunDetail]) -> (u32, String, bool) {
     // Tie-break 1: lowest cost
     let min_cost = tier1
         .iter()
-        .map(|d| ordered_f64(d.total_cost_usd.unwrap_or(f64::MAX)))
-        .min()
-        .unwrap_or_else(|| ordered_f64(0.0));
+        .map(|d| d.total_cost_usd.unwrap_or(f64::MAX))
+        .min_by(f64::total_cmp)
+        .unwrap_or(f64::MAX);
 
     let tier2: Vec<&BestOfRunDetail> = tier1
         .iter()
         .copied()
-        .filter(|d| ordered_f64(d.total_cost_usd.unwrap_or(f64::MAX)) == min_cost)
+        .filter(|d| d.total_cost_usd.unwrap_or(f64::MAX).total_cmp(&min_cost) == std::cmp::Ordering::Equal)
         .collect();
 
     if tier2.len() == 1 {
@@ -277,18 +277,6 @@ pub fn select_winner(runs: &[BestOfRunDetail]) -> (u32, String, bool) {
     )
 }
 
-/// Total ordering wrapper for f64 (NaN treated as MAX).
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
-struct OrderedF64(u64);
-
-fn ordered_f64(v: f64) -> OrderedF64 {
-    if v.is_nan() {
-        OrderedF64(u64::MAX)
-    } else {
-        OrderedF64(v.to_bits())
-    }
-}
-
 // ── Runner arguments ──────────────────────────────────────────────────────────
 
 /// Arguments for `agent best-of`.
@@ -349,7 +337,8 @@ pub fn validate_runs(n: u32) -> Result<(), String> {
 #[allow(clippy::too_many_lines)]
 pub async fn run(args: BestOfArgs) -> Result<ExitCode, Error> {
     // ── Validate name (no path traversal) ────────────────────────────────────
-    if args.best_of_name.contains('/')
+    if args.best_of_name.is_empty()
+        || args.best_of_name.contains('/')
         || args.best_of_name.contains('\\')
         || args.best_of_name.contains("..")
     {
@@ -420,7 +409,13 @@ pub async fn run(args: BestOfArgs) -> Result<ExitCode, Error> {
             task_timeout_secs: args.task_timeout_secs,
             cancellation: None,
             stream_addr: None,
-            patch_capture: None,
+            patch_capture: Some(crate::run::mini::PatchCaptureSpec {
+                base_commit: None,
+                workdir: std::env::current_dir()
+                    .unwrap_or_else(|_| std::path::PathBuf::from(".")),
+                patch_path: best_of_dir.join(format!("{trajectory_name}.patch")),
+                skip_patch_validation: false,
+            }),
             verification_checks: verification_checks.clone(),
             verification_timeout_secs: args.verify_timeout_secs,
             resume_from: None,
@@ -483,7 +478,6 @@ pub async fn run(args: BestOfArgs) -> Result<ExitCode, Error> {
                 skip_reason: None,
             }
         } else {
-            run_patch_texts.push(None);
             BestOfRunDetail {
                 run_index,
                 outcome: "error".into(),

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod annotate;
 pub mod apply;
+pub mod best_of;
 pub mod assert;
 pub mod audit;
 pub mod behavior;

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -3,10 +3,10 @@
 
 pub mod annotate;
 pub mod apply;
-pub mod best_of;
 pub mod assert;
 pub mod audit;
 pub mod behavior;
+pub mod best_of;
 pub mod bisect;
 pub mod budget_fit;
 pub mod bundle;

--- a/tests/agent_best_of.rs
+++ b/tests/agent_best_of.rs
@@ -40,7 +40,7 @@ fn validate_runs_one_is_error() {
     assert!(err.is_err(), "expected error for --runs 1");
     let msg = err.unwrap_err();
     assert!(
-        msg.contains("mini") || msg.contains("2"),
+        msg.contains("mini") || msg.contains('2'),
         "error should mention minimum 2 or suggest mini; got: {msg}"
     );
 }
@@ -239,8 +239,8 @@ fn select_winner_skipped_runs_not_selected() {
     run0.verify_checks_passed = 0;
     run0.patch_byte_len = None;
     let run1 = make_run(1, 1, 2, 0.010, 15, "patch-b");
-    let runs = vec![run0, run1];
-    let (idx, _rationale, _tie_break) = select_winner(&runs);
+    let run_list = vec![run0, run1];
+    let (idx, _rationale, _tie_break) = select_winner(&run_list);
     assert_eq!(idx, 1, "skipped run should not be selected as winner");
 }
 

--- a/tests/agent_best_of.rs
+++ b/tests/agent_best_of.rs
@@ -1,0 +1,623 @@
+//! Tests for `agent best-of` — issue #485.
+//!
+//! RED phase: tests reference the not-yet-implemented API and will fail to
+//! compile until the implementation is in place.
+//! GREEN phase: implement src/run/best_of.rs and wire the CLI.
+//! REFACTOR phase: clean up.
+
+#![allow(clippy::unwrap_used)]
+
+use maxwells_daemon::artifact::{ArtifactKind, ArtifactSchemaVersion};
+use maxwells_daemon::exit_code::ExitCode;
+use maxwells_daemon::run::best_of::{
+    BestOfRunDetail, BestOfResults, select_winner, validate_runs,
+};
+
+// ── Exit code unit tests ──────────────────────────────────────────────────────
+
+#[test]
+fn best_of_all_failed_exit_code_is_40() {
+    assert_eq!(ExitCode::BestOfAllFailed.as_i32(), 40);
+    assert_eq!(
+        ExitCode::BestOfAllFailed.outcome_class(),
+        "best_of_all_failed"
+    );
+}
+
+// ── ArtifactKind tests ────────────────────────────────────────────────────────
+
+#[test]
+fn artifact_kind_best_of_results_label() {
+    assert_eq!(ArtifactKind::BestOfResults.label(), "best_of_results");
+}
+
+// ── validate_runs tests ───────────────────────────────────────────────────────
+
+#[test]
+fn validate_runs_one_is_error() {
+    // best-of-1 is meaningless; min is 2
+    let err = validate_runs(1);
+    assert!(err.is_err(), "expected error for --runs 1");
+    let msg = err.unwrap_err();
+    assert!(
+        msg.contains("mini") || msg.contains("2"),
+        "error should mention minimum 2 or suggest mini; got: {msg}"
+    );
+}
+
+#[test]
+fn validate_runs_zero_is_error() {
+    assert!(validate_runs(0).is_err());
+}
+
+#[test]
+fn validate_runs_eleven_is_error() {
+    assert!(validate_runs(11).is_err());
+}
+
+#[test]
+fn validate_runs_two_is_ok() {
+    assert!(validate_runs(2).is_ok());
+}
+
+#[test]
+fn validate_runs_ten_is_ok() {
+    assert!(validate_runs(10).is_ok());
+}
+
+// ── BestOfRunDetail struct tests ─────────────────────────────────────────────
+
+#[test]
+fn best_of_run_detail_has_required_fields() {
+    let detail = BestOfRunDetail {
+        run_index: 0,
+        outcome: "submitted".into(),
+        verify_checks_passed: 2,
+        verify_checks_total: 2,
+        passed: true,
+        total_cost_usd: Some(0.005),
+        step_count: Some(10),
+        patch_byte_len: Some(42),
+        patch_sha256: Some("abc123".into()),
+        skipped: false,
+        skip_reason: None,
+    };
+    assert_eq!(detail.run_index, 0);
+    assert!(detail.passed);
+    assert_eq!(detail.verify_checks_passed, 2);
+    assert_eq!(detail.verify_checks_total, 2);
+    assert!(!detail.skipped);
+}
+
+// ── BestOfResults struct tests ────────────────────────────────────────────────
+
+#[test]
+fn best_of_results_has_required_fields() {
+    let results = BestOfResults {
+        schema_version: ArtifactSchemaVersion::CURRENT,
+        artifact_kind: ArtifactKind::BestOfResults,
+        task: "Fix the bug".into(),
+        runs: 3,
+        winner_run_index: Some(0),
+        passing_run_count: 1,
+        all_failed: false,
+        tie_break_applied: false,
+        selection_rationale: "most_verify_checks_passed".into(),
+        started_at: "2026-01-01T00:00:00Z".into(),
+        finished_at: "2026-01-01T00:01:00Z".into(),
+        runs_detail: vec![],
+    };
+    assert_eq!(results.runs, 3);
+    assert_eq!(results.winner_run_index, Some(0));
+    assert_eq!(results.passing_run_count, 1);
+    assert!(!results.all_failed);
+    assert!(!results.tie_break_applied);
+}
+
+// ── select_winner tests ───────────────────────────────────────────────────────
+
+fn make_run(
+    run_index: u32,
+    checks_passed: u32,
+    checks_total: u32,
+    cost: f64,
+    steps: u32,
+    patch: &str,
+) -> BestOfRunDetail {
+    use sha2::{Digest, Sha256};
+    let (sha, byte_len) = if patch.is_empty() {
+        (None, None)
+    } else {
+        let mut hasher = Sha256::new();
+        hasher.update(patch.as_bytes());
+        (
+            Some(format!("{:x}", hasher.finalize())),
+            Some(patch.len() as u64),
+        )
+    };
+    BestOfRunDetail {
+        run_index,
+        outcome: if checks_passed == checks_total && checks_total > 0 {
+            "submitted".into()
+        } else {
+            "verification_failed".into()
+        },
+        verify_checks_passed: checks_passed,
+        verify_checks_total: checks_total,
+        passed: checks_passed == checks_total && checks_total > 0,
+        total_cost_usd: Some(cost),
+        step_count: Some(steps),
+        patch_byte_len: byte_len,
+        patch_sha256: sha,
+        skipped: false,
+        skip_reason: None,
+    }
+}
+
+#[test]
+fn select_winner_prefers_most_checks_passed() {
+    // run 0: 1/2 checks, run 1: 2/2 checks → run 1 wins
+    let runs = vec![
+        make_run(0, 1, 2, 0.005, 10, "patch-a"),
+        make_run(1, 2, 2, 0.010, 15, "patch-b"),
+    ];
+    let (idx, rationale, tie_break) = select_winner(&runs);
+    assert_eq!(idx, 1, "run with more passing checks should win");
+    assert!(!tie_break);
+    assert!(!rationale.is_empty());
+}
+
+#[test]
+fn select_winner_tie_breaks_by_lowest_cost() {
+    // Both pass all checks; run 0 is cheaper
+    let runs = vec![
+        make_run(0, 2, 2, 0.003, 10, "patch-a"),
+        make_run(1, 2, 2, 0.007, 10, "patch-b"),
+    ];
+    let (idx, _rationale, tie_break) = select_winner(&runs);
+    assert_eq!(idx, 0, "lower cost should win tie");
+    assert!(tie_break);
+}
+
+#[test]
+fn select_winner_tie_breaks_by_fewest_steps() {
+    // Same checks, same cost → fewest steps wins
+    let runs = vec![
+        make_run(0, 2, 2, 0.005, 15, "patch-a"),
+        make_run(1, 2, 2, 0.005, 8, "patch-b"),
+    ];
+    let (idx, _rationale, tie_break) = select_winner(&runs);
+    assert_eq!(idx, 1, "fewer steps should win tie");
+    assert!(tie_break);
+}
+
+#[test]
+fn select_winner_tie_breaks_by_smallest_patch() {
+    // Same checks, same cost, same steps → smaller patch wins
+    let runs = vec![
+        make_run(0, 2, 2, 0.005, 10, "longer-patch-content-here"),
+        make_run(1, 2, 2, 0.005, 10, "short"),
+    ];
+    let (idx, _rationale, tie_break) = select_winner(&runs);
+    assert_eq!(idx, 1, "smaller patch should win tie");
+    assert!(tie_break);
+}
+
+#[test]
+fn select_winner_tie_breaks_by_sha256() {
+    // Same checks, same cost, same steps, same-length patches → lex smallest sha wins
+    // We create two patches of exactly the same byte length but different content
+    let runs = vec![
+        make_run(0, 2, 2, 0.005, 10, "zzzzz"),
+        make_run(1, 2, 2, 0.005, 10, "aaaaa"),
+    ];
+    let (idx, _rationale, tie_break) = select_winner(&runs);
+    // lex smallest sha of ("aaaaa") should beat sha of ("zzzzz")
+    assert!(tie_break);
+    // We just assert the same winner is picked deterministically
+    let (idx2, _, _) = select_winner(&runs);
+    assert_eq!(idx, idx2, "selection must be deterministic");
+    let _ = idx; // suppress unused warning if assertion passes
+}
+
+#[test]
+fn select_winner_all_failed_still_picks_best_scoring() {
+    // All fail, but one has more checks passed → select that one
+    let runs = vec![
+        make_run(0, 0, 2, 0.005, 10, "patch-a"),
+        make_run(1, 1, 2, 0.005, 10, "patch-b"),
+    ];
+    let (idx, _rationale, _tie_break) = select_winner(&runs);
+    assert_eq!(idx, 1, "run with more passing checks wins even when all fail");
+}
+
+#[test]
+fn select_winner_skipped_runs_not_selected() {
+    let mut run0 = make_run(0, 2, 2, 0.005, 10, "patch-a");
+    run0.skipped = true;
+    run0.passed = false;
+    run0.verify_checks_passed = 0;
+    run0.patch_byte_len = None;
+    let run1 = make_run(1, 1, 2, 0.010, 15, "patch-b");
+    let runs = vec![run0, run1];
+    let (idx, _rationale, _tie_break) = select_winner(&runs);
+    assert_eq!(idx, 1, "skipped run should not be selected as winner");
+}
+
+// ── summary_text tests ────────────────────────────────────────────────────────
+
+#[test]
+fn best_of_results_summary_contains_winner_banner() {
+    let results = make_full_results();
+    let text = results.summary_text();
+    assert!(
+        text.to_lowercase().contains("winner") || text.contains("WINNER"),
+        "summary should contain winner banner; got:\n{text}"
+    );
+}
+
+#[test]
+fn best_of_results_summary_contains_run_table() {
+    let results = make_full_results();
+    let text = results.summary_text();
+    assert!(
+        text.contains("RUN") || text.contains("run"),
+        "summary should contain run table header; got:\n{text}"
+    );
+}
+
+#[test]
+fn best_of_results_summary_all_failed_mentions_all_failed() {
+    let mut results = make_full_results();
+    results.all_failed = true;
+    results.winner_run_index = Some(0);
+    let text = results.summary_text();
+    assert!(
+        text.to_lowercase().contains("all") && text.to_lowercase().contains("fail"),
+        "summary should mention all-failed condition; got:\n{text}"
+    );
+}
+
+fn make_full_results() -> BestOfResults {
+    BestOfResults {
+        schema_version: ArtifactSchemaVersion::CURRENT,
+        artifact_kind: ArtifactKind::BestOfResults,
+        task: "Fix the null dereference".into(),
+        runs: 3,
+        winner_run_index: Some(1),
+        passing_run_count: 2,
+        all_failed: false,
+        tie_break_applied: false,
+        selection_rationale: "most_verify_checks_passed".into(),
+        started_at: "2026-01-01T00:00:00Z".into(),
+        finished_at: "2026-01-01T00:01:00Z".into(),
+        runs_detail: vec![
+            BestOfRunDetail {
+                run_index: 0,
+                outcome: "submitted".into(),
+                verify_checks_passed: 1,
+                verify_checks_total: 2,
+                passed: false,
+                total_cost_usd: Some(0.003),
+                step_count: Some(8),
+                patch_byte_len: Some(10),
+                patch_sha256: Some("abc".into()),
+                skipped: false,
+                skip_reason: None,
+            },
+            BestOfRunDetail {
+                run_index: 1,
+                outcome: "submitted".into(),
+                verify_checks_passed: 2,
+                verify_checks_total: 2,
+                passed: true,
+                total_cost_usd: Some(0.005),
+                step_count: Some(10),
+                patch_byte_len: Some(20),
+                patch_sha256: Some("def".into()),
+                skipped: false,
+                skip_reason: None,
+            },
+            BestOfRunDetail {
+                run_index: 2,
+                outcome: "submitted".into(),
+                verify_checks_passed: 2,
+                verify_checks_total: 2,
+                passed: true,
+                total_cost_usd: Some(0.007),
+                step_count: Some(12),
+                patch_byte_len: Some(30),
+                patch_sha256: Some("ghi".into()),
+                skipped: false,
+                skip_reason: None,
+            },
+        ],
+    }
+}
+
+// ── Integration tests (scripted-model path) ───────────────────────────────────
+
+#[cfg(test)]
+mod integration {
+    use super::*;
+    use maxwells_daemon::run::best_of::{BestOfArgs, run};
+
+    fn submit_response() -> String {
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nfixed\n```".into()
+    }
+
+    fn make_args(
+        tmpdir: &std::path::Path,
+        runs: u32,
+        verify: Vec<String>,
+        responses: Vec<String>,
+    ) -> BestOfArgs {
+        let mut cfg = maxwells_daemon::config::Config::defaults().unwrap();
+        cfg.root.model.name = "test-model".into();
+        BestOfArgs {
+            task: "Fix the bug".into(),
+            runs,
+            config: cfg,
+            output_dir: tmpdir.to_owned(),
+            best_of_name: "test-best-of".into(),
+            verify,
+            verify_timeout_secs: 60,
+            cost_limit_usd: None,
+            task_timeout_secs: Some(30),
+            step_limit: None,
+            per_task_budget_usd: None,
+            output_patch: None,
+            allow_no_pass: false,
+            deterministic_responses: Some(responses),
+            deterministic_usage_per_call: None,
+            print_summary: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn requires_verify_checks() {
+        // --verify is required; passing empty verify should cause the runner
+        // to return BestOfArgs with verify=[] being OK at the run level, but
+        // the CLI layer should validate this. Let's test via the run function
+        // which should handle it gracefully (the CLI catches this first).
+        // We test the validation at the CLI args level via a separate check.
+        // The run function itself should still complete (it uses verify for scoring).
+        let tmp = tempfile::tempdir().unwrap();
+        let args = make_args(tmp.path(), 2, vec![], vec![submit_response(), submit_response()]);
+        // With empty verify, the run still completes but uses fallback scoring
+        let result = run(args).await;
+        assert!(result.is_ok(), "run should complete even without verify checks");
+    }
+
+    #[tokio::test]
+    async fn two_runs_both_submit_writes_best_patch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let args = make_args(
+            tmp.path(),
+            2,
+            vec![],
+            vec![submit_response(), submit_response()],
+        );
+        let exit_code = run(args).await.unwrap();
+        assert_eq!(exit_code, ExitCode::Success);
+
+        let results_path = tmp
+            .path()
+            .join("test-best-of")
+            .join("best-of-results.json");
+        assert!(results_path.exists(), "best-of-results.json must be written");
+
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&results_path).unwrap()).unwrap();
+        assert_eq!(json["runs"].as_u64(), Some(2));
+        assert_eq!(json["artifact_kind"].as_str(), Some("best_of_results"));
+        assert!(json.get("schema_version").is_some());
+        assert!(json.get("winner_run_index").is_some());
+        assert!(json.get("passing_run_count").is_some());
+    }
+
+    #[tokio::test]
+    async fn best_patch_written_to_output_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let patch_path = tmp.path().join("winner.patch");
+        let mut cfg = maxwells_daemon::config::Config::defaults().unwrap();
+        cfg.root.model.name = "test-model".into();
+        let args = BestOfArgs {
+            task: "Fix the bug".into(),
+            runs: 2,
+            config: cfg,
+            output_dir: tmp.path().to_owned(),
+            best_of_name: "test-best-of".into(),
+            verify: vec![],
+            verify_timeout_secs: 60,
+            cost_limit_usd: None,
+            task_timeout_secs: Some(30),
+            step_limit: None,
+            per_task_budget_usd: None,
+            output_patch: Some(patch_path.clone()),
+            allow_no_pass: false,
+            deterministic_responses: Some(vec![submit_response(), submit_response()]),
+            deterministic_usage_per_call: None,
+            print_summary: false,
+        };
+        run(args).await.unwrap();
+        // The best.patch should have been written (even if empty for scripted model)
+        assert!(
+            patch_path.exists(),
+            "winner patch file must be written at the specified path"
+        );
+    }
+
+    #[tokio::test]
+    async fn all_failed_with_allow_no_pass_exits_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut cfg = maxwells_daemon::config::Config::defaults().unwrap();
+        cfg.root.model.name = "test-model".into();
+        let args = BestOfArgs {
+            task: "Fix the bug".into(),
+            runs: 2,
+            config: cfg,
+            output_dir: tmp.path().to_owned(),
+            best_of_name: "test-best-of".into(),
+            // Use a verify check that will always fail (command returns non-zero)
+            verify: vec!["always_fail:false".into()],
+            verify_timeout_secs: 60,
+            cost_limit_usd: None,
+            task_timeout_secs: Some(30),
+            step_limit: None,
+            per_task_budget_usd: None,
+            output_patch: None,
+            allow_no_pass: true,
+            deterministic_responses: Some(vec![submit_response(), submit_response()]),
+            deterministic_usage_per_call: None,
+            print_summary: false,
+        };
+        let exit_code = run(args).await.unwrap();
+        assert_eq!(
+            exit_code,
+            ExitCode::Success,
+            "--allow-no-pass should downgrade all-failed to exit 0"
+        );
+
+        let results_path = tmp
+            .path()
+            .join("test-best-of")
+            .join("best-of-results.json");
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&results_path).unwrap()).unwrap();
+        assert_eq!(
+            json["all_failed"].as_bool(),
+            Some(true),
+            "all_failed must be true in artifact"
+        );
+    }
+
+    #[tokio::test]
+    async fn all_failed_without_allow_no_pass_exits_40() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut cfg = maxwells_daemon::config::Config::defaults().unwrap();
+        cfg.root.model.name = "test-model".into();
+        let args = BestOfArgs {
+            task: "Fix the bug".into(),
+            runs: 2,
+            config: cfg,
+            output_dir: tmp.path().to_owned(),
+            best_of_name: "test-best-of".into(),
+            verify: vec!["always_fail:false".into()],
+            verify_timeout_secs: 60,
+            cost_limit_usd: None,
+            task_timeout_secs: Some(30),
+            step_limit: None,
+            per_task_budget_usd: None,
+            output_patch: None,
+            allow_no_pass: false,
+            deterministic_responses: Some(vec![submit_response(), submit_response()]),
+            deterministic_usage_per_call: None,
+            print_summary: false,
+        };
+        let exit_code = run(args).await.unwrap();
+        assert_eq!(
+            exit_code,
+            ExitCode::BestOfAllFailed,
+            "exit 40 when no run passes and --allow-no-pass is not set"
+        );
+    }
+
+    #[tokio::test]
+    async fn cost_limit_skips_remaining_runs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut cfg = maxwells_daemon::config::Config::defaults().unwrap();
+        cfg.root.model.name = "test-model".into();
+        let args = BestOfArgs {
+            task: "Fix the bug".into(),
+            runs: 3,
+            config: cfg,
+            output_dir: tmp.path().to_owned(),
+            best_of_name: "test-best-of".into(),
+            verify: vec![],
+            verify_timeout_secs: 60,
+            cost_limit_usd: Some(0.0), // zero cap → runs 2+ get skipped after run 1 spends
+            task_timeout_secs: Some(30),
+            step_limit: None,
+            per_task_budget_usd: None,
+            output_patch: None,
+            allow_no_pass: false,
+            deterministic_responses: Some(vec![
+                submit_response(),
+                submit_response(),
+                submit_response(),
+            ]),
+            deterministic_usage_per_call: Some(maxwells_daemon::model::ModelUsage {
+                input_tokens: 100,
+                output_tokens: 50,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
+                cost_usd: Some(0.01),
+            }),
+            print_summary: false,
+        };
+        run(args).await.unwrap();
+
+        let results_path = tmp
+            .path()
+            .join("test-best-of")
+            .join("best-of-results.json");
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&results_path).unwrap()).unwrap();
+        let detail = json["runs_detail"].as_array().unwrap();
+        let skipped_count = detail
+            .iter()
+            .filter(|d| d["skipped"].as_bool().unwrap_or(false))
+            .count();
+        assert!(
+            skipped_count >= 2,
+            "at least 2 runs should be skipped; got {skipped_count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn deterministic_same_inputs_byte_identical_results() {
+        let tmp1 = tempfile::tempdir().unwrap();
+        let tmp2 = tempfile::tempdir().unwrap();
+
+        let mk = |dir: &std::path::Path| {
+            let mut cfg = maxwells_daemon::config::Config::defaults().unwrap();
+            cfg.root.model.name = "test-model".into();
+            BestOfArgs {
+                task: "Fix the bug".into(),
+                runs: 2,
+                config: cfg,
+                output_dir: dir.to_owned(),
+                best_of_name: "test-best-of".into(),
+                verify: vec![],
+                verify_timeout_secs: 60,
+                cost_limit_usd: None,
+                task_timeout_secs: Some(30),
+                step_limit: None,
+                per_task_budget_usd: None,
+                output_patch: None,
+                allow_no_pass: false,
+                deterministic_responses: Some(vec![submit_response(), submit_response()]),
+                deterministic_usage_per_call: None,
+                print_summary: false,
+            }
+        };
+
+        run(mk(tmp1.path())).await.unwrap();
+        run(mk(tmp2.path())).await.unwrap();
+
+        let read = |p: &std::path::Path| -> serde_json::Value {
+            let path = p.join("test-best-of").join("best-of-results.json");
+            serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+        };
+        let r1 = read(tmp1.path());
+        let r2 = read(tmp2.path());
+
+        assert_eq!(r1["runs"], r2["runs"]);
+        assert_eq!(r1["winner_run_index"], r2["winner_run_index"]);
+        assert_eq!(r1["passing_run_count"], r2["passing_run_count"]);
+        assert_eq!(r1["artifact_kind"], r2["artifact_kind"]);
+        assert_eq!(r1["schema_version"], r2["schema_version"]);
+        assert_eq!(r1["selection_rationale"], r2["selection_rationale"]);
+    }
+}

--- a/tests/agent_best_of.rs
+++ b/tests/agent_best_of.rs
@@ -5,7 +5,7 @@
 //! GREEN phase: implement src/run/best_of.rs and wire the CLI.
 //! REFACTOR phase: clean up.
 
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::unwrap_used, clippy::large_futures)]
 
 use maxwells_daemon::artifact::{ArtifactKind, ArtifactSchemaVersion};
 use maxwells_daemon::exit_code::ExitCode;

--- a/tests/agent_best_of.rs
+++ b/tests/agent_best_of.rs
@@ -9,9 +9,7 @@
 
 use maxwells_daemon::artifact::{ArtifactKind, ArtifactSchemaVersion};
 use maxwells_daemon::exit_code::ExitCode;
-use maxwells_daemon::run::best_of::{
-    BestOfRunDetail, BestOfResults, select_winner, validate_runs,
-};
+use maxwells_daemon::run::best_of::{BestOfResults, BestOfRunDetail, select_winner, validate_runs};
 
 // ── Exit code unit tests ──────────────────────────────────────────────────────
 
@@ -228,7 +226,10 @@ fn select_winner_all_failed_still_picks_best_scoring() {
         make_run(1, 1, 2, 0.005, 10, "patch-b"),
     ];
     let (idx, _rationale, _tie_break) = select_winner(&runs);
-    assert_eq!(idx, 1, "run with more passing checks wins even when all fail");
+    assert_eq!(
+        idx, 1,
+        "run with more passing checks wins even when all fail"
+    );
 }
 
 #[test]
@@ -383,10 +384,18 @@ mod integration {
         // We test the validation at the CLI args level via a separate check.
         // The run function itself should still complete (it uses verify for scoring).
         let tmp = tempfile::tempdir().unwrap();
-        let args = make_args(tmp.path(), 2, vec![], vec![submit_response(), submit_response()]);
+        let args = make_args(
+            tmp.path(),
+            2,
+            vec![],
+            vec![submit_response(), submit_response()],
+        );
         // With empty verify, the run still completes but uses fallback scoring
         let result = run(args).await;
-        assert!(result.is_ok(), "run should complete even without verify checks");
+        assert!(
+            result.is_ok(),
+            "run should complete even without verify checks"
+        );
     }
 
     #[tokio::test]
@@ -401,11 +410,11 @@ mod integration {
         let exit_code = run(args).await.unwrap();
         assert_eq!(exit_code, ExitCode::Success);
 
-        let results_path = tmp
-            .path()
-            .join("test-best-of")
-            .join("best-of-results.json");
-        assert!(results_path.exists(), "best-of-results.json must be written");
+        let results_path = tmp.path().join("test-best-of").join("best-of-results.json");
+        assert!(
+            results_path.exists(),
+            "best-of-results.json must be written"
+        );
 
         let json: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&results_path).unwrap()).unwrap();
@@ -479,10 +488,7 @@ mod integration {
             "--allow-no-pass should downgrade all-failed to exit 0"
         );
 
-        let results_path = tmp
-            .path()
-            .join("test-best-of")
-            .join("best-of-results.json");
+        let results_path = tmp.path().join("test-best-of").join("best-of-results.json");
         let json: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&results_path).unwrap()).unwrap();
         assert_eq!(
@@ -558,10 +564,7 @@ mod integration {
         };
         run(args).await.unwrap();
 
-        let results_path = tmp
-            .path()
-            .join("test-best-of")
-            .join("best-of-results.json");
+        let results_path = tmp.path().join("test-best-of").join("best-of-results.json");
         let json: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&results_path).unwrap()).unwrap();
         let detail = json["runs_detail"].as_array().unwrap();


### PR DESCRIPTION
## Summary

Implements the `agent best-of` command (issue #485) that runs a task N times through the existing `mini` execution path with identical configuration, scores each candidate patch using the operator's `--verify` checks, and emits the single best patch using a deterministic selection policy.

## Key Changes

- **New module `src/run/best_of.rs`** (672 lines):
  - `BestOfRunDetail` and `BestOfResults` structs for schema-versioned result artifacts
  - `select_winner()` function implementing a fully deterministic tie-break chain:
    1. Most `verify_checks_passed`
    2. Lowest `total_cost_usd`
    3. Fewest `step_count`
    4. Smallest patch byte length
    5. Lexicographically smallest `patch_sha256`
  - `run()` async function that orchestrates N runs via the `mini` path, collects results, selects a winner, and writes artifacts
  - `validate_runs()` to enforce 2..=10 run count constraint
  - `BestOfArgs` struct for command arguments
  - Human-readable summary rendering via `BestOfResults::summary_text()`

- **CLI integration in `src/cli/args.rs`**:
  - New `BestOfCmd` struct with flags for task, runs, model, verify checks, cost limits, timeouts, output paths, and format selection
  - `BestOfFormatArg` enum for text/json output format

- **CLI handler in `src/cli/mod.rs`**:
  - `agent_best_of_cmd()` function that validates arguments, resolves task text (from `--task` or `--task-file`), loads config with CLI overrides, and invokes the runner
  - Enforces `--verify` requirement (exit with usage error if omitted)
  - Handles cost-limit-usd budget tracking across runs

- **Exit code addition in `src/exit_code.rs`**:
  - `BestOfAllFailed = 40` for when all runs fail verify checks (unless `--allow-no-pass` is set)

- **Artifact kind in `src/artifact.rs`**:
  - `ArtifactKind::BestOfResults` for schema versioning

- **Module export in `src/run/mod.rs`**:
  - Public `best_of` module

- **Comprehensive test suite in `tests/agent_best_of.rs`** (623 lines):
  - Unit tests for exit codes, artifact kinds, validation, selection policy, and summary rendering
  - Integration tests using scripted model backend for end-to-end verification

- **Specification document `docs/spec-agent-best-of.md`**:
  - Complete usage guide, flag reference, selection policy, artifact schema, and exit-code matrix

- **Documentation in `README.md`**:
  - Added section 8 describing the new command with example usage

## Notable Implementation Details

- **Deterministic selection**: All tie-breaks are fully deterministic; repeated runs with identical inputs produce identical winners
- **Cost tracking**: Cumulative cost across runs is tracked; remaining runs are marked `skipped` when budget is exhausted
- **Patch capture**: Per-run patches are read from sibling files and scored by SHA-256 hash
- **Verify check integration**: Reuses existing verification infrastructure from `mini` path; falls back to outcome-based scoring if no checks are configured
- **Skipped run handling**: Runs skipped due to budget exhaustion are excluded from winner selection but recorded in results
- **All-failed handling**: When no run passes all checks, the best-scoring run is still selected; `all_failed: true` is set in results; exit code 40 is returned unless `--allow-no-pass` is set

https://claude.ai/code/session_01SLXL9AenbmS2cp8C1cY2YU