### PR TITLE
🛡️ Sentry: Resolve clippy lints and add retry_after_secs test

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -149,7 +149,7 @@ impl ModelError {
                 let digits: &str = msg[pos + prefix.len()..]
                     .split(|c: char| !c.is_ascii_digit())
                     .next()
-                    .unwrap_or("");
+                    .unwrap_or_default();
                 if let Ok(n) = digits.parse::<u64>() {
                     return Some(n);
                 }
@@ -191,6 +191,12 @@ mod tests {
     fn retry_after_secs_handles_space_variant() {
         let e = ModelError::RateLimited("retry after: 90".into());
         assert_eq!(e.retry_after_secs(), Some(90));
+    }
+
+    #[test]
+    fn retry_after_secs_handles_empty_digits() {
+        let e = ModelError::RateLimited("retry after: tomorrow".into());
+        assert_eq!(e.retry_after_secs(), None);
     }
 }
 

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -8024,11 +8024,7 @@ instance = "inst"
                 };
                 let mut buf = Vec::new();
                 let mut chunk = [0u8; 8192];
-                loop {
-                    let n = match socket.read(&mut chunk).await {
-                        Ok(n) => n,
-                        Err(_) => break,
-                    };
+                while let Ok(n) = socket.read(&mut chunk).await {
                     if n == 0 {
                         break;
                     }

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -626,7 +626,7 @@ mod tests {
         match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((s, _))) => s,
             Ok(Err(e)) => panic!("accept error: {e}"),
-            Err(_) => panic!("accept timed out"),
+            Err(tokio::time::error::Elapsed { .. }) => panic!("accept timed out"),
         }
     }
 
@@ -637,7 +637,7 @@ mod tests {
             let n = match tokio::time::timeout(TEST_IO_TIMEOUT, socket.read(&mut chunk)).await {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => panic!("read error: {e}"),
-                Err(_) => panic!("read timed out"),
+                Err(tokio::time::error::Elapsed { .. }) => panic!("read timed out"),
             };
             if n == 0 {
                 break;
@@ -654,7 +654,7 @@ mod tests {
     }
 
     fn body_of(req: &str) -> &str {
-        req.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("")
+        req.split_once("\r\n\r\n").map_or("", |(_, b)| b)
     }
 
     fn is_complete_http(buf: &[u8]) -> bool {


### PR DESCRIPTION
🎯 Target: `src/run/swebench.rs`, `src/stream/sweep_webhook.rs`, and `src/error.rs`.
💣 Risk: Resolves multiple clippy lint failures preventing clean builds and improves parsing code test coverage.
🧪 Strategy: Refactored loops, updated match arms for explicit typing, replaced map-unwrap-or chains, and added a specific unit test for `retry_after_secs`.
🔬 Verification: `cargo test --lib error::tests` and `cargo clippy --all-targets --all-features`.

---
*PR created automatically by Jules for task [10287712552519457780](https://jules.google.com/task/10287712552519457780) started by @madmax983*