### PR TITLE
🌟 Nova: TableExporter for CLI Trajectory Inspection

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2773,14 +2773,14 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
+    /// In instance mode, also accepts `markdown`, `table`, `html`, `csv`, and `mermaid`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `table`, `html`, `csv`, and `mermaid` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3695,13 +3695,16 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "table"
+    ) {
         return bench_inspect_export(i);
     }
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (markdown/table/html/csv/mermaid), not `{}`",
             i.format
         ))));
     }
@@ -3711,7 +3714,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         "json" => crate::run::inspect::InspectFormat::Json,
         other => {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, or `mermaid`)"
+                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `table`, `html`, `csv`, or `mermaid`)"
             ))));
         }
     };
@@ -3771,6 +3774,10 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "markdown" => {
             use crate::trajectory::export::{MarkdownExporter, TrajectoryExporter};
             MarkdownExporter::export(&traj)
+        }
+        "table" => {
+            use crate::trajectory::export::{TableExporter, TrajectoryExporter};
+            TableExporter::export(&traj)
         }
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -245,11 +245,62 @@ impl TrajectoryExporter for MermaidExporter {
     }
 }
 
+pub struct TableExporter;
+
+impl TrajectoryExporter for TableExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let mut table = comfy_table::Table::new();
+        table
+            .load_preset(comfy_table::presets::UTF8_FULL)
+            .apply_modifier(comfy_table::modifiers::UTF8_ROUND_CORNERS)
+            .set_header(vec!["Turn", "Role", "Content Snippet"]);
+
+        let redactor = Redactor::default_enabled();
+        for (i, msg) in trajectory.messages.iter().enumerate() {
+            let role = match msg.role.as_str() {
+                "system" => "System",
+                "user" => "User",
+                "assistant" => "Assistant",
+                "tool" => "Tool",
+                other => other,
+            };
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            let snippet = if content.chars().count() > 100 {
+                format!("{}...", content.chars().take(97).collect::<String>())
+            } else {
+                content
+            };
+            table.add_row(vec![
+                i.to_string(),
+                role.to_string(),
+                snippet.replace('\n', " "),
+            ]);
+        }
+        table.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::model::Message;
     use crate::trajectory::outcome;
+
+    #[test]
+    fn test_table_export_format() {
+        let mut t = Trajectory::new();
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::assistant("Hello user"));
+
+        let out = TableExporter::export(&t);
+        assert!(out.contains("System prompt"));
+        assert!(out.contains("Hello agent"));
+        assert!(out.contains("Hello user"));
+        assert!(out.contains("Turn"));
+        assert!(out.contains("Role"));
+        assert!(out.contains("Content Snippet"));
+    }
 
     #[test]
     fn test_markdown_export_format() {


### PR DESCRIPTION
💡 **The Spark:** "Trajectories can be dense and long. We already use `comfy-table` for aggregate metrics, but we don't have a way to view a single agent run as a high-level summary table."
🚀 **The Feature:** "Implemented `TableExporter` for `max bench inspect --format table` that summarizes a trajectory run with Turn, Role, and a snippet of Content."
🔮 **The Potential:** "Allows rapid visual scanning of conversational cadence and tool loops directly in the terminal."
⚠️ **Risk:** "Low. Isolated in `src/trajectory/export.rs` and `src/cli/mod.rs`."

---
*PR created automatically by Jules for task [14103917948409284119](https://jules.google.com/task/14103917948409284119) started by @madmax983*