### PR TITLE
⚡ Bolt: Optimized Edit-Before-Read Ratio Calculation

### DIFF
--- a/src/run/contamination_check.rs
+++ b/src/run/contamination_check.rs
@@ -226,18 +226,25 @@ pub struct ContaminationReport {
 ///
 /// Returns the fraction of `edits` whose path was never in `reads_before_edit`.
 /// Returns `0.0` when `edits` is empty (no suspicion if no edits).
-pub fn compute_edit_before_read_ratio<S: std::hash::BuildHasher>(
+pub fn compute_edit_before_read_ratio<'a, S, I, T>(
     reads_before_edit: &HashSet<String, S>,
-    edits: &[String],
-) -> f64 {
-    if edits.is_empty() {
+    edits: I,
+) -> f64
+where
+    S: std::hash::BuildHasher,
+    I: IntoIterator<Item = &'a T>,
+    I::IntoIter: ExactSizeIterator,
+    T: AsRef<str> + 'a + ?Sized,
+{
+    let edits_iter = edits.into_iter();
+    let len = edits_iter.len();
+    if len == 0 {
         return 0.0;
     }
-    let unread_edits = edits
-        .iter()
-        .filter(|p| !reads_before_edit.contains(*p))
+    let unread_edits = edits_iter
+        .filter(|p| !reads_before_edit.contains(p.as_ref()))
         .count();
-    unread_edits as f64 / edits.len() as f64
+    unread_edits as f64 / len as f64
 }
 
 /// Compute the time-to-first-edit suspicion signal.
@@ -619,17 +626,11 @@ fn compute_ebr_ordered(messages: &[TrajMessage]) -> f64 {
         }
     }
 
-    compute_edit_before_read_ratio(
-        &{
-            let reads_before_edit: HashSet<String> = edited_all
-                .iter()
-                .filter(|p| !edited_unread.contains(*p))
-                .cloned()
-                .collect();
-            reads_before_edit
-        },
-        &edited_all.into_iter().collect::<Vec<_>>(),
-    )
+    if edited_all.is_empty() {
+        0.0
+    } else {
+        edited_unread.len() as f64 / edited_all.len() as f64
+    }
 }
 
 /// Weighted sum of signal values, clamped to `[0.0, 1.0]`.

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -5037,7 +5037,7 @@ pub fn apply_subset(
         if !unknown.is_empty() {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
                 "--instance-ids references unknown id(s): {}",
-                unknown.into_iter().collect::<Vec<_>>().join(", ")
+                unknown.into_iter().collect::<Vec<&str>>().join(", ")
             ))));
         }
         let include: HashSet<&str> = ids.iter().map(String::as_str).collect();
@@ -8024,11 +8024,7 @@ instance = "inst"
                 };
                 let mut buf = Vec::new();
                 let mut chunk = [0u8; 8192];
-                loop {
-                    let n = match socket.read(&mut chunk).await {
-                        Ok(n) => n,
-                        Err(_) => break,
-                    };
+                while let Ok(n) = socket.read(&mut chunk).await {
                     if n == 0 {
                         break;
                     }

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -626,7 +626,7 @@ mod tests {
         match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((s, _))) => s,
             Ok(Err(e)) => panic!("accept error: {e}"),
-            Err(_) => panic!("accept timed out"),
+            Err(e) => panic!("accept timed out: {e}"),
         }
     }
 
@@ -637,7 +637,7 @@ mod tests {
             let n = match tokio::time::timeout(TEST_IO_TIMEOUT, socket.read(&mut chunk)).await {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => panic!("read error: {e}"),
-                Err(_) => panic!("read timed out"),
+                Err(e) => panic!("read timed out: {e}"),
             };
             if n == 0 {
                 break;
@@ -654,7 +654,7 @@ mod tests {
     }
 
     fn body_of(req: &str) -> &str {
-        req.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("")
+        req.split_once("\r\n\r\n").map_or("", |(_, b)| b)
     }
 
     fn is_complete_http(buf: &[u8]) -> bool {


### PR DESCRIPTION
💡 What: Removed intermediate `HashSet` and `Vec` allocations in `compute_ebr_ordered` by calculating the edit-before-read ratio directly from existing `edited_unread` and `edited_all` sets. Also fixed several clippy warnings (`while_let_loop`, `map_unwrap_or`, `match_wild_err_arm`).
🎯 Why: The previous implementation cloned `String`s into a new `HashSet` and collected another set into a `Vec` just to compute a simple mathematical ratio.
📊 Impact: Removes two intermediate memory allocations (`HashSet`, `Vec`) and multiple `String` clones per processed trajectory message in contamination checks, improving performance on this path.
🔬 Measurement: Run `cargo bench` or `cargo test --test bench_contamination_check` to verify no regressions in functionality.

---
*PR created automatically by Jules for task [13723889605214067418](https://jules.google.com/task/13723889605214067418) started by @madmax983*