### PR TITLE
🎨 Mosaic: UI Polish for Skill Coverage CLI

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -3322,6 +3322,11 @@ pub struct SkillCoverageCmd {
     #[arg(long)]
     pub filter: Option<String>,
 
+    /// Hide skills with fewer than N total activations from the text table.
+    /// The JSON artifact always contains all skills.
+    #[arg(long, default_value_t = 0)]
+    pub min_invocations: usize,
+
     /// Emit per-instance skill activation counts in the JSON output and artifact.
     #[arg(long, default_value_t = false)]
     pub per_instance: bool,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4771,7 +4771,7 @@ fn bench_skill_coverage(t: args::SkillCoverageCmd) -> Result<(), Error> {
     } else {
         print!(
             "{}",
-            crate::run::skill_coverage::render_text(&report, bucket.as_deref())
+            crate::run::skill_coverage::render_text(&report, bucket.as_deref(), t.min_invocations)
         );
     }
     Ok(())

--- a/src/run/skill_coverage.rs
+++ b/src/run/skill_coverage.rs
@@ -135,7 +135,11 @@ pub fn run(args: &SkillCoverageArgs) -> Result<SkillCoverageReport, Error> {
 // ── text rendering ────────────────────────────────────────────────────────────
 
 #[allow(clippy::too_many_lines)]
-pub fn render_text(report: &SkillCoverageReport, bucket_filter: Option<&str>) -> String {
+pub fn render_text(
+    report: &SkillCoverageReport,
+    bucket_filter: Option<&str>,
+    min_invocations: usize,
+) -> String {
     use comfy_table::Table;
     use comfy_table::modifiers::UTF8_ROUND_CORNERS;
     use comfy_table::presets::UTF8_FULL;
@@ -175,6 +179,7 @@ pub fn render_text(report: &SkillCoverageReport, bucket_filter: Option<&str>) ->
     let mut rows: Vec<(&str, &SkillMetrics)> = report
         .by_skill
         .iter()
+        .filter(|(_, m)| m.total_activations >= min_invocations)
         .map(|(name, m)| (name.as_str(), m))
         .collect();
 


### PR DESCRIPTION
🖌️ **Before:** `bench skill-coverage` outputs every single skill, even if it had 0 activations, cluttering the UI.
✨ **After:** Added a `--min-invocations` flag to hide unactivated skills from the text table, mirroring `--min-invocations` on `bench tool-coverage`.
🖼️ **Visuals:** Now we can run `bench skill-coverage --min-invocations 1` to get a cleaner, actionable dashboard instead of a huge list.

---
*PR created automatically by Jules for task [7743591242568273496](https://jules.google.com/task/7743591242568273496) started by @madmax983*