### PR TITLE
👺 Havoc: Fix string slicing crashes in redaction & unsafe env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,6 +1362,7 @@ dependencies = [
  "sha2",
  "similar",
  "tar",
+ "temp-env",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -2262,6 +2263,16 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "futures",
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ comfy-table = "7.2.2"
 tempfile = "3"
 flate2 = "1.1"
 tar = "0.4"
+temp-env = { version = "0.3.6", features = ["async_closure"] }
 
 # NOTE on model backend:
 # `litellm-rs` ships a library API (`completion`, message constructors,

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -321,15 +321,43 @@ impl Redactor {
         let mut out = String::with_capacity(input.len());
         let mut last = 0usize;
         for matched in filtered {
-            out.push_str(&input[last..matched.start]);
+            let start = matched.start.min(input.len());
+            let end = matched.end.min(input.len());
+
+            // Fast path for valid byte indices
+            if input.is_char_boundary(last) && input.is_char_boundary(start) && last <= start {
+                out.push_str(&input[last..start]);
+            } else {
+                // Slower character-aware fallback for malformed indices or split multibyte chars
+                let chars: Vec<char> = input.chars().collect();
+                let last_char_idx = input[..last.min(input.len())].chars().count();
+                let start_char_idx = input[..start].chars().count();
+                if last_char_idx <= start_char_idx && start_char_idx <= chars.len() {
+                    out.push_str(
+                        &chars[last_char_idx..start_char_idx]
+                            .iter()
+                            .collect::<String>(),
+                    );
+                }
+            }
+
             let marker = self.marker_for(&matched.raw, &matched.kind);
             out.push_str(&marker);
             if let Some(srf) = surface {
                 self.increment(srf, &matched.kind);
             }
-            last = matched.end;
+            last = end;
         }
-        out.push_str(&input[last..]);
+
+        if input.is_char_boundary(last) && last <= input.len() {
+            out.push_str(&input[last..]);
+        } else {
+            let chars: Vec<char> = input.chars().collect();
+            let last_char_idx = input[..last.min(input.len())].chars().count();
+            if last_char_idx <= chars.len() {
+                out.push_str(&chars[last_char_idx..].iter().collect::<String>());
+            }
+        }
         (out, true)
     }
 
@@ -517,7 +545,26 @@ impl Redactor {
         let mut last = 0usize;
 
         for m in &filtered {
-            out_text.push_str(&input[last..m.start]);
+            let start = m.start.min(input.len());
+            let end = m.end.min(input.len());
+
+            // Fast path for valid byte indices
+            if input.is_char_boundary(last) && input.is_char_boundary(start) && last <= start {
+                out_text.push_str(&input[last..start]);
+            } else {
+                // Slower character-aware fallback for malformed indices or split multibyte chars
+                let chars: Vec<char> = input.chars().collect();
+                let last_char_idx = input[..last.min(input.len())].chars().count();
+                let start_char_idx = input[..start].chars().count();
+                if last_char_idx <= start_char_idx && start_char_idx <= chars.len() {
+                    out_text.push_str(
+                        &chars[last_char_idx..start_char_idx]
+                            .iter()
+                            .collect::<String>(),
+                    );
+                }
+            }
+
             let marker = self.marker_for(&m.raw, &m.kind);
             check_matches.push(CheckMatch {
                 start: m.start,
@@ -526,9 +573,18 @@ impl Redactor {
                 source: m.source_label.clone(),
             });
             out_text.push_str(&marker);
-            last = m.end;
+            last = end;
         }
-        out_text.push_str(&input[last..]);
+
+        if input.is_char_boundary(last) && last <= input.len() {
+            out_text.push_str(&input[last..]);
+        } else {
+            let chars: Vec<char> = input.chars().collect();
+            let last_char_idx = input[..last.min(input.len())].chars().count();
+            if last_char_idx <= chars.len() {
+                out_text.push_str(&chars[last_char_idx..].iter().collect::<String>());
+            }
+        }
 
         let unmatched_literal_indices = self
             .inner

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -3830,26 +3830,28 @@ index 8a1218a..24c5735 100644\n\
         // AC: Secrets injected via env (*_API_KEY, *_TOKEN, *_SECRET) must not
         // appear in the serialized manifest.
         let tmp = tempfile::tempdir().unwrap();
+        let tmp_path = tmp.path().to_path_buf();
 
         // Inject a fake secret as an environment variable that the redactor picks up.
         // We use a value that looks like a real API key pattern so the redactor fires.
         let fake_secret = "sk-ant-fake-secret-value-for-test-0123456789abcdef";
-        // SAFETY: test-only; single-threaded context for secret injection.
-        unsafe { std::env::set_var("TEST_MANIFEST_API_KEY", fake_secret) };
+        let fut = temp_env::async_with_vars(
+            [("TEST_MANIFEST_API_KEY", Some(fake_secret))],
+            async move {
+                let args = make_mini_args_for_manifest_test(tmp_path.clone(), "secret-test");
+                run(args).await.unwrap();
 
-        let args = make_mini_args_for_manifest_test(tmp.path().to_path_buf(), "secret-test");
-        run(args).await.unwrap();
+                let traj_path = tmp_path.join("secret-test.traj.json");
+                let content = std::fs::read_to_string(&traj_path).unwrap();
 
-        // Clean up env var
-        unsafe { std::env::remove_var("TEST_MANIFEST_API_KEY") };
-
-        let traj_path = tmp.path().join("secret-test.traj.json");
-        let content = std::fs::read_to_string(&traj_path).unwrap();
-
-        assert!(
-            !content.contains(fake_secret),
-            "serialized manifest must not contain secret value from env; found in: {content}"
+                assert!(
+                    !content.contains(fake_secret),
+                    "serialized manifest must not contain secret value from env; found in: {content}"
+                );
+            },
         );
+        #[allow(clippy::large_futures)]
+        Box::pin(fut).await;
     }
 
     #[tokio::test]

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -455,28 +455,31 @@ mod tests {
         // Synthetic env var picked up automatically by from_config_lossy.
         let unique_val = format!("sk-deadbeef-sweep-wh-{}", addr.port());
         let env_name = format!("FAKE_API_KEY_SWH_{}", addr.port());
-        // SAFETY: single-threaded test context; no concurrent env reads.
-        unsafe { std::env::set_var(&env_name, &unique_val) };
-        let redactor = Redactor::default_enabled();
 
-        let sink = SweepWebhookSink::new(url, &[], redactor, "sweep-redact".to_owned()).unwrap();
-        sink.emit(SweepNotificationEvent::InstanceCompleted {
-            instance_id: unique_val.clone(),
-            resolved: false,
-            failure_category: None,
-            cost_usd: None,
-            duration_secs: None,
-        });
+        let fut =
+            temp_env::async_with_vars([(env_name.clone(), Some(unique_val.clone()))], async move {
+                let redactor = Redactor::default_enabled();
 
-        let socket = accept(&listener).await;
-        let req = read_http(socket).await;
-        // SAFETY: single-threaded test context; no concurrent env reads.
-        unsafe { std::env::remove_var(&env_name) };
+                let sink =
+                    SweepWebhookSink::new(url, &[], redactor, "sweep-redact".to_owned()).unwrap();
+                sink.emit(SweepNotificationEvent::InstanceCompleted {
+                    instance_id: unique_val.clone(),
+                    resolved: false,
+                    failure_category: None,
+                    cost_usd: None,
+                    duration_secs: None,
+                });
 
-        assert!(
-            !req.contains(&unique_val),
-            "sensitive env var value must not appear verbatim in posted payload"
-        );
+                let socket = accept(&listener).await;
+                let req = read_http(socket).await;
+
+                assert!(
+                    !req.contains(&unique_val),
+                    "sensitive env var value must not appear verbatim in posted payload"
+                );
+            });
+        #[allow(clippy::large_futures)]
+        Box::pin(fut).await;
     }
 
     // ── RED: drop counting ─────────────────────────────────────────────────

--- a/tests/fuzz_redaction.rs
+++ b/tests/fuzz_redaction.rs
@@ -1,0 +1,24 @@
+use maxwells_daemon::config::schema::RedactionCfg;
+use maxwells_daemon::redaction::Redactor;
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(5000))]
+    #[test]
+    fn string_boundary_byte_slicing_fuzz(
+        ref s in ".*",
+        ref secret in ".*",
+    ) {
+        let config = RedactionCfg {
+            enabled: true,
+            unsafe_allow_secret_leaks: false,
+            secret_literals: vec![secret.clone()],
+            custom_patterns: vec![],
+        };
+        if let Ok(redactor) = Redactor::from_config(&config) {
+            let redacted = redactor.redact_text(s, "test");
+            let _unredacted = redactor.unredact_text(&redacted.text);
+            let _ = redactor.check(s);
+        }
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** Multibyte character boundary panics in String operations & data races via `std::env::set_var`
📉 **The Stack Trace:** Panics on byte slicing not at char boundary, plus data races in concurrent tests modifying global env state.
🧪 **Reproduction:** `cargo test --test fuzz_redaction`
😈 **Comment:** Chaos proved your thread safety and string boundaries were fragile. Replaced your global mutability with `temp_env` context wrapping and enforced unicode-aware substring boundary tests.

---
*PR created automatically by Jules for task [15598829452735189251](https://jules.google.com/task/15598829452735189251) started by @madmax983*