### PR TITLE
🌟 Nova: JSONL Trajectory Exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+jsonl-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2786,14 +2786,14 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`, and `jsonl`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `jsonl` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3681,7 +3681,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         }
         if i.output.is_some() {
             return Err(Error::Config(crate::error::ConfigError::Invalid(
-                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid)".into(),
+                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/jsonl)".into(),
             )));
         }
         let format = parse_trajectory_diff_format(&i.format)?;
@@ -3696,13 +3696,16 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "jsonl"
+    ) {
         return bench_inspect_export(i);
     }
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/jsonl), not `{}`",
             i.format
         ))));
     }
@@ -3712,7 +3715,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         "json" => crate::run::inspect::InspectFormat::Json,
         other => {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, or `mermaid`)"
+                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, `mermaid`, or `jsonl`)"
             ))));
         }
     };
@@ -3754,7 +3757,8 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     })?;
     let instance_id = i.instance.as_deref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
-            "inspect: --instance is required for export formats (markdown/html/csv/mermaid)".into(),
+            "inspect: --instance is required for export formats (markdown/html/csv/mermaid/jsonl)"
+                .into(),
         ))
     })?;
     let traj_path =
@@ -3776,6 +3780,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "jsonl" => inspect_export_jsonl(&traj)?,
         _ => unreachable!("dispatch guarded by caller"),
     };
 
@@ -3829,6 +3834,22 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "format_unavailable: --format html requires the `html-export` Cargo feature; \
          rebuild with `--features html-export`"
+            .into(),
+    )))
+}
+
+#[cfg(feature = "jsonl-export")]
+#[allow(clippy::unnecessary_wraps)]
+fn inspect_export_jsonl(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    use crate::trajectory::export::{JsonlExporter, TrajectoryExporter};
+    Ok(JsonlExporter::export(traj))
+}
+
+#[cfg(not(feature = "jsonl-export"))]
+fn inspect_export_jsonl(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "format_unavailable: --format jsonl requires the `jsonl-export` Cargo feature; \
+         rebuild with `--features jsonl-export`"
             .into(),
     )))
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -53,7 +53,33 @@ pub struct MermaidExporter;
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
+#[cfg(feature = "jsonl-export")]
+pub struct JsonlExporter;
+
 use std::fmt::Write;
+
+#[cfg(feature = "jsonl-export")]
+impl TrajectoryExporter for JsonlExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut jsonl = String::new();
+
+        for msg in &trajectory.messages {
+            // We clone to safely redact the content without mutating the original
+            let mut safe_msg = msg.clone();
+            safe_msg.content = redactor
+                .redact_text(&safe_msg.content, surface::EXPORT)
+                .text;
+
+            // For a single line JSON, serde_json::to_string does exactly what we want
+            if let Ok(line) = serde_json::to_string(&safe_msg) {
+                let _ = writeln!(jsonl, "{line}");
+            }
+        }
+
+        jsonl
+    }
+}
 
 #[cfg(feature = "csv-export")]
 impl TrajectoryExporter for CsvExporter {
@@ -319,6 +345,31 @@ mod tests {
         assert!(mermaid.contains("U->>A: Hello \"user\""));
 
         assert!(mermaid.contains("Note over S,T: Outcome: submitted"));
+    }
+
+    #[cfg(feature = "jsonl-export")]
+    #[test]
+    fn test_jsonl_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent\nMulti-line"));
+
+        let jsonl = JsonlExporter::export(&t);
+
+        let lines: Vec<&str> = jsonl.lines().collect();
+        assert_eq!(lines.len(), 2);
+
+        let sys_line = lines[0];
+        let user_line = lines[1];
+
+        assert!(sys_line.contains(r#""role":"system""#));
+        assert!(sys_line.contains(r#""content":"System prompt""#));
+
+        assert!(user_line.contains(r#""role":"user""#));
+        assert!(user_line.contains(r#""content":"Hello agent\nMulti-line""#));
     }
 
     #[cfg(feature = "html-export")]


### PR DESCRIPTION
💡 **The Spark:** "The project provides various human-readable exports (Markdown, HTML, CSV, Mermaid) but lacks a machine-readable format suitable for streaming processing or loading into databases without parsing the entire `traj.json` object."
🚀 **The Feature:** "Implemented `JsonlExporter` to output trajectory messages as JSON Lines, with each message on a new line."
🔮 **The Potential:** "This allows operators to easily pipe the agent's history through tools like `jq` or load it into big data systems line-by-line for analysis."
⚠️ **Risk:** "Low. Isolated under the new `jsonl-export` feature flag and within the `export` module."

---
*PR created automatically by Jules for task [17159029353264891842](https://jules.google.com/task/17159029353264891842) started by @madmax983*