### PR TITLE
🎨 Mosaic: UI Polish for CLI Errors

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -67,8 +67,13 @@ pub async fn run() -> Result<(), Error> {
         // for non-zero exits (exit 0 means --help / --version, not an error).
         let _ = e.print();
         if e.exit_code() != 0 {
-            eprintln!("outcome_class: {}", ExitCode::UsageError.outcome_class());
-            eprintln!("error: {e}");
+            use crossterm::style::Stylize;
+            eprintln!(
+                "{} {}",
+                "outcome_class:".dim(),
+                ExitCode::UsageError.outcome_class().dim()
+            );
+            eprintln!("{} {e}", "error:".red().bold());
         }
         std::process::exit(e.exit_code());
     });
@@ -2127,8 +2132,9 @@ async fn bench_forecast(s: args::SwebenchCmd) -> Result<(), Error> {
 /// Used for outcomes that are driven by explicit CLI logic (regression gate,
 /// budget-halt forecast, tail abort) rather than propagated `Error` variants.
 fn exit_with_outcome(code: ExitCode, detail: &str) -> ! {
-    eprintln!("outcome_class: {}", code.outcome_class());
-    eprintln!("error: {detail}");
+    use crossterm::style::Stylize;
+    eprintln!("{} {}", "outcome_class:".dim(), code.outcome_class().dim());
+    eprintln!("{} {}", "error:".red().bold(), detail);
     // Flush stdout so piped consumers receive any buffered report output
     // before the process terminates (process::exit bypasses Drop).
     let _ = std::io::Write::flush(&mut std::io::stdout());


### PR DESCRIPTION
* 🖌️ **Before:** CLI initialization errors and exits printed raw `outcome_class: ... \n error: ...` text to standard error without formatting, resembling a log file.
* ✨ **After:** Error outputs are formatted using `crossterm` colors with a bold red `error:` prefix, and the `outcome_class` debug information is dimmed so it recedes into the visual hierarchy.
* 🖼️ **Visuals:** Red colored `error:` tags and dimmed debug output for all CLI error exits.

---
*PR created automatically by Jules for task [9364451959914574599](https://jules.google.com/task/9364451959914574599) started by @madmax983*