### PR TITLE
⚒️ Forge: Refactor loop patterns and eliminate allocations on error paths

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -271,7 +271,7 @@ pub trait Model: Send + Sync {
 /// if more than 4 messages carry `Breakpoint`, keep the **first** four
 /// (stable/oldest cached prefix, which is what we want for a system prompt
 /// + long-lived context) and demote the rest to `None`. Returns an iterator
-/// over `(&Message, CacheHint)`.
+///   over `(&Message, CacheHint)`.
 pub fn cap_breakpoints<const N: usize>(
     messages: &[Message],
 ) -> impl Iterator<Item = (&Message, CacheHint)> + '_ {

--- a/src/run/evaluator_selftest.rs
+++ b/src/run/evaluator_selftest.rs
@@ -497,8 +497,8 @@ fn evaluate_via_docker_tests(
             let row = serde_json::json!({
                 "instance_id": inst.instance_id,
                 "image": inst.image,
-                "FAIL_TO_PASS": inst.other.get("FAIL_TO_PASS").cloned().unwrap_or(serde_json::Value::Array(vec![])),
-                "PASS_TO_PASS": inst.other.get("PASS_TO_PASS").cloned().unwrap_or(serde_json::Value::Array(vec![])),
+                "FAIL_TO_PASS": inst.other.get("FAIL_TO_PASS").cloned().unwrap_or_else(|| serde_json::Value::Array(vec![])),
+                "PASS_TO_PASS": inst.other.get("PASS_TO_PASS").cloned().unwrap_or_else(|| serde_json::Value::Array(vec![])),
                 // Preserve oracle-test, runner, and alternate image fields so
                 // docker-tests can resolve the image and apply oracle tests.
                 "test_patch": inst.other.get("test_patch").cloned().unwrap_or(serde_json::Value::Null),

--- a/src/run/rate_limit.rs
+++ b/src/run/rate_limit.rs
@@ -378,7 +378,7 @@ impl RateLimitGovernor {
     /// message string. Handles:
     /// - Numeric: `"retry-after: 30"` / `"retry_after: 30"`
     /// - HTTP-date: `"retry-after: Wed, 21 Oct 2026 12:00:00 GMT"`
-    /// Returns `None` when no recognizable pattern is found.
+    ///   Returns `None` when no recognizable pattern is found.
     #[must_use]
     pub fn parse_retry_after_from_error(msg: &str) -> Option<u64> {
         let lower = msg.to_lowercase();


### PR DESCRIPTION
🚰 Smell: There are clippy warnings for `doc-lazy-continuation` in `src/model/mod.rs` and `src/run/rate_limit.rs`. In `src/run/evaluator_selftest.rs`, `unwrap_or(serde_json::Value::Array(vec![]))` was used instead of `unwrap_or_else(|| ...)` leading to unnecessary allocations on error paths.
✨ Solution: Formatted documentation properly. Modified `unwrap_or` to `unwrap_or_else` in `src/run/evaluator_selftest.rs` to ensure lazy evaluation. (A loop-to-while-let refactoring in evaluate.rs was reverted due to incorrect error handling).
🧼 Benefit: Code becomes more idiomatic Rust, documentation renders cleanly, and we avoid allocating memory on fallback paths.
🛡️ Verification: Ran `cargo fmt`, `cargo clippy`, and `cargo test` successfully. No logic was altered.

---
*PR created automatically by Jules for task [13910754352722166989](https://jules.google.com/task/13910754352722166989) started by @madmax983*