### PR TITLE
⚡ Bolt: Remove intermediate allocations when joining strings

### DIFF
--- a/src/run/calibrate.rs
+++ b/src/run/calibrate.rs
@@ -583,7 +583,7 @@ fn build_mismatches(
 }
 
 fn sorted_join(values: BTreeSet<&str>) -> String {
-    values.into_iter().collect::<Vec<_>>().join(",")
+    values.iter().enumerate().fold(String::with_capacity(values.iter().map(|s| s.len() + 1).sum()), |mut acc, (i, s)| { if i > 0 { acc.push(','); } acc.push_str(s); acc })
 }
 
 fn compare_field(

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -5037,7 +5037,7 @@ pub fn apply_subset(
         if !unknown.is_empty() {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
                 "--instance-ids references unknown id(s): {}",
-                unknown.into_iter().collect::<Vec<_>>().join(", ")
+                unknown.iter().enumerate().fold(String::with_capacity(unknown.iter().map(|s| s.len() + 2).sum()), |mut acc, (i, s)| { if i > 0 { acc.push_str(", "); } acc.push_str(s); acc })
             ))));
         }
         let include: HashSet<&str> = ids.iter().map(String::as_str).collect();
@@ -8024,11 +8024,7 @@ instance = "inst"
                 };
                 let mut buf = Vec::new();
                 let mut chunk = [0u8; 8192];
-                loop {
-                    let n = match socket.read(&mut chunk).await {
-                        Ok(n) => n,
-                        Err(_) => break,
-                    };
+                while let Ok(n) = socket.read(&mut chunk).await {
                     if n == 0 {
                         break;
                     }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -549,7 +549,7 @@ fn normalize_search_text(text: &str) -> String {
             out.push(' ');
         }
     }
-    out.split_whitespace().collect::<Vec<_>>().join(" ")
+    out.split_whitespace().enumerate().fold(String::new(), |mut acc, (i, s)| { if i > 0 { acc.push(' '); } acc.push_str(s); acc })
 }
 
 fn is_stopword(token: &str) -> bool {

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -626,7 +626,7 @@ mod tests {
         match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((s, _))) => s,
             Ok(Err(e)) => panic!("accept error: {e}"),
-            Err(_) => panic!("accept timed out"),
+            Err(e) => panic!("accept timed out: {e}"),
         }
     }
 
@@ -637,7 +637,7 @@ mod tests {
             let n = match tokio::time::timeout(TEST_IO_TIMEOUT, socket.read(&mut chunk)).await {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => panic!("read error: {e}"),
-                Err(_) => panic!("read timed out"),
+                Err(e) => panic!("read timed out: {e}"),
             };
             if n == 0 {
                 break;
@@ -654,7 +654,7 @@ mod tests {
     }
 
     fn body_of(req: &str) -> &str {
-        req.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("")
+        req.split_once("\r\n\r\n").map_or("", |(_, b)| b)
     }
 
     fn is_complete_http(buf: &[u8]) -> bool {


### PR DESCRIPTION
💡 What: Replaced `.collect::<Vec<_>>().join(...)` with `.fold(...)` along with `String::with_capacity` to build strings directly. Additionally resolved a `while_let_loop` lint and `map_unwrap_or` lint in unrelated files.
🎯 Why: `.collect::<Vec<_>>().join(...)` allocates an intermediate vector before allocating the joined string, taking extra CPU cycles and memory. Doing it manually with `.fold` skips the intermediate vector entirely.
📊 Impact: Reduces heap allocs by 1 vector allocation for each call.
🔬 Measurement: Verified the code compiles, works correctly, and passes all tests without regressions via `cargo check` and `cargo test`.

---
*PR created automatically by Jules for task [15264098696242478243](https://jules.google.com/task/15264098696242478243) started by @madmax983*