### PR TITLE
⚡ Bolt: Remove intermediate Vec allocations in string joins

### DIFF
--- a/src/run/calibrate.rs
+++ b/src/run/calibrate.rs
@@ -583,7 +583,17 @@ fn build_mismatches(
 }
 
 fn sorted_join(values: BTreeSet<&str>) -> String {
-    values.into_iter().collect::<Vec<_>>().join(",")
+    let capacity = values.iter().map(|s| s.len()).sum::<usize>() + values.len().saturating_sub(1);
+    values
+        .into_iter()
+        .enumerate()
+        .fold(String::with_capacity(capacity), |mut acc, (i, w)| {
+            if i > 0 {
+                acc.push(',');
+            }
+            acc.push_str(w);
+            acc
+        })
 }
 
 fn compare_field(

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -549,7 +549,18 @@ fn normalize_search_text(text: &str) -> String {
             out.push(' ');
         }
     }
-    out.split_whitespace().collect::<Vec<_>>().join(" ")
+    let words = out.split_whitespace();
+    let capacity =
+        words.clone().map(str::len).sum::<usize>() + words.clone().count().saturating_sub(1);
+    words
+        .enumerate()
+        .fold(String::with_capacity(capacity), |mut acc, (i, w)| {
+            if i > 0 {
+                acc.push(' ');
+            }
+            acc.push_str(w);
+            acc
+        })
 }
 
 fn is_stopword(token: &str) -> bool {


### PR DESCRIPTION
💡 What: Replaced `.collect::<Vec<_>>().join(...)` with iterator `.fold(...)` combined with `String::with_capacity` in `src/run/calibrate.rs` and `src/skills.rs`. Omitted cold error paths to preserve readability.
🎯 Why: Creating an intermediate `Vec` just to join an iterator of strings into a single string causes unnecessary heap allocations. Using `.fold()` avoids allocating these temporary vectors. Pre-calculating the capacity ensures the final string only allocates once, mirroring the performance profile of the standard library's `[T]::join` without the intermediate array.
📊 Impact: Eliminates intermediate heap allocations per string join operation on hot paths, while strictly preserving optimal string buffer allocation behavior.
🔬 Measurement: Run `cargo check` and `cargo test` to verify logic correctness and lack of regressions.

---
*PR created automatically by Jules for task [8799848875215712818](https://jules.google.com/task/8799848875215712818) started by @madmax983*