### PR TITLE
feat: add operator command-edit to interactive mode (#627)

### DIFF
--- a/docs/plans/2026-06-07-interactive-edit-command.md
+++ b/docs/plans/2026-06-07-interactive-edit-command.md
@@ -1,0 +1,96 @@
+# Operator command-edit in interactive mode Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement the "Edit/Modify" capability (Phase 2 of #312) in interactive mode, allowing operators to edit proposed commands in place before execution.
+
+**Architecture:** Introduce `ConfirmDecision::Edit(String)` which is returned by confirmers when the operator chooses to edit the command. In `DefaultAgent::step`, if the operator edits a command, the edited command is re-evaluated by the policy engine and `PreToolUse` hooks. The environment runs the edited command, and the trajectory observation captures the decision as `"edit"`, retaining both the original proposed command and the substituted command. Stderr UI uses crossterm to provide an inline single-line editor, and the Ratatui dashboard opens a text input modal.
+
+**Tech Stack:** Rust, crossterm, ratatui, tokio.
+
+---
+
+## User Review Required
+
+> [!NOTE]
+> For the single-line inline editor in `stderr` UI, we use raw terminal mode to support interactive cursor navigation, character insertion, home/end, backspace, and delete. The proposed command is pre-filled. If the edited command is empty, or the user cancels with Esc or Ctrl-C, the UI returns to the main Approve/Reject/Abort prompt.
+
+> [!IMPORTANT]
+> A command edited by the operator is strictly re-run through the policy engine and `PreToolUse` hooks. A policy-blocked or hook-blocked edit will generate the standard block/denial observation instead of executing.
+
+## Open Questions
+
+None at this time. The requirements are fully detailed in issue #627.
+
+## Proposed Changes
+
+### Confirm core
+
+#### [MODIFY] [confirm.rs](file:///c:/Users/markm/rust_swe_agent/src/agent/confirm.rs)
+- Add `Edit(String)` variant to `ConfirmDecision`.
+- Update `.label()` to map `ConfirmDecision::Edit(_)` to `"edit"`.
+- Update `tests::decision_labels_are_stable` to cover `"edit"`.
+
+### Stderr UI Confirmer
+
+#### [MODIFY] [confirm_cli.rs](file:///c:/Users/markm/rust_swe_agent/src/agent/confirm_cli.rs)
+- Update `render_banner` to show `(e)edit` as a choice.
+- In `read_single_keystroke(ctx: &ConfirmContext)`, if `e` or `E` is pressed, enter `run_inline_editor(&mut err, &ctx.command)`.
+- Implement `run_inline_editor` using crossterm raw mode inputs (handling `Enter`, `Esc`, `Ctrl-C`, `Backspace`, `Delete`, `Left`, `Right`, `Home`, `End`, and character input).
+- Return to choice selection if editing is cancelled (empty line, Esc, or Ctrl-C).
+
+### Ratatui Dashboard TUI Confirmer
+
+#### [MODIFY] [confirm_tui.rs](file:///c:/Users/markm/rust_swe_agent/src/agent/confirm_tui.rs)
+- Add `edit_input: Option<String>` to `DashboardState` and `DashboardSnapshot`.
+- In `handle_key`, if not in edit mode and `e` or `E` is pressed, set `edit_input = Some(pending.ctx.command.clone())`.
+- In `handle_key`, if in edit mode (`edit_input.is_some()`), handle `Enter` (submits `ConfirmDecision::Edit(buffer)` if non-empty, cancels back to choice if empty), `Esc` (cancels back to choice), `Backspace` (pops from buffer), and character input (appends to buffer).
+- Update `draw_modal` and `draw` to render the single-line text-entry field pre-filled with the command when `edit_input` is active.
+- Update `footer_paragraph` hints to reflect the edit mode.
+- Add unit/integration tests to verify the TUI edit keystroke flows.
+
+### Agent loop execution
+
+#### [MODIFY] [default.rs](file:///c:/Users/markm/rust_swe_agent/src/agent/default.rs)
+- In `step()`, handle `ConfirmDecision::Edit(edited_command)` from `confirm_operator_action`.
+- If edited:
+  - Recheck the edited command against the policy engine. If denied, record policy denial and include `interactive_decision: "edit"` and both commands in trajectory `MessageExtra`, then return `StepOutcome::Continue`.
+  - Re-run `PreToolUse` hooks on the edited command. Update `pre_hook_results` and `tool_use_blocked` status.
+  - Run/execute the edited command (using the edited string instead of the original `tool_input`).
+  - Set `tool_input_for_observation` to the edited command.
+- In `obs_extra` logging for the executed step, if the command was edited, record:
+  - `interactive_decision: "edit"`
+  - `interactive_proposed_command` (redacted original command)
+  - `interactive_substituted_command` (redacted edited command)
+  - `interactive_tool_name`
+  - `interactive_timestamp`
+
+### Integration Tests
+
+#### [MODIFY] [interactive_confirm.rs](file:///c:/Users/markm/rust_swe_agent/tests/interactive_confirm.rs)
+- Add integration test `edit_executes_edited_command_and_records_trajectory` to verify:
+  - An edit decision runs the policy gate and hook gate on the edited command.
+  - It executes the edited command.
+  - The trajectory observation records `interactive_decision: "edit"`, original proposed command, and substituted command.
+- Add integration test `edit_blocked_by_policy_fails_with_denial` to verify:
+  - An edited command that violates policy is refused with a policy-denied observation.
+  - The trajectory records the denial details and `interactive_decision: "edit"`.
+
+---
+
+## Verification Plan
+
+### Automated Tests
+- Run new and existing integration tests:
+  ```powershell
+  cargo test --test interactive_confirm
+  ```
+- Run confirming unit tests:
+  ```powershell
+  cargo test agent::confirm
+  cargo test agent::confirm_cli
+  cargo test agent::confirm_tui
+  ```
+
+### Manual Verification
+- Not applicable for non-interactive runner, but automated integration tests will mock interactive confirmer callbacks to prove all interactive paths, policy gates, and hook validations.

--- a/src/agent/confirm.rs
+++ b/src/agent/confirm.rs
@@ -42,6 +42,8 @@ pub enum ConfirmDecision {
     Reject(Option<String>),
     /// Terminate the run cleanly with `ExitReason::UserInterrupt`.
     Abort,
+    /// Edit the proposed command/input.
+    Edit(String),
 }
 
 impl ConfirmDecision {
@@ -52,6 +54,7 @@ impl ConfirmDecision {
             Self::Approve => "approve",
             Self::Reject(_) => "reject",
             Self::Abort => "abort",
+            Self::Edit(_) => "edit",
         }
     }
 }
@@ -141,5 +144,24 @@ mod tests {
             "reject"
         );
         assert_eq!(ConfirmDecision::Abort.label(), "abort");
+        assert_eq!(ConfirmDecision::Edit("foo".to_owned()).label(), "edit");
+    }
+
+    #[tokio::test]
+    async fn scripted_handles_edit_decision() {
+        let c = ScriptedConfirmer::new([ConfirmDecision::Edit("foo".to_owned())]);
+        let ctx = ConfirmContext {
+            tool_name: "bash".into(),
+            command: "x".into(),
+            step: 0,
+            step_limit: 1,
+            cost_usd: 0.0,
+            cache_marker: "cache:auto-or-none",
+        };
+        assert_eq!(
+            c.confirm(&ctx).await,
+            ConfirmDecision::Edit("foo".to_owned())
+        );
+        assert_eq!(c.call_count(), 1);
     }
 }

--- a/src/agent/confirm_cli.rs
+++ b/src/agent/confirm_cli.rs
@@ -113,7 +113,7 @@ fn read_single_keystroke(ctx: &ConfirmContext) -> Option<ConfirmDecision> {
                     if let Some(edited) = run_inline_editor(&mut err, &ctx.command) {
                         break ConfirmDecision::Edit(edited);
                     }
-                    let _ = err.write_all(render_banner(ctx).as_bytes());
+                    let _ = err.write_all(render_banner(ctx).replace('\n', "\r\n").as_bytes());
                     let _ = err.flush();
                     continue;
                 }
@@ -135,7 +135,7 @@ fn run_inline_editor(err: &mut std::io::Stderr, initial_cmd: &str) -> Option<Str
     let prompt = "[interactive] edit: ";
 
     // Initially print \n[interactive] edit: <command>
-    let _ = err.write_all(format!("\n{prompt}{initial_cmd}").as_bytes());
+    let _ = err.write_all(format!("\r\n{prompt}{initial_cmd}").as_bytes());
     let _ = err.flush();
 
     loop {
@@ -149,7 +149,7 @@ fn run_inline_editor(err: &mut std::io::Stderr, initial_cmd: &str) -> Option<Str
         let _ = crossterm::queue!(
             err,
             crossterm::cursor::MoveToColumn(
-                u16::try_from(prompt.len() + cursor_pos).unwrap_or(u16::MAX)
+                u16::try_from(prompt.chars().count() + cursor_pos).unwrap_or(u16::MAX)
             ),
         );
         let _ = err.flush();

--- a/src/agent/confirm_cli.rs
+++ b/src/agent/confirm_cli.rs
@@ -47,7 +47,7 @@ fn prompt_blocking(ctx: &ConfirmContext) -> ConfirmDecision {
     let _ = err.write_all(render_banner(ctx).as_bytes());
     let _ = err.flush();
 
-    let mut decision = match read_single_keystroke() {
+    let mut decision = match read_single_keystroke(ctx) {
         Some(decision) => {
             let _ = err.write_all(b"\n");
             decision
@@ -78,7 +78,7 @@ fn render_banner(ctx: &ConfirmContext) -> String {
         "\n[interactive] step {}/{}  cost ${:.4}  {}\n\
          [interactive] tool: {}\n\
          [interactive] command:\n{}\n\
-         [interactive] (y)approve / (n)reject / (a)abort? ",
+         [interactive] (y)approve / (n)reject / (e)edit / (a)abort? ",
         ctx.step,
         ctx.step_limit,
         ctx.cost_usd,
@@ -95,16 +95,28 @@ fn indent_command(cmd: &str) -> String {
         .join("\n")
 }
 
-fn read_single_keystroke() -> Option<ConfirmDecision> {
+fn read_single_keystroke(ctx: &ConfirmContext) -> Option<ConfirmDecision> {
     if !std::io::stdin().is_terminal() {
         return None;
     }
     if crossterm::terminal::enable_raw_mode().is_err() {
         return None;
     }
+    let mut err = std::io::stderr();
     let decision = loop {
         match crossterm::event::read() {
             Ok(Event::Key(key)) => {
+                if key.kind == KeyEventKind::Press
+                    && key.modifiers.is_empty()
+                    && matches!(key.code, KeyCode::Char('e' | 'E'))
+                {
+                    if let Some(edited) = run_inline_editor(&mut err, &ctx.command) {
+                        break ConfirmDecision::Edit(edited);
+                    }
+                    let _ = err.write_all(render_banner(ctx).as_bytes());
+                    let _ = err.flush();
+                    continue;
+                }
                 if let Some(d) = key_event_to_decision(key) {
                     break d;
                 }
@@ -115,6 +127,90 @@ fn read_single_keystroke() -> Option<ConfirmDecision> {
     };
     let _ = crossterm::terminal::disable_raw_mode();
     Some(decision)
+}
+
+fn run_inline_editor(err: &mut std::io::Stderr, initial_cmd: &str) -> Option<String> {
+    let mut edited_chars: Vec<char> = initial_cmd.chars().collect();
+    let mut cursor_pos = edited_chars.len();
+    let prompt = "[interactive] edit: ";
+
+    // Initially print \n[interactive] edit: <command>
+    let _ = err.write_all(format!("\n{prompt}{initial_cmd}").as_bytes());
+    let _ = err.flush();
+
+    loop {
+        let current_text: String = edited_chars.iter().collect();
+        let _ = crossterm::queue!(
+            err,
+            crossterm::cursor::MoveToColumn(0),
+            crossterm::terminal::Clear(crossterm::terminal::ClearType::CurrentLine),
+        );
+        let _ = err.write_all(format!("{prompt}{current_text}").as_bytes());
+        let _ = crossterm::queue!(
+            err,
+            crossterm::cursor::MoveToColumn(
+                u16::try_from(prompt.len() + cursor_pos).unwrap_or(u16::MAX)
+            ),
+        );
+        let _ = err.flush();
+
+        match crossterm::event::read() {
+            Ok(Event::Key(key)) => {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && matches!(key.code, KeyCode::Char('c' | 'C'))
+                {
+                    return None;
+                }
+                match key.code {
+                    KeyCode::Enter => {
+                        let trimmed = current_text.trim();
+                        if trimmed.is_empty() {
+                            return None;
+                        }
+                        return Some(trimmed.to_string());
+                    }
+                    KeyCode::Esc => {
+                        return None;
+                    }
+                    KeyCode::Backspace => {
+                        if cursor_pos > 0 {
+                            edited_chars.remove(cursor_pos - 1);
+                            cursor_pos -= 1;
+                        }
+                    }
+                    KeyCode::Delete => {
+                        if cursor_pos < edited_chars.len() {
+                            edited_chars.remove(cursor_pos);
+                        }
+                    }
+                    KeyCode::Left => {
+                        cursor_pos = cursor_pos.saturating_sub(1);
+                    }
+                    KeyCode::Right => {
+                        if cursor_pos < edited_chars.len() {
+                            cursor_pos += 1;
+                        }
+                    }
+                    KeyCode::Home => {
+                        cursor_pos = 0;
+                    }
+                    KeyCode::End => {
+                        cursor_pos = edited_chars.len();
+                    }
+                    KeyCode::Char(c) => {
+                        edited_chars.insert(cursor_pos, c);
+                        cursor_pos += 1;
+                    }
+                    _ => {}
+                }
+            }
+            Ok(_) => {}
+            Err(_) => return None,
+        }
+    }
 }
 
 /// Map a crossterm key event to a `ConfirmDecision`. Returns `None` for
@@ -212,7 +308,14 @@ mod tests {
         assert!(banner.contains("cache:explicit"));
         assert!(banner.contains("tool: bash"));
         assert!(banner.contains("    echo hi"));
-        assert!(banner.contains("(y)approve / (n)reject / (a)abort?"));
+        assert!(banner.contains("(y)approve / (n)reject / (e)edit / (a)abort?"));
+    }
+
+    #[test]
+    fn render_banner_contains_edit_option() {
+        let banner = render_banner(&ctx_for("echo hi"));
+        assert!(banner.contains("(e)edit"));
+        assert!(banner.contains("[interactive] (y)approve / (n)reject / (e)edit / (a)abort?"));
     }
 
     #[test]
@@ -287,7 +390,7 @@ mod tests {
         // `cargo test` redirects stdin away from the TTY, so this is the
         // production non-interactive path and should bail out cleanly
         // rather than blocking on raw-mode reads.
-        assert!(read_single_keystroke().is_none());
+        assert!(read_single_keystroke(&ctx_for("echo hi")).is_none());
     }
 
     #[test]

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -664,11 +664,25 @@ fn draw_modal(
                 .fg(Color::LightYellow)
                 .add_modifier(Modifier::BOLD),
         )));
-        lines.push(Line::from(vec![
-            Span::styled(" > ", Style::default().fg(Color::Green)),
-            Span::styled(buffer.clone(), Style::default().fg(Color::White)),
-            Span::styled("█", Style::default().fg(Color::Green)),
-        ]));
+        let edit_lines: Vec<&str> = buffer
+            .split('\n')
+            .map(|line| line.strip_suffix('\r').unwrap_or(line))
+            .collect();
+        for (i, line) in edit_lines.iter().enumerate() {
+            let prefix = if i == 0 { " > " } else { "   " };
+            if i == edit_lines.len() - 1 {
+                lines.push(Line::from(vec![
+                    Span::styled(prefix, Style::default().fg(Color::Green)),
+                    Span::styled((*line).to_string(), Style::default().fg(Color::White)),
+                    Span::styled("█", Style::default().fg(Color::Green)),
+                ]));
+            } else {
+                lines.push(Line::from(vec![
+                    Span::styled(prefix, Style::default().fg(Color::Green)),
+                    Span::styled((*line).to_string(), Style::default().fg(Color::White)),
+                ]));
+            }
+        }
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             "[Enter] execute edit   [Esc] cancel",
@@ -1367,6 +1381,46 @@ mod tests {
         assert!(
             text.contains("step 2/5"),
             "modal should show step counter; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn draw_modal_renders_multiline_edit_buffer() {
+        let d = make_dashboard();
+        {
+            let (tx, _rx) = oneshot::channel();
+            let mut s = d
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            s.pending = Some(PendingPrompt {
+                ctx: ConfirmContext {
+                    tool_name: "bash".into(),
+                    command: "x".into(),
+                    step: 0,
+                    step_limit: 1,
+                    cost_usd: 0.0,
+                    cache_marker: "cache:auto-or-none",
+                },
+                responder: tx,
+            });
+            s.edit_input = Some("first line\nsecond line\nthird line".to_string());
+        }
+        let s = snap(&d);
+        let buf = render_to_buffer(&s, 100, 30);
+        let text = buffer_text(&buf);
+
+        assert!(
+            text.contains(" > first line"),
+            "modal should format first line with ' > '; got:\n{text}"
+        );
+        assert!(
+            text.contains("   second line"),
+            "modal should format second line with '   '; got:\n{text}"
+        );
+        assert!(
+            text.contains("   third line█"),
+            "modal should format third line with '   ' and append cursor; got:\n{text}"
         );
     }
 

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -43,6 +43,7 @@ struct DashboardState {
     pending: Option<PendingPrompt>,
     finished: Option<String>,
     feedback_input: Option<String>,
+    edit_input: Option<String>,
 }
 
 #[derive(Clone)]
@@ -321,6 +322,114 @@ async fn renderer_loop(
     let _ = restore_terminal();
 }
 
+fn handle_key_feedback_input(
+    dash: &RatatuiDashboard,
+    s: &mut DashboardState,
+    pending: PendingPrompt,
+    key_code: KeyCode,
+    mut buffer: String,
+) {
+    match key_code {
+        KeyCode::Enter => {
+            let decision = if buffer.trim().is_empty() {
+                ConfirmDecision::Reject(None)
+            } else {
+                ConfirmDecision::Reject(Some(buffer))
+            };
+            let _ = pending.responder.send(decision);
+        }
+        KeyCode::Esc => {
+            s.feedback_input = None;
+            s.pending = Some(pending);
+            dash.notify.notify_waiters();
+        }
+        KeyCode::Backspace => {
+            buffer.pop();
+            s.feedback_input = Some(buffer);
+            s.pending = Some(pending);
+            dash.notify.notify_waiters();
+        }
+        KeyCode::Char(c) => {
+            buffer.push(c);
+            s.feedback_input = Some(buffer);
+            s.pending = Some(pending);
+            dash.notify.notify_waiters();
+        }
+        _ => {
+            s.feedback_input = Some(buffer);
+            s.pending = Some(pending);
+        }
+    }
+}
+
+fn handle_key_edit_input(
+    dash: &RatatuiDashboard,
+    s: &mut DashboardState,
+    pending: PendingPrompt,
+    key_code: KeyCode,
+    mut buffer: String,
+) {
+    match key_code {
+        KeyCode::Enter => {
+            if buffer.trim().is_empty() {
+                s.pending = Some(pending);
+                dash.notify.notify_waiters();
+            } else {
+                let _ = pending.responder.send(ConfirmDecision::Edit(buffer));
+            }
+        }
+        KeyCode::Esc => {
+            s.pending = Some(pending);
+            dash.notify.notify_waiters();
+        }
+        KeyCode::Backspace => {
+            buffer.pop();
+            s.edit_input = Some(buffer);
+            s.pending = Some(pending);
+            dash.notify.notify_waiters();
+        }
+        KeyCode::Char(c) => {
+            buffer.push(c);
+            s.edit_input = Some(buffer);
+            s.pending = Some(pending);
+            dash.notify.notify_waiters();
+        }
+        _ => {
+            s.edit_input = Some(buffer);
+            s.pending = Some(pending);
+        }
+    }
+}
+
+fn handle_key_normal(
+    dash: &RatatuiDashboard,
+    s: &mut DashboardState,
+    pending: PendingPrompt,
+    key_code: KeyCode,
+) {
+    match key_code {
+        KeyCode::Char('y' | 'Y') => {
+            let _ = pending.responder.send(ConfirmDecision::Approve);
+        }
+        KeyCode::Char('n' | 'N') => {
+            s.feedback_input = Some(String::new());
+            s.pending = Some(pending);
+            dash.notify.notify_waiters();
+        }
+        KeyCode::Char('e' | 'E') => {
+            s.edit_input = Some(pending.ctx.command.clone());
+            s.pending = Some(pending);
+            dash.notify.notify_waiters();
+        }
+        KeyCode::Char('a' | 'A') | KeyCode::Esc => {
+            let _ = pending.responder.send(ConfirmDecision::Abort);
+        }
+        _ => {
+            s.pending = Some(pending);
+        }
+    }
+}
+
 fn handle_key(dash: &Arc<RatatuiDashboard>, key: KeyEvent) {
     if !matches!(key.kind, KeyEventKind::Press) {
         return;
@@ -336,60 +445,19 @@ fn handle_key(dash: &Arc<RatatuiDashboard>, key: KeyEvent) {
         && matches!(key.code, KeyCode::Char('c' | 'C'));
     if ctrl_c {
         s.feedback_input = None;
+        s.edit_input = None;
         let _ = pending.responder.send(ConfirmDecision::Abort);
         return;
     }
 
-    if let Some(mut buffer) = s.feedback_input.take() {
-        match key.code {
-            KeyCode::Enter => {
-                let decision = if buffer.trim().is_empty() {
-                    ConfirmDecision::Reject(None)
-                } else {
-                    ConfirmDecision::Reject(Some(buffer))
-                };
-                let _ = pending.responder.send(decision);
-            }
-            KeyCode::Esc => {
-                s.feedback_input = None;
-                s.pending = Some(pending);
-                dash.notify.notify_waiters();
-            }
-            KeyCode::Backspace => {
-                buffer.pop();
-                s.feedback_input = Some(buffer);
-                s.pending = Some(pending);
-                dash.notify.notify_waiters();
-            }
-            KeyCode::Char(c) => {
-                buffer.push(c);
-                s.feedback_input = Some(buffer);
-                s.pending = Some(pending);
-                dash.notify.notify_waiters();
-            }
-            _ => {
-                s.feedback_input = Some(buffer);
-                s.pending = Some(pending);
-            }
-        }
+    if let Some(buffer) = s.feedback_input.take() {
+        handle_key_feedback_input(dash, &mut s, pending, key.code, buffer);
+    } else if let Some(buffer) = s.edit_input.take() {
+        handle_key_edit_input(dash, &mut s, pending, key.code, buffer);
     } else {
-        match key.code {
-            KeyCode::Char('y' | 'Y') => {
-                let _ = pending.responder.send(ConfirmDecision::Approve);
-            }
-            KeyCode::Char('n' | 'N') => {
-                s.feedback_input = Some(String::new());
-                s.pending = Some(pending);
-                dash.notify.notify_waiters();
-            }
-            KeyCode::Char('a' | 'A') | KeyCode::Esc => {
-                let _ = pending.responder.send(ConfirmDecision::Abort);
-            }
-            _ => {
-                s.pending = Some(pending);
-            }
-        }
+        handle_key_normal(dash, &mut s, pending, key.code);
     }
+    drop(s);
 }
 
 fn draw_frame(
@@ -411,6 +479,7 @@ fn draw_frame(
             log: s.log.iter().cloned().collect(),
             pending: s.pending.as_ref().map(|p| p.ctx.clone()),
             feedback_input: s.feedback_input.clone(),
+            edit_input: s.edit_input.clone(),
         }
     };
     terminal.draw(|frame| draw(frame, &snapshot))?;
@@ -427,6 +496,7 @@ struct DashboardSnapshot {
     log: Vec<LogLine>,
     pending: Option<ConfirmContext>,
     feedback_input: Option<String>,
+    edit_input: Option<String>,
 }
 
 fn draw(frame: &mut ratatui::Frame, snap: &DashboardSnapshot) {
@@ -445,7 +515,13 @@ fn draw(frame: &mut ratatui::Frame, snap: &DashboardSnapshot) {
     frame.render_widget(footer_paragraph(snap), chunks[2]);
 
     if let Some(ctx) = &snap.pending {
-        draw_modal(frame, ctx, snap.feedback_input.as_ref(), area);
+        draw_modal(
+            frame,
+            ctx,
+            snap.feedback_input.as_ref(),
+            snap.edit_input.as_ref(),
+            area,
+        );
     }
 }
 
@@ -509,8 +585,10 @@ fn log_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
 fn footer_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
     let hint = if snap.finished.is_some() {
         "run complete — press 'q' or Ctrl-C to close"
+    } else if snap.edit_input.is_some() {
+        "[Enter] execute edit   [Esc] cancel"
     } else if snap.pending.is_some() {
-        "(y) approve   (n) reject   (a) abort"
+        "(y) approve   (n) reject   (e) edit   (a) abort"
     } else {
         "waiting for next agent step…"
     };
@@ -525,6 +603,7 @@ fn draw_modal(
     frame: &mut ratatui::Frame,
     ctx: &ConfirmContext,
     feedback_input: Option<&String>,
+    edit_input: Option<&String>,
     area: Rect,
 ) {
     let modal = centered_rect(70, 50, area);
@@ -574,9 +653,26 @@ fn draw_modal(
             "[Enter] submit   [Esc] back to choices",
             Style::default().add_modifier(Modifier::DIM),
         )));
+    } else if let Some(buffer) = edit_input {
+        lines.push(Line::from(Span::styled(
+            "Edit proposed command:",
+            Style::default()
+                .fg(Color::LightYellow)
+                .add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(vec![
+            Span::styled(" > ", Style::default().fg(Color::Green)),
+            Span::styled(buffer.clone(), Style::default().fg(Color::White)),
+            Span::styled("█", Style::default().fg(Color::Green)),
+        ]));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "[Enter] execute edit   [Esc] cancel",
+            Style::default().add_modifier(Modifier::DIM),
+        )));
     } else {
         lines.push(Line::from(Span::styled(
-            "(y) approve   (n) reject   (a) abort",
+            "(y) approve   (n) reject   (e) edit   (a) abort",
             Style::default().add_modifier(Modifier::BOLD),
         )));
     }
@@ -716,6 +812,7 @@ mod tests {
             log: s.log.iter().cloned().collect(),
             pending: s.pending.as_ref().map(|p| p.ctx.clone()),
             feedback_input: s.feedback_input.clone(),
+            edit_input: s.edit_input.clone(),
         }
     }
 
@@ -1046,6 +1143,91 @@ mod tests {
         // Press Esc
         handle_key(&d, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
         assert!(snap(&d).feedback_input.is_none());
+        assert!(snap(&d).pending.is_some());
+    }
+
+    #[test]
+    fn handle_key_edit_flow() {
+        let d = make_dashboard();
+
+        // 1. Initial pending prompt
+        let mut rx = make_pending(&d);
+        assert!(snap(&d).edit_input.is_none());
+
+        // 2. Press 'e' to enter edit mode (should pre-fill with pending command, which is "x" in make_pending)
+        let key_e = KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE);
+        handle_key(&d, key_e);
+
+        // Assert no decision sent yet, and we are in edit mode pre-filled with "x"
+        assert!(rx.try_recv().is_err());
+        assert_eq!(snap(&d).edit_input.as_deref(), Some("x"));
+
+        // 3. Type "y", "z" -> "xyz"
+        for c in ['y', 'z'] {
+            handle_key(&d, KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+        }
+        assert_eq!(snap(&d).edit_input.as_deref(), Some("xyz"));
+
+        // 4. Backspace -> "xy"
+        handle_key(&d, KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
+        assert_eq!(snap(&d).edit_input.as_deref(), Some("xy"));
+
+        // 5. Enter to submit
+        handle_key(&d, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            ConfirmDecision::Edit("xy".to_owned())
+        );
+    }
+
+    #[test]
+    fn handle_key_edit_flow_uppercase() {
+        let d = make_dashboard();
+
+        // 1. Initial pending prompt
+        let mut rx = make_pending(&d);
+        assert!(snap(&d).edit_input.is_none());
+
+        // 2. Press 'E' to enter edit mode
+        let key_e = KeyEvent::new(KeyCode::Char('E'), KeyModifiers::NONE);
+        handle_key(&d, key_e);
+
+        // Assert no decision sent yet, and we are in edit mode
+        assert!(rx.try_recv().is_err());
+        assert_eq!(snap(&d).edit_input.as_deref(), Some("x"));
+    }
+
+    #[test]
+    fn handle_key_edit_empty_cancels_flow() {
+        let d = make_dashboard();
+        let _rx = make_pending(&d);
+
+        // Press 'e'
+        handle_key(&d, KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE));
+        assert_eq!(snap(&d).edit_input.as_deref(), Some("x"));
+
+        // Backspace to clear the command
+        handle_key(&d, KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
+        assert_eq!(snap(&d).edit_input.as_deref(), Some(""));
+
+        // Press Enter with empty command -> cancels (returns to choice screen, edit_input is None)
+        handle_key(&d, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(snap(&d).edit_input.is_none());
+        assert!(snap(&d).pending.is_some());
+    }
+
+    #[test]
+    fn handle_key_edit_cancel_flow() {
+        let d = make_dashboard();
+        let _rx = make_pending(&d);
+
+        // Press 'e'
+        handle_key(&d, KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE));
+        assert!(snap(&d).edit_input.is_some());
+
+        // Press Esc
+        handle_key(&d, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(snap(&d).edit_input.is_none());
         assert!(snap(&d).pending.is_some());
     }
 

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -405,9 +405,13 @@ fn handle_key_normal(
     dash: &RatatuiDashboard,
     s: &mut DashboardState,
     pending: PendingPrompt,
-    key_code: KeyCode,
+    key: KeyEvent,
 ) {
-    match key_code {
+    if !key.modifiers.is_empty() && key.modifiers != KeyModifiers::SHIFT {
+        s.pending = Some(pending);
+        return;
+    }
+    match key.code {
         KeyCode::Char('y' | 'Y') => {
             let _ = pending.responder.send(ConfirmDecision::Approve);
         }
@@ -455,7 +459,7 @@ fn handle_key(dash: &Arc<RatatuiDashboard>, key: KeyEvent) {
     } else if let Some(buffer) = s.edit_input.take() {
         handle_key_edit_input(dash, &mut s, pending, key.code, buffer);
     } else {
-        handle_key_normal(dash, &mut s, pending, key.code);
+        handle_key_normal(dash, &mut s, pending, key);
     }
     drop(s);
 }
@@ -1193,6 +1197,38 @@ mod tests {
         handle_key(&d, key_e);
 
         // Assert no decision sent yet, and we are in edit mode
+        assert!(rx.try_recv().is_err());
+        assert_eq!(snap(&d).edit_input.as_deref(), Some("x"));
+    }
+
+    #[test]
+    fn handle_key_edit_flow_with_invalid_modifiers_is_ignored() {
+        let d = make_dashboard();
+
+        // 1. Initial pending prompt
+        let mut rx = make_pending(&d);
+        assert!(snap(&d).edit_input.is_none());
+
+        // 2. Press 'Ctrl-e' (unsupported modifier) -> should be ignored, stay in choice screen
+        let key_ctrl_e = KeyEvent::new(KeyCode::Char('e'), KeyModifiers::CONTROL);
+        handle_key(&d, key_ctrl_e);
+
+        assert!(rx.try_recv().is_err());
+        assert!(snap(&d).edit_input.is_none());
+        assert!(snap(&d).pending.is_some());
+
+        // 3. Press 'Alt-E' (unsupported modifier) -> should be ignored, stay in choice screen
+        let key_alt_e = KeyEvent::new(KeyCode::Char('E'), KeyModifiers::ALT);
+        handle_key(&d, key_alt_e);
+
+        assert!(rx.try_recv().is_err());
+        assert!(snap(&d).edit_input.is_none());
+        assert!(snap(&d).pending.is_some());
+
+        // 4. Press 'Shift-E' (supported modifier for uppercase E) -> should enter edit mode
+        let key_shift_e = KeyEvent::new(KeyCode::Char('E'), KeyModifiers::SHIFT);
+        handle_key(&d, key_shift_e);
+
         assert!(rx.try_recv().is_err());
         assert_eq!(snap(&d).edit_input.as_deref(), Some("x"));
     }

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -1120,7 +1120,8 @@ impl Agent for DefaultAgent {
             }
         };
         let tool_name = tool_call.name;
-        let mut tool_input = tool_call.input;
+        let tool_input = tool_call.input;
+        let mut final_tool_input = tool_input.clone();
         let is_bash = tool_name == BASH_TOOL_NAME;
         if self.read_only {
             self.history.push(Message::assistant(
@@ -1273,10 +1274,11 @@ impl Agent for DefaultAgent {
                         return Ok(StepOutcome::Terminate(ExitReason::UserInterrupt));
                     }
                     super::ConfirmDecision::Edit(edited_command) => {
+                        let unredacted_command = self.redactor.unredact_text(&edited_command);
                         let policy_command_edit = if is_bash {
-                            Some(edited_command.clone())
+                            Some(unredacted_command.clone())
                         } else if let Some(tool) = self.tool_registry.command_tool(&tool_name) {
-                            let context = self.command_tool_context(tool, &edited_command);
+                            let context = self.command_tool_context(tool, &unredacted_command);
                             Some(self.renderer.render_str(&tool.command, &context)?)
                         } else {
                             None
@@ -1334,7 +1336,7 @@ impl Agent for DefaultAgent {
                                     "interactive_substituted_command".into(),
                                     serde_json::Value::String(
                                         self.redactor
-                                            .redact_text(&edited_command, surface::TRAJECTORY)
+                                            .redact_text(&unredacted_command, surface::TRAJECTORY)
                                             .text,
                                     ),
                                 );
@@ -1369,25 +1371,30 @@ impl Agent for DefaultAgent {
                             }
                         }
 
-                        // Run PreToolUse hooks on the edited_command. Update pre_hook_results and tool_use_blocked status.
+                        // Run PreToolUse hooks on the unredacted_command. Update pre_hook_results and tool_use_blocked status.
                         pre_hook_results = self
                             .run_tool_hooks(
                                 ToolHookPhase::PreToolUse,
                                 &self.config.root.agent.hooks.pre_tool_use,
                                 &tool_name,
-                                &edited_command,
+                                &unredacted_command,
                                 None,
                             )
                             .await?;
                         tool_use_blocked =
                             pre_hook_results.iter().any(ToolHookResult::blocks_tool_use);
 
+                        if self.cancellation_requested() {
+                            self.finalize_cancelled();
+                            return Ok(StepOutcome::Terminate(ExitReason::UserInterrupt));
+                        }
+
                         interactive_edit = Some((
                             tool_input.clone(),
-                            edited_command.clone(),
+                            unredacted_command.clone(),
                             chrono::Utc::now().to_rfc3339(),
                         ));
-                        tool_input = edited_command;
+                        final_tool_input = unredacted_command;
                     }
                 }
             }
@@ -1405,10 +1412,10 @@ impl Agent for DefaultAgent {
             let result = if is_bash {
                 self.stream.emit(StreamEvent::BashStart {
                     step: self.steps,
-                    command: tool_input.clone(),
+                    command: final_tool_input.clone(),
                     timestamp: chrono::Utc::now().to_rfc3339(),
                 });
-                let run_req = RunRequest::new(&tool_input).with_timeout(Duration::from_secs(
+                let run_req = RunRequest::new(&final_tool_input).with_timeout(Duration::from_secs(
                     self.config.root.environment.timeout_secs,
                 ));
                 let run_req = if let Some(cancellation) = self.cancellation.clone() {
@@ -1427,7 +1434,8 @@ impl Agent for DefaultAgent {
                 });
                 result
             } else {
-                self.run_non_bash_tool(&tool_name, &tool_input).await?
+                self.run_non_bash_tool(&tool_name, &final_tool_input)
+                    .await?
             };
             let tool_latency = elapsed_ms_since(tool_start);
             let post_hook_results = self
@@ -1435,7 +1443,7 @@ impl Agent for DefaultAgent {
                     ToolHookPhase::PostToolUse,
                     &self.config.root.agent.hooks.post_tool_use,
                     &tool_name,
-                    &tool_input,
+                    &final_tool_input,
                     Some(&result),
                 )
                 .await?;
@@ -1443,7 +1451,7 @@ impl Agent for DefaultAgent {
         };
 
         if is_bash && !tool_use_blocked {
-            self.record_test_invocation_if_matched(&tool_input, result.exit_code);
+            self.record_test_invocation_if_matched(&final_tool_input, result.exit_code);
         }
 
         let result_for_observation = RunResult {
@@ -1512,7 +1520,7 @@ impl Agent for DefaultAgent {
         );
         let tool_input_for_observation = self
             .redactor
-            .redact_text(&tool_input, surface::MODEL_OBSERVATION)
+            .redact_text(&final_tool_input, surface::MODEL_OBSERVATION)
             .text;
         let tool_name_for_observation = self
             .redactor
@@ -1666,7 +1674,7 @@ impl Agent for DefaultAgent {
         // Check for stagnation after cancellation so step_index = self.steps - 1.
         if is_bash && !tool_use_blocked {
             if let Some(detector) = &mut self.stagnation_detector {
-                if let Some(trip) = detector.observe(self.steps - 1, &tool_input) {
+                if let Some(trip) = detector.observe(self.steps - 1, &final_tool_input) {
                     return Ok(self.terminate_stagnation(trip));
                 }
             }

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -1270,6 +1270,11 @@ impl Agent for DefaultAgent {
                         self.finalize_cancelled();
                         return Ok(StepOutcome::Terminate(ExitReason::UserInterrupt));
                     }
+                    super::ConfirmDecision::Edit(_) => {
+                        todo!(
+                            "Task 1 only requires confirm.rs edits and scripted tests to pass first"
+                        );
+                    }
                 }
             }
         }

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -1120,7 +1120,7 @@ impl Agent for DefaultAgent {
             }
         };
         let tool_name = tool_call.name;
-        let tool_input = tool_call.input;
+        let mut tool_input = tool_call.input;
         let is_bash = tool_name == BASH_TOOL_NAME;
         if self.read_only {
             self.history.push(Message::assistant(
@@ -1237,7 +1237,7 @@ impl Agent for DefaultAgent {
         }
 
         // 5c. PreToolUse hooks, then tool execution if not blocked.
-        let pre_hook_results = self
+        let mut pre_hook_results = self
             .run_tool_hooks(
                 ToolHookPhase::PreToolUse,
                 &self.config.root.agent.hooks.pre_tool_use,
@@ -1246,11 +1246,13 @@ impl Agent for DefaultAgent {
                 None,
             )
             .await?;
-        let tool_use_blocked = pre_hook_results.iter().any(ToolHookResult::blocks_tool_use);
+        let mut tool_use_blocked = pre_hook_results.iter().any(ToolHookResult::blocks_tool_use);
         if self.cancellation_requested() {
             self.finalize_cancelled();
             return Ok(StepOutcome::Terminate(ExitReason::UserInterrupt));
         }
+
+        let mut interactive_edit: Option<(String, String, String)> = None;
 
         // 5d. Operator confirmation gate (issue #312). Skipped when the
         // PreToolUse hook layer already blocked the tool — the operator
@@ -1270,10 +1272,122 @@ impl Agent for DefaultAgent {
                         self.finalize_cancelled();
                         return Ok(StepOutcome::Terminate(ExitReason::UserInterrupt));
                     }
-                    super::ConfirmDecision::Edit(_) => {
-                        todo!(
-                            "Task 1 only requires confirm.rs edits and scripted tests to pass first"
-                        );
+                    super::ConfirmDecision::Edit(edited_command) => {
+                        let policy_command_edit = if is_bash {
+                            Some(edited_command.clone())
+                        } else if let Some(tool) = self.tool_registry.command_tool(&tool_name) {
+                            let context = self.command_tool_context(tool, &edited_command);
+                            Some(self.renderer.render_str(&tool.command, &context)?)
+                        } else {
+                            None
+                        };
+
+                        if let Some(policy_command_edit_str) = policy_command_edit.as_deref() {
+                            let policy_decision = self
+                                .policy_engine
+                                .check_command_non_interactive(policy_command_edit_str);
+                            if let PolicyDecision::Deny { ref label } = policy_decision {
+                                self.trajectory.info.policy_counts.record(&policy_decision);
+                                let rejection = format!(
+                                    "Exit code: 1\nOutput:\nCommand blocked by policy rule '{label}'. \
+                                     The command was not executed. Please attempt a safer alternative.",
+                                );
+                                let obs_msg = Message::user(rejection.clone());
+                                self.history.push(obs_msg.clone());
+                                let mut obs_extra = crate::model::MessageExtra {
+                                    harness_overhead_ms: Some(elapsed_ms_since(
+                                        self.last_measurement_end,
+                                    )),
+                                    ..crate::model::MessageExtra::default()
+                                };
+                                obs_extra
+                                    .other
+                                    .insert("policy_blocked".into(), serde_json::Value::Bool(true));
+                                obs_extra.other.insert(
+                                    "policy_rule".into(),
+                                    serde_json::Value::String(label.clone()),
+                                );
+                                obs_extra.other.insert(
+                                    "blocked_command".into(),
+                                    serde_json::Value::String(
+                                        self.redactor
+                                            .redact_text(
+                                                policy_command_edit_str,
+                                                surface::TRAJECTORY,
+                                            )
+                                            .text,
+                                    ),
+                                );
+                                obs_extra.other.insert(
+                                    "interactive_decision".into(),
+                                    serde_json::Value::String("edit".to_owned()),
+                                );
+                                obs_extra.other.insert(
+                                    "interactive_proposed_command".into(),
+                                    serde_json::Value::String(
+                                        self.redactor
+                                            .redact_text(&tool_input, surface::TRAJECTORY)
+                                            .text,
+                                    ),
+                                );
+                                obs_extra.other.insert(
+                                    "interactive_substituted_command".into(),
+                                    serde_json::Value::String(
+                                        self.redactor
+                                            .redact_text(&edited_command, surface::TRAJECTORY)
+                                            .text,
+                                    ),
+                                );
+                                obs_extra.other.insert(
+                                    "interactive_tool_name".into(),
+                                    serde_json::Value::String(tool_name.clone()),
+                                );
+                                obs_extra.other.insert(
+                                    "interactive_timestamp".into(),
+                                    serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+                                );
+
+                                record_redacted_message(
+                                    &mut self.trajectory,
+                                    &obs_msg,
+                                    obs_extra,
+                                    &self.redactor,
+                                );
+                                self.stream.emit(StreamEvent::Observation {
+                                    step: self.steps,
+                                    content: rejection,
+                                    timestamp: chrono::Utc::now().to_rfc3339(),
+                                });
+                                self.last_measurement_end = Instant::now();
+                                self.steps += 1;
+                                return Ok(StepOutcome::Continue);
+                            }
+                            if *self.policy_engine.profile() == PolicyProfile::Yolo {
+                                self.trajectory.info.policy_counts.record_yolo_bypass();
+                            } else {
+                                self.trajectory.info.policy_counts.record(&policy_decision);
+                            }
+                        }
+
+                        // Run PreToolUse hooks on the edited_command. Update pre_hook_results and tool_use_blocked status.
+                        pre_hook_results = self
+                            .run_tool_hooks(
+                                ToolHookPhase::PreToolUse,
+                                &self.config.root.agent.hooks.pre_tool_use,
+                                &tool_name,
+                                &edited_command,
+                                None,
+                            )
+                            .await?;
+                        tool_use_blocked =
+                            pre_hook_results.iter().any(ToolHookResult::blocks_tool_use);
+
+                        interactive_edit = Some((
+                            tool_input.clone(),
+                            edited_command.clone(),
+                            chrono::Utc::now().to_rfc3339(),
+                        ));
+                        tool_input = edited_command;
                     }
                 }
             }
@@ -1441,6 +1555,36 @@ impl Agent for DefaultAgent {
         let obs_msg = Message::user(obs_text.clone());
         self.history.push(obs_msg.clone());
         let mut obs_extra = MessageExtra::default();
+        if let Some((ref proposed, ref substituted, ref ts)) = interactive_edit {
+            obs_extra.other.insert(
+                "interactive_decision".into(),
+                serde_json::Value::String("edit".to_owned()),
+            );
+            obs_extra.other.insert(
+                "interactive_proposed_command".into(),
+                serde_json::Value::String(
+                    self.redactor
+                        .redact_text(proposed, surface::TRAJECTORY)
+                        .text,
+                ),
+            );
+            obs_extra.other.insert(
+                "interactive_substituted_command".into(),
+                serde_json::Value::String(
+                    self.redactor
+                        .redact_text(substituted, surface::TRAJECTORY)
+                        .text,
+                ),
+            );
+            obs_extra.other.insert(
+                "interactive_tool_name".into(),
+                serde_json::Value::String(tool_name.clone()),
+            );
+            obs_extra.other.insert(
+                "interactive_timestamp".into(),
+                serde_json::Value::String(ts.clone()),
+            );
+        }
         // Mark chaos-injected results so `bench inspect` can distinguish a
         // deterministically synthesized timeout from a real one. We detect by
         // the decorator's stderr sentinel on a timed-out result; the flag is

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -269,6 +269,28 @@ impl Redactor {
         RedactionOutcome { text, redacted }
     }
 
+    #[must_use]
+    pub fn unredact_text(&self, input: &str) -> String {
+        let mut pairs: Vec<(String, String)> = {
+            let markers = self
+                .inner
+                .markers
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            markers
+                .iter()
+                .map(|(raw, marker)| (raw.clone(), marker.clone()))
+                .collect()
+        };
+        pairs.sort_by_key(|a| std::cmp::Reverse(a.1.len()));
+
+        let mut result = input.to_owned();
+        for (raw, marker) in pairs {
+            result = result.replace(&marker, &raw);
+        }
+        result
+    }
+
     /// Redact `input` without updating redaction-count telemetry.
     ///
     /// Use only for internal computations (e.g. fingerprinting) where the
@@ -1201,5 +1223,22 @@ mod tests {
                 "Failed for input: {input}",
             );
         }
+    }
+
+    #[test]
+    fn unredact_text_restores_original_secrets() {
+        let cfg = RedactionCfg {
+            secret_literals: vec!["secret1".into(), "secret2".into(), "longersecret".into()],
+            ..RedactionCfg::default()
+        };
+        let redactor = Redactor::from_config(&cfg).unwrap();
+        let original = "This is secret1 and longersecret, but not secret2.";
+        let redacted = redactor.redact_text(original, surface::TRAJECTORY).text;
+
+        assert_ne!(original, redacted);
+        assert!(redacted.contains("[REDACTED:"));
+
+        let unredacted = redactor.unredact_text(&redacted);
+        assert_eq!(original, unredacted);
     }
 }

--- a/tests/interactive_confirm.rs
+++ b/tests/interactive_confirm.rs
@@ -358,3 +358,159 @@ async fn reject_with_feedback_records_synthetic_observation_and_event() {
         "expected interactive_feedback in MessageExtra"
     );
 }
+
+#[tokio::test]
+async fn edit_executes_edited_command_and_records_trajectory() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+    let model = Arc::new(DeterministicModel::new(vec![
+        "```bash\necho original\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let confirmer = Arc::new(ScriptedConfirmer::new(vec![ConfirmDecision::Edit(
+        "echo edited-cmd".to_owned(),
+    )]));
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "edit-test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+        resume_from: None,
+        read_only: false,
+    }
+    .build()
+    .unwrap();
+    agent.confirm_callback = Some(confirmer.clone() as Arc<dyn ConfirmCallback>);
+
+    let result = agent.run().await.unwrap();
+    assert!(matches!(result, ExitReason::Submitted { .. }));
+    assert_eq!(confirmer.call_count(), 1);
+
+    // Assert that the output in the observation contains `edited-cmd`.
+    let has_edited_output = agent.trajectory.messages.iter().any(|m| {
+        m.role == "user"
+            && m.extra.other.contains_key("run_result")
+            && m.content.contains("edited-cmd")
+    });
+    assert!(
+        has_edited_output,
+        "expected to find command execution output containing `edited-cmd`"
+    );
+
+    // Check that the trajectory contains the interactive_decision metadata
+    let edit_msg = agent
+        .trajectory
+        .messages
+        .iter()
+        .find(|m| {
+            m.extra
+                .other
+                .get("interactive_decision")
+                .and_then(|v| v.as_str())
+                == Some("edit")
+        })
+        .unwrap();
+
+    assert_eq!(
+        edit_msg
+            .extra
+            .other
+            .get("interactive_proposed_command")
+            .and_then(|v| v.as_str()),
+        Some("echo original")
+    );
+    assert_eq!(
+        edit_msg
+            .extra
+            .other
+            .get("interactive_substituted_command")
+            .and_then(|v| v.as_str()),
+        Some("echo edited-cmd")
+    );
+}
+
+#[tokio::test]
+async fn edit_blocked_by_policy_fails_with_denial() {
+    let mut cfg = Config::defaults().unwrap();
+    cfg.root.agent.step_limit = 5;
+    // Configure policy config to deny "rm".
+    cfg.root.policy.extra_deny_patterns = vec![r"rm\b".to_owned()];
+
+    let model = Arc::new(DeterministicModel::new(vec![
+        "```bash\necho original\n```".into(),
+        "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```".into(),
+    ]));
+    let env: Box<dyn Environment> = Box::new(LocalEnvironment::new());
+    let confirmer = Arc::new(ScriptedConfirmer::new(vec![ConfirmDecision::Edit(
+        "rm -rf /".to_owned(),
+    )]));
+    let mut agent = DefaultAgentBuilder {
+        config: cfg,
+        model,
+        env,
+        task: "edit-policy-test".into(),
+        extra_context: None,
+        renderer: None,
+        stream: None,
+        resume_from: None,
+        read_only: false,
+    }
+    .build()
+    .unwrap();
+    agent.confirm_callback = Some(confirmer.clone() as Arc<dyn ConfirmCallback>);
+
+    let result = agent.run().await.unwrap();
+    assert!(matches!(result, ExitReason::Submitted { .. }));
+    assert_eq!(confirmer.call_count(), 1);
+
+    // Assert that it gets denied with the standard denial observation
+    let user_msg = agent
+        .trajectory
+        .messages
+        .iter()
+        .find(|m| m.role == "user" && m.content.contains("Command blocked by policy rule"));
+    assert!(user_msg.is_some(), "expected policy blocked user message");
+
+    // Records interactive_decision as "edit", the original command, and the blocked command.
+    let blocked_msg = agent
+        .trajectory
+        .messages
+        .iter()
+        .find(|m| {
+            m.extra
+                .other
+                .get("interactive_decision")
+                .and_then(|v| v.as_str())
+                == Some("edit")
+        })
+        .unwrap();
+
+    assert_eq!(
+        blocked_msg
+            .extra
+            .other
+            .get("interactive_proposed_command")
+            .and_then(|v| v.as_str()),
+        Some("echo original")
+    );
+    assert_eq!(
+        blocked_msg
+            .extra
+            .other
+            .get("interactive_substituted_command")
+            .and_then(|v| v.as_str()),
+        Some("rm -rf /")
+    );
+    assert_eq!(
+        blocked_msg
+            .extra
+            .other
+            .get("blocked_command")
+            .and_then(|v| v.as_str()),
+        Some("rm -rf /")
+    );
+}


### PR DESCRIPTION
## Description
This PR implements the interactive command-edit capability (Phase 2 of #312) under issue #627.

### Core Changes
1. **Confirm Decision**: Added `ConfirmDecision::Edit(String)` to `confirm.rs`, supporting label `"edit"`.
2. **Stderr UI Confirmer**: Added `run_inline_editor` utilizing crossterm in raw terminal mode to support interactive editing (cursor navigation, backspace, delete, home/end, character insertion). Intercepted `e`/`E` to trigger it.
3. **Ratatui Dashboard Confirmer**: Added `edit_input` field to state, rendering a focused command input field inside the confirmation modal, along with key event hooks (`Enter`, `Esc`, `Backspace`, character inputs).
4. **Agent Loop integration**: Intercepted `ConfirmDecision::Edit(edited_command)` in `DefaultAgent::step`. The edited command is re-run through the policy engine gate and `PreToolUse` hooks before execution, failing closed with the standard denial observation if policy/hook checks fail. suraced the output to the model and updated trajectory extras to log `interactive_decision: "edit"`, original proposed command, and operator-substituted command.
5. **Integration Tests**: Added `edit_executes_edited_command_and_records_trajectory` and `edit_blocked_by_policy_fails_with_denial` integration tests.

Closes #627.