### PR TITLE
🌟 Nova: Raw JSON Trajectory Exporter

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2927,13 +2927,13 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
+    /// In instance mode, also accepts `raw`, `markdown`, `html`, `csv`, and `mermaid`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
-    /// Write output to a file instead of stdout. Supported with `markdown`,
+    /// Write output to a file instead of stdout. Supported with `raw`, `markdown`,
     /// `html`, `csv`, and `mermaid` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3703,13 +3703,16 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "raw" | "markdown" | "html" | "csv" | "mermaid"
+    ) {
         return bench_inspect_export(i);
     }
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (raw/markdown/html/csv/mermaid), not `{}`",
             i.format
         ))));
     }
@@ -3719,7 +3722,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         "json" => crate::run::inspect::InspectFormat::Json,
         other => {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, or `mermaid`)"
+                "unknown --format `{other}` (expected `text`, `json`, `raw`, `markdown`, `html`, `csv`, or `mermaid`)"
             ))));
         }
     };
@@ -3761,7 +3764,8 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     })?;
     let instance_id = i.instance.as_deref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
-            "inspect: --instance is required for export formats (markdown/html/csv/mermaid)".into(),
+            "inspect: --instance is required for export formats (raw/markdown/html/csv/mermaid)"
+                .into(),
         ))
     })?;
     let traj_path =
@@ -3776,6 +3780,10 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         .map_err(|e| Error::Trajectory(format!("inspect: failed to parse trajectory: {e}")))?;
 
     let content = match i.format.as_str() {
+        "raw" => {
+            use crate::trajectory::export::{JsonExporter, TrajectoryExporter};
+            JsonExporter::export(&traj)
+        }
         "markdown" => {
             use crate::trajectory::export::{MarkdownExporter, TrajectoryExporter};
             MarkdownExporter::export(&traj)

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -41,6 +41,9 @@ pub trait TrajectoryExporter {
 /// ```
 pub struct MarkdownExporter;
 
+/// Transforms a [`Trajectory`] into a raw JSON string.
+pub struct JsonExporter;
+
 /// Transforms a [`Trajectory`] into a flat CSV file, with `role` and `content` columns.
 ///
 /// Note: This exporter properly handles and escapes embedded quotes and newlines in message content.
@@ -116,6 +119,12 @@ impl TrajectoryExporter for MarkdownExporter {
         }
 
         md
+    }
+}
+
+impl TrajectoryExporter for JsonExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        serde_json::to_string_pretty(trajectory).unwrap_or_else(|_| "{}".to_string())
     }
 }
 
@@ -273,6 +282,18 @@ mod tests {
         assert!(md.contains("Hello agent"));
         assert!(md.contains("### Assistant"));
         assert!(md.contains("Hello user"));
+    }
+
+    #[test]
+    fn test_json_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        let json = JsonExporter::export(&t);
+
+        assert!(json.starts_with('{'));
+        assert!(json.contains("\"task\": \"Add a feature\""));
     }
 
     #[cfg(feature = "csv-export")]


### PR DESCRIPTION
💡 The Spark: We can export trajectories to human-readable formats but can't easily extract the raw JSON programmatically for piping.
🚀 The Feature: Implemented `JsonExporter` and wired it into `bench inspect --format raw`.
🔮 The Potential: Easily pipe raw trajectory JSON into jq or other tools.
⚠️ Risk: Minimal.

---
*PR created automatically by Jules for task [831702448786184220](https://jules.google.com/task/831702448786184220) started by @madmax983*