### PR TITLE
⚒️ Forge: Refactor loop patterns in evaluator_selftest

### DIFF
--- a/src/run/evaluator_selftest.rs
+++ b/src/run/evaluator_selftest.rs
@@ -658,21 +658,13 @@ fn unix_to_ymd_hms(secs: u64) -> (u32, u32, u32, u32, u32, u32) {
 
     let mut year = 1970u32;
     let mut remaining = days;
-    loop {
-        let dy = days_in_year(year);
-        if remaining < dy {
-            break;
-        }
-        remaining -= dy;
+    while remaining >= days_in_year(year) {
+        remaining -= days_in_year(year);
         year += 1;
     }
     let mut month = 1u32;
-    loop {
-        let dm = days_in_month(year, month);
-        if remaining < dm {
-            break;
-        }
-        remaining -= dm;
+    while remaining >= days_in_month(year, month) {
+        remaining -= days_in_month(year, month);
         month += 1;
     }
     let day = remaining + 1;


### PR DESCRIPTION
🪨 Smell: `loop { ... if cond { break; } }` pattern used for simple while loops.
✨ Solution: Replaced `loop` with idiomatic `while` conditions.
🧼 Benefit: Reduces visual noise and makes the loop termination conditions obvious at the start of the block.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [13339792560850905000](https://jules.google.com/task/13339792560850905000) started by @madmax983*