### PR TITLE
🌟 Nova: [Jupyter Notebook Exporter]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+jupyter-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
 

--- a/docs/spec-inspect.md
+++ b/docs/spec-inspect.md
@@ -15,6 +15,7 @@ max bench inspect --sweep <dir> --instance <instance_id> --format markdown --out
 max bench inspect --sweep <dir> --instance <instance_id> --format html --output traj.html
 max bench inspect --sweep <dir> --instance <instance_id> --format csv --output traj.csv
 max bench inspect --sweep <dir> --instance <instance_id> --format mermaid --output traj.mmd
+max bench inspect --sweep <dir> --instance <instance_id> --format jupyter --output traj.ipynb
 max bench inspect --sweep <dir> --instance <instance_id> --show-expected
 max bench inspect --sweep <dir> --filter resolved=false
 max bench inspect --sweep <dir> --filter failure_category=step_limit
@@ -40,13 +41,14 @@ max bench compare --baseline <dir> --candidate <dir> --emit-diff-script <out.sh>
   | `html`     | Self-contained HTML (inline CSS, no external refs)     | `html-export`          |
   | `csv`      | Flat CSV with `role` and `content` columns             | `csv-export`           |
   | `mermaid`  | Mermaid `sequenceDiagram` of the conversation          | `mermaid-export`       |
+  | `jupyter`  | Jupyter Notebook (`.ipynb`) with Markdown cells        | `jupyter-export`       |
   | `unified`  | Unified diff (diff mode only)                          | —                      |
 
   When the binary is built without the required feature, `--format <name>` exits
   with a `format_unavailable` error naming the missing feature. See
   [`src/trajectory/export.rs`](../src/trajectory/export.rs) for exporter unit tests.
 * `--output <PATH>`: write output to a file instead of stdout. Supported with
-  `markdown`, `html`, `csv`, and `mermaid` formats in instance mode. Stdout is
+  `markdown`, `html`, `csv`, `mermaid`, and `jupyter` formats in instance mode. Stdout is
   empty when `--output` is set.
 * `--full`: disable stdout/stderr truncation in transcript mode.
 * `--show-expected`: also print `PASS_TO_PASS` / `FAIL_TO_PASS` expected-test groupings read
@@ -59,7 +61,7 @@ max bench compare --baseline <dir> --candidate <dir> --emit-diff-script <out.sh>
 Exactly one of `--instance` or `--filter` is required.
 Diff mode is separate and cannot be combined with `--sweep`, `--instance`, or
 `--filter`.
-Export formats (`markdown`, `html`, `csv`, `mermaid`) require `--instance` and
+Export formats (`markdown`, `html`, `csv`, `mermaid`, `jupyter`) require `--instance` and
 `--sweep`; they cannot be combined with `--filter`.
 
 ### Output redaction

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2927,14 +2927,14 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`, and `jupyter`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `jupyter` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3702,13 +3702,16 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "jupyter"
+    ) {
         return bench_inspect_export(i);
     }
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/jupyter), not `{}`",
             i.format
         ))));
     }
@@ -3718,7 +3721,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         "json" => crate::run::inspect::InspectFormat::Json,
         other => {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, or `mermaid`)"
+                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, `mermaid`, or `jupyter`)"
             ))));
         }
     };
@@ -3760,7 +3763,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     })?;
     let instance_id = i.instance.as_deref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
-            "inspect: --instance is required for export formats (markdown/html/csv/mermaid)".into(),
+            "inspect: --instance is required for export formats (markdown/html/csv/mermaid/jupyter)".into(),
         ))
     })?;
     let traj_path =
@@ -3782,6 +3785,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "jupyter" => inspect_export_jupyter(&traj)?,
         _ => unreachable!("dispatch guarded by caller"),
     };
 
@@ -3867,6 +3871,22 @@ fn inspect_export_mermaid(_traj: &crate::trajectory::Trajectory) -> Result<Strin
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "format_unavailable: --format mermaid requires the `mermaid-export` Cargo feature; \
          rebuild with `--features mermaid-export`"
+            .into(),
+    )))
+}
+
+#[cfg(feature = "jupyter-export")]
+#[allow(clippy::unnecessary_wraps)]
+fn inspect_export_jupyter(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    use crate::trajectory::export::{JupyterExporter, TrajectoryExporter};
+    Ok(JupyterExporter::export(traj))
+}
+
+#[cfg(not(feature = "jupyter-export"))]
+fn inspect_export_jupyter(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "format_unavailable: --format jupyter requires the `jupyter-export` Cargo feature; \
+         rebuild with `--features jupyter-export`"
             .into(),
     )))
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -53,6 +53,9 @@ pub struct MermaidExporter;
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
+#[cfg(feature = "jupyter-export")]
+pub struct JupyterExporter;
+
 use std::fmt::Write;
 
 #[cfg(feature = "csv-export")]
@@ -245,6 +248,55 @@ impl TrajectoryExporter for MermaidExporter {
     }
 }
 
+#[cfg(feature = "jupyter-export")]
+impl TrajectoryExporter for JupyterExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut cells = Vec::new();
+
+        let mut first_cell_source = String::from("# Trajectory Export\n\n");
+        if let Some(task) = &trajectory.info.task {
+            let task = redactor.redact_text(task, surface::EXPORT).text;
+            let _ = write!(first_cell_source, "**Task:** {task}\n\n");
+        }
+        if let Some(outcome) = &trajectory.info.outcome {
+            let outcome = redactor.redact_text(outcome, surface::EXPORT).text;
+            let _ = write!(first_cell_source, "**Outcome:** {outcome}\n\n");
+        }
+        cells.push(serde_json::json!({
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [first_cell_source]
+        }));
+
+        for msg in &trajectory.messages {
+            let role_title = match msg.role.as_str() {
+                "system" => "System",
+                "user" => "User",
+                "assistant" => "Assistant",
+                "tool" => "Tool",
+                other => other,
+            };
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            let source = format!("### {role_title}\n\n{content}\n\n");
+            cells.push(serde_json::json!({
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": [source]
+            }));
+        }
+
+        let notebook = serde_json::json!({
+            "cells": cells,
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5
+        });
+
+        serde_json::to_string_pretty(&notebook).unwrap_or_default()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -339,5 +391,23 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+
+    #[cfg(feature = "jupyter-export")]
+    #[test]
+    fn test_jupyter_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some("submitted".to_string());
+
+        t.record_message(&Message::user("Hello agent"));
+
+        let jupyter = JupyterExporter::export(&t);
+
+        assert!(jupyter.contains("\"nbformat\": 4"));
+        assert!(jupyter.contains("Add a feature"));
+        assert!(jupyter.contains("submitted"));
+        assert!(jupyter.contains("Hello agent"));
+        assert!(jupyter.contains("### User"));
     }
 }


### PR DESCRIPTION
💡 The Spark: The agent's output is dense for humans but structured. We have several exporters, but data scientists and researchers often use Jupyter Notebooks for analysis. Providing an export format directly to `.ipynb` would bridge the gap.

🚀 The Feature: Implemented `JupyterExporter` that formats a trajectory into a Jupyter Notebook file, creating a Markdown cell for each message. Added the corresponding `--format jupyter` to CLI and `jupyter-export` Cargo feature.

🔮 The Potential: Opens up new avenues for researchers to easily load, analyze, and visualize agent interactions within their existing data science workflows.

⚠️ Risk: Low. Isolated in the trajectory export module and behind the `jupyter-export` feature flag.

---
*PR created automatically by Jules for task [5099009661373443995](https://jules.google.com/task/5099009661373443995) started by @madmax983*