### PR TITLE
🗺️ Atlas: Unify isolated subsystem error enums into central crate::Error

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,61 @@
+1. **The Tangle**: Currently `ArtifactSchemaError`, `WebhookSinkError`, `SweepWebhookSinkError`, `BundleError` and perhaps a few other minor errors implement `std::error::Error` or use `#[derive(thiserror::Error)]` without being part of the central `crate::error::Error` enum.
+2. **The Blueprint**: We will unify error handling into the central `crate::error::Error` enum.
+We will add `ArtifactSchema(#[from] crate::artifact::ArtifactSchemaError)`, `Bundle(#[from] crate::run::bundle::BundleError)`, `Webhook(#[from] crate::stream::webhook::WebhookSinkError)`, and `SweepWebhook(#[from] crate::stream::sweep_webhook::SweepWebhookSinkError)` into `crate::error::Error`.
+Also, we need to fix any places in the code that will break if we modify these.
+Wait, let's check if there are other isolated `thiserror::Error` types. `grep -rn "derive.*thiserror::Error" src/` gave us exactly these 4 enums:
+- `ArtifactSchemaError` in `src/artifact.rs`
+- `WebhookSinkError` in `src/stream/webhook.rs`
+- `SweepWebhookSinkError` in `src/stream/sweep_webhook.rs`
+- `BundleError` in `src/run/bundle.rs`
+Wait, are there any more? Let's check `grep -rn "thiserror::Error" src/`.
+- `src/artifact.rs:12`
+- `src/stream/webhook.rs:72`
+- `src/stream/sweep_webhook.rs:193`
+- `src/run/bundle.rs:40`
+- `src/error.rs:4`
+
+This confirms there are exactly 4 separate error types outside `src/error.rs` using `thiserror`.
+We will add them as variants to `crate::error::Error` in `src/error.rs`.
+
+```rust
+    #[error(transparent)]
+    ArtifactSchema(#[from] crate::artifact::ArtifactSchemaError),
+
+    #[error(transparent)]
+    Bundle(#[from] crate::run::bundle::BundleError),
+
+    #[error(transparent)]
+    Webhook(#[from] crate::stream::webhook::WebhookSinkError),
+
+    #[error(transparent)]
+    SweepWebhook(#[from] crate::stream::sweep_webhook::SweepWebhookSinkError),
+```
+
+Wait, `crate::error::Error` does not use these types currently. Are there places where they are returned that we should change to `Result<T, crate::error::Error>` instead?
+Let's check where they are used.
+`ArtifactSchemaError` is returned by `src/artifact.rs`.
+`WebhookSinkError` is returned by `WebhookSink::new`.
+`SweepWebhookSinkError` is returned by `SweepWebhookSink::new`.
+`BundleError` is returned by `src/run/bundle.rs` functions.
+
+Let's just integrate them into `crate::error::Error`.
+Wait, what if `BundleError` has conflicting `#[from]` inside it?
+`BundleError` has:
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+`crate::error::Error` also has `Io` and `Json`.
+If we have `Bundle(#[from] BundleError)` in `crate::error::Error`, there's an ambiguity if we do `?` on `io::Error` in a function returning `Result<T, crate::error::Error>`?
+No, the compiler will use the direct `From<io::Error> for Error` if we're converting `io::Error` to `Error`. If we're converting `BundleError` to `Error`, it will use `From<BundleError> for Error`.
+
+Wait, Atlas directive says: "Standardize error types across modules (e.g., Result<T, crate::Error>)."
+By wrapping these subsystem errors into `crate::error::Error`, we unify the error type.
+Let's see if we can refactor `BundleError`, `ArtifactSchemaError`, etc. to just be part of the central Error, OR if we keep them as separate enums and use `#[from]` in `crate::error::Error`.
+The `src/error.rs` doc comment says:
+"Error types. One top-level `Error` composed of focused subsystem enums, so call sites can match on the specific failure mode without a catch-all."
+So keeping them as separate enums but wrapping them in `crate::error::Error` is the EXACT right pattern for this codebase!
+
+3. **Execution**:
+   - Add the missing `#[error(transparent)]` subsystem variants to `src/error.rs`.
+   - Update tests to ensure `cargo check` passes.

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,18 @@ pub enum Error {
     #[error(transparent)]
     Json(#[from] serde_json::Error),
 
+    #[error(transparent)]
+    ArtifactSchema(#[from] crate::artifact::ArtifactSchemaError),
+
+    #[error(transparent)]
+    Bundle(#[from] crate::run::bundle::BundleError),
+
+    #[error(transparent)]
+    Webhook(#[from] crate::stream::webhook::WebhookSinkError),
+
+    #[error(transparent)]
+    SweepWebhook(#[from] crate::stream::sweep_webhook::SweepWebhookSinkError),
+
     /// One or more operator-supplied verification checks did not pass.
     /// `(failed_count, total_count)`.
     #[error("verification failed: {0} of {1} check(s) did not pass")]

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -269,7 +269,11 @@ impl ExitCode {
             | Error::Trajectory(_)
             | Error::Github(_)
             | Error::Io(_)
-            | Error::Json(_) => Self::InternalError,
+            | Error::Json(_)
+            | Error::ArtifactSchema(_)
+            | Error::Bundle(_)
+            | Error::Webhook(_)
+            | Error::SweepWebhook(_) => Self::InternalError,
             Error::GithubIssue(issue_e) => match issue_e {
                 crate::error::GithubIssueError::MissingToken(_) => Self::GithubIssueMissingToken,
                 crate::error::GithubIssueError::NotFound(_) => Self::GithubIssueNotFound,

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -8024,11 +8024,7 @@ instance = "inst"
                 };
                 let mut buf = Vec::new();
                 let mut chunk = [0u8; 8192];
-                loop {
-                    let n = match socket.read(&mut chunk).await {
-                        Ok(n) => n,
-                        Err(_) => break,
-                    };
+                while let Ok(n) = socket.read(&mut chunk).await {
                     if n == 0 {
                         break;
                     }

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -626,7 +626,7 @@ mod tests {
         match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((s, _))) => s,
             Ok(Err(e)) => panic!("accept error: {e}"),
-            Err(_) => panic!("accept timed out"),
+            Err(e) => panic!("accept timed out: {e}"),
         }
     }
 
@@ -637,7 +637,7 @@ mod tests {
             let n = match tokio::time::timeout(TEST_IO_TIMEOUT, socket.read(&mut chunk)).await {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => panic!("read error: {e}"),
-                Err(_) => panic!("read timed out"),
+                Err(e) => panic!("read timed out: {e}"),
             };
             if n == 0 {
                 break;
@@ -654,7 +654,7 @@ mod tests {
     }
 
     fn body_of(req: &str) -> &str {
-        req.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("")
+        req.split_once("\r\n\r\n").map_or("", |(_, b)| b)
     }
 
     fn is_complete_http(buf: &[u8]) -> bool {


### PR DESCRIPTION
🕸️ Tangle: The structural problem where `ArtifactSchemaError`, `WebhookSinkError`, `SweepWebhookSinkError`, and `BundleError` implemented `std::error::Error` or used `#[derive(thiserror::Error)]` without being composable variants in the central `crate::error::Error` enum, causing fragmented error handling across the codebase.
📐 Blueprint: Wrapped these specific isolated subsystem enums inside `crate::error::Error` using `#[error(transparent)] ... #[from] ...`, adhering strictly to the "composed of focused subsystem enums" architectural pattern documented in `src/error.rs`.
🧱 Stability: Reduced coupling by ensuring standard `Result<T, crate::Error>` types can transparently return errors from the `artifact`, `run::bundle`, `stream::webhook`, and `stream::sweep_webhook` modules.
🔬 Verification: Builds successfully, strict separation enforced.

---
*PR created automatically by Jules for task [2817987248438785447](https://jules.google.com/task/2817987248438785447) started by @madmax983*