### PR TITLE
⚡ Bolt: Remove intermediate vector allocations in string join chains

### DIFF
--- a/src/run/calibrate.rs
+++ b/src/run/calibrate.rs
@@ -583,7 +583,16 @@ fn build_mismatches(
 }
 
 fn sorted_join(values: BTreeSet<&str>) -> String {
-    values.into_iter().collect::<Vec<_>>().join(",")
+    let cap = values.iter().map(|s| s.len()).sum::<usize>() + values.len().saturating_sub(1);
+    values
+        .into_iter()
+        .fold(String::with_capacity(cap), |mut acc, s| {
+            if !acc.is_empty() {
+                acc.push(',');
+            }
+            acc.push_str(s);
+            acc
+        })
 }
 
 fn compare_field(

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -549,7 +549,14 @@ fn normalize_search_text(text: &str) -> String {
             out.push(' ');
         }
     }
-    out.split_whitespace().collect::<Vec<_>>().join(" ")
+    out.split_whitespace()
+        .fold(String::with_capacity(out.len()), |mut acc, s| {
+            if !acc.is_empty() {
+                acc.push(' ');
+            }
+            acc.push_str(s);
+            acc
+        })
 }
 
 fn is_stopword(token: &str) -> bool {


### PR DESCRIPTION
💡 What: Replaced `.collect::<Vec<_>>().join(...)` with iterator `.fold(...)` using pre-allocated strings across two hot paths (`src/skills.rs` and `src/run/calibrate.rs`).
🎯 Why: Collecting into intermediate vectors causes unnecessary heap allocations. Using `.fold()` with `String::with_capacity()` avoids this.
📊 Impact: Eliminates multiple vector allocations and string re-allocations on hot paths.
🔬 Measurement: Verify with `cargo test --lib skills run::calibrate` and observe improved memory profile during heavy runs.

---
*PR created automatically by Jules for task [16946301680844860538](https://jules.google.com/task/16946301680844860538) started by @madmax983*