### PR TITLE
👺 Havoc: [Fix unbounded pipe reading in local and docker envs causing OOM]

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -329,13 +329,14 @@ where
     (handle, buffer)
 }
 
-async fn read_pipe_to_buffer<R>(mut pipe: R, buffer: Arc<Mutex<Vec<u8>>>) -> Result<(), EnvError>
+async fn read_pipe_to_buffer<R>(pipe: R, buffer: Arc<Mutex<Vec<u8>>>) -> Result<(), EnvError>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
+    let mut reader = tokio::io::BufReader::new(pipe).take(crate::env::MAX_OUTPUT_BYTES);
     let mut chunk = [0u8; 8192];
     loop {
-        let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
+        let n = reader.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {
             return Ok(());
         }

--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -250,13 +250,14 @@ where
     (handle, buffer)
 }
 
-async fn read_pipe_to_buffer<R>(mut pipe: R, buffer: Arc<Mutex<Vec<u8>>>) -> Result<(), EnvError>
+async fn read_pipe_to_buffer<R>(pipe: R, buffer: Arc<Mutex<Vec<u8>>>) -> Result<(), EnvError>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
+    let mut reader = tokio::io::BufReader::new(pipe).take(crate::env::MAX_OUTPUT_BYTES);
     let mut chunk = [0u8; 8192];
     loop {
-        let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
+        let n = reader.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {
             return Ok(());
         }

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -18,6 +18,8 @@ pub mod chaos;
 pub mod docker;
 pub mod local;
 
+pub const MAX_OUTPUT_BYTES: u64 = 16 * 1024 * 1024;
+
 /// Stderr sentinel written on a [`RunResult`] synthesized by
 /// [`chaos::ChaosEnvironment`]. The agent loop and `bench inspect` use it to
 /// recognize a chaos-injected timeout and distinguish it from a real one.


### PR DESCRIPTION
👺 Havoc: [Fix unbounded pipe reading in local and docker envs causing OOM]

🧨 The Trigger: A process outputting massive logs via stdout or stderr.
📉 The Stack Trace: None available (simulated memory exhaustion).
🧪 Reproduction: Spawn a process that loops indefinitely printing text in either environment.
😈 Comment: You assumed the buffer would never be larger than RAM. You were wrong.

---
*PR created automatically by Jules for task [18154114575017985212](https://jules.google.com/task/18154114575017985212) started by @madmax983*