### PR TITLE
🛡️ Sentry: Add test for Redactor check early return

### DIFF
--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -984,6 +984,18 @@ mod tests {
     use super::*;
 
     #[test]
+    fn check_returns_original_input_when_disabled() {
+        let redactor = Redactor::disabled();
+        let input = "some secret input ghp_0123456789ABCDEF0123456789ABCDEF0123";
+        let result = redactor.check(input);
+
+        assert_eq!(result.redacted, input);
+        assert!(result.matches.is_empty());
+        assert!(result.unmatched_literal_indices.is_empty());
+        assert!(result.unmatched_pattern_indices.is_empty());
+    }
+
+    #[test]
     fn same_value_gets_same_marker() {
         let redactor = Redactor::default_enabled();
         let one = redactor.redact_text("ghp_0123456789ABCDEF0123456789ABCDEF0123", "a");


### PR DESCRIPTION
🎯 Target: `src/redaction.rs::Redactor::check`
💣 Risk: Missing test coverage for early return when the redactor is disabled, potentially leading to accidental redaction in check mode or masking bugs in configuration toggles.
🧪 Strategy: Added a test case `check_returns_original_input_when_disabled` that verifies `check` returns the exact input and empty matches when initialized via `Redactor::disabled()`.
🔭 Verification: `cargo test -p maxwells-daemon --lib -- redaction::tests::check_returns_original_input_when_disabled`

---
*PR created automatically by Jules for task [5074110181543238157](https://jules.google.com/task/5074110181543238157) started by @madmax983*