### PR TITLE
⚡ Bolt: Remove intermediate allocations in string formatting

### DIFF
--- a/src/run/calibrate.rs
+++ b/src/run/calibrate.rs
@@ -582,8 +582,23 @@ fn build_mismatches(
     mismatches
 }
 
+/// Joins a set of strings with a comma separator.
+/// ⚡ Bolt optimization: Pre-computes exact string capacity and joins directly,
+/// removing the intermediate `Vec` allocation from `.collect::<Vec<_>>().join(",")`.
 fn sorted_join(values: BTreeSet<&str>) -> String {
-    values.into_iter().collect::<Vec<_>>().join(",")
+    let len = values.iter().copied().map(str::len).sum::<usize>() + values.len().saturating_sub(1);
+    let mut iter = values.into_iter();
+    if let Some(first) = iter.next() {
+        let mut res = String::with_capacity(len);
+        res.push_str(first);
+        for s in iter {
+            res.push(',');
+            res.push_str(s);
+        }
+        res
+    } else {
+        String::new()
+    }
 }
 
 fn compare_field(

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -540,6 +540,9 @@ fn searchable_tokens(name: &str, description: &str) -> BTreeSet<String> {
         .collect()
 }
 
+/// Normalizes search text by converting to lowercase and replacing non-alphanumeric characters.
+/// ⚡ Bolt optimization: Pre-allocates string and uses a single loop to join tokens,
+/// completely avoiding the intermediate `Vec` heap allocation previously caused by `.collect::<Vec<_>>().join(" ")`.
 fn normalize_search_text(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     for ch in text.chars() {
@@ -549,7 +552,16 @@ fn normalize_search_text(text: &str) -> String {
             out.push(' ');
         }
     }
-    out.split_whitespace().collect::<Vec<_>>().join(" ")
+    let mut res = String::with_capacity(out.len());
+    let mut iter = out.split_whitespace();
+    if let Some(first) = iter.next() {
+        res.push_str(first);
+        for s in iter {
+            res.push(' ');
+            res.push_str(s);
+        }
+    }
+    res
 }
 
 fn is_stopword(token: &str) -> bool {


### PR DESCRIPTION
⚡ Bolt: Remove intermediate allocations in string formatting

💡 What: Replaced `.collect::<Vec<_>>().join(SEPARATOR)` with optimized `for` loops that pre-allocate strings. Added inline documentation explaining the optimizations.
🎯 Why: Gathering intermediate collections into a `Vec` prior to joining causes an unnecessary heap allocation, which can be avoided by writing directly to a pre-allocated string.
📊 Impact: Removes one intermediate heap allocation per string joining operation.
🔬 Measurement: Run `cargo test` and `cargo check`.

---
*PR created automatically by Jules for task [15979414477061502610](https://jules.google.com/task/15979414477061502610) started by @madmax983*