### PR TITLE
🌟 Nova: Jsonl Exporter

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2927,14 +2927,14 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
-    /// (each maps to the corresponding trajectory exporter; feature-gated
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`,
+    /// and `jsonl` (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `jsonl` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3703,13 +3703,16 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "jsonl"
+    ) {
         return bench_inspect_export(i);
     }
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/jsonl), not `{}`",
             i.format
         ))));
     }
@@ -3719,7 +3722,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         "json" => crate::run::inspect::InspectFormat::Json,
         other => {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, or `mermaid`)"
+                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, `mermaid`, or `jsonl`)"
             ))));
         }
     };
@@ -3761,7 +3764,8 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     })?;
     let instance_id = i.instance.as_deref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
-            "inspect: --instance is required for export formats (markdown/html/csv/mermaid)".into(),
+            "inspect: --instance is required for export formats (markdown/html/csv/mermaid/jsonl)"
+                .into(),
         ))
     })?;
     let traj_path =
@@ -3779,6 +3783,10 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "markdown" => {
             use crate::trajectory::export::{MarkdownExporter, TrajectoryExporter};
             MarkdownExporter::export(&traj)
+        }
+        "jsonl" => {
+            use crate::trajectory::export::{JsonlFinetuneExporter, TrajectoryExporter};
+            JsonlFinetuneExporter::export(&traj)
         }
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -53,6 +53,12 @@ pub struct MermaidExporter;
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
+/// Transforms a [`Trajectory`] into a single-line JSONL format containing a `"messages"` array.
+///
+/// This format is designed for OpenAI-compatible fine-tuning, extracting only
+/// the conversation flow.
+pub struct JsonlFinetuneExporter;
+
 use std::fmt::Write;
 
 #[cfg(feature = "csv-export")]
@@ -116,6 +122,27 @@ impl TrajectoryExporter for MarkdownExporter {
         }
 
         md
+    }
+}
+
+impl TrajectoryExporter for JsonlFinetuneExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+
+        let messages: Vec<serde_json::Value> = trajectory
+            .messages
+            .iter()
+            .map(|msg| {
+                let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+                serde_json::json!({
+                    "role": msg.role,
+                    "content": content
+                })
+            })
+            .collect();
+
+        serde_json::to_string(&serde_json::json!({ "messages": messages }))
+            .unwrap_or_else(|_| r#"{"messages":[]}"#.to_string())
     }
 }
 
@@ -319,6 +346,24 @@ mod tests {
         assert!(mermaid.contains("U->>A: Hello \"user\""));
 
         assert!(mermaid.contains("Note over S,T: Outcome: submitted"));
+    }
+    #[test]
+    fn test_jsonl_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some("submitted".to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent\nMulti-line"));
+        t.record_message(&Message::assistant("Hello \"user\""));
+
+        let jsonl = JsonlFinetuneExporter::export(&t);
+
+        assert!(jsonl.starts_with(r#"{"messages":["#));
+        assert!(jsonl.contains(r#"{"content":"System prompt","role":"system"}"#));
+        assert!(jsonl.contains(r#"{"content":"Hello agent\nMulti-line","role":"user"}"#));
+        assert!(jsonl.contains(r#"{"content":"Hello \"user\"","role":"assistant"}"#));
+        assert!(!jsonl.contains('\n'));
     }
 
     #[cfg(feature = "html-export")]


### PR DESCRIPTION
💡 The Spark: I noticed we have great execution trajectories but no way to automatically convert them into training data for other models.
🚀 The Feature: Implemented `JsonlFinetuneExporter` that exports trajectories as an OpenAI-compatible JSONL chat format (one line per trajectory).
🔮 The Potential: Could be used to train specialized SWE agents based on successful runs using standard tools or directly via OpenAI API.
⚠️ Risk: Low. Isolated in `src/trajectory/export.rs`.

---
*PR created automatically by Jules for task [17700974681006952214](https://jules.google.com/task/17700974681006952214) started by @madmax983*