### PR TITLE
Add `bench export-otlp` to backfill OTLP traces from completed sweeps (#513)

### DIFF
--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -104,6 +104,7 @@ coarse sweep-level result.
 | `agent redact-audit`            | `success`, `usage_error`, `redact_audit_findings`, `redact_audit_scan_error`, `internal_error` |
 | `bench assert`                  | `success`, `usage_error`, `slo_rule_failure`, `internal_error` |
 | `agent apply`                   | `success`, `usage_error`, `apply_check_failed`, `apply_redacted_refused`, `apply_dirty_tree_refused`, `internal_error` |
+| `bench export-otlp`             | `success`, `usage_error`, `preflight_failure`, `internal_error` (see `docs/spec-export-otlp.md`) |
 
 > **Note:** `hello-world` does not produce distinct outcome classes beyond
 > `success` / `internal_error`; it is an interactive debugging surface.

--- a/docs/spec-export-otlp.md
+++ b/docs/spec-export-otlp.md
@@ -1,0 +1,148 @@
+# `bench export-otlp` — Backfill OTLP Traces from a Completed Sweep
+
+## Overview
+
+`bench export-otlp` reads a completed sweep directory and re-exports
+reconstructed **sweep + instance spans** to an OTLP/HTTP collector
+(Jaeger / Tempo / Honeycomb / any OTLP-compatible backend). It exists because
+OTLP trace export is otherwise **live-only**: spans are emitted to the collector
+*during* a sweep, and only when an endpoint is configured *at launch*. The
+common headless / cron case — including this repo's own nightly smoke — runs
+without a collector, and a collector outage mid-sweep drops spans the same way.
+In both cases the spans are lost permanently even though the canonical
+trajectories persist on disk.
+
+This command closes that gap. It walks the sweep directory, reconstructs each
+instance's span tree from the persisted trajectory (the same
+`telemetry::instance_span_data_from_trajectory` primitive the live path uses),
+and exports them through the same OTLP/HTTP/JSON exporter (`export_sweep`) — so
+a backfilled run and a live-exported run are **indistinguishable** in the
+collector.
+
+It is **read-only with respect to inputs**: it never re-runs instances, never
+calls a model, never starts a container, and never modifies the sweep
+directory. The only side effect is the OTLP POST (skipped entirely under
+`--dry-run`).
+
+## Usage
+
+```
+bench export-otlp --sweep <DIR> [--otlp-endpoint <URL>] [--dry-run]
+```
+
+### Arguments
+
+| Argument | Required | Description |
+|---|---|---|
+| `--sweep <DIR>` | yes | Completed sweep directory produced by `bench swebench` |
+| `--otlp-endpoint <URL>` | no¹ | OTLP/HTTP collector base URL, e.g. `http://localhost:4318`. `/v1/traces` is appended |
+| `--dry-run` | no | Reconstruct and count spans, print the summary, and open no socket |
+
+¹ Required for a real export unless an endpoint is supplied via the OTel env
+vars below. Not required for `--dry-run`.
+
+## Endpoint resolution
+
+The endpoint resolves with the **same precedence as the live exporter**
+(`telemetry::resolve_endpoint`), first match wins:
+
+1. `--otlp-endpoint <URL>` — treated as a base URL; `/v1/traces` is appended.
+2. `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` — used as-is (already a full URL per the
+   OTel spec).
+3. `OTEL_EXPORTER_OTLP_ENDPOINT` — base URL; `/v1/traces` is appended.
+
+If none resolve (and this is not a dry-run), the command exits `2`
+(`usage_error`) with a message naming the missing input.
+
+## Authentication headers
+
+Export headers honour the existing `resolve_otlp_headers()` env contract:
+`OTEL_EXPORTER_OTLP_TRACES_HEADERS` takes precedence, then
+`OTEL_EXPORTER_OTLP_HEADERS` (comma-separated `key=value` pairs, values
+percent-decoded). This lets authenticated SaaS collectors (e.g. Honeycomb's
+`x-honeycomb-team`) work without any new flags.
+
+## ID determinism guarantee
+
+Trace and span IDs for a given sweep are **deterministic and identical** to what
+the live exporter would have produced for the same run:
+
+* The sweep-level ID is recomputed with `swebench::compute_sweep_id`, the exact
+  function the live path uses — `sha256(output_dir_path + started_at_utc)`
+  truncated to 64 bits. The `started_at_utc` timestamp is read from the
+  persisted provenance manifest, and the output-directory path is the `--sweep`
+  directory, so the value matches the live run.
+* The sweep span's trace/span IDs derive from that sweep ID via
+  `telemetry::new_trace_id("sweep", sweep_id)` /
+  `telemetry::new_span_id("sweep_span", …)`.
+* Each instance reuses the **persisted** `trace_id` (written to `results.json`
+  and the trajectory by the live run) when present, and otherwise recomputes it
+  with `telemetry::new_trace_id(instance_id, sweep_id)` — exactly as the live
+  path does for instances that completed before OTLP was enabled.
+* Child model-call / tool-call span IDs derive deterministically from the
+  instance trace ID inside the shared `export_sweep` serialiser.
+
+The result: exporting the same fixture sweep twice — once via the live path,
+once via `export-otlp` — emits byte-identical trace/span IDs (verified by the
+test `live_and_backfilled_exports_have_identical_ids`). Span *timestamps* on the
+sweep root reflect the manifest's recorded start/finish, not wall-clock at
+export time.
+
+## Span shape
+
+The exported spans use the same shape and attributes as the live path (no new
+attributes or schema):
+
+* one **`sweep`** root span (attributes: `sweep_id`, `dataset`, `model`,
+  `instance_count`, `resolved_count`, `total_cost_usd`, `harness_version`,
+  optional `git_sha`);
+* one **`instance`** span per instance (its own trace, linked back to the sweep
+  span via an OTel span link), with `model_call` and `tool_call` child spans
+  reconstructed from the trajectory.
+
+Instances whose trajectory is missing on disk (e.g. build-env failures before
+the agent initialised) get a minimal instance-only span via
+`instance_span_data_from_result`. Fields not present in persisted trajectories
+are not reconstructed — the command exports what is on disk and never re-runs
+instances.
+
+## Output and exit codes
+
+On success the command prints a one-paragraph summary to stdout reporting the
+count of instances and spans sent, the sweep ID, and the resolved endpoint, and
+writes **no files**.
+
+Exit codes reuse the stable contract in [`docs/exit-codes.md`](exit-codes.md) —
+no new codes are introduced:
+
+| Exit | Outcome class | Condition |
+|---|---|---|
+| `0` | `success` | Export (or `--dry-run`) completed; summary reports instance and span counts |
+| `2` | `usage_error` | Missing/invalid sweep directory, corrupt/absent `results.json`, no provenance manifest, or no endpoint resolved for a real export |
+| `3` | `preflight_failure` | The collector was unreachable or rejected the export (one or more spans dropped) |
+| `1` | `internal_error` | Unexpected I/O failure |
+
+`--dry-run` always reconstructs, counts, prints the summary, and exits `0`
+without opening a socket — so operators can validate before sending.
+
+## Examples
+
+```bash
+# Backfill a nightly cron sweep into a local collector.
+bench export-otlp --sweep runs/nightly-2026-06-08 --otlp-endpoint http://localhost:4318
+
+# Validate span counts without sending anything.
+bench export-otlp --sweep runs/nightly-2026-06-08 --dry-run
+
+# Authenticated SaaS collector via env (no new flags).
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io
+export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=$HONEYCOMB_API_KEY"
+bench export-otlp --sweep runs/nightly-2026-06-08
+```
+
+## Out of scope
+
+* OTLP **metrics** export (see `docs/spec-otlp-metrics.md`) and OTLP **logs**.
+* Any change to the live in-sweep exporter (see `docs/spec-otlp-traces.md`).
+* New span attributes or schema beyond what the live path emits.
+* Reconstructing spans for fields not present in persisted trajectories.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1257,6 +1257,32 @@ pub enum BenchCmd {
     EvalParity(EvalParityCmd),
     /// Report sweep concurrency efficiency (effective parallelism, utilization, idle waste).
     Utilization(UtilizationCmd),
+    /// Backfill OTLP traces from a completed sweep directory to a collector (zero model cost: reads only on-disk artifacts).
+    ExportOtlp(ExportOtlpCmd),
+}
+
+/// `bench export-otlp` — re-export reconstructed sweep + instance spans from a
+/// completed sweep directory to an OTLP/HTTP collector.
+///
+/// OTLP trace export is otherwise live-only; this command backfills runs done
+/// without a collector (or during an outage) using the same span shape and the
+/// same deterministic trace/span IDs the live exporter would have produced.
+/// Reads only on-disk artifacts; never re-runs instances or mutates the sweep.
+#[derive(Debug, Args)]
+pub struct ExportOtlpCmd {
+    /// Completed sweep directory produced by `bench swebench`.
+    #[arg(long)]
+    pub sweep: std::path::PathBuf,
+
+    /// OTLP/HTTP collector base URL (e.g. `http://localhost:4318`). Takes
+    /// precedence over `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and
+    /// `OTEL_EXPORTER_OTLP_ENDPOINT`.
+    #[arg(long, value_name = "URL")]
+    pub otlp_endpoint: Option<String>,
+
+    /// Reconstruct and count spans, print the summary, and open no socket.
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 /// `bench utilization` — report how efficiently a sweep used its configured

--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -278,6 +278,12 @@ pub fn entries() -> &'static [CatalogEntry] {
             stage: "publish",
         },
         CatalogEntry {
+            path: "bench export-otlp",
+            summary: "Backfill OTLP traces from a completed sweep to a collector with live-identical IDs",
+            cost_tier: "free",
+            stage: "publish",
+        },
+        CatalogEntry {
             path: "bench failure-digest",
             summary: "Emit a self-contained failure summary for one instance in a completed sweep",
             cost_tier: "free",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -138,6 +138,7 @@ pub async fn run() -> Result<(), Error> {
             args::BenchCmd::Subset(s) => bench_subset(s),
             args::BenchCmd::EvalParity(p) => bench_eval_parity(p),
             args::BenchCmd::Utilization(u) => bench_utilization(u),
+            args::BenchCmd::ExportOtlp(c) => Box::pin(bench_export_otlp(c)).await,
         },
         Command::Agent { cmd } => match *cmd {
             args::AgentCmd::SkillsPreview(s) => agent_skills_preview_cmd(&s),
@@ -6081,6 +6082,17 @@ fn bench_utilization(u: args::UtilizationCmd) -> Result<(), Error> {
             ),
         );
     }
+    Ok(())
+}
+
+async fn bench_export_otlp(c: args::ExportOtlpCmd) -> Result<(), Error> {
+    let summary = crate::run::export_otlp::run(&crate::run::export_otlp::ExportOtlpArgs {
+        sweep_dir: c.sweep,
+        otlp_endpoint: c.otlp_endpoint,
+        dry_run: c.dry_run,
+    })
+    .await?;
+    print!("{}", crate::run::export_otlp::render_text(&summary));
     Ok(())
 }
 

--- a/src/run/export_otlp.rs
+++ b/src/run/export_otlp.rs
@@ -1,0 +1,417 @@
+//! `bench export-otlp`: backfill OTLP traces from a completed sweep (issue #513).
+//!
+//! OTLP trace export is otherwise **live-only**: spans are emitted to the
+//! collector during a sweep, and only when an endpoint is configured at launch.
+//! Headless / cron runs (or a collector outage mid-sweep) lose their spans
+//! permanently even though the canonical trajectories persist on disk. This
+//! command reads the persisted trajectory/result artifacts under a sweep
+//! directory and re-exports reconstructed sweep + instance spans to an
+//! OTLP/HTTP collector, using the *same* span shape and the *same* trace/span
+//! IDs the live exporter would have produced (see [`compute_sweep_id`] and
+//! [`crate::telemetry::new_trace_id`]), so a re-exported run and a live-exported
+//! run are indistinguishable in the collector.
+//!
+//! Read-only with respect to inputs: it never re-runs instances and never
+//! mutates the sweep directory. The only side effect is the OTLP POST (skipped
+//! entirely under `--dry-run`).
+//!
+//! See `docs/spec-export-otlp.md` for the full contract.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::error::{ConfigError, Error};
+use crate::run::swebench::{
+    InstanceResult, ProvenanceManifest, SweepResults, compute_sweep_id,
+    existing_patch_path_for_run, existing_trajectory_path_for_run,
+};
+use crate::telemetry::{
+    self, InstanceSpanData, SweepSpanData, Tracer, instance_span_data_from_result,
+    instance_span_data_from_trajectory, new_span_id, new_trace_id,
+};
+use crate::trajectory::Trajectory;
+
+/// Inputs to [`run`].
+#[derive(Debug, Clone)]
+pub struct ExportOtlpArgs {
+    /// Completed sweep directory produced by `bench swebench`.
+    pub sweep_dir: PathBuf,
+    /// Explicit `--otlp-endpoint` flag value (base URL). When `None`, the
+    /// endpoint is resolved from the standard OTel env vars.
+    pub otlp_endpoint: Option<String>,
+    /// When `true`, reconstruct and count spans but open no socket.
+    pub dry_run: bool,
+}
+
+/// The reconstructed span tree for a sweep, ready to hand to the exporter.
+pub struct Reconstructed {
+    /// Stable sweep-level ID seeding every trace/span ID.
+    pub sweep_id: String,
+    /// The sweep's recorded start timestamp (RFC3339), from the manifest.
+    pub started_at_utc: String,
+    /// Root sweep span data.
+    pub sweep_span: SweepSpanData,
+    /// Per-instance span data (each its own trace, linked to the sweep span).
+    pub instance_spans: Vec<InstanceSpanData>,
+}
+
+/// Outcome of an export, returned for both real and dry-run exports.
+#[derive(Debug, Clone)]
+pub struct ExportOtlpSummary {
+    /// Sweep directory path as supplied on the command line.
+    pub sweep: String,
+    /// Stable sweep-level ID used to seed the trace/span IDs.
+    pub sweep_id: String,
+    /// Fully-resolved OTLP traces endpoint URL. `None` only in a dry-run when
+    /// no endpoint resolved (a real export requires one).
+    pub endpoint: Option<String>,
+    /// Whether this was a dry-run (no socket opened).
+    pub dry_run: bool,
+    /// Number of instances whose spans were reconstructed.
+    pub instance_count: u64,
+    /// Total spans (sweep root + per-instance trees).
+    pub span_count: u64,
+}
+
+fn invalid(msg: String) -> Error {
+    Error::Config(ConfigError::Invalid(msg))
+}
+
+/// Parse an RFC3339 timestamp into Unix nanoseconds, or `None` when absent /
+/// unparseable / pre-epoch.
+fn rfc3339_to_nanos(s: &str) -> Option<u64> {
+    chrono::DateTime::parse_from_rfc3339(s).ok().and_then(|dt| {
+        let secs = dt.timestamp();
+        if secs < 0 {
+            return None;
+        }
+        u64::try_from(secs)
+            .ok()
+            .map(|s| s * 1_000_000_000 + u64::from(dt.timestamp_subsec_nanos()))
+    })
+}
+
+fn now_unix_nanos() -> u64 {
+    u64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos(),
+    )
+    .unwrap_or(u64::MAX)
+}
+
+/// Total spans in an export: sweep root + per-instance (instance + children).
+#[must_use]
+pub fn count_spans(instances: &[InstanceSpanData]) -> u64 {
+    1 + instances
+        .iter()
+        .map(|i| 1 + i.model_calls.len() as u64 + i.tool_calls.len() as u64)
+        .sum::<u64>()
+}
+
+/// Recover the configured `--rerun`/`--samples` count from the manifest argv so
+/// we read the same (terminal) run slot the live exporter exported. Defaults to
+/// 1 when the flag is absent.
+fn reruns_from_manifest(manifest: &ProvenanceManifest) -> u32 {
+    let argv = &manifest.cli.argv;
+    for (idx, arg) in argv.iter().enumerate() {
+        for key in ["--rerun", "--samples"] {
+            if let Some(value) = arg.strip_prefix(&format!("{key}=")) {
+                if let Ok(n) = value.parse::<u32>() {
+                    return n.max(1);
+                }
+            }
+            if arg == key && idx + 1 < argv.len() {
+                if let Ok(n) = argv[idx + 1].parse::<u32>() {
+                    return n.max(1);
+                }
+            }
+        }
+    }
+    1
+}
+
+/// Reconstruct the full span tree for a completed sweep directory.
+///
+/// Errors map to `usage_error` (exit 2): a missing directory, a missing /
+/// corrupt `results.json`, or a results file with no provenance manifest (the
+/// manifest carries the `started_at_utc` timestamp required to recompute the
+/// deterministic sweep ID).
+pub fn reconstruct(sweep_dir: &Path) -> Result<Reconstructed, Error> {
+    if !sweep_dir.exists() {
+        return Err(invalid(format!(
+            "export-otlp: sweep directory does not exist: {}",
+            sweep_dir.display()
+        )));
+    }
+    let results_path = sweep_dir.join("results.json");
+    if !results_path.exists() {
+        return Err(invalid(format!(
+            "export-otlp: no results.json under {}; this command requires a \
+             completed sweep produced by `bench swebench`",
+            sweep_dir.display()
+        )));
+    }
+    let text = std::fs::read_to_string(&results_path).map_err(|e| {
+        invalid(format!(
+            "export-otlp: could not read {}: {e}",
+            results_path.display()
+        ))
+    })?;
+    let sweep: SweepResults = serde_json::from_str(&text).map_err(|e| {
+        invalid(format!(
+            "export-otlp: {} is not a valid sweep results file: {e}",
+            results_path.display()
+        ))
+    })?;
+
+    let manifest = sweep.manifest.as_ref().ok_or_else(|| {
+        invalid(format!(
+            "export-otlp: no provenance manifest in {}; cannot recompute the \
+             deterministic sweep ID (run produced by an older harness?)",
+            results_path.display()
+        ))
+    })?;
+
+    let started_at_utc = manifest.runtime.started_at_utc.clone();
+    let sweep_id = compute_sweep_id(sweep_dir, &started_at_utc);
+    let sweep_trace_id = new_trace_id("sweep", &sweep_id);
+    let sweep_span_id = new_span_id("sweep_span", &sweep_trace_id);
+
+    let sweep_start_nanos = rfc3339_to_nanos(&started_at_utc).unwrap_or_else(now_unix_nanos);
+    let sweep_end_nanos = manifest
+        .runtime
+        .finished_at_utc
+        .as_deref()
+        .and_then(rfc3339_to_nanos)
+        .unwrap_or(sweep_start_nanos);
+
+    let resolved_count = sweep
+        .instances
+        .iter()
+        .filter(|r| r.resolved_count > 0)
+        .count() as u64;
+
+    let sweep_span = SweepSpanData {
+        sweep_id: sweep_id.clone(),
+        dataset: manifest.dataset.path.clone(),
+        model: manifest.model.name.clone(),
+        instance_count: sweep.total as u64,
+        resolved_count,
+        total_cost_usd: sweep.actual_cost_usd.unwrap_or(sweep.estimated_cost_usd),
+        harness_version: manifest.harness.version.clone(),
+        git_sha: manifest.harness.git_sha.clone(),
+        start_nanos: sweep_start_nanos,
+        end_nanos: sweep_end_nanos,
+    };
+
+    let last_run = reruns_from_manifest(manifest);
+    let mut instance_spans: Vec<InstanceSpanData> = Vec::with_capacity(sweep.instances.len());
+    for ir in &sweep.instances {
+        let span = reconstruct_instance(
+            sweep_dir,
+            &sweep_id,
+            &sweep_span_id,
+            last_run,
+            sweep_start_nanos,
+            sweep_end_nanos,
+            ir,
+        );
+        instance_spans.push(span);
+    }
+
+    Ok(Reconstructed {
+        sweep_id,
+        started_at_utc,
+        sweep_span,
+        instance_spans,
+    })
+}
+
+/// Build the span data for a single instance, preferring the persisted
+/// trajectory (full model/tool child spans) and falling back to a minimal
+/// instance-only span when no trajectory is on disk.
+fn reconstruct_instance(
+    sweep_dir: &Path,
+    sweep_id: &str,
+    sweep_span_id: &str,
+    last_run: u32,
+    sweep_start_nanos: u64,
+    sweep_end_nanos: u64,
+    ir: &InstanceResult,
+) -> InstanceSpanData {
+    // Reuse the persisted trace ID when present (it is authoritative for the
+    // original run); otherwise recompute it exactly as the live exporter would.
+    let trace_id = ir
+        .trace_id
+        .clone()
+        .unwrap_or_else(|| new_trace_id(&ir.instance_id, sweep_id));
+
+    let repo = crate::run::evaluate::parse_repo_from_instance_id(&ir.instance_id).unwrap_or_default();
+
+    let traj_path = existing_trajectory_path_for_run(sweep_dir, &ir.instance_id, last_run);
+    let final_patch_bytes = existing_patch_path_for_run(sweep_dir, &ir.instance_id, last_run)
+        .metadata()
+        .map_or(0, |m| m.len());
+
+    let traj = std::fs::read_to_string(&traj_path)
+        .ok()
+        .and_then(|json| serde_json::from_str::<Trajectory>(&json).ok());
+
+    if let Some(traj) = traj {
+        let mut span = instance_span_data_from_trajectory(
+            &trace_id,
+            sweep_span_id,
+            &ir.instance_id,
+            &repo,
+            &traj,
+            final_patch_bytes,
+            sweep_start_nanos,
+        );
+        // Prefer the authoritative result outcome (the final InstanceResult may
+        // differ from the trajectory outcome after post-processing).
+        if let Some(outcome) = ir.outcome.as_deref() {
+            outcome.clone_into(&mut span.outcome);
+        }
+        span
+    } else {
+        instance_span_data_from_result(
+            &trace_id,
+            sweep_span_id,
+            &ir.instance_id,
+            &repo,
+            ir,
+            final_patch_bytes,
+            sweep_start_nanos,
+            sweep_end_nanos,
+        )
+    }
+}
+
+/// Reconstruct spans from `args.sweep_dir` and export them to the resolved OTLP
+/// collector (unless `--dry-run`).
+///
+/// Exit-code contract (via [`crate::exit_code::ExitCode::from_error`]):
+/// * `usage_error` (2) — missing/invalid sweep directory, or no endpoint
+///   resolved for a real export.
+/// * `preflight_failure` (3) — the collector was unreachable or rejected the
+///   export.
+/// * `success` (0) — the export (or dry-run) completed.
+pub async fn run(args: &ExportOtlpArgs) -> Result<ExportOtlpSummary, Error> {
+    let rec = reconstruct(&args.sweep_dir)?;
+    let instance_count = rec.instance_spans.len() as u64;
+    let span_count = count_spans(&rec.instance_spans);
+
+    let resolved = telemetry::resolve_endpoint(args.otlp_endpoint.as_deref());
+
+    if args.dry_run {
+        return Ok(ExportOtlpSummary {
+            sweep: args.sweep_dir.display().to_string(),
+            sweep_id: rec.sweep_id,
+            endpoint: resolved,
+            dry_run: true,
+            instance_count,
+            span_count,
+        });
+    }
+
+    let endpoint = resolved.ok_or_else(|| {
+        invalid(
+            "export-otlp: no OTLP endpoint resolved; pass --otlp-endpoint or set \
+             OTEL_EXPORTER_OTLP_TRACES_ENDPOINT / OTEL_EXPORTER_OTLP_ENDPOINT"
+                .to_owned(),
+        )
+    })?;
+
+    let dropped = Arc::new(AtomicU64::new(0));
+    let tracer = Tracer::new(endpoint.clone(), dropped.clone());
+    tracer.export_sweep(&rec.sweep_span, &rec.instance_spans).await;
+
+    let dropped_n = dropped.load(Ordering::Relaxed);
+    if dropped_n > 0 {
+        return Err(Error::Preflight(format!(
+            "export-otlp: collector at {endpoint} was unreachable or rejected the \
+             export ({dropped_n} of {span_count} spans dropped)"
+        )));
+    }
+
+    Ok(ExportOtlpSummary {
+        sweep: args.sweep_dir.display().to_string(),
+        sweep_id: rec.sweep_id,
+        endpoint: Some(endpoint),
+        dry_run: false,
+        instance_count,
+        span_count,
+    })
+}
+
+/// Render a human-readable one-paragraph summary of an export.
+#[must_use]
+pub fn render_text(summary: &ExportOtlpSummary) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let verb = if summary.dry_run {
+        "Would export (dry-run)"
+    } else {
+        "Exported"
+    };
+    let _ = writeln!(
+        out,
+        "{verb} {} spans across {} instances from sweep {}",
+        summary.span_count, summary.instance_count, summary.sweep
+    );
+    let _ = writeln!(out, "  sweep_id: {}", summary.sweep_id);
+    match &summary.endpoint {
+        Some(ep) => {
+            let _ = writeln!(out, "  endpoint: {ep}");
+        }
+        None => {
+            let _ = writeln!(out, "  endpoint: (none resolved)");
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn count_spans_counts_root_plus_trees() {
+        // No instances → just the sweep root span.
+        assert_eq!(count_spans(&[]), 1);
+    }
+
+    #[test]
+    fn rfc3339_to_nanos_parses_and_rejects() {
+        assert!(rfc3339_to_nanos("2026-05-01T00:00:00Z").is_some());
+        assert!(rfc3339_to_nanos("not-a-date").is_none());
+    }
+
+    #[test]
+    fn reconstruct_missing_dir_is_config_error() {
+        let Err(err) = reconstruct(Path::new("/no/such/sweep/dir/xyz")) else {
+            panic!("expected an error for a missing sweep directory");
+        };
+        assert!(matches!(err, Error::Config(_)));
+    }
+
+    #[test]
+    fn render_text_marks_dry_run() {
+        let s = ExportOtlpSummary {
+            sweep: "/tmp/s".into(),
+            sweep_id: "abc".into(),
+            endpoint: None,
+            dry_run: true,
+            instance_count: 3,
+            span_count: 7,
+        };
+        let text = render_text(&s);
+        assert!(text.contains("dry-run"));
+        assert!(text.contains('7'));
+        assert!(text.contains('3'));
+    }
+}

--- a/src/run/export_otlp.rs
+++ b/src/run/export_otlp.rs
@@ -23,7 +23,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::error::{ConfigError, Error};
 use crate::run::swebench::{
-    InstanceResult, ProvenanceManifest, SweepResults, compute_sweep_id,
+    EXIT_REASON_BUDGET_HALT, InstanceResult, ProvenanceManifest, SweepResults, compute_sweep_id,
     existing_patch_path_for_run, existing_trajectory_path_for_run,
 };
 use crate::telemetry::{
@@ -249,7 +249,8 @@ fn reconstruct_instance(
         .clone()
         .unwrap_or_else(|| new_trace_id(&ir.instance_id, sweep_id));
 
-    let repo = crate::run::evaluate::parse_repo_from_instance_id(&ir.instance_id).unwrap_or_default();
+    let repo =
+        crate::run::evaluate::parse_repo_from_instance_id(&ir.instance_id).unwrap_or_default();
 
     let traj_path = existing_trajectory_path_for_run(sweep_dir, &ir.instance_id, last_run);
     let final_patch_bytes = existing_patch_path_for_run(sweep_dir, &ir.instance_id, last_run)
@@ -277,6 +278,15 @@ fn reconstruct_instance(
         }
         span
     } else {
+        // Mirror the live exporter's no-trajectory shape: budget-halted rows
+        // never ran, so give them an instantaneous span (collapsed at the sweep
+        // finish) instead of one spanning the whole sweep — otherwise they
+        // appear as long-running failures and distort duration dashboards.
+        let (inst_start, inst_end) = if ir.exit_reason == EXIT_REASON_BUDGET_HALT {
+            (sweep_end_nanos, sweep_end_nanos)
+        } else {
+            (sweep_start_nanos, sweep_end_nanos)
+        };
         instance_span_data_from_result(
             &trace_id,
             sweep_span_id,
@@ -284,8 +294,8 @@ fn reconstruct_instance(
             &repo,
             ir,
             final_patch_bytes,
-            sweep_start_nanos,
-            sweep_end_nanos,
+            inst_start,
+            inst_end,
         )
     }
 }
@@ -327,7 +337,9 @@ pub async fn run(args: &ExportOtlpArgs) -> Result<ExportOtlpSummary, Error> {
 
     let dropped = Arc::new(AtomicU64::new(0));
     let tracer = Tracer::new(endpoint.clone(), dropped.clone());
-    tracer.export_sweep(&rec.sweep_span, &rec.instance_spans).await;
+    tracer
+        .export_sweep(&rec.sweep_span, &rec.instance_spans)
+        .await;
 
     let dropped_n = dropped.load(Ordering::Relaxed);
     if dropped_n > 0 {

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -30,6 +30,7 @@ pub mod eval_parity;
 pub mod evaluate;
 pub mod evaluator_selftest;
 pub mod export_ci;
+pub mod export_otlp;
 pub mod failure_digest;
 pub mod forecast;
 pub mod fork;

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -1457,6 +1457,27 @@ fn default_attempts() -> u32 {
     1
 }
 
+/// Derive the stable sweep-level ID used to seed every OTLP trace/span ID for a
+/// run. Hashes the output-directory path together with the sweep's
+/// `started_at_utc` timestamp so the value is deterministic for a given sweep
+/// directory yet distinct across re-runs into the same path.
+///
+/// Both the live exporter (`run_swebench`) and the post-hoc backfill command
+/// (`bench export-otlp`, issue #513) call this so a re-exported run and a
+/// live-exported run produce byte-identical trace/span IDs.
+#[must_use]
+pub fn compute_sweep_id(output_dir: &std::path::Path, started_at_utc: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(output_dir.display().to_string().as_bytes());
+    h.update(started_at_utc.as_bytes());
+    let hash = h.finalize();
+    format!(
+        "{:016x}",
+        u64::from_be_bytes(hash[..8].try_into().unwrap_or([0u8; 8]))
+    )
+}
+
 /// Path where `run_one` writes the trajectory for an instance. Centralized so
 /// the resume-skip check stays in lockstep with the writer.
 #[must_use]
@@ -1502,7 +1523,7 @@ fn legacy_patch_path_for(output_dir: &std::path::Path, instance_id: &str) -> Pat
     output_dir.join(format!("{instance_id}.patch"))
 }
 
-fn existing_trajectory_path_for_run(
+pub fn existing_trajectory_path_for_run(
     output_dir: &std::path::Path,
     instance_id: &str,
     run_index: u32,
@@ -1859,18 +1880,9 @@ pub async fn run(mut args: SwebenchArgs) -> Result<SweepResults, Error> {
                 span_export_dropped.clone(),
             ))
         });
-    // Stable sweep-level ID derived from the output directory path.
-    let sweep_id = {
-        use sha2::{Digest, Sha256};
-        let mut h = Sha256::new();
-        h.update(args.output_dir.display().to_string().as_bytes());
-        h.update(started_at_utc.as_bytes());
-        let hash = h.finalize();
-        format!(
-            "{:016x}",
-            u64::from_be_bytes(hash[..8].try_into().unwrap_or([0u8; 8]))
-        )
-    };
+    // Stable sweep-level ID derived from the output directory path. Shared with
+    // `bench export-otlp` so post-hoc backfill reproduces identical IDs.
+    let sweep_id = compute_sweep_id(&args.output_dir, &started_at_utc);
     let sweep_start_nanos = u64::try_from(
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/tests/bench_export_otlp.rs
+++ b/tests/bench_export_otlp.rs
@@ -1,0 +1,642 @@
+//! `bench export-otlp`: backfill OTLP traces from a completed sweep (issue #513).
+//!
+//! Red/green/refactor TDD coverage. These tests exercise the library entry
+//! points (`reconstruct` / `run` / `render_text`) and the CLI surface
+//! (`max bench export-otlp`), including endpoint precedence, the `--dry-run`
+//! path, the exit-code contract, and the success-metric determinism guarantee:
+//! a run exported live and the same run backfilled via `export-otlp` must emit
+//! byte-identical trace/span IDs.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::too_many_lines,
+    clippy::await_holding_lock
+)]
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+use maxwells_daemon::run::export_otlp::{ExportOtlpArgs, reconstruct, render_text, run};
+use maxwells_daemon::run::swebench::{SwebenchArgs, compute_sweep_id};
+
+mod support;
+use support::binary_path;
+
+/// Serialize tests that mutate OTEL env vars — env vars are process-global.
+static ENV_VAR_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+fn env_var_lock() -> std::sync::MutexGuard<'static, ()> {
+    ENV_VAR_MUTEX.get_or_init(|| Mutex::new(())).lock().unwrap()
+}
+
+// ── shared scaffolding (mirrors tests/otlp_traces.rs) ───────────────────────
+
+fn write_dataset(path: &Path, instance_ids: &[&str]) {
+    let mut s = String::new();
+    for id in instance_ids {
+        let _ = writeln!(
+            s,
+            "{{\"instance_id\":\"{id}\",\"problem_statement\":\"noop\"}}"
+        );
+    }
+    std::fs::write(path, s).unwrap();
+}
+
+fn init_repo(dir: &Path) {
+    fn git(dir: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    git(dir, &["init", "-q", "-b", "main"]);
+    git(dir, &["config", "user.email", "test@test"]);
+    git(dir, &["config", "user.name", "test"]);
+    git(dir, &["config", "commit.gpgSign", "false"]);
+    git(dir, &["config", "tag.gpgSign", "false"]);
+    git(dir, &["commit", "-q", "--allow-empty", "-m", "base"]);
+}
+
+fn config_with_workdir(dir: &Path) -> maxwells_daemon::Config {
+    let workdir = dir
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    let toml = format!("[environment]\nworkdir = \"{workdir}\"\n");
+    maxwells_daemon::Config::from_toml_str(&toml).unwrap()
+}
+
+fn swebench_args(
+    dataset: std::path::PathBuf,
+    cache_dir: std::path::PathBuf,
+    output: std::path::PathBuf,
+    cfg: maxwells_daemon::Config,
+    otlp_endpoint: Option<String>,
+) -> SwebenchArgs {
+    SwebenchArgs {
+        dataset_source: maxwells_daemon::run::dataset::DatasetSource::LocalPath(dataset),
+        dataset_cache_dir: cache_dir,
+        output_dir: output,
+        parallel: 1,
+        config: cfg,
+        reruns: 1,
+        resume: false,
+        cost_limit_usd: None,
+        task_timeout_secs: None,
+        instance_ids: None,
+        limit: None,
+        sample: None,
+        seed: None,
+        stratify_by: None,
+        stratify_mode: maxwells_daemon::run::swebench::StratifyMode::Proportional,
+        max_retries: 0,
+        retry_on: None,
+        retry_backoff_base_ms: 1000,
+        retry_backoff_cap_s: 60,
+        retry_on_resume: false,
+        deterministic_responses: Some(vec![
+            "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\ntest\n```".into(),
+        ]),
+        deterministic_usage_per_call: None,
+        config_overlay_paths: vec![],
+        dry_run: false,
+        skip_preflight: true,
+        preflight_format: "text".into(),
+        skip_model_probe: true,
+        preflight_check_timeout_s: 10,
+        preflight_total_timeout_s: 60,
+        preflight_mode: "swebench".into(),
+        skip_patch_validation: true,
+        event_log: None,
+        max_rpm: None,
+        max_input_tpm: None,
+        cancel_deadline_secs: 30,
+        install_os_signal_handlers: false,
+        cancellation_signals: None,
+        github_pr: None,
+        reproduced_from: None,
+        abort_on_systemic_failure: false,
+        systemic_failure_min_samples: 5,
+        systemic_failure_share_pct: 80,
+        otlp_endpoint,
+        otlp_metrics_interval_secs: None,
+        rehearse: false,
+        skip_evaluator: false,
+        eval_backend: "rehearsal".to_string(),
+        sb_subset: None,
+        sb_split: None,
+        eval_timeout_secs: None,
+        notify_webhook_url: None,
+        notify_webhook_headers: vec![],
+    }
+}
+
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+/// A mock OTLP/HTTP collector that records every request body and replies 200.
+async fn start_mock_collector() -> (
+    String,
+    tokio::task::JoinHandle<()>,
+    tokio::sync::mpsc::UnboundedReceiver<(String, String, String)>,
+) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let endpoint = format!("http://{addr}");
+    // (path, headers, body)
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<(String, String, String)>();
+    let handle = tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 65536];
+                let mut read_bytes = 0;
+                loop {
+                    match stream.read(&mut buf[read_bytes..]).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => {
+                            read_bytes += n;
+                            if let Some(pos) = find_subsequence(&buf[..read_bytes], b"\r\n\r\n") {
+                                let headers_part =
+                                    String::from_utf8_lossy(&buf[..pos]).to_string();
+                                let mut content_len = 0;
+                                for line in headers_part.lines() {
+                                    if line.to_lowercase().starts_with("content-length:") {
+                                        if let Some(val) =
+                                            line.split_once(':').map(|(_, v)| v.trim())
+                                        {
+                                            content_len = val.parse::<usize>().unwrap_or(0);
+                                        }
+                                    }
+                                }
+                                let body_start = pos + 4;
+                                if read_bytes >= body_start + content_len {
+                                    let body = String::from_utf8_lossy(
+                                        &buf[body_start..body_start + content_len],
+                                    )
+                                    .to_string();
+                                    let path = headers_part
+                                        .lines()
+                                        .next()
+                                        .and_then(|l| l.split_whitespace().nth(1))
+                                        .unwrap_or("")
+                                        .to_string();
+                                    let _ = tx.send((path, headers_part, body));
+                                    let response =
+                                        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}";
+                                    let _ = stream.write_all(response.as_bytes()).await;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    });
+    (endpoint, handle, rx)
+}
+
+/// Extract the set of `(traceId, spanId)` pairs from an OTLP/JSON trace body.
+fn id_pairs(body: &str) -> BTreeSet<(String, String)> {
+    let val: serde_json::Value = serde_json::from_str(body).unwrap();
+    let mut out = BTreeSet::new();
+    for rs in val["resourceSpans"].as_array().into_iter().flatten() {
+        for ss in rs["scopeSpans"].as_array().into_iter().flatten() {
+            for span in ss["spans"].as_array().into_iter().flatten() {
+                let tid = span["traceId"].as_str().unwrap_or("").to_string();
+                let sid = span["spanId"].as_str().unwrap_or("").to_string();
+                out.insert((tid, sid));
+            }
+        }
+    }
+    out
+}
+
+/// Run a tiny single-instance sweep into `output`, emitting live spans to
+/// `live_endpoint`, and return the live-emitted OTLP body.
+async fn run_live_sweep(work: &Path, output: &Path, live_endpoint: String) -> String {
+    let repo = work.join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+    let dataset = work.join("dataset.jsonl");
+    std::fs::create_dir_all(output).unwrap();
+    write_dataset(&dataset, &["repo__DET__1"]);
+
+    let (endpoint, _handle, mut rx) = start_mock_collector().await;
+    let _ = live_endpoint; // mock endpoint chosen here
+    let cfg = config_with_workdir(&repo);
+    let args = swebench_args(
+        dataset,
+        work.to_path_buf(),
+        output.to_path_buf(),
+        cfg,
+        Some(endpoint),
+    );
+    let _ = run_swebench_and_drain(args, &mut rx).await;
+    // Drain the captured live body (traces only).
+    drain_traces(&mut rx).await
+}
+
+async fn run_swebench_and_drain(
+    args: SwebenchArgs,
+    _rx: &mut tokio::sync::mpsc::UnboundedReceiver<(String, String, String)>,
+) -> maxwells_daemon::run::swebench::SweepResults {
+    maxwells_daemon::run::swebench::run(args).await.unwrap()
+}
+
+async fn drain_traces(
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<(String, String, String)>,
+) -> String {
+    // The traces exporter posts exactly one body to /v1/traces at sweep end.
+    loop {
+        match tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv()).await {
+            Ok(Some((path, _hdr, body))) if path.ends_with("/v1/traces") => return body,
+            Ok(Some(_)) => {}
+            _ => panic!("did not receive a /v1/traces export"),
+        }
+    }
+}
+
+// ── success-metric determinism test ─────────────────────────────────────────
+
+#[tokio::test]
+async fn live_and_backfilled_exports_have_identical_ids() {
+    let work = tempfile::tempdir().unwrap();
+    let output = work.path().join("runs");
+
+    // 1. Run the sweep live, capturing the live OTLP body.
+    let live_body = run_live_sweep(work.path(), &output, String::new()).await;
+    let live_ids = id_pairs(&live_body);
+    assert!(!live_ids.is_empty(), "live export emitted no spans");
+
+    // 2. Backfill the same sweep dir via export-otlp into a fresh collector.
+    let (endpoint, _handle, mut rx) = start_mock_collector().await;
+    let summary = run(&ExportOtlpArgs {
+        sweep_dir: output.clone(),
+        otlp_endpoint: Some(endpoint),
+        dry_run: false,
+    })
+    .await
+    .unwrap();
+    assert_eq!(summary.instance_count, 1);
+    assert!(summary.span_count >= 2, "expected sweep + instance spans");
+
+    let export_body = drain_traces(&mut rx).await;
+    let export_ids = id_pairs(&export_body);
+
+    assert_eq!(
+        live_ids, export_ids,
+        "re-exported run must emit identical trace/span IDs as the live export"
+    );
+}
+
+// ── reconstruct() determinism (no network) ──────────────────────────────────
+
+#[tokio::test]
+async fn reconstruct_uses_stable_sweep_id() {
+    let work = tempfile::tempdir().unwrap();
+    let output = work.path().join("runs");
+    // Produce a real sweep dir with a dead endpoint so trace_ids are persisted.
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+    let dataset = work.path().join("dataset.jsonl");
+    std::fs::create_dir_all(&output).unwrap();
+    write_dataset(&dataset, &["repo__REC__1"]);
+    let cfg = config_with_workdir(&repo);
+    let args = swebench_args(
+        dataset,
+        work.path().to_path_buf(),
+        output.clone(),
+        cfg,
+        Some("http://127.0.0.1:1".into()),
+    );
+    maxwells_daemon::run::swebench::run(args).await.unwrap();
+
+    let rec = reconstruct(&output).unwrap();
+    // Recompute the sweep_id from the manifest's started_at_utc.
+    let started = rec.started_at_utc.clone();
+    let expected = compute_sweep_id(&output, &started);
+    assert_eq!(rec.sweep_id, expected);
+    assert_eq!(rec.instance_spans.len(), 1);
+    // Instance trace id matches the persisted/recomputed value.
+    let expected_tid =
+        maxwells_daemon::telemetry::new_trace_id("repo__REC__1", &rec.sweep_id);
+    assert_eq!(rec.instance_spans[0].trace_id, expected_tid);
+}
+
+// ── library-level exit/behavior tests ───────────────────────────────────────
+
+#[tokio::test]
+async fn dry_run_opens_no_socket_and_counts_spans() {
+    let work = tempfile::tempdir().unwrap();
+    let output = work.path().join("runs");
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+    let dataset = work.path().join("dataset.jsonl");
+    std::fs::create_dir_all(&output).unwrap();
+    write_dataset(&dataset, &["repo__DRY__1"]);
+    let cfg = config_with_workdir(&repo);
+    let args = swebench_args(
+        dataset,
+        work.path().to_path_buf(),
+        output.clone(),
+        cfg,
+        Some("http://127.0.0.1:1".into()),
+    );
+    maxwells_daemon::run::swebench::run(args).await.unwrap();
+
+    // Bind a listener we expect to receive ZERO connections during dry-run.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let summary = run(&ExportOtlpArgs {
+        sweep_dir: output,
+        otlp_endpoint: Some(format!("http://{addr}")),
+        dry_run: true,
+    })
+    .await
+    .unwrap();
+
+    assert!(summary.dry_run);
+    assert_eq!(summary.instance_count, 1);
+    assert!(summary.span_count >= 2);
+
+    match listener.accept() {
+        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+        Ok(_) => panic!("dry-run opened a socket to the collector"),
+        Err(e) => panic!("unexpected listener error: {e}"),
+    }
+
+    let text = render_text(&summary);
+    assert!(text.to_lowercase().contains("dry"));
+    assert!(text.contains('1'));
+}
+
+#[tokio::test]
+async fn successful_export_reports_counts() {
+    let work = tempfile::tempdir().unwrap();
+    let output = work.path().join("runs");
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+    let dataset = work.path().join("dataset.jsonl");
+    std::fs::create_dir_all(&output).unwrap();
+    write_dataset(&dataset, &["repo__OK__1"]);
+    let cfg = config_with_workdir(&repo);
+    let args = swebench_args(
+        dataset,
+        work.path().to_path_buf(),
+        output.clone(),
+        cfg,
+        Some("http://127.0.0.1:1".into()),
+    );
+    maxwells_daemon::run::swebench::run(args).await.unwrap();
+
+    let (endpoint, _handle, mut rx) = start_mock_collector().await;
+    let summary = run(&ExportOtlpArgs {
+        sweep_dir: output,
+        otlp_endpoint: Some(endpoint),
+        dry_run: false,
+    })
+    .await
+    .unwrap();
+    assert_eq!(summary.instance_count, 1);
+    assert!(summary.span_count >= 2);
+    // Collector received exactly one /v1/traces body.
+    let body = drain_traces(&mut rx).await;
+    assert!(!id_pairs(&body).is_empty());
+}
+
+#[tokio::test]
+async fn unreachable_collector_is_preflight_error() {
+    let work = tempfile::tempdir().unwrap();
+    let output = work.path().join("runs");
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+    let dataset = work.path().join("dataset.jsonl");
+    std::fs::create_dir_all(&output).unwrap();
+    write_dataset(&dataset, &["repo__DOWN__1"]);
+    let cfg = config_with_workdir(&repo);
+    let args = swebench_args(
+        dataset,
+        work.path().to_path_buf(),
+        output.clone(),
+        cfg,
+        Some("http://127.0.0.1:1".into()),
+    );
+    maxwells_daemon::run::swebench::run(args).await.unwrap();
+
+    let err = run(&ExportOtlpArgs {
+        sweep_dir: output,
+        otlp_endpoint: Some("http://127.0.0.1:1".into()),
+        dry_run: false,
+    })
+    .await
+    .unwrap_err();
+    assert_eq!(
+        maxwells_daemon::exit_code::ExitCode::from_error(&err),
+        maxwells_daemon::exit_code::ExitCode::PreflightFailure
+    );
+}
+
+#[tokio::test]
+async fn missing_endpoint_is_usage_error() {
+    let _guard = env_var_lock();
+    // SAFETY: serialized by env_var_lock.
+    unsafe {
+        std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
+        std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
+    }
+    let work = tempfile::tempdir().unwrap();
+    let output = work.path().join("runs");
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+    let dataset = work.path().join("dataset.jsonl");
+    std::fs::create_dir_all(&output).unwrap();
+    write_dataset(&dataset, &["repo__NOEP__1"]);
+    let cfg = config_with_workdir(&repo);
+    let args = swebench_args(
+        dataset,
+        work.path().to_path_buf(),
+        output.clone(),
+        cfg,
+        Some("http://127.0.0.1:1".into()),
+    );
+    maxwells_daemon::run::swebench::run(args).await.unwrap();
+
+    let err = run(&ExportOtlpArgs {
+        sweep_dir: output,
+        otlp_endpoint: None,
+        dry_run: false,
+    })
+    .await
+    .unwrap_err();
+    assert_eq!(
+        maxwells_daemon::exit_code::ExitCode::from_error(&err),
+        maxwells_daemon::exit_code::ExitCode::UsageError
+    );
+}
+
+#[tokio::test]
+async fn missing_sweep_dir_is_usage_error() {
+    let work = tempfile::tempdir().unwrap();
+    let err = run(&ExportOtlpArgs {
+        sweep_dir: work.path().join("does-not-exist"),
+        otlp_endpoint: Some("http://127.0.0.1:4318".into()),
+        dry_run: false,
+    })
+    .await
+    .unwrap_err();
+    assert_eq!(
+        maxwells_daemon::exit_code::ExitCode::from_error(&err),
+        maxwells_daemon::exit_code::ExitCode::UsageError
+    );
+}
+
+#[tokio::test]
+async fn endpoint_flag_beats_env() {
+    let _guard = env_var_lock();
+    // SAFETY: serialized by env_var_lock.
+    unsafe {
+        std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-host:4318");
+        std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
+    }
+    let work = tempfile::tempdir().unwrap();
+    let output = work.path().join("runs");
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+    let dataset = work.path().join("dataset.jsonl");
+    std::fs::create_dir_all(&output).unwrap();
+    write_dataset(&dataset, &["repo__PREC__1"]);
+    let cfg = config_with_workdir(&repo);
+    let args = swebench_args(
+        dataset,
+        work.path().to_path_buf(),
+        output.clone(),
+        cfg,
+        Some("http://127.0.0.1:1".into()),
+    );
+    maxwells_daemon::run::swebench::run(args).await.unwrap();
+
+    let (endpoint, _handle, mut rx) = start_mock_collector().await;
+    let summary = run(&ExportOtlpArgs {
+        sweep_dir: output,
+        otlp_endpoint: Some(endpoint.clone()),
+        dry_run: false,
+    })
+    .await
+    .unwrap();
+    // The flag endpoint must have been used, not the env var.
+    assert_eq!(summary.endpoint.as_deref(), Some(format!("{endpoint}/v1/traces").as_str()));
+    unsafe {
+        std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
+    }
+    let _ = drain_traces(&mut rx).await;
+}
+
+#[tokio::test]
+async fn otlp_headers_from_env_are_sent() {
+    let _guard = env_var_lock();
+    // SAFETY: serialized by env_var_lock.
+    unsafe {
+        std::env::set_var("OTEL_EXPORTER_OTLP_HEADERS", "x-export-otlp-test=tok123");
+        std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_HEADERS");
+    }
+    let work = tempfile::tempdir().unwrap();
+    let output = work.path().join("runs");
+    let repo = work.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+    let dataset = work.path().join("dataset.jsonl");
+    std::fs::create_dir_all(&output).unwrap();
+    write_dataset(&dataset, &["repo__HDR__1"]);
+    let cfg = config_with_workdir(&repo);
+    let args = swebench_args(
+        dataset,
+        work.path().to_path_buf(),
+        output.clone(),
+        cfg,
+        Some("http://127.0.0.1:1".into()),
+    );
+    maxwells_daemon::run::swebench::run(args).await.unwrap();
+
+    let (endpoint, _handle, mut rx) = start_mock_collector().await;
+    run(&ExportOtlpArgs {
+        sweep_dir: output,
+        otlp_endpoint: Some(endpoint),
+        dry_run: false,
+    })
+    .await
+    .unwrap();
+
+    // Collect the headers of the /v1/traces request.
+    let headers = loop {
+        match tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv()).await {
+            Ok(Some((path, hdr, _body))) if path.ends_with("/v1/traces") => break hdr,
+            Ok(Some(_)) => {}
+            _ => panic!("did not receive a /v1/traces export"),
+        }
+    };
+    // SAFETY: serialized by env_var_lock.
+    unsafe {
+        std::env::remove_var("OTEL_EXPORTER_OTLP_HEADERS");
+    }
+    assert!(
+        headers.to_lowercase().contains("x-export-otlp-test: tok123"),
+        "expected auth header forwarded to collector; got:\n{headers}"
+    );
+}
+
+// ── CLI-level exit-code tests ───────────────────────────────────────────────
+
+#[test]
+fn cli_missing_sweep_dir_exits_2() {
+    let work = tempfile::tempdir().unwrap();
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "export-otlp",
+            "--sweep",
+            work.path().join("nope").to_str().unwrap(),
+            "--otlp-endpoint",
+            "http://127.0.0.1:4318",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(2), "expected usage_error (2)");
+}
+
+#[test]
+fn cli_help_lists_command() {
+    let out = Command::new(binary_path())
+        .args(["bench", "export-otlp", "--help"])
+        .output()
+        .unwrap();
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(help.contains("--sweep"));
+    assert!(help.contains("--otlp-endpoint"));
+    assert!(help.contains("--dry-run"));
+}

--- a/tests/bench_export_otlp.rs
+++ b/tests/bench_export_otlp.rs
@@ -173,8 +173,7 @@ async fn start_mock_collector() -> (
                         Ok(n) => {
                             read_bytes += n;
                             if let Some(pos) = find_subsequence(&buf[..read_bytes], b"\r\n\r\n") {
-                                let headers_part =
-                                    String::from_utf8_lossy(&buf[..pos]).to_string();
+                                let headers_part = String::from_utf8_lossy(&buf[..pos]).to_string();
                                 let mut content_len = 0;
                                 for line in headers_part.lines() {
                                     if line.to_lowercase().starts_with("content-length:") {
@@ -198,8 +197,7 @@ async fn start_mock_collector() -> (
                                         .unwrap_or("")
                                         .to_string();
                                     let _ = tx.send((path, headers_part, body));
-                                    let response =
-                                        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}";
+                                    let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}";
                                     let _ = stream.write_all(response.as_bytes()).await;
                                     break;
                                 }
@@ -337,8 +335,7 @@ async fn reconstruct_uses_stable_sweep_id() {
     assert_eq!(rec.sweep_id, expected);
     assert_eq!(rec.instance_spans.len(), 1);
     // Instance trace id matches the persisted/recomputed value.
-    let expected_tid =
-        maxwells_daemon::telemetry::new_trace_id("repo__REC__1", &rec.sweep_id);
+    let expected_tid = maxwells_daemon::telemetry::new_trace_id("repo__REC__1", &rec.sweep_id);
     assert_eq!(rec.instance_spans[0].trace_id, expected_tid);
 }
 
@@ -550,7 +547,10 @@ async fn endpoint_flag_beats_env() {
     .await
     .unwrap();
     // The flag endpoint must have been used, not the env var.
-    assert_eq!(summary.endpoint.as_deref(), Some(format!("{endpoint}/v1/traces").as_str()));
+    assert_eq!(
+        summary.endpoint.as_deref(),
+        Some(format!("{endpoint}/v1/traces").as_str())
+    );
     unsafe {
         std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
     }
@@ -605,7 +605,9 @@ async fn otlp_headers_from_env_are_sent() {
         std::env::remove_var("OTEL_EXPORTER_OTLP_HEADERS");
     }
     assert!(
-        headers.to_lowercase().contains("x-export-otlp-test: tok123"),
+        headers
+            .to_lowercase()
+            .contains("x-export-otlp-test: tok123"),
         "expected auth header forwarded to collector; got:\n{headers}"
     );
 }


### PR DESCRIPTION
OTLP trace export was live-only: spans were emitted during a sweep and only
when an endpoint was configured at launch. Headless/cron runs (or a collector
outage) lost their spans permanently even though trajectories persist on disk.

This adds `bench export-otlp --sweep <DIR> [--otlp-endpoint <URL>] [--dry-run]`,
which reconstructs sweep + instance spans from the on-disk artifacts and
re-exports them via the same OTLP/HTTP exporter and span shape as the live path.

Determinism: the sweep-level ID is recomputed with the shared
`swebench::compute_sweep_id` helper (extracted from the live path) and instance
trace IDs reuse the persisted `trace_id` (or recompute via `new_trace_id`), so a
backfilled run and a live-exported run emit byte-identical trace/span IDs.

- endpoint precedence reuses `telemetry::resolve_endpoint` (flag >
  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT > OTEL_EXPORTER_OTLP_ENDPOINT); none -> exit 2
- auth headers honor the existing `resolve_otlp_headers()` env contract
- exit 0 on success (reports instance/span counts), exit 3 if the collector is
  unreachable/rejects, exit 2 on missing/invalid sweep dir or unresolved endpoint
- `--dry-run` reconstructs and counts spans, opens no socket, exits 0
- docs/spec-export-otlp.md + exit-codes.md row (no new exit codes)

Reads only on-disk artifacts; never re-runs instances or mutates the sweep.