### PR TITLE
🌟 Nova: [JSON Exporter]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+json-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2531,7 +2531,7 @@ pub struct InspectCmd {
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `json-export` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3595,7 +3595,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         }
         if i.output.is_some() {
             return Err(Error::Config(crate::error::ConfigError::Invalid(
-                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid)".into(),
+                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/json-export)".into(),
             )));
         }
         let format = parse_trajectory_diff_format(&i.format)?;
@@ -3610,13 +3610,16 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "json-export"
+    ) {
         return bench_inspect_export(i);
     }
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/json-export), not `{}`",
             i.format
         ))));
     }
@@ -3626,7 +3629,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         "json" => crate::run::inspect::InspectFormat::Json,
         other => {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, or `mermaid`)"
+                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, `mermaid`, or `json-export`)"
             ))));
         }
     };
@@ -3668,7 +3671,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     })?;
     let instance_id = i.instance.as_deref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
-            "inspect: --instance is required for export formats (markdown/html/csv/mermaid)".into(),
+            "inspect: --instance is required for export formats (markdown/html/csv/mermaid/json-export)".into(),
         ))
     })?;
     let traj_path =
@@ -3690,6 +3693,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "json-export" => inspect_export_json(&traj)?,
         _ => unreachable!("dispatch guarded by caller"),
     };
 
@@ -3775,6 +3779,22 @@ fn inspect_export_mermaid(_traj: &crate::trajectory::Trajectory) -> Result<Strin
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "format_unavailable: --format mermaid requires the `mermaid-export` Cargo feature; \
          rebuild with `--features mermaid-export`"
+            .into(),
+    )))
+}
+
+#[cfg(feature = "json-export")]
+#[allow(clippy::unnecessary_wraps)]
+fn inspect_export_json(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    use crate::trajectory::export::{JsonExporter, TrajectoryExporter};
+    Ok(JsonExporter::export(traj))
+}
+
+#[cfg(not(feature = "json-export"))]
+fn inspect_export_json(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "format_unavailable: --format json-export requires the `json-export` Cargo feature; \
+         rebuild with `--features json-export`"
             .into(),
     )))
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -50,6 +50,26 @@ pub struct CsvExporter;
 #[cfg(feature = "mermaid-export")]
 pub struct MermaidExporter;
 
+/// Transforms a [`Trajectory`] into a JSON formatted string containing the task, outcome, and all messages.
+///
+/// ## Examples
+///
+/// ```rust
+/// use maxwells_daemon::trajectory::Trajectory;
+/// use maxwells_daemon::model::Message;
+/// use maxwells_daemon::trajectory::export::{TrajectoryExporter, JsonExporter};
+///
+/// let mut traj = Trajectory::new();
+/// traj.info.task = Some("Fix tests".to_string());
+/// traj.record_message(&Message::user("Hello agent"));
+///
+/// let json = JsonExporter::export(&traj);
+/// assert!(json.contains("Fix tests"));
+/// assert!(json.contains("Hello agent"));
+/// ```
+#[cfg(feature = "json-export")]
+pub struct JsonExporter;
+
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
@@ -245,6 +265,13 @@ impl TrajectoryExporter for MermaidExporter {
     }
 }
 
+#[cfg(feature = "json-export")]
+impl TrajectoryExporter for JsonExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        serde_json::to_string_pretty(&trajectory).unwrap_or_else(|_| "{}".to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -339,5 +366,23 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+
+    #[cfg(feature = "json-export")]
+    #[test]
+    fn test_json_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some("submitted".to_string());
+
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::user("Hello user"));
+
+        let json_str = JsonExporter::export(&t);
+
+        assert!(json_str.contains("Add a feature"));
+        assert!(json_str.contains("submitted"));
+        assert!(json_str.contains("Hello agent"));
+        assert!(json_str.contains("Hello user"));
     }
 }


### PR DESCRIPTION
💡 **The Spark:** We have multiple exporters (`markdown`, `html`, `csv`, `mermaid`) but lack a raw JSON exporter that serializes the Trajectory directly, which could be extremely useful for programmatic consumption and integration.

🚀 **The Feature:** Implemented `JsonExporter` struct in `src/trajectory/export.rs` implementing `TrajectoryExporter` and added `json-export` format support to `bench inspect`.

🔮 **The Potential:** This enables piping the parsed Trajectory output directly into other scripts, tools, and reporting pipelines as raw JSON.

⚠️ **Risk:** Low. Isolated under the `json-export` feature flag and in the `export.rs` module.

---
*PR created automatically by Jules for task [2024721560215768464](https://jules.google.com/task/2024721560215768464) started by @madmax983*