### PR TITLE
🛠️ Forge: Refactor loop into while let and handle wildcard match arms

### DIFF
--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -8024,11 +8024,7 @@ instance = "inst"
                 };
                 let mut buf = Vec::new();
                 let mut chunk = [0u8; 8192];
-                loop {
-                    let n = match socket.read(&mut chunk).await {
-                        Ok(n) => n,
-                        Err(_) => break,
-                    };
+                while let Ok(n) = socket.read(&mut chunk).await {
                     if n == 0 {
                         break;
                     }

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -626,7 +626,7 @@ mod tests {
         match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((s, _))) => s,
             Ok(Err(e)) => panic!("accept error: {e}"),
-            Err(_) => panic!("accept timed out"),
+            Err(e) => panic!("accept timed out: {e}"),
         }
     }
 
@@ -637,7 +637,7 @@ mod tests {
             let n = match tokio::time::timeout(TEST_IO_TIMEOUT, socket.read(&mut chunk)).await {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => panic!("read error: {e}"),
-                Err(_) => panic!("read timed out"),
+                Err(e) => panic!("read timed out: {e}"),
             };
             if n == 0 {
                 break;
@@ -654,7 +654,7 @@ mod tests {
     }
 
     fn body_of(req: &str) -> &str {
-        req.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("")
+        req.split_once("\r\n\r\n").map_or("", |(_, b)| b)
     }
 
     fn is_complete_http(buf: &[u8]) -> bool {


### PR DESCRIPTION
* 🚽 Smell: Usage of `loop` with `match` inside instead of `while let` in `src/run/swebench.rs`. `Err(_)` used as wildcard catch-all for errors in `src/stream/sweep_webhook.rs`. Unidiomatic usage of `.map(...).unwrap_or(...)` instead of `.map_or(...)` in `src/stream/sweep_webhook.rs`.
* ✨ Solution: Refactored `loop` into `while let`, replaced wildcard error match arms with specific bindings (`Err(e)`), and replaced `.map(...).unwrap_or(...)` with `.map_or(...)`.
* 🧼 Benefit: Reduces cognitive load, aligns with Rust idioms, and removes clippy warnings.
* 🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [8515491536292132575](https://jules.google.com/task/8515491536292132575) started by @madmax983*