### PR TITLE
⚒️ Forge: Resolve clippy warnings in swebench and webhook test helpers

### DIFF
--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -8024,11 +8024,7 @@ instance = "inst"
                 };
                 let mut buf = Vec::new();
                 let mut chunk = [0u8; 8192];
-                loop {
-                    let n = match socket.read(&mut chunk).await {
-                        Ok(n) => n,
-                        Err(_) => break,
-                    };
+                while let Ok(n) = socket.read(&mut chunk).await {
                     if n == 0 {
                         break;
                     }

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -626,7 +626,7 @@ mod tests {
         match tokio::time::timeout(TEST_IO_TIMEOUT, listener.accept()).await {
             Ok(Ok((s, _))) => s,
             Ok(Err(e)) => panic!("accept error: {e}"),
-            Err(_) => panic!("accept timed out"),
+            Err(tokio::time::error::Elapsed { .. }) => panic!("accept timed out"),
         }
     }
 
@@ -637,7 +637,7 @@ mod tests {
             let n = match tokio::time::timeout(TEST_IO_TIMEOUT, socket.read(&mut chunk)).await {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => panic!("read error: {e}"),
-                Err(_) => panic!("read timed out"),
+                Err(tokio::time::error::Elapsed { .. }) => panic!("read timed out"),
             };
             if n == 0 {
                 break;
@@ -654,7 +654,7 @@ mod tests {
     }
 
     fn body_of(req: &str) -> &str {
-        req.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("")
+        req.split_once("\r\n\r\n").map_or("", |(_, b)| b)
     }
 
     fn is_complete_http(buf: &[u8]) -> bool {


### PR DESCRIPTION
- 🚰 Smell: Non-idiomatic loops and unhandled match variants, specifically a `loop { match ... }` pattern that can be simplified, wildcard `Err(_)` matches that obscure specific errors, and `.map().unwrap_or()` chains that are less readable.
- ✨ Solution: Refactored a `loop` into a `while let` in `swebench.rs`. Replaced `Err(_)` wildcards with explicit `Err(tokio::time::error::Elapsed { .. })` in `sweep_webhook.rs`. Simplified Option chains using `.map_or()` in `sweep_webhook.rs`.
- 🧼 Benefit: Improves code readability, adheres to idiomatic Rust patterns (as enforced by clippy), and explicitly handles timeout errors.
- 🛡️ Verification: Ran `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` successfully without behavior changes.

---
*PR created automatically by Jules for task [4350193815485715904](https://jules.google.com/task/4350193815485715904) started by @madmax983*