### PR TITLE
feat(interactive): prompt for operator feedback on command rejection (#626)

### DIFF
--- a/docs/plans/2026-06-07-corrective-feedback-design.md
+++ b/docs/plans/2026-06-07-corrective-feedback-design.md
@@ -1,0 +1,48 @@
+# Corrective Feedback on Rejection Design Document
+
+**Goal:** Enable operators to steer the agent during interactive mode by supplying corrective feedback upon command rejection.
+
+## Proposed Changes
+
+### 1. `ConfirmDecision` modification
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfirmDecision {
+    Approve,
+    Reject(Option<String>),
+    Abort,
+}
+```
+
+We will remove `Copy` from `ConfirmDecision` and update `.label()` to take `&self`.
+
+### 2. CLI UI (`--ui stderr`)
+
+When `prompt_blocking` reads `n`/`N` (reject):
+1. Raw mode is disabled.
+2. We print a newline, followed by `Provide corrective feedback (optional): `.
+3. We read a single line of input from stdin.
+4. If the trimmed line is not empty, we return `ConfirmDecision::Reject(Some(feedback))`. Otherwise, we return `ConfirmDecision::Reject(None)`.
+
+### 3. Ratatui TUI (`--ui ratatui`)
+
+We will add a state variable `feedback_input: Option<String>` to track when the user is typing feedback.
+- When `feedback_input` is `Some(buffer)`:
+  - Any typed character (alphanumeric/spaces/etc.) is appended to `buffer`.
+  - `Backspace` removes the last character.
+  - `Esc` cancels back to the choices.
+  - `Enter` submits the feedback (if empty, maps to `Reject(None)`, otherwise `Reject(Some(buffer))`).
+- When `feedback_input` is `None`:
+  - `n`/`N` transitions to `feedback_input = Some(String::new())` rather than submitting immediately.
+
+The modal dialog will be updated to display the text entry field when `feedback_input` is active.
+
+### 4. Rejection Handling and Trajectory
+
+In `record_interactive_rejection`:
+- The feedback is redacted through the existing `self.redactor.redact_text(feedback, surface)`.
+- If feedback is present:
+  - The model-facing observation uses `"Exit code: 1\nOutput:\nCommand rejected by operator (interactive mode). The command was not executed. <redacted_feedback>"`.
+  - The trajectory record's `MessageExtra` receives a new field `interactive_feedback` containing the trajectory-redacted feedback string.
+- If feedback is absent, the behavior remains exactly as it is today.

--- a/src/agent/confirm.rs
+++ b/src/agent/confirm.rs
@@ -34,12 +34,12 @@ pub struct ConfirmContext {
 }
 
 /// The operator's decision returned by `ConfirmCallback::confirm`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConfirmDecision {
     /// Execute the proposed action normally.
     Approve,
     /// Skip execution; surface a synthetic observation to the model.
-    Reject,
+    Reject(Option<String>),
     /// Terminate the run cleanly with `ExitReason::UserInterrupt`.
     Abort,
 }
@@ -47,10 +47,10 @@ pub enum ConfirmDecision {
 impl ConfirmDecision {
     /// Stable lowercase label for trajectory `interactive_decision` entries.
     #[must_use]
-    pub fn label(self) -> &'static str {
+    pub fn label(&self) -> &'static str {
         match self {
             Self::Approve => "approve",
-            Self::Reject => "reject",
+            Self::Reject(_) => "reject",
             Self::Abort => "abort",
         }
     }
@@ -117,7 +117,7 @@ mod tests {
 
     #[tokio::test]
     async fn scripted_returns_decisions_in_order_then_default_approve() {
-        let c = ScriptedConfirmer::new([ConfirmDecision::Reject, ConfirmDecision::Abort]);
+        let c = ScriptedConfirmer::new([ConfirmDecision::Reject(None), ConfirmDecision::Abort]);
         let ctx = ConfirmContext {
             tool_name: "bash".into(),
             command: "x".into(),
@@ -126,7 +126,7 @@ mod tests {
             cost_usd: 0.0,
             cache_marker: "cache:auto-or-none",
         };
-        assert_eq!(c.confirm(&ctx).await, ConfirmDecision::Reject);
+        assert_eq!(c.confirm(&ctx).await, ConfirmDecision::Reject(None));
         assert_eq!(c.confirm(&ctx).await, ConfirmDecision::Abort);
         assert_eq!(c.confirm(&ctx).await, ConfirmDecision::Approve);
         assert_eq!(c.call_count(), 3);
@@ -135,7 +135,11 @@ mod tests {
     #[test]
     fn decision_labels_are_stable() {
         assert_eq!(ConfirmDecision::Approve.label(), "approve");
-        assert_eq!(ConfirmDecision::Reject.label(), "reject");
+        assert_eq!(ConfirmDecision::Reject(None).label(), "reject");
+        assert_eq!(
+            ConfirmDecision::Reject(Some("feedback".to_owned())).label(),
+            "reject"
+        );
         assert_eq!(ConfirmDecision::Abort.label(), "abort");
     }
 }

--- a/src/agent/confirm_cli.rs
+++ b/src/agent/confirm_cli.rs
@@ -47,13 +47,28 @@ fn prompt_blocking(ctx: &ConfirmContext) -> ConfirmDecision {
     let _ = err.write_all(render_banner(ctx).as_bytes());
     let _ = err.flush();
 
-    match read_single_keystroke() {
+    let mut decision = match read_single_keystroke() {
         Some(decision) => {
             let _ = err.write_all(b"\n");
             decision
         }
         None => read_line_buffered(),
+    };
+
+    if let ConfirmDecision::Reject(_) = decision {
+        if std::io::stdin().is_terminal() {
+            let _ = err.write_all(b"Provide corrective feedback (optional): ");
+            let _ = err.flush();
+            let mut feedback = String::new();
+            if std::io::stdin().read_line(&mut feedback).is_ok() {
+                let trimmed = feedback.trim();
+                if !trimmed.is_empty() {
+                    decision = ConfirmDecision::Reject(Some(trimmed.to_owned()));
+                }
+            }
+        }
     }
+    decision
 }
 
 /// Pure renderer for the stderr prompt banner, factored out so tests can
@@ -116,7 +131,7 @@ fn key_event_to_decision(key: KeyEvent) -> Option<ConfirmDecision> {
     }
     match key.code {
         KeyCode::Char('y' | 'Y') => Some(ConfirmDecision::Approve),
-        KeyCode::Char('n' | 'N') => Some(ConfirmDecision::Reject),
+        KeyCode::Char('n' | 'N') => Some(ConfirmDecision::Reject(None)),
         KeyCode::Char('a' | 'A') | KeyCode::Esc => Some(ConfirmDecision::Abort),
         _ => None,
     }
@@ -146,7 +161,7 @@ pub fn parse_line_decision(input: &str) -> ConfirmDecision {
     let trimmed = input.trim().to_ascii_lowercase();
     match trimmed.as_str() {
         "y" | "yes" => ConfirmDecision::Approve,
-        "n" | "no" => ConfirmDecision::Reject,
+        "n" | "no" => ConfirmDecision::Reject(None),
         _ => ConfirmDecision::Abort,
     }
 }
@@ -165,8 +180,8 @@ mod tests {
         assert_eq!(parse_line_decision("y\n"), ConfirmDecision::Approve);
         assert_eq!(parse_line_decision(" Y "), ConfirmDecision::Approve);
         assert_eq!(parse_line_decision("yes"), ConfirmDecision::Approve);
-        assert_eq!(parse_line_decision("n"), ConfirmDecision::Reject);
-        assert_eq!(parse_line_decision("NO"), ConfirmDecision::Reject);
+        assert_eq!(parse_line_decision("n"), ConfirmDecision::Reject(None));
+        assert_eq!(parse_line_decision("NO"), ConfirmDecision::Reject(None));
         assert_eq!(parse_line_decision("a"), ConfirmDecision::Abort);
         assert_eq!(parse_line_decision("abort"), ConfirmDecision::Abort);
         assert_eq!(parse_line_decision(""), ConfirmDecision::Abort);
@@ -222,12 +237,12 @@ mod tests {
             (
                 KeyCode::Char('n'),
                 KeyModifiers::NONE,
-                Some(ConfirmDecision::Reject),
+                Some(ConfirmDecision::Reject(None)),
             ),
             (
                 KeyCode::Char('N'),
                 KeyModifiers::NONE,
-                Some(ConfirmDecision::Reject),
+                Some(ConfirmDecision::Reject(None)),
             ),
             (
                 KeyCode::Char('a'),

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -42,6 +42,7 @@ struct DashboardState {
     log: VecDeque<LogLine>,
     pending: Option<PendingPrompt>,
     finished: Option<String>,
+    feedback_input: Option<String>,
 }
 
 #[derive(Clone)]
@@ -324,36 +325,70 @@ fn handle_key(dash: &Arc<RatatuiDashboard>, key: KeyEvent) {
     if !matches!(key.kind, KeyEventKind::Press) {
         return;
     }
-    let pending = {
-        let mut s = dash
-            .state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        s.pending.take()
-    };
-    let Some(pending) = pending else {
+    let mut s = dash
+        .state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let Some(pending) = s.pending.take() else {
         return;
     };
     let ctrl_c = key.modifiers.contains(KeyModifiers::CONTROL)
         && matches!(key.code, KeyCode::Char('c' | 'C'));
-    let decision = if ctrl_c {
-        Some(ConfirmDecision::Abort)
+    if ctrl_c {
+        s.feedback_input = None;
+        let _ = pending.responder.send(ConfirmDecision::Abort);
+        return;
+    }
+
+    if let Some(mut buffer) = s.feedback_input.take() {
+        match key.code {
+            KeyCode::Enter => {
+                let decision = if buffer.trim().is_empty() {
+                    ConfirmDecision::Reject(None)
+                } else {
+                    ConfirmDecision::Reject(Some(buffer))
+                };
+                let _ = pending.responder.send(decision);
+            }
+            KeyCode::Esc => {
+                s.feedback_input = None;
+                s.pending = Some(pending);
+                dash.notify.notify_waiters();
+            }
+            KeyCode::Backspace => {
+                buffer.pop();
+                s.feedback_input = Some(buffer);
+                s.pending = Some(pending);
+                dash.notify.notify_waiters();
+            }
+            KeyCode::Char(c) => {
+                buffer.push(c);
+                s.feedback_input = Some(buffer);
+                s.pending = Some(pending);
+                dash.notify.notify_waiters();
+            }
+            _ => {
+                s.feedback_input = Some(buffer);
+                s.pending = Some(pending);
+            }
+        }
     } else {
         match key.code {
-            KeyCode::Char('y' | 'Y') => Some(ConfirmDecision::Approve),
-            KeyCode::Char('n' | 'N') => Some(ConfirmDecision::Reject),
-            KeyCode::Char('a' | 'A') | KeyCode::Esc => Some(ConfirmDecision::Abort),
-            _ => None,
+            KeyCode::Char('y' | 'Y') => {
+                let _ = pending.responder.send(ConfirmDecision::Approve);
+            }
+            KeyCode::Char('n' | 'N') => {
+                s.feedback_input = Some(String::new());
+                s.pending = Some(pending);
+                dash.notify.notify_waiters();
+            }
+            KeyCode::Char('a' | 'A') | KeyCode::Esc => {
+                let _ = pending.responder.send(ConfirmDecision::Abort);
+            }
+            _ => {
+                s.pending = Some(pending);
+            }
         }
-    };
-    if let Some(d) = decision {
-        let _ = pending.responder.send(d);
-    } else {
-        let mut s = dash
-            .state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        s.pending = Some(pending);
     }
 }
 
@@ -375,6 +410,7 @@ fn draw_frame(
             finished: s.finished.clone(),
             log: s.log.iter().cloned().collect(),
             pending: s.pending.as_ref().map(|p| p.ctx.clone()),
+            feedback_input: s.feedback_input.clone(),
         }
     };
     terminal.draw(|frame| draw(frame, &snapshot))?;
@@ -390,6 +426,7 @@ struct DashboardSnapshot {
     finished: Option<String>,
     log: Vec<LogLine>,
     pending: Option<ConfirmContext>,
+    feedback_input: Option<String>,
 }
 
 fn draw(frame: &mut ratatui::Frame, snap: &DashboardSnapshot) {
@@ -408,7 +445,7 @@ fn draw(frame: &mut ratatui::Frame, snap: &DashboardSnapshot) {
     frame.render_widget(footer_paragraph(snap), chunks[2]);
 
     if let Some(ctx) = &snap.pending {
-        draw_modal(frame, ctx, area);
+        draw_modal(frame, ctx, snap.feedback_input.as_ref(), area);
     }
 }
 
@@ -484,7 +521,12 @@ fn footer_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
     .block(Block::default().borders(Borders::ALL))
 }
 
-fn draw_modal(frame: &mut ratatui::Frame, ctx: &ConfirmContext, area: Rect) {
+fn draw_modal(
+    frame: &mut ratatui::Frame,
+    ctx: &ConfirmContext,
+    feedback_input: Option<&String>,
+    area: Rect,
+) {
     let modal = centered_rect(70, 50, area);
     frame.render_widget(Clear, modal);
     let mut lines = vec![
@@ -514,10 +556,31 @@ fn draw_modal(frame: &mut ratatui::Frame, ctx: &ConfirmContext, area: Rect) {
         )));
     }
     lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        "(y) approve   (n) reject   (a) abort",
-        Style::default().add_modifier(Modifier::BOLD),
-    )));
+
+    if let Some(buffer) = feedback_input {
+        lines.push(Line::from(Span::styled(
+            "Provide corrective feedback (optional):",
+            Style::default()
+                .fg(Color::LightYellow)
+                .add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(vec![
+            Span::styled(" > ", Style::default().fg(Color::Green)),
+            Span::styled(buffer.clone(), Style::default().fg(Color::White)),
+            Span::styled("█", Style::default().fg(Color::Green)),
+        ]));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "[Enter] submit   [Esc] back to choices",
+            Style::default().add_modifier(Modifier::DIM),
+        )));
+    } else {
+        lines.push(Line::from(Span::styled(
+            "(y) approve   (n) reject   (a) abort",
+            Style::default().add_modifier(Modifier::BOLD),
+        )));
+    }
+
     let block = Block::default()
         .borders(Borders::ALL)
         .title(" confirm action ");
@@ -652,6 +715,7 @@ mod tests {
             finished: s.finished.clone(),
             log: s.log.iter().cloned().collect(),
             pending: s.pending.as_ref().map(|p| p.ctx.clone()),
+            feedback_input: s.feedback_input.clone(),
         }
     }
 
@@ -905,10 +969,6 @@ mod tests {
                 ConfirmDecision::Approve,
             ),
             (
-                KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE),
-                ConfirmDecision::Reject,
-            ),
-            (
                 KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
                 ConfirmDecision::Abort,
             ),
@@ -925,6 +985,68 @@ mod tests {
             handle_key(&d, key);
             assert_eq!(rx.try_recv().unwrap(), expected);
         }
+    }
+
+    #[test]
+    fn handle_key_rejection_feedback_flow() {
+        let d = make_dashboard();
+
+        // 1. Initial pending prompt
+        let mut rx = make_pending(&d);
+        assert!(snap(&d).feedback_input.is_none());
+
+        // 2. Press 'n' to enter feedback mode
+        let key_n = KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE);
+        handle_key(&d, key_n);
+
+        // Assert no decision sent yet, and we are in feedback mode
+        assert!(rx.try_recv().is_err());
+        assert_eq!(snap(&d).feedback_input.as_deref(), Some(""));
+
+        // 3. Type "f", "i", "x"
+        for c in ['f', 'i', 'x'] {
+            handle_key(&d, KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+        }
+        assert_eq!(snap(&d).feedback_input.as_deref(), Some("fix"));
+
+        // 4. Backspace
+        handle_key(&d, KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
+        assert_eq!(snap(&d).feedback_input.as_deref(), Some("fi"));
+
+        // 5. Enter to submit
+        handle_key(&d, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            ConfirmDecision::Reject(Some("fi".to_owned()))
+        );
+    }
+
+    #[test]
+    fn handle_key_rejection_empty_feedback_flow() {
+        let d = make_dashboard();
+        let mut rx = make_pending(&d);
+
+        // Press 'n'
+        handle_key(&d, KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
+
+        // Press Enter without typing feedback
+        handle_key(&d, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(rx.try_recv().unwrap(), ConfirmDecision::Reject(None));
+    }
+
+    #[test]
+    fn handle_key_rejection_cancel_flow() {
+        let d = make_dashboard();
+        let _rx = make_pending(&d);
+
+        // Press 'n'
+        handle_key(&d, KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
+        assert!(snap(&d).feedback_input.is_some());
+
+        // Press Esc
+        handle_key(&d, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(snap(&d).feedback_input.is_none());
+        assert!(snap(&d).pending.is_some());
     }
 
     #[test]

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -1259,8 +1259,8 @@ impl Agent for DefaultAgent {
             if let Some(decision) = self.confirm_operator_action(&tool_name, &tool_input).await {
                 match decision {
                     super::ConfirmDecision::Approve => {}
-                    super::ConfirmDecision::Reject => {
-                        self.record_interactive_rejection(&tool_name, &tool_input);
+                    super::ConfirmDecision::Reject(feedback) => {
+                        self.record_interactive_rejection(&tool_name, &tool_input, feedback);
                         self.last_measurement_end = Instant::now();
                         self.steps += 1;
                         return Ok(StepOutcome::Continue);
@@ -1817,11 +1817,27 @@ impl DefaultAgent {
     /// Record an operator rejection: surface a synthetic observation to
     /// the model so it can revise, and tag the trajectory record with
     /// the structured `interactive_decision: "reject"` event.
-    fn record_interactive_rejection(&mut self, tool_name: &str, tool_input: &str) {
+    fn record_interactive_rejection(
+        &mut self,
+        tool_name: &str,
+        tool_input: &str,
+        feedback: Option<String>,
+    ) {
         let ts = chrono::Utc::now().to_rfc3339();
-        let rejection = "Exit code: 1\nOutput:\nCommand rejected by operator (interactive mode). \
-                         The command was not executed. Please attempt a safer alternative."
-            .to_owned();
+        let rejection = if let Some(ref text) = feedback {
+            let model_feedback = self
+                .redactor
+                .redact_text(text, surface::MODEL_OBSERVATION)
+                .text;
+            format!(
+                "Exit code: 1\nOutput:\nCommand rejected by operator (interactive mode). \
+                 The command was not executed. {model_feedback}"
+            )
+        } else {
+            "Exit code: 1\nOutput:\nCommand rejected by operator (interactive mode). \
+             The command was not executed. Please attempt a safer alternative."
+                .to_owned()
+        };
         let obs_msg = Message::user(rejection.clone());
         self.history.push(obs_msg.clone());
 
@@ -1836,7 +1852,11 @@ impl DefaultAgent {
         obs_extra.timestamp = Some(ts.clone());
         obs_extra.other.insert(
             "interactive_decision".into(),
-            serde_json::Value::String(super::ConfirmDecision::Reject.label().to_owned()),
+            serde_json::Value::String(
+                super::ConfirmDecision::Reject(feedback.clone())
+                    .label()
+                    .to_owned(),
+            ),
         );
         obs_extra.other.insert(
             "interactive_proposed_command".into(),
@@ -1850,6 +1870,13 @@ impl DefaultAgent {
             "interactive_timestamp".into(),
             serde_json::Value::String(ts),
         );
+        if let Some(text) = feedback {
+            let trajectory_feedback = self.redactor.redact_text(&text, surface::TRAJECTORY).text;
+            obs_extra.other.insert(
+                "interactive_feedback".into(),
+                serde_json::Value::String(trajectory_feedback),
+            );
+        }
         record_redacted_message(&mut self.trajectory, &obs_msg, obs_extra, &self.redactor);
         self.stream.emit(StreamEvent::Observation {
             step: self.steps,

--- a/tests/interactive_confirm.rs
+++ b/tests/interactive_confirm.rs
@@ -70,7 +70,7 @@ async fn reject_records_synthetic_observation_and_event() {
         "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nrecovered\n```".into(),
     ]));
     let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
-    let confirmer = Arc::new(ScriptedConfirmer::new(vec![ConfirmDecision::Reject]));
+    let confirmer = Arc::new(ScriptedConfirmer::new(vec![ConfirmDecision::Reject(None)]));
     let mut agent = DefaultAgentBuilder {
         config: cfg,
         model,
@@ -162,7 +162,7 @@ async fn scripted_approve_reject_approve_abort_sequence() {
     let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
     let confirmer = Arc::new(ScriptedConfirmer::new(vec![
         ConfirmDecision::Approve,
-        ConfirmDecision::Reject,
+        ConfirmDecision::Reject(None),
         ConfirmDecision::Approve,
         ConfirmDecision::Abort,
     ]));
@@ -299,4 +299,62 @@ async fn confirm_context_carries_command_and_step_metadata() {
     assert_eq!(ctx.step_limit, 7);
     assert_eq!(ctx.step, 0);
     assert!(ctx.cost_usd >= 0.0);
+}
+
+#[tokio::test]
+async fn reject_with_feedback_records_synthetic_observation_and_event() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+    let model = Arc::new(DeterministicModel::new(vec![
+        "```bash\nrm -rf /tmp/should-never-run\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nrecovered\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let confirmer = Arc::new(ScriptedConfirmer::new(vec![ConfirmDecision::Reject(Some(
+        "please use ls instead".into(),
+    ))]));
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "reject-feedback-test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+        resume_from: None,
+        read_only: false,
+    }
+    .build()
+    .unwrap();
+    agent.confirm_callback = Some(confirmer.clone() as Arc<dyn ConfirmCallback>);
+
+    let result = agent.run().await.unwrap();
+    assert!(matches!(result, ExitReason::Submitted { .. }));
+    assert_eq!(confirmer.call_count(), 1);
+
+    // Check that the observation contains the feedback
+    let user_msg = agent
+        .trajectory
+        .messages
+        .iter()
+        .find(|m| m.role == "user" && m.content.contains("Command rejected by operator"));
+    assert!(user_msg.is_some(), "expected rejection user message");
+    let content = &user_msg.unwrap().content;
+    assert!(
+        content.contains("please use ls instead"),
+        "expected feedback in user message, got: {content}"
+    );
+
+    // Check that trajectory's MessageExtra has "interactive_feedback"
+    let has_feedback = agent.trajectory.messages.iter().any(|m| {
+        m.extra
+            .other
+            .get("interactive_feedback")
+            .and_then(|v| v.as_str())
+            == Some("please use ls instead")
+    });
+    assert!(
+        has_feedback,
+        "expected interactive_feedback in MessageExtra"
+    );
 }


### PR DESCRIPTION
Closes #626.

Enables operators to steer the agent during interactive mode by supplying corrective feedback upon command rejection in both CLI and TUI modes.