### PR TITLE
🛡️ Sentry: [test coverage improvement] Add tests for cap_canonical and fix clippy warnings

### DIFF
--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -245,4 +245,34 @@ mod tests {
         let s = "no secrets here";
         assert_eq!(normalize_redaction_markers(s), s);
     }
+
+    #[test]
+    fn cap_canonical_does_not_truncate_if_within_capacity() {
+        let (s, truncated) = cap_canonical("hello world", 20);
+        assert_eq!(s, "hello world");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn cap_canonical_truncates_and_appends_marker_if_exceeds_capacity() {
+        let (s, truncated) = cap_canonical("hello world", 5);
+        assert_eq!(s, "hello[truncated]");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn cap_canonical_handles_char_boundaries_correctly() {
+        // '🦀' is 4 bytes long
+        let input = "a🦀b";
+
+        // If we cap at 3, it should cut before the crab
+        let (s1, truncated1) = cap_canonical(input, 3);
+        assert_eq!(s1, "a[truncated]");
+        assert!(truncated1);
+
+        // If we cap at 5, it should include the crab
+        let (s2, truncated2) = cap_canonical(input, 5);
+        assert_eq!(s2, "a🦀[truncated]");
+        assert!(truncated2);
+    }
 }

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -8024,11 +8024,7 @@ instance = "inst"
                 };
                 let mut buf = Vec::new();
                 let mut chunk = [0u8; 8192];
-                loop {
-                    let n = match socket.read(&mut chunk).await {
-                        Ok(n) => n,
-                        Err(_) => break,
-                    };
+                while let Ok(n) = socket.read(&mut chunk).await {
                     if n == 0 {
                         break;
                     }

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -626,7 +626,7 @@ mod tests {
         match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((s, _))) => s,
             Ok(Err(e)) => panic!("accept error: {e}"),
-            Err(_) => panic!("accept timed out"),
+            Err(e) => panic!("accept timed out: {e}"),
         }
     }
 
@@ -637,7 +637,7 @@ mod tests {
             let n = match tokio::time::timeout(TEST_IO_TIMEOUT, socket.read(&mut chunk)).await {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => panic!("read error: {e}"),
-                Err(_) => panic!("read timed out"),
+                Err(e) => panic!("read timed out: {e}"),
             };
             if n == 0 {
                 break;
@@ -654,7 +654,7 @@ mod tests {
     }
 
     fn body_of(req: &str) -> &str {
-        req.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("")
+        req.split_once("\r\n\r\n").map_or("", |(_, b)| b)
     }
 
     fn is_complete_http(buf: &[u8]) -> bool {


### PR DESCRIPTION
🎯 Target: `cap_canonical` in `src/fingerprint.rs`, `src/run/swebench.rs`, and `src/stream/sweep_webhook.rs`.
💣 Risk: Missing test coverage for `cap_canonical` could lead to regressions in truncation logic, especially around multi-byte characters. Pre-existing clippy warnings violated strict linting rules.
🧪 Strategy: Added unit tests for `cap_canonical` covering standard truncation, exact bounds, and multi-byte character boundary handling. Fixed `while_let_loop` and `manual_let_else` in `src/run/swebench.rs` and `match_wild_err_arm` and `map_unwrap_or` in `src/stream/sweep_webhook.rs`.
🔭 Verification: `cargo test --manifest-path Cargo.toml --lib fingerprint` and `cargo clippy --all-targets --all-features -- -D warnings`.

---
*PR created automatically by Jules for task [3496668756582303704](https://jules.google.com/task/3496668756582303704) started by @madmax983*