### PR TITLE
🌟 Nova: [Trajectory Summary Exporter]

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2954,14 +2954,14 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`, and `summary`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     #[arg(long, default_value = "text")]
     pub format: String,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `summary` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3689,7 +3689,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         }
         if i.output.is_some() {
             return Err(Error::Config(crate::error::ConfigError::Invalid(
-                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid)".into(),
+                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/summary)".into(),
             )));
         }
         let format = parse_trajectory_diff_format(&i.format)?;
@@ -3710,7 +3710,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/summary), not `{}`",
             i.format
         ))));
     }
@@ -3762,7 +3762,7 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     })?;
     let instance_id = i.instance.as_deref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
-            "inspect: --instance is required for export formats (markdown/html/csv/mermaid)".into(),
+            "inspect: --instance is required for export formats (markdown/html/csv/mermaid/summary)".into(),
         ))
     })?;
     let traj_path =
@@ -3784,6 +3784,10 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         "html" => inspect_export_html(&traj)?,
         "csv" => inspect_export_csv(&traj)?,
         "mermaid" => inspect_export_mermaid(&traj)?,
+        "summary" => {
+            use crate::trajectory::export::{SummaryExporter, TrajectoryExporter};
+            SummaryExporter::export(&traj)
+        }
         _ => unreachable!("dispatch guarded by caller"),
     };
 

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -53,7 +53,44 @@ pub struct MermaidExporter;
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
+pub struct SummaryExporter;
+
 use std::fmt::Write;
+
+impl TrajectoryExporter for SummaryExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let mut table = comfy_table::Table::new();
+        table.set_header(vec!["Metric", "Value"]);
+
+        let task = trajectory.info.task.as_deref().unwrap_or("Unknown");
+        table.add_row(vec!["Task", task]);
+
+        let outcome = trajectory.info.outcome.as_deref().unwrap_or("Unknown");
+        table.add_row(vec!["Outcome", outcome]);
+
+        if let Some(tokens) = &trajectory.info.token_usage {
+            let total = tokens.total_prompt_tokens() + tokens.completion_tokens;
+            table.add_row(vec!["Total Tokens", &total.to_string()]);
+        }
+
+        if let Some(cost) = trajectory.info.total_cost_usd {
+            table.add_row(vec!["Total Cost (USD)", &format!("{cost:.4}")]);
+        }
+
+        if let Some(duration) = trajectory.info.duration_secs {
+            table.add_row(vec!["Duration (s)", &format!("{duration:.2}")]);
+        }
+
+        let steps = trajectory
+            .messages
+            .iter()
+            .filter(|m| m.role == "tool")
+            .count();
+        table.add_row(vec!["Tool Steps", &steps.to_string()]);
+
+        table.to_string()
+    }
+}
 
 #[cfg(feature = "csv-export")]
 impl TrajectoryExporter for CsvExporter {
@@ -339,5 +376,24 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+
+    #[test]
+    fn test_summary_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some("submitted".to_string());
+        t.info.duration_secs = Some(15.5);
+        t.record_message(&Message::system("sys"));
+        t.record_message(&Message::user("Hello"));
+        let mut tool_msg = Message::user("tool_output");
+        tool_msg.role = crate::model::Role::Tool;
+        t.record_message(&tool_msg);
+
+        let summary = SummaryExporter::export(&t);
+        assert!(summary.contains("Add a feature"));
+        assert!(summary.contains("submitted"));
+        assert!(summary.contains("15.50"));
+        assert!(summary.contains("Tool Steps"));
     }
 }


### PR DESCRIPTION
💡 **The Spark:** "Trajectories are huge and JSON is dense. We have full text and full markdown, but no way to get a quick 10,000-foot view of a single trajectory's metrics and tool usage in the terminal."
🚀 **The Feature:** "Added a `SummaryExporter` and `--format summary` to `bench inspect` using `comfy-table`."
🔮 **The Potential:** "Lets operators instantly grok the shape of a trajectory (cost, duration, tool mix) without scrolling through thousands of lines of prompts."
⚠️ **Risk:** "Low. Isolated additive export format."

---
*PR created automatically by Jules for task [10295663267255474229](https://jules.google.com/task/10295663267255474229) started by @madmax983*