### PR TITLE
🌟 Nova: JSONL Exporter for Trajectories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+jsonl-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
 

--- a/docs/spec-inspect.md
+++ b/docs/spec-inspect.md
@@ -40,13 +40,14 @@ max bench compare --baseline <dir> --candidate <dir> --emit-diff-script <out.sh>
   | `html`     | Self-contained HTML (inline CSS, no external refs)     | `html-export`          |
   | `csv`      | Flat CSV with `role` and `content` columns             | `csv-export`           |
   | `mermaid`  | Mermaid `sequenceDiagram` of the conversation          | `mermaid-export`       |
+  | `jsonl`    | JSON Lines format containing role and content          | `jsonl-export`         |
   | `unified`  | Unified diff (diff mode only)                          | —                      |
 
   When the binary is built without the required feature, `--format <name>` exits
   with a `format_unavailable` error naming the missing feature. See
   [`src/trajectory/export.rs`](../src/trajectory/export.rs) for exporter unit tests.
 * `--output <PATH>`: write output to a file instead of stdout. Supported with
-  `markdown`, `html`, `csv`, and `mermaid` formats in instance mode. Stdout is
+  `markdown`, `html`, `csv`, `mermaid`, and `jsonl` formats in instance mode. Stdout is
   empty when `--output` is set.
 * `--full`: disable stdout/stderr truncation in transcript mode.
 * `--show-expected`: also print `PASS_TO_PASS` / `FAIL_TO_PASS` expected-test groupings read
@@ -59,7 +60,7 @@ max bench compare --baseline <dir> --candidate <dir> --emit-diff-script <out.sh>
 Exactly one of `--instance` or `--filter` is required.
 Diff mode is separate and cannot be combined with `--sweep`, `--instance`, or
 `--filter`.
-Export formats (`markdown`, `html`, `csv`, `mermaid`) require `--instance` and
+Export formats (`markdown`, `html`, `csv`, `mermaid`, `jsonl`) require `--instance` and
 `--sweep`; they cannot be combined with `--filter`.
 
 ### Output redaction

--- a/docs/spec-redact-audit.md
+++ b/docs/spec-redact-audit.md
@@ -54,7 +54,7 @@ The scanner walks the tree and inspects these file kinds:
   see `docs/spec-event-log.md`)
 - `*.output.txt`
 - `*.patch` (submitted patches — first-class, frequently-shared artifacts)
-- exported `*.md`, `*.html`, `*.csv`, `*.mermaid`
+- exported `*.md`, `*.html`, `*.csv`, `*.mermaid`, `*.jsonl`
 - `*.tar.gz` / `*.tgz` bundles — extracted to a temp dir and scanned member by
   member. Findings inside a bundle are labelled `archive.tar.gz!inner/path`.
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2786,14 +2786,14 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`, and `jsonl`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `jsonl` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3696,13 +3696,16 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "jsonl"
+    ) {
         return bench_inspect_export(i);
     }
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/jsonl), not `{}`",
             i.format
         ))));
     }
@@ -3712,7 +3715,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         "json" => crate::run::inspect::InspectFormat::Json,
         other => {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, or `mermaid`)"
+                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, `mermaid`, or `jsonl`)"
             ))));
         }
     };
@@ -3754,7 +3757,8 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     })?;
     let instance_id = i.instance.as_deref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
-            "inspect: --instance is required for export formats (markdown/html/csv/mermaid)".into(),
+            "inspect: --instance is required for export formats (markdown/html/csv/mermaid/jsonl)"
+                .into(),
         ))
     })?;
     let traj_path =
@@ -3776,6 +3780,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "jsonl" => inspect_export_jsonl(&traj)?,
         _ => unreachable!("dispatch guarded by caller"),
     };
 
@@ -3829,6 +3834,22 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "format_unavailable: --format html requires the `html-export` Cargo feature; \
          rebuild with `--features html-export`"
+            .into(),
+    )))
+}
+
+#[cfg(feature = "jsonl-export")]
+#[allow(clippy::unnecessary_wraps)]
+fn inspect_export_jsonl(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    use crate::trajectory::export::{JsonlExporter, TrajectoryExporter};
+    Ok(JsonlExporter::export(traj))
+}
+
+#[cfg(not(feature = "jsonl-export"))]
+fn inspect_export_jsonl(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "format_unavailable: --format jsonl requires the `jsonl-export` Cargo feature; \
+         rebuild with `--features jsonl-export`"
             .into(),
     )))
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -53,6 +53,9 @@ pub struct MermaidExporter;
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
+#[cfg(feature = "jsonl-export")]
+pub struct JsonlExporter;
+
 use std::fmt::Write;
 
 #[cfg(feature = "csv-export")]
@@ -80,6 +83,28 @@ impl TrajectoryExporter for CsvExporter {
         }
 
         csv
+    }
+}
+
+#[cfg(feature = "jsonl-export")]
+impl TrajectoryExporter for JsonlExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut jsonl = String::new();
+
+        for msg in &trajectory.messages {
+            let role = msg.role.as_str();
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            let val = serde_json::json!({
+                "role": role,
+                "content": content
+            });
+            if let Ok(s) = serde_json::to_string(&val) {
+                let _ = writeln!(jsonl, "{s}");
+            }
+        }
+
+        jsonl
     }
 }
 
@@ -319,6 +344,25 @@ mod tests {
         assert!(mermaid.contains("U->>A: Hello \"user\""));
 
         assert!(mermaid.contains("Note over S,T: Outcome: submitted"));
+    }
+
+    #[cfg(feature = "jsonl-export")]
+    #[test]
+    fn test_jsonl_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent\nMulti-line"));
+
+        let jsonl = JsonlExporter::export(&t);
+        let lines: Vec<&str> = jsonl.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("\"role\":\"system\""));
+        assert!(lines[0].contains("\"content\":\"System prompt\""));
+        assert!(lines[1].contains("\"role\":\"user\""));
+        assert!(lines[1].contains("\"content\":\"Hello agent\\nMulti-line\""));
     }
 
     #[cfg(feature = "html-export")]


### PR DESCRIPTION
💡 The Spark: The `max bench inspect` command currently supports multiple formats (`csv`, `html`, `markdown`), but lacks an easy format for programmatic machine-readable line-by-line processing of the messages.
🚀 The Feature: Added `jsonl` as an output format for the inspect tool by implementing a `JsonlExporter` behind a `jsonl-export` feature flag.
🔭 The Potential: Enables easier parsing and extraction of messages for downstream scripting without needing to load the entire trajectory as one giant JSON array.
⚠️ Risk: Low. Isolated in `src/trajectory/export.rs` and behind a new feature flag `jsonl-export`.

---
*PR created automatically by Jules for task [1635395681445214580](https://jules.google.com/task/1635395681445214580) started by @madmax983*