### PR TITLE
🎻 Bard: Documentation for template module

### DIFF
--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -12,6 +12,23 @@ use std::sync::Arc;
 
 use crate::error::Error;
 
+/// A rendering engine for evaluating prompt templates and agent observations.
+///
+/// The `Renderer` provides a pre-configured `minijinja::Environment` specialized
+/// for the CLI environment. Because agents output bash commands rather than HTML,
+/// auto-escaping is intentionally disabled. It also explicitly bridges system
+/// environment variables (via `env.USER`, etc.) to the templates.
+///
+/// ## Examples
+///
+/// ```
+/// use std::collections::BTreeMap;
+/// use maxwells_daemon::template::Renderer;
+///
+/// let r = Renderer::new();
+/// let rendered = r.render_str("echo {{ msg }}", &BTreeMap::from([("msg", "hello")])).unwrap();
+/// assert_eq!(rendered, "echo hello");
+/// ```
 pub struct Renderer {
     env: Environment<'static>,
 }
@@ -23,6 +40,16 @@ impl Default for Renderer {
 }
 
 impl Renderer {
+    /// Creates a new `Renderer` initialized with environment variables.
+    ///
+    /// Autoescaping is turned off globally for the enclosed environment.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use maxwells_daemon::template::Renderer;
+    /// let r = Renderer::new();
+    /// ```
     pub fn new() -> Self {
         let mut env = Environment::new();
         env.set_auto_escape_callback(|_| minijinja::AutoEscape::None);
@@ -34,22 +61,68 @@ impl Renderer {
         Self { env }
     }
 
-    /// Render a template string against a context value that serializes to
-    /// a map. The `context!` macro from `minijinja` is the recommended way
+    /// Renders a template string against a generic serialize-able context.
+    ///
+    /// This exists as a convenience wrapper around `render_with` when your
+    /// template context is a plain struct or a `BTreeMap` instead of a
+    /// dynamic `Value`.
+    ///
+    /// The `context!` macro from `minijinja` is the recommended way
     /// to build ad-hoc contexts at call sites.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use maxwells_daemon::template::Renderer;
+    ///
+    /// let r = Renderer::new();
+    /// let ctx = BTreeMap::from([("tool", "bash")]);
+    /// let out = r.render_str("Tool: {{ tool }}", &ctx).unwrap();
+    /// assert_eq!(out, "Tool: bash");
+    /// ```
     pub fn render_str<T: Serialize>(&self, tmpl: &str, ctx: &T) -> Result<String, Error> {
         self.env
             .render_str(tmpl, Value::from_serialize(ctx))
             .map_err(Into::into)
     }
 
+    /// Renders a template string using a dynamic `Value` context.
+    ///
+    /// This exists to evaluate templates constructed at runtime where the shape
+    /// of the context might not map directly to a static Rust struct.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use minijinja::context;
+    /// use maxwells_daemon::template::Renderer;
+    ///
+    /// let r = Renderer::new();
+    /// let ctx = context!(name => "world");
+    /// let out = r.render_with("hello {{ name }}", ctx).unwrap();
+    /// assert_eq!(out, "hello world");
+    /// ```
     pub fn render_with(&self, tmpl: &str, ctx: Value) -> Result<String, Error> {
         self.env.render_str(tmpl, ctx).map_err(Into::into)
     }
 }
 
-/// Build a context with the keys mini-swe-agent conventionally exposes:
-/// `task`, `output`, `returncode`, plus arbitrary extras.
+/// Builds a standardized context object for formatting agent observations.
+///
+/// This exists to ensure that every evaluation of `observation_template`
+/// receives a consistent shape, exposing standard keys like `output` and
+/// `returncode` that are expected by prompt templates.
+///
+/// ## Examples
+///
+/// ```
+/// use std::collections::BTreeMap;
+/// use maxwells_daemon::template::observation_context;
+///
+/// let extras = BTreeMap::from([("task".to_string(), "id1".to_string())]);
+/// let ctx = observation_context("Success", 0, &extras);
+/// ```
 pub fn observation_context(
     output: &str,
     returncode: i32,
@@ -59,7 +132,20 @@ pub fn observation_context(
     context!(output => output, returncode => returncode, extras => extras_val)
 }
 
-/// Small helper — used by `InteractiveAgent` status strings and banners.
+/// Evaluates a simple template against an array of key-value tuples.
+///
+/// This exists to eliminate the boilerplate of constructing a `Renderer`
+/// instance and manually building a map when all you need is trivial
+/// string replacement for status messages or CLI banners.
+///
+/// ## Examples
+///
+/// ```
+/// use maxwells_daemon::template::render_simple;
+///
+/// let out = render_simple("Current step: {{ step }}", &[("step", "4")]).unwrap();
+/// assert_eq!(out, "Current step: 4");
+/// ```
 pub fn render_simple(tmpl: &str, vars: &[(&str, &str)]) -> Result<String, Error> {
     let mut env = Environment::new();
     env.set_auto_escape_callback(|_| minijinja::AutoEscape::None);


### PR DESCRIPTION
📖 Chapter: The `template` module
🔦 Insight: Clarified the `Renderer` purpose and added missing method documentation.
🧪 Example: Added executable doctests for template rendering.
🖼️ Preview: Documentation renders cleanly without warnings.

---
*PR created automatically by Jules for task [6053532753369755809](https://jules.google.com/task/6053532753369755809) started by @madmax983*