### PR TITLE
⚡ Bolt: Remove intermediate allocations in `normalize_search_text`

### DIFF
--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -8024,11 +8024,7 @@ instance = "inst"
                 };
                 let mut buf = Vec::new();
                 let mut chunk = [0u8; 8192];
-                loop {
-                    let n = match socket.read(&mut chunk).await {
-                        Ok(n) => n,
-                        Err(_) => break,
-                    };
+                while let Ok(n) = socket.read(&mut chunk).await {
                     if n == 0 {
                         break;
                     }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -540,16 +540,27 @@ fn searchable_tokens(name: &str, description: &str) -> BTreeSet<String> {
         .collect()
 }
 
+/// Normalizes search text by converting it to lowercase, filtering out unallowed symbols,
+/// and collapsing multiple spaces into a single space.
+///
+/// Performance optimization:
+/// Constructs the final string directly in a single pass to eliminate intermediate
+/// collections (`Vec`) and allocations (`.join(" ")`).
 fn normalize_search_text(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
+    let mut in_word = false;
     for ch in text.chars() {
         if ch.is_ascii_alphanumeric() || ch == '$' || ch == '@' || ch == '/' {
+            if !in_word && !out.is_empty() {
+                out.push(' ');
+            }
             out.push(ch.to_ascii_lowercase());
+            in_word = true;
         } else {
-            out.push(' ');
+            in_word = false;
         }
     }
-    out.split_whitespace().collect::<Vec<_>>().join(" ")
+    out
 }
 
 fn is_stopword(token: &str) -> bool {
@@ -623,4 +634,22 @@ fn expand_skill_path(path: &String) -> PathBuf {
         }
     }
     PathBuf::from(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_search_text() {
+        assert_eq!(normalize_search_text("Hello World!"), "hello world");
+        assert_eq!(
+            normalize_search_text("  multiple   spaces  "),
+            "multiple spaces"
+        );
+        assert_eq!(
+            normalize_search_text("symbols &*() kept $/"),
+            "symbols kept $/"
+        );
+    }
 }

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -626,7 +626,7 @@ mod tests {
         match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((s, _))) => s,
             Ok(Err(e)) => panic!("accept error: {e}"),
-            Err(_) => panic!("accept timed out"),
+            Err(tokio::time::error::Elapsed { .. }) => panic!("accept timed out"),
         }
     }
 
@@ -637,7 +637,7 @@ mod tests {
             let n = match tokio::time::timeout(TEST_IO_TIMEOUT, socket.read(&mut chunk)).await {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => panic!("read error: {e}"),
-                Err(_) => panic!("read timed out"),
+                Err(tokio::time::error::Elapsed { .. }) => panic!("read timed out"),
             };
             if n == 0 {
                 break;
@@ -654,7 +654,7 @@ mod tests {
     }
 
     fn body_of(req: &str) -> &str {
-        req.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("")
+        req.split_once("\r\n\r\n").map_or("", |(_, b)| b)
     }
 
     fn is_complete_http(buf: &[u8]) -> bool {


### PR DESCRIPTION
💡 What: Rewrote `normalize_search_text` in `src/skills.rs` to construct the normalized string directly, avoiding intermediate `String` and `Vec` allocations, and fixed existing clippy warnings.
🎯 Why: `.split_whitespace().collect::<Vec<_>>().join(" ")` causes unnecessary heap allocations.
📊 Impact: Reduces memory allocations during skill indexing by building the normalized string in a single pre-allocated pass.
🔬 Measurement: Run `cargo test` and `cargo bench`.

---
*PR created automatically by Jules for task [7326076267954398302](https://jules.google.com/task/7326076267954398302) started by @madmax983*