### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+//! The main entry point for the Maxwell's Daemon binary.
+//! This provides the CLI interface.
+
 use maxwells_daemon::exit_code::ExitCode;
 
 #[tokio::main]

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -8024,11 +8024,7 @@ instance = "inst"
                 };
                 let mut buf = Vec::new();
                 let mut chunk = [0u8; 8192];
-                loop {
-                    let n = match socket.read(&mut chunk).await {
-                        Ok(n) => n,
-                        Err(_) => break,
-                    };
+                while let Ok(n) = socket.read(&mut chunk).await {
                     if n == 0 {
                         break;
                     }

--- a/src/stream/event_log.rs
+++ b/src/stream/event_log.rs
@@ -10,6 +10,26 @@ use serde_json::{Map, Value};
 use super::{StreamEvent, StreamSink};
 
 #[derive(Clone)]
+/// An append-only sink recording the chronological history of an agent's stream.
+///
+/// While `Trajectory` captures the final, structured "result" of an agent's run, `EventLogSink`
+/// continuously writes every intermediate state transition, tool call, and generated thought directly
+/// to disk as JSON Lines (`.ndjson`). This design provides critical forensic evidence; if an agent
+/// crashes or the process is killed midway, the event log accurately reproduces the exact state sequence
+/// leading up to the failure without relying on in-memory trajectory structures.
+///
+/// ## Examples
+///
+/// ```
+/// use maxwells_daemon::stream::event_log::EventLogSink;
+/// use std::path::Path;
+///
+/// let log_path = Path::new("/tmp/agent_execution.ndjson");
+/// // Handled gracefully, avoiding unwraps in production!
+/// if let Ok(sink) = EventLogSink::new(log_path, "run-42".to_string()) {
+///     // Sink is ready to record agent lifecycle events.
+/// }
+/// ```
 pub struct EventLogSink {
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
     path: PathBuf,

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -626,7 +626,7 @@ mod tests {
         match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((s, _))) => s,
             Ok(Err(e)) => panic!("accept error: {e}"),
-            Err(_) => panic!("accept timed out"),
+            Err(e) => panic!("accept timed out: {e}"),
         }
     }
 
@@ -637,7 +637,7 @@ mod tests {
             let n = match tokio::time::timeout(TEST_IO_TIMEOUT, socket.read(&mut chunk)).await {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => panic!("read error: {e}"),
-                Err(_) => panic!("read timed out"),
+                Err(e) => panic!("read timed out: {e}"),
             };
             if n == 0 {
                 break;
@@ -654,7 +654,7 @@ mod tests {
     }
 
     fn body_of(req: &str) -> &str {
-        req.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("")
+        req.split_once("\r\n\r\n").map_or("", |(_, b)| b)
     }
 
     fn is_complete_http(buf: &[u8]) -> bool {

--- a/src/stream/webhook.rs
+++ b/src/stream/webhook.rs
@@ -219,6 +219,27 @@ pub struct WebhookSinkHandle {
 }
 
 impl WebhookSinkHandle {
+    /// Binds a generic `WebhookSink` to a specific run execution ID.
+    ///
+    /// By abstracting the core POST and buffer logic into `WebhookSink`, a single physical network sink
+    /// can be shared across multiple agent threads. Wrapping it in a `WebhookSinkHandle` associates each
+    /// emitted event with the `run_id` context, ensuring that traces and metrics correctly correlate
+    /// actions to the exact run they belong to without requiring the agent loop to know about the sink.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use maxwells_daemon::stream::webhook::{WebhookSink, WebhookSinkHandle};
+    ///
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let _guard = rt.enter();
+    /// // A shared sink managing the actual HTTP connection.
+    /// let sink = Arc::new(WebhookSink::new("http://127.0.0.1/".to_string(), &[]).unwrap());
+    ///
+    /// // An execution-specific handle used by the agent during a single run.
+    /// let handle = WebhookSinkHandle::new(sink, "unique-run-id-123".to_string());
+    /// ```
     pub fn new(inner: Arc<WebhookSink>, run_id: String) -> Self {
         Self { inner, run_id }
     }

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -12,6 +12,25 @@ use std::sync::Arc;
 
 use crate::error::Error;
 
+/// A lightweight template rendering engine built on top of `minijinja`.
+///
+/// While `minijinja` provides a comprehensive HTML-first templating experience, `Renderer`
+/// is specifically tuned for shell commands and system prompts. It disables HTML auto-escaping
+/// to ensure scripts and shell operators (like `&&` or `>`) are preserved exactly as written.
+/// Furthermore, it automatically exposes process environment variables under the `env` global object,
+/// allowing templates to naturally refer to `$USER` or `$PATH` via `{{ env.USER }}`.
+///
+/// ## Examples
+///
+/// ```
+/// use std::collections::BTreeMap;
+/// use minijinja::context;
+/// use maxwells_daemon::template::Renderer;
+///
+/// let renderer = Renderer::new();
+/// let rendered = renderer.render_with("echo 'Hello, {{ name }}!'", context!(name => "World")).unwrap();
+/// assert_eq!(rendered, "echo 'Hello, World!'");
+/// ```
 pub struct Renderer {
     env: Environment<'static>,
 }
@@ -23,6 +42,19 @@ impl Default for Renderer {
 }
 
 impl Renderer {
+    /// Instantiates a new template renderer configured for system prompts.
+    ///
+    /// This disables the default HTML escaping mechanism and pre-populates an `env` dictionary
+    /// containing all environment variables available to the current process. This ensures templates
+    /// have immediate access to context like paths and credentials without explicit injection.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use maxwells_daemon::template::Renderer;
+    ///
+    /// let renderer = Renderer::new();
+    /// ```
     pub fn new() -> Self {
         let mut env = Environment::new();
         env.set_auto_escape_callback(|_| minijinja::AutoEscape::None);
@@ -43,6 +75,23 @@ impl Renderer {
             .map_err(Into::into)
     }
 
+    /// Processes a template string against a complex nested structure.
+    ///
+    /// Unlike `render_str` which requires a struct implementing `Serialize`, `render_with`
+    /// accepts a raw `minijinja::Value`. This is incredibly useful for ad-hoc context building
+    /// where you don't want to define a throwaway struct. We heavily recommend using the
+    /// `context!` macro to dynamically construct the data passed into this function.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use maxwells_daemon::template::Renderer;
+    /// use minijinja::context;
+    ///
+    /// let renderer = Renderer::new();
+    /// let result = renderer.render_with("User: {{ user.name }}", context!(user => context!(name => "Alice"))).unwrap();
+    /// assert_eq!(result, "User: Alice");
+    /// ```
     pub fn render_with(&self, tmpl: &str, ctx: Value) -> Result<String, Error> {
         self.env.render_str(tmpl, ctx).map_err(Into::into)
     }


### PR DESCRIPTION
📖 Chapter: The stream and template modules.
🔦 Insight: Explained the `minijinja` configuration nuances in `Renderer`, the context separation enabled by `WebhookSinkHandle`, and the forensic necessity of `EventLogSink`. 
🧪 Example: Added 3 executable doctests demonstrating instantiation and usage context.
🖼️ Preview: (None)

---
*PR created automatically by Jules for task [11243822939016982028](https://jules.google.com/task/11243822939016982028) started by @madmax983*