### PR TITLE
👺 Havoc: Fix panic due to arbitrary string truncation on byte boundaries

### DIFF
--- a/src/run/instance_history.rs
+++ b/src/run/instance_history.rs
@@ -740,7 +740,15 @@ pub fn render_text(
 }
 
 fn truncate(s: &str, max: usize) -> &str {
-    if s.len() <= max { s } else { &s[..max] }
+    if s.len() <= max {
+        s
+    } else {
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        &s[..end]
+    }
 }
 
 // ── write output ──────────────────────────────────────────────────────────────
@@ -764,6 +772,11 @@ pub fn write_output(report: &InstanceHistoryReport, path: &Path) -> Result<(), E
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn truncate_panics_on_non_char_boundary() {
+        assert_eq!(truncate("こんにちは世界", 2), "");
+    }
 
     #[test]
     fn classify_default_threshold() {


### PR DESCRIPTION
🧨 **The Trigger:** String slicing with arbitrary max values (e.g., `&s[..max]`) causes runtime panic when the index splits a multi-byte UTF-8 character.
📉 **The Stack Trace:**
```text
thread 'test_char_boundary_panic' (35333) panicked at test_havoc.rs:7:42:
byte index 2 is not a char boundary; it is inside 'こ' (bytes 0..3) of `こんにちは世界`
```
🧪 **Reproduction:** "Run `cargo test --lib -- tests::truncate_panics_on_non_char_boundary` on the code before the fix."
😈 **Comment:** "You assumed UTF-8 characters were 1 byte long. You were wrong."

---
*PR created automatically by Jules for task [15914022872661344533](https://jules.google.com/task/15914022872661344533) started by @madmax983*