### PR TITLE
⚒️ Forge: [refactor manual loops]

### DIFF
--- a/src/run/behavior.rs
+++ b/src/run/behavior.rs
@@ -1043,14 +1043,12 @@ fn resolve_trajectory_paths(sweep: &Path, instance_id: &str) -> Vec<PathBuf> {
     let instance_dir = sweep.join(instance_id);
     if instance_dir.is_dir() {
         let mut run_paths = Vec::new();
-        let mut n = 1usize;
-        loop {
+        for n in 1.. {
             let p = instance_dir.join(format!("run-{n}.traj.json"));
             if !p.exists() {
                 break;
             }
             run_paths.push(p);
-            n += 1;
         }
         if !run_paths.is_empty() {
             return run_paths;

--- a/src/run/claude_driver.rs
+++ b/src/run/claude_driver.rs
@@ -541,18 +541,16 @@ pub async fn drive(
             let mut retained: Vec<u8> = Vec::new();
             let mut tmp = [0u8; 8192];
             let mut stderr = stderr;
-            loop {
-                match stderr.read(&mut tmp).await {
-                    Ok(0) | Err(_) => break,
-                    Ok(n) => {
-                        if retained.len() < CAP {
-                            let take = (CAP - retained.len()).min(n);
-                            retained.extend_from_slice(&tmp[..take]);
-                        }
-                        // Continue reading (and discarding) past the cap so
-                        // the child's write end is never blocked.
-                    }
+            while let Ok(n) = stderr.read(&mut tmp).await {
+                if n == 0 {
+                    break;
                 }
+                if retained.len() < CAP {
+                    let take = (CAP - retained.len()).min(n);
+                    retained.extend_from_slice(&tmp[..take]);
+                }
+                // Continue reading (and discarding) past the cap so
+                // the child's write end is never blocked.
             }
             String::from_utf8_lossy(&retained).into_owned()
         })

--- a/src/run/codex_driver.rs
+++ b/src/run/codex_driver.rs
@@ -171,15 +171,13 @@ pub async fn drive(
             let mut retained: Vec<u8> = Vec::new();
             let mut tmp = [0u8; 8192];
             let mut stderr = stderr;
-            loop {
-                match stderr.read(&mut tmp).await {
-                    Ok(0) | Err(_) => break,
-                    Ok(n) => {
-                        if retained.len() < CAP {
-                            let take = (CAP - retained.len()).min(n);
-                            retained.extend_from_slice(&tmp[..take]);
-                        }
-                    }
+            while let Ok(n) = stderr.read(&mut tmp).await {
+                if n == 0 {
+                    break;
+                }
+                if retained.len() < CAP {
+                    let take = (CAP - retained.len()).min(n);
+                    retained.extend_from_slice(&tmp[..take]);
                 }
             }
             String::from_utf8_lossy(&retained).into_owned()

--- a/src/run/command_stats.rs
+++ b/src/run/command_stats.rs
@@ -648,14 +648,12 @@ fn resolve_trajectory_paths(sweep: &Path, instance_id: &str) -> Vec<PathBuf> {
     let instance_dir = sweep.join(instance_id);
     if instance_dir.is_dir() {
         let mut run_paths = Vec::new();
-        let mut n = 1usize;
-        loop {
+        for n in 1.. {
             let p = instance_dir.join(format!("run-{n}.traj.json"));
             if !p.exists() {
                 break;
             }
             run_paths.push(p);
-            n += 1;
         }
         if !run_paths.is_empty() {
             return run_paths;

--- a/src/run/reproduce.rs
+++ b/src/run/reproduce.rs
@@ -476,11 +476,13 @@ fn hash_file_sha256(path: &Path) -> Option<[u8; 32]> {
     let mut hasher = Sha256::new();
     let mut buf = [0u8; 8192];
     loop {
-        match reader.read(&mut buf) {
-            Ok(0) => break,
-            Ok(n) => hasher.update(&buf[..n]),
-            Err(_) => return None,
+        let Ok(n) = reader.read(&mut buf) else {
+            return None;
+        };
+        if n == 0 {
+            break;
         }
+        hasher.update(&buf[..n]);
     }
     Some(hasher.finalize().into())
 }


### PR DESCRIPTION
🚬 Smell: Usage of raw `loop` with internal counters or `match` statements where `for` loops or `while let`/`let else` bindings would be cleaner.
✨ Solution: Replaced explicit `n += 1` loops with `for n in 1..`. Replaced nested `match` inside `loop` with `while let` or early returns via guard clauses (`let else`).
🧼 Benefit: Reduces nesting and cognitive load, embracing standard idiomatic Rust constructs.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [6996014265316627725](https://jules.google.com/task/6996014265316627725) started by @madmax983*