### PR TITLE
🗺️ Atlas: Extract GithubIssueError to github_issue module

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ pub enum Error {
     Github(String),
 
     #[error("github issue: {0}")]
-    GithubIssue(#[from] GithubIssueError),
+    GithubIssue(#[from] crate::run::github_issue::GithubIssueError),
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
@@ -240,19 +240,4 @@ impl From<toml::de::Error> for ConfigError {
     fn from(e: toml::de::Error) -> Self {
         Self::Toml(e.to_string())
     }
-}
-
-#[derive(Debug, Error)]
-pub enum GithubIssueError {
-    #[error("missing GitHub token: set `{0}` to a PAT or GitHub App installation token")]
-    MissingToken(String),
-
-    #[error("GitHub issue or repo not found: {0}")]
-    NotFound(String),
-
-    #[error("GitHub API rate limited: {0}")]
-    RateLimited(String),
-
-    #[error("GitHub API request failed: {0}")]
-    RequestFailed(String),
 }

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -271,10 +271,10 @@ impl ExitCode {
             | Error::Io(_)
             | Error::Json(_) => Self::InternalError,
             Error::GithubIssue(issue_e) => match issue_e {
-                crate::error::GithubIssueError::MissingToken(_) => Self::GithubIssueMissingToken,
-                crate::error::GithubIssueError::NotFound(_) => Self::GithubIssueNotFound,
-                crate::error::GithubIssueError::RateLimited(_) => Self::GithubIssueRateLimited,
-                crate::error::GithubIssueError::RequestFailed(_) => Self::TaskUnsuccessful,
+                crate::run::github_issue::GithubIssueError::MissingToken(_) => Self::GithubIssueMissingToken,
+                crate::run::github_issue::GithubIssueError::NotFound(_) => Self::GithubIssueNotFound,
+                crate::run::github_issue::GithubIssueError::RateLimited(_) => Self::GithubIssueRateLimited,
+                crate::run::github_issue::GithubIssueError::RequestFailed(_) => Self::TaskUnsuccessful,
             },
         }
     }

--- a/src/run/github_issue.rs
+++ b/src/run/github_issue.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, GithubIssueError};
+use crate::error::Error;
 use crate::prompt_guard::{PromptGuard, UntrustedKind};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -421,4 +421,21 @@ mod tests {
             _ => panic!("expected RequestFailed, got {err:?}"),
         }
     }
+}
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GithubIssueError {
+    #[error("missing GitHub token: set `{0}` to a PAT or GitHub App installation token")]
+    MissingToken(String),
+
+    #[error("GitHub issue or repo not found: {0}")]
+    NotFound(String),
+
+    #[error("GitHub API rate limited: {0}")]
+    RateLimited(String),
+
+    #[error("GitHub API request failed: {0}")]
+    RequestFailed(String),
 }


### PR DESCRIPTION
🕸️ Tangle: The `GithubIssueError` type is defined in the top-level `error.rs` file, which is a structural leak. The error type belongs with the specific GitHub issue handling logic.
📐 Blueprint: Moved the `GithubIssueError` enum from `src/error.rs` to its domain module `src/run/github_issue.rs` and updated the top-level `Error` enum to reference the new location.
🧱 Stability: Improved module cohesion by keeping domain-specific error types close to the logic that generates them, reducing the bloat of the central `error.rs` file.
🔬 Verification: Verified via `cargo check`, `cargo test`, and `cargo clippy` that the extraction compiles cleanly and causes no regressions.

---
*PR created automatically by Jules for task [5475375121508458195](https://jules.google.com/task/5475375121508458195) started by @madmax983*