### PR TITLE
🎨 Mosaic: UI Polish for Catalog

### DIFF
--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -1,6 +1,6 @@
 use super::args::CatalogCmd;
 use crate::error::Error;
-use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+use comfy_table::{Cell, Color, Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 use serde::Serialize;
 
 pub const STAGES: &[&str] = &["preflight", "run", "inspect", "analyze", "publish"];
@@ -509,10 +509,26 @@ pub fn run_catalog(cmd: CatalogCmd) -> Result<(), Error> {
     table
         .load_preset(UTF8_FULL)
         .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_header(["Command", "Summary", "Cost", "Stage"]);
+        .set_header(vec![
+            Cell::new("Command").fg(Color::Cyan),
+            Cell::new("Summary").fg(Color::White),
+            Cell::new("Cost").fg(Color::Cyan),
+            Cell::new("Stage").fg(Color::Cyan),
+        ]);
 
     for entry in &filtered {
-        table.add_row([entry.path, entry.summary, entry.cost_tier, entry.stage]);
+        let cost_color = if entry.cost_tier == "free" {
+            Color::Green
+        } else {
+            Color::Yellow
+        };
+
+        table.add_row(vec![
+            Cell::new(entry.path).fg(Color::Cyan),
+            Cell::new(entry.summary),
+            Cell::new(entry.cost_tier).fg(cost_color),
+            Cell::new(entry.stage).fg(Color::Magenta),
+        ]);
     }
 
     println!("{table}");


### PR DESCRIPTION
🖌️ Before: The `max catalog` command output was a plain monochrome text wall, lacking visual hierarchy and making it harder for operators to scan through cost tiers and command stages quickly.
✨ After: Added `comfy-table` color styling to the catalog TUI. Command names are now distinct, the stage is color-coded, and crucially, the cost tier is explicitly highlighted (green for free, yellow for paid) to follow the feedback loop principle.
🖼️ Visuals: Command column is Cyan, Summary is default (White), Cost is Green/Yellow, and Stage is Magenta. Headers are also styled for better pop.

---
*PR created automatically by Jules for task [16309682880134175726](https://jules.google.com/task/16309682880134175726) started by @madmax983*