### PR TITLE
🌟 Nova: Yaml Trajectory Exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ markdown-export = []
 html-export = []
 webhook = []
 csv-export = []
+yaml-export = []
 mermaid-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2632,14 +2632,14 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`, and `yaml`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `yaml` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3596,7 +3596,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         }
         if i.output.is_some() {
             return Err(Error::Config(crate::error::ConfigError::Invalid(
-                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid)".into(),
+                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/yaml)".into(),
             )));
         }
         let format = parse_trajectory_diff_format(&i.format)?;
@@ -3611,13 +3611,16 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "yaml"
+    ) {
         return bench_inspect_export(i);
     }
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/yaml), not `{}`",
             i.format
         ))));
     }
@@ -3669,7 +3672,8 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     })?;
     let instance_id = i.instance.as_deref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
-            "inspect: --instance is required for export formats (markdown/html/csv/mermaid)".into(),
+            "inspect: --instance is required for export formats (markdown/html/csv/mermaid/yaml)"
+                .into(),
         ))
     })?;
     let traj_path =
@@ -3691,6 +3695,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "yaml" => inspect_export_yaml(&traj)?,
         _ => unreachable!("dispatch guarded by caller"),
     };
 
@@ -3776,6 +3781,22 @@ fn inspect_export_mermaid(_traj: &crate::trajectory::Trajectory) -> Result<Strin
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "format_unavailable: --format mermaid requires the `mermaid-export` Cargo feature; \
          rebuild with `--features mermaid-export`"
+            .into(),
+    )))
+}
+
+#[cfg(feature = "yaml-export")]
+#[allow(clippy::unnecessary_wraps)]
+fn inspect_export_yaml(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    use crate::trajectory::export::{TrajectoryExporter, YamlExporter};
+    Ok(YamlExporter::export(traj))
+}
+
+#[cfg(not(feature = "yaml-export"))]
+fn inspect_export_yaml(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "format_unavailable: --format yaml requires the `yaml-export` Cargo feature; \
+         rebuild with `--features yaml-export`"
             .into(),
     )))
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -53,6 +53,9 @@ pub struct MermaidExporter;
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
+#[cfg(feature = "yaml-export")]
+pub struct YamlExporter;
+
 use std::fmt::Write;
 
 #[cfg(feature = "csv-export")]
@@ -191,6 +194,13 @@ impl TrajectoryExporter for HtmlExporter {
 
         html.push_str("</body>\n</html>");
         html
+    }
+}
+
+#[cfg(feature = "yaml-export")]
+impl TrajectoryExporter for YamlExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        serde_yml::to_string(trajectory).unwrap_or_else(|e| format!("Error exporting to YAML: {e}"))
     }
 }
 
@@ -339,5 +349,24 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+
+    #[cfg(feature = "yaml-export")]
+    #[test]
+    fn test_yaml_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::assistant("Hello user"));
+
+        let yaml = YamlExporter::export(&t);
+
+        assert!(yaml.contains("task: Add a feature"));
+        assert!(yaml.contains("outcome: submitted"));
+        assert!(yaml.contains("role: system"));
+        assert!(yaml.contains("content: System prompt"));
     }
 }


### PR DESCRIPTION
💡 **The Spark:** I noticed we use `serde_yml` as a dependency but lacked an exporter for YAML trajectories. YAML is an incredibly readable format for deep nested JSON data compared to Markdown.
🚀 **The Feature:** Implemented `YamlExporter` under a new `yaml-export` cargo feature, bridging `serde_yml` with the existing `TrajectoryExporter` ecosystem and CLI args.
🔮 **The Potential:** Enables developers to read and debug `*.traj.json` instances right in their terminal via a clean, nested YAML view without the overhead of HTML or Mermaid rendering.
⚠️ **Risk:** Low. The code is isolated in a new trait implementation and gated behind an opt-in `yaml-export` cargo feature.

---
*PR created automatically by Jules for task [4139695949313205265](https://jules.google.com/task/4139695949313205265) started by @madmax983*