### PR TITLE
🌟 Nova: [JSON Exporter]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+json-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
 

--- a/docs/spec-inspect.md
+++ b/docs/spec-inspect.md
@@ -40,13 +40,14 @@ max bench compare --baseline <dir> --candidate <dir> --emit-diff-script <out.sh>
   | `html`     | Self-contained HTML (inline CSS, no external refs)     | `html-export`          |
   | `csv`      | Flat CSV with `role` and `content` columns             | `csv-export`           |
   | `mermaid`  | Mermaid `sequenceDiagram` of the conversation          | `mermaid-export`       |
+  | `json-export` | Redacted trajectory JSON                              | `json-export`          |
   | `unified`  | Unified diff (diff mode only)                          | —                      |
 
   When the binary is built without the required feature, `--format <name>` exits
   with a `format_unavailable` error naming the missing feature. See
   [`src/trajectory/export.rs`](../src/trajectory/export.rs) for exporter unit tests.
 * `--output <PATH>`: write output to a file instead of stdout. Supported with
-  `markdown`, `html`, `csv`, and `mermaid` formats in instance mode. Stdout is
+  `markdown`, `html`, `csv`, `mermaid`, and `json-export` formats in instance mode. Stdout is
   empty when `--output` is set.
 * `--full`: disable stdout/stderr truncation in transcript mode.
 * `--show-expected`: also print `PASS_TO_PASS` / `FAIL_TO_PASS` expected-test groupings read

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2927,14 +2927,14 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
-    /// (each maps to the corresponding trajectory exporter; feature-gated
-    /// formats require the matching Cargo feature at build time).
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`,
+    /// and `json-export` (each maps to the corresponding trajectory exporter;
+    /// feature-gated formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `json-export` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3703,13 +3703,16 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "json-export"
+    ) {
         return bench_inspect_export(i);
     }
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/json-export), not `{}`",
             i.format
         ))));
     }
@@ -3719,7 +3722,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         "json" => crate::run::inspect::InspectFormat::Json,
         other => {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, or `mermaid`)"
+                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, `mermaid`, or `json-export`)"
             ))));
         }
     };
@@ -3783,6 +3786,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "json-export" => inspect_export_json_export(&traj)?,
         _ => unreachable!("dispatch guarded by caller"),
     };
 
@@ -3852,6 +3856,22 @@ fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, E
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "format_unavailable: --format csv requires the `csv-export` Cargo feature; \
          rebuild with `--features csv-export`"
+            .into(),
+    )))
+}
+
+#[cfg(feature = "json-export")]
+#[allow(clippy::unnecessary_wraps)]
+fn inspect_export_json_export(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    use crate::trajectory::export::{JsonExporter, TrajectoryExporter};
+    Ok(JsonExporter::export(traj))
+}
+
+#[cfg(not(feature = "json-export"))]
+fn inspect_export_json_export(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "format_unavailable: --format json-export requires the `json-export` Cargo feature; \
+         rebuild with `--features json-export`"
             .into(),
     )))
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -47,6 +47,9 @@ pub struct MarkdownExporter;
 #[cfg(feature = "csv-export")]
 pub struct CsvExporter;
 
+#[cfg(feature = "json-export")]
+pub struct JsonExporter;
+
 #[cfg(feature = "mermaid-export")]
 pub struct MermaidExporter;
 
@@ -54,6 +57,47 @@ pub struct MermaidExporter;
 pub struct HtmlExporter;
 
 use std::fmt::Write;
+
+#[cfg(feature = "json-export")]
+impl TrajectoryExporter for JsonExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+
+        let Ok(mut val) = serde_json::to_value(trajectory) else {
+            return String::new();
+        };
+
+        if let Some(info) = val.get_mut("info").and_then(|i| i.as_object_mut()) {
+            if let Some(task) = info.get("task").and_then(|t| t.as_str()) {
+                let redacted_task = redactor.redact_text(task, surface::EXPORT).text;
+                info.insert("task".to_string(), serde_json::Value::String(redacted_task));
+            }
+            if let Some(outcome) = info.get("outcome").and_then(|o| o.as_str()) {
+                let redacted_outcome = redactor.redact_text(outcome, surface::EXPORT).text;
+                info.insert(
+                    "outcome".to_string(),
+                    serde_json::Value::String(redacted_outcome),
+                );
+            }
+        }
+
+        if let Some(messages) = val.get_mut("messages").and_then(|m| m.as_array_mut()) {
+            for msg in messages {
+                if let Some(msg_obj) = msg.as_object_mut() {
+                    if let Some(content) = msg_obj.get("content").and_then(|c| c.as_str()) {
+                        let redacted_content = redactor.redact_text(content, surface::EXPORT).text;
+                        msg_obj.insert(
+                            "content".to_string(),
+                            serde_json::Value::String(redacted_content),
+                        );
+                    }
+                }
+            }
+        }
+
+        serde_json::to_string_pretty(&val).unwrap_or_default()
+    }
+}
 
 #[cfg(feature = "csv-export")]
 impl TrajectoryExporter for CsvExporter {
@@ -273,6 +317,29 @@ mod tests {
         assert!(md.contains("Hello agent"));
         assert!(md.contains("### Assistant"));
         assert!(md.contains("Hello user"));
+    }
+
+    #[cfg(feature = "json-export")]
+    #[test]
+    fn test_json_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent\nMulti-line"));
+        t.record_message(&Message::assistant("Hello \"user\""));
+
+        let json = JsonExporter::export(&t);
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&json) {
+            assert_eq!(parsed["info"]["task"], "Add a feature");
+            assert_eq!(parsed["info"]["outcome"], outcome::SUBMITTED.to_string());
+            assert_eq!(parsed["messages"][0]["content"], "System prompt");
+            assert_eq!(parsed["messages"][1]["content"], "Hello agent\nMulti-line");
+            assert_eq!(parsed["messages"][2]["content"], "Hello \"user\"");
+        } else {
+            panic!("Failed to parse JSON export");
+        }
     }
 
     #[cfg(feature = "csv-export")]


### PR DESCRIPTION
💡 **The Spark:** The codebase supports exporting trajectories to Markdown, HTML, CSV, and Mermaid formats, but there isn't a direct way to export a *redacted*, fully structured JSON representation of the trajectory that can be piped or saved directly to a file using the standard exporter pattern.
🚀 **The Feature:** Implemented `JsonExporter` behind a `json-export` feature flag and exposed it via `--format json-export` in the CLI.
🔮 **The Potential:** Allows operators to export clean, redacted trajectory JSON artifacts that can be safely shared or ingested by external analysis tools that expect JSON rather than Markdown or HTML.
⚠️ **Risk:** Low. The change is isolated behind a feature flag and hooks into the existing `TrajectoryExporter` pattern.

---
*PR created automatically by Jules for task [3320697109006630173](https://jules.google.com/task/3320697109006630173) started by @madmax983*