### PR TITLE
🌟 Nova: Yaml Exporter for Trajectories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+yaml-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2688,14 +2688,14 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
-    /// (each maps to the corresponding trajectory exporter; feature-gated
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`,
+    /// and `yaml` (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `yaml` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3612,7 +3612,10 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "yaml"
+    ) {
         return bench_inspect_export(i);
     }
 
@@ -3628,7 +3631,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         "json" => crate::run::inspect::InspectFormat::Json,
         other => {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, or `mermaid`)"
+                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, `mermaid`, or `yaml`)"
             ))));
         }
     };
@@ -3670,7 +3673,8 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     })?;
     let instance_id = i.instance.as_deref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
-            "inspect: --instance is required for export formats (markdown/html/csv/mermaid)".into(),
+            "inspect: --instance is required for export formats (markdown/html/csv/mermaid/yaml)"
+                .into(),
         ))
     })?;
     let traj_path =
@@ -3692,6 +3696,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "yaml" => inspect_export_yaml(&traj)?,
         _ => unreachable!("dispatch guarded by caller"),
     };
 
@@ -3745,6 +3750,22 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "format_unavailable: --format html requires the `html-export` Cargo feature; \
          rebuild with `--features html-export`"
+            .into(),
+    )))
+}
+
+#[cfg(feature = "yaml-export")]
+#[allow(clippy::unnecessary_wraps)]
+fn inspect_export_yaml(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    use crate::trajectory::export::{TrajectoryExporter, YamlExporter};
+    Ok(YamlExporter::export(traj))
+}
+
+#[cfg(not(feature = "yaml-export"))]
+fn inspect_export_yaml(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "format_unavailable: --format yaml requires the `yaml-export` Cargo feature; \
+         rebuild with `--features yaml-export`"
             .into(),
     )))
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -53,6 +53,9 @@ pub struct MermaidExporter;
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
+#[cfg(feature = "yaml-export")]
+pub struct YamlExporter;
+
 use std::fmt::Write;
 
 #[cfg(feature = "csv-export")]
@@ -245,6 +248,29 @@ impl TrajectoryExporter for MermaidExporter {
     }
 }
 
+#[cfg(feature = "yaml-export")]
+impl TrajectoryExporter for YamlExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut redacted_traj = trajectory.clone();
+
+        if let Some(task) = &mut redacted_traj.info.task {
+            *task = redactor.redact_text(task, surface::EXPORT).text;
+        }
+
+        if let Some(outcome) = &mut redacted_traj.info.outcome {
+            *outcome = redactor.redact_text(outcome, surface::EXPORT).text;
+        }
+
+        for msg in &mut redacted_traj.messages {
+            msg.content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+        }
+
+        serde_yml::to_string(&redacted_traj)
+            .unwrap_or_else(|_| "Failed to export as YAML".to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -339,5 +365,23 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+
+    #[cfg(feature = "yaml-export")]
+    #[test]
+    fn test_yaml_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::assistant("Hello user"));
+
+        let yaml = YamlExporter::export(&t);
+
+        assert!(yaml.contains("task: Add a feature"));
+        assert!(yaml.contains("outcome: submitted"));
+        assert!(yaml.contains("content: Hello agent"));
+        assert!(yaml.contains("content: Hello user"));
     }
 }


### PR DESCRIPTION
💡 **The Spark:** "We have CSV, Markdown, HTML, and Mermaid exporters, but a structured human-readable data format like YAML is missing."
🚀 **The Feature:** "Implemented `YamlExporter` and the `yaml-export` feature for exporting trajectories."
🔮 **The Potential:** "Could be used to quickly inspect trajectories in the terminal with syntax highlighting (e.g. using `bat`) or to integrate with YAML-based tools."
⚠️ **Risk:** "Low. Isolated in `src/trajectory/export.rs` and CLI routing behind a feature flag."

---
*PR created automatically by Jules for task [4815380765560303509](https://jules.google.com/task/4815380765560303509) started by @madmax983*