### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -471,7 +471,7 @@ impl Redactor {
 
     /// Run redaction and return per-match annotations for operator verification.
     ///
-    /// Unlike [`redact_text`], this method does not update surface-level telemetry
+    /// Unlike [`Self::redact_text`], this method does not update surface-level telemetry
     /// counts and does not require a surface label. It is designed for the
     /// `agent redact-check` preflight command.
     #[must_use]

--- a/src/run/claude_driver.rs
+++ b/src/run/claude_driver.rs
@@ -412,6 +412,7 @@ fn record_claude_config(agent: &mut DefaultAgent, cwd: &Path, isolated: bool) {
 ///   reproducible measurement run. Note: `--bare` forces API-key-only auth, so
 ///   OAuth/keychain logins do not apply in this mode.
 #[allow(clippy::too_many_lines)]
+#[allow(rustdoc::private_intra_doc_links)]
 pub async fn drive(
     agent: &mut DefaultAgent,
     task: String,

--- a/src/run/codex_driver.rs
+++ b/src/run/codex_driver.rs
@@ -3,7 +3,7 @@
 //! Similar to `claude_driver.rs`, this module lets an operator point the *same*
 //! run machinery at the OpenAI Codex CLI instead of the built-in bash-first loop.
 //! `codex` runs in `--full-auto --json` mode; we read its newline-delimited JSON
-//! stream and translate each event into the harness [`Trajectory`] format so that
+//! stream and translate each event into the harness [`crate::trajectory::Trajectory`] format so that
 //! patch capture, verification, `bench inspect`, and evaluation all keep working
 //! unchanged.
 //!

--- a/src/run/contamination_check.rs
+++ b/src/run/contamination_check.rs
@@ -6,9 +6,9 @@
 //!
 //! | Signal | Description | Range |
 //! |--------|-------------|-------|
-//! | `edit_before_read_ratio` | Fraction of edited files never read before patching | [0,1] |
-//! | `patch_similarity_to_gold` | Normalised similarity between agent patch and gold patch | [0,1] |
-//! | `time_to_first_edit` | Suspicion from early first edit (step 0 → 1.0, last step → 0.0) | [0,1] |
+//! | `edit_before_read_ratio` | Fraction of edited files never read before patching | \[0,1\] |
+//! | `patch_similarity_to_gold` | Normalised similarity between agent patch and gold patch | \[0,1\] |
+//! | `time_to_first_edit` | Suspicion from early first edit (step 0 → 1.0, last step → 0.0) | \[0,1\] |
 //! | `verbatim_recall` | Whether agent message contains ≥ N tokens from gold patch surface | {0,1} |
 //!
 //! # Risk tiers

--- a/src/run/redact_audit.rs
+++ b/src/run/redact_audit.rs
@@ -1,6 +1,6 @@
 //! `agent redact-audit <dir>` — post-hoc secret-leak detection for sweep artifacts.
 //!
-//! Issue #342. The runtime [`Redactor`](crate::redaction::Redactor) masks secrets
+//! Issue #342. The runtime [`crate::redaction::Redactor`] masks secrets
 //! *at write-time* and explicitly does not retroactively rewrite stored
 //! artifacts. Trajectories and sweep outputs are routinely shared (PRs, HTML
 //! exports, bundles), so a redaction-config bug or an unanticipated secret shape

--- a/src/run/ui.rs
+++ b/src/run/ui.rs
@@ -39,7 +39,7 @@ pub struct InstanceEntry {
     pub traj_path: PathBuf,
 }
 
-/// Arguments forwarded from the CLI to [`run`].
+/// Arguments forwarded from the CLI to [`run`](crate::cli::run).
 pub struct UiArgs {
     pub sweep: PathBuf,
     pub port: u16,


### PR DESCRIPTION
📖 Chapter: Fixes broken links and warnings in documentation for `run` modules and `redaction.rs`.
🔦 Insight: Fixed intra-doc links, escaped bracketed ranges, and resolved redundant explicit targets.
🧪 Example: Verified via `cargo doc --no-deps`.
🖼️ Preview: Documentation builds without warnings now.

---
*PR created automatically by Jules for task [10415394691686326573](https://jules.google.com/task/10415394691686326573) started by @madmax983*