### PR TITLE
🌟 Nova: ChatML Exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+chatml-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
 

--- a/docs/spec-inspect.md
+++ b/docs/spec-inspect.md
@@ -15,6 +15,7 @@ max bench inspect --sweep <dir> --instance <instance_id> --format markdown --out
 max bench inspect --sweep <dir> --instance <instance_id> --format html --output traj.html
 max bench inspect --sweep <dir> --instance <instance_id> --format csv --output traj.csv
 max bench inspect --sweep <dir> --instance <instance_id> --format mermaid --output traj.mmd
+max bench inspect --sweep <dir> --instance <instance_id> --format chatml --output traj.chatml
 max bench inspect --sweep <dir> --instance <instance_id> --show-expected
 max bench inspect --sweep <dir> --filter resolved=false
 max bench inspect --sweep <dir> --filter failure_category=step_limit
@@ -40,13 +41,14 @@ max bench compare --baseline <dir> --candidate <dir> --emit-diff-script <out.sh>
   | `html`     | Self-contained HTML (inline CSS, no external refs)     | `html-export`          |
   | `csv`      | Flat CSV with `role` and `content` columns             | `csv-export`           |
   | `mermaid`  | Mermaid `sequenceDiagram` of the conversation          | `mermaid-export`       |
+  | `chatml`   | ChatML formatted conversation log                      | `chatml-export`        |
   | `unified`  | Unified diff (diff mode only)                          | —                      |
 
   When the binary is built without the required feature, `--format <name>` exits
   with a `format_unavailable` error naming the missing feature. See
   [`src/trajectory/export.rs`](../src/trajectory/export.rs) for exporter unit tests.
 * `--output <PATH>`: write output to a file instead of stdout. Supported with
-  `markdown`, `html`, `csv`, and `mermaid` formats in instance mode. Stdout is
+  `markdown`, `html`, `csv`, `mermaid`, and `chatml` formats in instance mode. Stdout is
   empty when `--output` is set.
 * `--full`: disable stdout/stderr truncation in transcript mode.
 * `--show-expected`: also print `PASS_TO_PASS` / `FAIL_TO_PASS` expected-test groupings read
@@ -59,7 +61,7 @@ max bench compare --baseline <dir> --candidate <dir> --emit-diff-script <out.sh>
 Exactly one of `--instance` or `--filter` is required.
 Diff mode is separate and cannot be combined with `--sweep`, `--instance`, or
 `--filter`.
-Export formats (`markdown`, `html`, `csv`, `mermaid`) require `--instance` and
+Export formats (`markdown`, `html`, `csv`, `mermaid`, `chatml`) require `--instance` and
 `--sweep`; they cannot be combined with `--filter`.
 
 ### Output redaction

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2954,14 +2954,14 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`, and `chatml`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `chatml` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3704,7 +3704,10 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if matches!(
+        i.format.as_str(),
+        "markdown" | "html" | "csv" | "mermaid" | "chatml"
+    ) {
         return bench_inspect_export(i);
     }
 
@@ -3784,6 +3787,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "chatml" => inspect_export_chatml(&traj)?,
         _ => unreachable!("dispatch guarded by caller"),
     };
 
@@ -3837,6 +3841,22 @@ fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, 
     Err(Error::Config(crate::error::ConfigError::Invalid(
         "format_unavailable: --format html requires the `html-export` Cargo feature; \
          rebuild with `--features html-export`"
+            .into(),
+    )))
+}
+
+#[cfg(feature = "chatml-export")]
+#[allow(clippy::unnecessary_wraps)]
+fn inspect_export_chatml(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    use crate::trajectory::export::{ChatmlExporter, TrajectoryExporter};
+    Ok(ChatmlExporter::export(traj))
+}
+
+#[cfg(not(feature = "chatml-export"))]
+fn inspect_export_chatml(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
+    Err(Error::Config(crate::error::ConfigError::Invalid(
+        "format_unavailable: --format chatml requires the `chatml-export` Cargo feature; \
+         rebuild with `--features chatml-export`"
             .into(),
     )))
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -53,6 +53,9 @@ pub struct MermaidExporter;
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
+#[cfg(feature = "chatml-export")]
+pub struct ChatmlExporter;
+
 use std::fmt::Write;
 
 #[cfg(feature = "csv-export")]
@@ -245,6 +248,22 @@ impl TrajectoryExporter for MermaidExporter {
     }
 }
 
+#[cfg(feature = "chatml-export")]
+impl TrajectoryExporter for ChatmlExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut chatml = String::new();
+
+        for msg in &trajectory.messages {
+            let role = msg.role.as_str();
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            let _ = write!(chatml, "<|im_start|>{role}\n{content}<|im_end|>\n");
+        }
+
+        chatml
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -339,5 +358,20 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+
+    #[cfg(feature = "chatml-export")]
+    #[test]
+    fn test_chatml_export_format() {
+        let mut t = Trajectory::new();
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::assistant("Hello user"));
+
+        let chatml = ChatmlExporter::export(&t);
+
+        assert!(chatml.contains("<|im_start|>system\nSystem prompt<|im_end|>\n"));
+        assert!(chatml.contains("<|im_start|>user\nHello agent<|im_end|>\n"));
+        assert!(chatml.contains("<|im_start|>assistant\nHello user<|im_end|>\n"));
     }
 }

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -2378,6 +2378,75 @@ fn format_mermaid_produces_sequence_diagram() {
     );
 }
 
+#[cfg(not(feature = "chatml-export"))]
+#[test]
+fn format_chatml_without_feature_gives_format_unavailable_error() {
+    let sweep = tempfile::tempdir().unwrap();
+    write_traj(sweep.path(), "abc", false);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "abc",
+            "--format",
+            "chatml",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "should fail when chatml-export feature is not enabled"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("format_unavailable"),
+        "expected format_unavailable in stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("chatml-export"),
+        "expected feature name in error message:\n{stderr}"
+    );
+}
+
+#[cfg(feature = "chatml-export")]
+#[test]
+fn format_chatml_produces_self_contained_chatml() {
+    let sweep = tempfile::tempdir().unwrap();
+    write_traj(sweep.path(), "abc", false);
+
+    let out = Command::new(binary_path())
+        .args([
+            "bench",
+            "inspect",
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--instance",
+            "abc",
+            "--format",
+            "chatml",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("<|im_start|>"),
+        "expected ChatML start token:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("<|im_end|>"),
+        "expected ChatML end token:\n{stdout}"
+    );
+}
+
 #[test]
 #[allow(clippy::too_many_lines)]
 fn inspect_displays_submission_class_and_warning_for_test_only_patches() {


### PR DESCRIPTION
💡 The Spark: I noticed that while we support formats like Markdown, CSV, and Mermaid for trajectory exports, we lack an exporter that formats the trajectory natively in ChatML, which is highly useful for LLM fine-tuning datasets and quick readable logging in ChatML format.
🚀 The Feature: Implemented `ChatmlExporter` behind the `chatml-export` feature flag in `max bench inspect`.
🔮 The Potential: This allows developers to easily convert SWE-agent trajectories into ready-to-use ChatML text sequences that can be directly used for fine-tuning open source models.
⚠️ Risk: Low. Isolated in `src/trajectory/export.rs` and cleanly wired up in `src/cli/mod.rs` as another format string via the `--format chatml` argument.

---
*PR created automatically by Jules for task [7118910839423994452](https://jules.google.com/task/7118910839423994452) started by @madmax983*