### PR TITLE
Add trajectory export format registry and conformance spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
       - run: cargo build --all-targets --no-default-features
       - run: cargo test --all-targets --no-default-features
       - run: cargo test --doc --no-default-features
+      # Run the export redaction conformance test with every exporter feature enabled so
+      # all registered formats (csv/html/mermaid), not just markdown, are covered. See
+      # docs/spec-export.md (mandatory redaction invariant).
+      - run: cargo test --all-features --test export_redaction_conformance
 
   swebench-cancel:
     name: swebench cancellation (${{ matrix.os }})

--- a/docs/spec-export.md
+++ b/docs/spec-export.md
@@ -1,0 +1,167 @@
+# `bench inspect --format` — Trajectory Export Format Contract
+
+Governs the human/integration export surface of trajectory files. `bench inspect` renders
+a single trajectory into a portable format for downstream tooling, review, or notebook
+sharing. This spec enumerates every supported export format, its stability tier, the
+mandatory redaction invariant that all formats must satisfy, and the acceptance bar for
+new exporters.
+
+This family is **not** a substitute for versioned machine artifacts — see the
+[relationship to the artifact contract](#relationship-to-the-artifact-contract) section.
+
+## Usage
+
+```
+max bench inspect --sweep <SWEEP_DIR> --instance <INSTANCE_ID> --format <FORMAT> [--output <PATH>]
+max bench inspect --list-formats
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--sweep PATH` | required | Completed sweep directory. |
+| `--instance ID` | required for export formats | Instance ID to export. |
+| `--format FORMAT` | `text` | Export format; see table below. |
+| `--output PATH` | stdout | Write output to a file instead of stdout. |
+| `--list-formats` | — | Print all formats compiled into this build with their tier and consumer; exit 0. |
+
+## Supported formats
+
+| Format | Stability tier | Cargo feature | Intended downstream consumer |
+|--------|---------------|---------------|------------------------------|
+| `markdown` | stable | always compiled | docs, PR review, human readers |
+| `csv` | stable | `csv-export` | spreadsheets, jq pipelines, tabular tools |
+| `html` | stable | `html-export` | self-contained browser view, shared notebooks |
+| `mermaid` | experimental | `mermaid-export` | Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live) |
+
+Feature-gated formats require rebuilding with the corresponding feature:
+
+```bash
+cargo build --features csv-export,html-export,mermaid-export
+```
+
+When a format is requested but its Cargo feature was not compiled in, the command exits
+with code 2 and a message of the form:
+
+```
+format_unavailable: --format html requires the `html-export` Cargo feature; rebuild with `--features html-export`
+```
+
+## Stability tiers
+
+### `stable`
+
+Schema and layout are governed. A change that alters the output in a way that would break
+an existing downstream consumer (column order, heading names, structural markup) requires:
+
+1. A documented rationale in the PR description.
+2. An update to this spec (format version note or change log entry).
+
+This mirrors the minor/major bump policy in [`docs/artifact-contract.md`](artifact-contract.md):
+additive changes (new optional fields, new sections at the end) need only a note;
+structural rearrangements that break existing consumers need a version bump entry here.
+
+### `experimental`
+
+The output layout may change without notice. Operators should not build stable automation
+against `experimental` formats. A format graduates from `experimental` to `stable` when
+its layout is considered settled and tested for at least one minor release.
+
+## Mandatory redaction invariant
+
+**Every exporter MUST apply the same `Redactor`/secret-surfacing pass as the canonical
+`bench inspect` view path before emitting any output.** Concretely: every `export()`
+implementation calls `Redactor::default_enabled()` and passes each piece of user-visible
+text through `redactor.redact_text(text, surface::EXPORT)` before writing it to the
+output buffer.
+
+The following secret shapes are redacted:
+
+- Configured secret literals (`config.redaction.secret_literals`).
+- Structured token patterns: GitHub tokens (`ghp_*`, `ghs_*`, `gho_*`, `github_pat_*`),
+  bearer tokens, API keys (`sk-*`, `sk-ant-*`, `AKIA*`), PEM private-key blocks.
+- Current-process environment variable values whose names contain `TOKEN`, `SECRET`,
+  `KEY`, `PASSWORD`, or `CREDENTIAL`.
+- `.env`-style assignments with sensitive names.
+
+Redacted values are replaced with stable digest markers:
+`[REDACTED:<kind>:<size_class>:<hash>]`
+
+See [`docs/spec-secret-redaction.md`](spec-secret-redaction.md) for the full redaction
+contract.
+
+### Enforcement
+
+The shared conformance test at `tests/export_redaction_conformance.rs` iterates
+`trajectory::export::registry()` — the single source of truth for all compiled-in
+exporters — and asserts for every format that:
+
+1. No raw canary secret (`ghp_…`) appears in the output.
+2. At least one `[REDACTED:` marker appears in the output.
+
+The test runs in CI with `--all-features` so every feature-gated exporter is covered.
+**Adding an exporter that skips redaction fails CI at this test.** Adding an exporter
+that is not registered in `registry()` is not covered and must not be done.
+
+## Discoverability
+
+An operator can enumerate all export formats compiled into the current build without
+reading source:
+
+```
+$ max bench inspect --list-formats
+markdown    stable        docs, PR review, human readers
+csv         stable        spreadsheets, jq pipelines, tabular tools
+html        stable        self-contained browser view, shared notebooks
+mermaid     experimental  Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live)
+```
+
+The output lists only formats compiled into the running binary (feature-gated formats
+appear only when their Cargo feature is enabled). The format is plain text, one format
+per line, tab-separated columns: `name`, `tier`, `consumer`. Suitable for scripting with
+`awk` / `grep`.
+
+## Relationship to the artifact contract
+
+Trajectory exports are **human/integration views**, NOT versioned machine artifacts.
+
+The canonical trajectory artifact is `*.traj.json`, governed by
+[`docs/artifact-contract.md`](artifact-contract.md) with explicit `artifact_kind` and
+`schema_version` fields, a reader-compatibility class policy, and a no-bump change log.
+
+Export formats defined in this spec:
+
+- Carry **no** `artifact_kind` or `schema_version` metadata.
+- Must **not** be used as the input to `bench evaluate`, `bench compare`, `bench triage`,
+  or any other command that expects a versioned artifact.
+- Are not a substitute for `bench bundle` (archival) or `*.traj.json` (replay,
+  evaluation).
+
+The two contracts serve different consumers and must not drift by treating one as a
+proxy for the other.
+
+## Acceptance bar for in-flight exporter PRs
+
+PRs #499 (JSONL), #477 (OpenAI fine-tuning), #460 (Jupyter), and #454 (JUnit) each add
+an exporter. Each **must** satisfy this bar before merging:
+
+1. **Register** the new `ExportFormat` entry in `trajectory::export::registry()` with a
+   declared `StabilityTier`.
+2. **Redaction**: the `export()` impl calls `Redactor::default_enabled()` and routes all
+   user-visible text through `redactor.redact_text(text, surface::EXPORT)`.
+3. **CI green**: `cargo test --all-features --test export_redaction_conformance` passes
+   with the new format included.
+4. **Spec update**: this document is updated to add the new format row to the supported
+   formats table with its tier and consumer.
+
+## Out of scope
+
+- Implementing any new exporter format (JSONL, Jupyter, JUnit, fine-tuning are tracked
+  in their own PRs).
+- The OTLP trace export path (`bench export-otlp`, `docs/spec-export-otlp.md`) and
+  SWE-bench prediction/leaderboard bundles (`bench export-ci`, `docs/spec-export-ci.md`)
+  — those are machine-artifact and telemetry surfaces, not this human/integration family.
+- Choosing the concrete CLI surface, trait shape, or Cargo feature-flag strategy beyond
+  what is already implemented.
+- Live streaming or real-time export from in-flight sweeps.

--- a/docs/spec-export.md
+++ b/docs/spec-export.md
@@ -76,9 +76,9 @@ implementation calls `Redactor::default_enabled()` and passes each piece of user
 text through `redactor.redact_text(text, surface::EXPORT)` before writing it to the
 output buffer.
 
-The following secret shapes are redacted:
+`Redactor::default_enabled()` applies the built-in structured-secret pass (it does **not**
+load operator-configured literals — see the note below). The following shapes are redacted:
 
-- Configured secret literals (`config.redaction.secret_literals`).
 - Structured token patterns: GitHub tokens (`ghp_*`, `ghs_*`, `gho_*`, `github_pat_*`),
   bearer tokens, API keys (`sk-*`, `sk-ant-*`, `AKIA*`), PEM private-key blocks.
 - Current-process environment variable values whose names contain `TOKEN`, `SECRET`,
@@ -88,8 +88,14 @@ The following secret shapes are redacted:
 Redacted values are replaced with stable digest markers:
 `[REDACTED:<kind>:<size_class>:<hash>]`
 
-See [`docs/spec-secret-redaction.md`](spec-secret-redaction.md) for the full redaction
-contract.
+**Note on configured literals.** Operator-configured `config.redaction.secret_literals`
+and `custom_patterns` are part of the broader redaction surface but are **not** applied by
+this view/export pass: `Redactor::default_enabled()` is built from `RedactionCfg::default()`.
+This matches the canonical `bench inspect` text/JSON view exactly (it uses the same
+`default_enabled()` constructor), which is the invariant this spec enforces — export is
+neither stronger nor weaker than the canonical human-readable view. Configured-literal
+redaction at write time is governed separately by
+[`docs/spec-secret-redaction.md`](spec-secret-redaction.md).
 
 ### Enforcement
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2932,6 +2932,7 @@ pub struct EvaluateCmd {
 }
 
 #[derive(Debug, Args)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct InspectCmd {
     /// Completed sweep directory produced by `bench swebench`.
     #[arg(long)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2957,8 +2957,16 @@ pub struct InspectCmd {
     /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
+    /// Use `--list-formats` to enumerate all formats compiled into this build
+    /// along with their stability tier (`stable` / `experimental`) and consumer.
     #[arg(long, default_value = "text")]
     pub format: String,
+
+    /// List all trajectory export formats compiled into this build (name, stability
+    /// tier, intended consumer) and exit. Useful for operator discoverability without
+    /// reading source. See `docs/spec-export.md` for the full export-format contract.
+    #[arg(long, default_value_t = false)]
+    pub list_formats: bool,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
     /// `html`, `csv`, and `mermaid` formats in instance mode.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3712,7 +3712,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         return Ok(());
     }
 
-    if matches!(i.format.as_str(), "markdown" | "html" | "csv" | "mermaid") {
+    if crate::trajectory::export::is_export_format(&i.format) {
         return bench_inspect_export(i);
     }
 
@@ -3785,17 +3785,20 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         .map_err(|e| Error::Trajectory(format!("inspect: failed to parse trajectory: {e}")))?;
 
     let content = {
-        use crate::trajectory::export::registry;
+        use crate::trajectory::export::{FEATURE_GATED_FORMATS, registry};
         if let Some(fmt) = registry().into_iter().find(|f| f.name == i.format.as_str()) {
             (fmt.render)(&traj)
+        } else if let Some((name, feature)) = FEATURE_GATED_FORMATS
+            .iter()
+            .find(|(n, _)| *n == i.format.as_str())
+        {
+            // Known format, but its Cargo feature was not compiled into this build.
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "format_unavailable: --format {name} requires the `{feature}` Cargo feature; \
+                 rebuild with `--features {feature}`"
+            ))));
         } else {
-            // Format is known (routing guard above) but not compiled into this build.
-            match i.format.as_str() {
-                "html" => inspect_export_html(&traj)?,
-                "csv" => inspect_export_csv(&traj)?,
-                "mermaid" => inspect_export_mermaid(&traj)?,
-                _ => unreachable!("dispatch guarded by caller"),
-            }
+            unreachable!("dispatch guarded by is_export_format")
         }
     };
 
@@ -3835,54 +3838,6 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
         print!("{content}");
     }
     Ok(())
-}
-
-#[cfg(feature = "html-export")]
-#[allow(clippy::unnecessary_wraps)]
-fn inspect_export_html(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
-    use crate::trajectory::export::{HtmlExporter, TrajectoryExporter};
-    Ok(HtmlExporter::export(traj))
-}
-
-#[cfg(not(feature = "html-export"))]
-fn inspect_export_html(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
-    Err(Error::Config(crate::error::ConfigError::Invalid(
-        "format_unavailable: --format html requires the `html-export` Cargo feature; \
-         rebuild with `--features html-export`"
-            .into(),
-    )))
-}
-
-#[cfg(feature = "csv-export")]
-#[allow(clippy::unnecessary_wraps)]
-fn inspect_export_csv(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
-    use crate::trajectory::export::{CsvExporter, TrajectoryExporter};
-    Ok(CsvExporter::export(traj))
-}
-
-#[cfg(not(feature = "csv-export"))]
-fn inspect_export_csv(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
-    Err(Error::Config(crate::error::ConfigError::Invalid(
-        "format_unavailable: --format csv requires the `csv-export` Cargo feature; \
-         rebuild with `--features csv-export`"
-            .into(),
-    )))
-}
-
-#[cfg(feature = "mermaid-export")]
-#[allow(clippy::unnecessary_wraps)]
-fn inspect_export_mermaid(traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
-    use crate::trajectory::export::{MermaidExporter, TrajectoryExporter};
-    Ok(MermaidExporter::export(traj))
-}
-
-#[cfg(not(feature = "mermaid-export"))]
-fn inspect_export_mermaid(_traj: &crate::trajectory::Trajectory) -> Result<String, Error> {
-    Err(Error::Config(crate::error::ConfigError::Invalid(
-        "format_unavailable: --format mermaid requires the `mermaid-export` Cargo feature; \
-         rebuild with `--features mermaid-export`"
-            .into(),
-    )))
 }
 
 fn bench_command_stats(c: args::CommandStatsCmd) -> Result<(), Error> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3676,6 +3676,14 @@ fn parse_breakdown_selection(
 }
 
 fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
+    if i.list_formats {
+        use crate::trajectory::export::registry;
+        for fmt in registry() {
+            println!("{:<12}{:<14}{}", fmt.name, fmt.tier.as_str(), fmt.consumer);
+        }
+        return Ok(());
+    }
+
     if !i.diff.is_empty() {
         if i.instance.is_some() || i.filter.is_some() || i.sweep.is_some() {
             return Err(Error::Config(crate::error::ConfigError::Invalid(
@@ -3776,15 +3784,19 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     let traj: crate::trajectory::Trajectory = serde_json::from_str(&text)
         .map_err(|e| Error::Trajectory(format!("inspect: failed to parse trajectory: {e}")))?;
 
-    let content = match i.format.as_str() {
-        "markdown" => {
-            use crate::trajectory::export::{MarkdownExporter, TrajectoryExporter};
-            MarkdownExporter::export(&traj)
+    let content = {
+        use crate::trajectory::export::registry;
+        if let Some(fmt) = registry().into_iter().find(|f| f.name == i.format.as_str()) {
+            (fmt.render)(&traj)
+        } else {
+            // Format is known (routing guard above) but not compiled into this build.
+            match i.format.as_str() {
+                "html" => inspect_export_html(&traj)?,
+                "csv" => inspect_export_csv(&traj)?,
+                "mermaid" => inspect_export_mermaid(&traj)?,
+                _ => unreachable!("dispatch guarded by caller"),
+            }
         }
-        "html" => inspect_export_html(&traj)?,
-        "csv" => inspect_export_csv(&traj)?,
-        "mermaid" => inspect_export_mermaid(&traj)?,
-        _ => unreachable!("dispatch guarded by caller"),
     };
 
     if let Some(output_path) = i.output {

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -27,8 +27,8 @@ pub enum StabilityTier {
 impl StabilityTier {
     pub fn as_str(self) -> &'static str {
         match self {
-            StabilityTier::Stable => "stable",
-            StabilityTier::Experimental => "experimental",
+            Self::Stable => "stable",
+            Self::Experimental => "experimental",
         }
     }
 }
@@ -60,6 +60,10 @@ pub struct ExportFormat {
 /// 3. Document the format and its tier in `docs/spec-export.md`.
 /// 4. The shared conformance test in `tests/export_redaction_conformance.rs` will cover it automatically.
 pub fn registry() -> Vec<ExportFormat> {
+    // `mut` is only used when at least one feature-gated format is compiled in.
+    // Under `--no-default-features` none of the `push` calls exist, so the binding
+    // would otherwise trip `-D warnings`/`unused_mut`.
+    #[allow(unused_mut)]
     let mut formats = vec![ExportFormat {
         name: "markdown",
         tier: StabilityTier::Stable,
@@ -92,6 +96,31 @@ pub fn registry() -> Vec<ExportFormat> {
     });
 
     formats
+}
+
+/// Export format names that exist in the codebase but are gated behind a Cargo feature,
+/// paired with the feature that enables each.
+///
+/// Used to emit a helpful "feature not compiled in" error when an operator requests a
+/// format whose feature is disabled. Compiled-in formats (with metadata and a render fn)
+/// live in [`registry`]; a format gated *out* of this build is absent from `registry()`
+/// but present here so the CLI can still route it and explain how to enable it.
+pub const FEATURE_GATED_FORMATS: &[(&str, &str)] = &[
+    ("csv", "csv-export"),
+    ("html", "html-export"),
+    ("mermaid", "mermaid-export"),
+];
+
+/// Returns `true` if `name` is a trajectory export format known to this codebase,
+/// whether or not its Cargo feature is compiled into the current build.
+///
+/// CLI routing uses this so a request for a gated-out format still reaches the export
+/// dispatch path (and gets a helpful "rebuild with --features" error) instead of falling
+/// through to a generic "unknown format" message. This keeps [`registry`] the single
+/// source of truth for *compiled* formats while still recognizing the full catalog.
+pub fn is_export_format(name: &str) -> bool {
+    registry().iter().any(|f| f.name == name)
+        || FEATURE_GATED_FORMATS.iter().any(|(n, _)| *n == name)
 }
 
 /// A contract for types that can convert a [`Trajectory`] into a specialized string format.

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -6,9 +6,93 @@
 //! narrative document, complete with headers and code blocks.
 //!
 //! You can extend this module with new formats by implementing the [`crate::trajectory::export::TrajectoryExporter`] trait.
+//! Every new exporter MUST register in [`registry`] and MUST apply redaction via
+//! [`crate::redaction::Redactor::default_enabled`] on [`crate::redaction::surface::EXPORT`] before emitting any output.
+//! See `docs/spec-export.md` for the full governing contract.
 
 use super::Trajectory;
 use crate::redaction::{Redactor, surface};
+
+/// Stability tier for a trajectory export format.
+///
+/// `stable` formats guarantee that schema/layout changes require a documented version bump.
+/// `experimental` formats may change without notice.
+/// See `docs/spec-export.md` for the full tier definitions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StabilityTier {
+    Stable,
+    Experimental,
+}
+
+impl StabilityTier {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            StabilityTier::Stable => "stable",
+            StabilityTier::Experimental => "experimental",
+        }
+    }
+}
+
+/// Descriptor for a registered trajectory export format.
+///
+/// The `render` function pointer calls the exporter implementation directly, which ensures
+/// the registry stays in sync with the trait impls without duplicating redaction logic.
+pub struct ExportFormat {
+    /// CLI `--format` value (e.g. `"markdown"`, `"csv"`).
+    pub name: &'static str,
+    /// Stability guarantee for this format's output layout.
+    pub tier: StabilityTier,
+    /// Intended downstream consumer (for documentation and `--list-formats` output).
+    pub consumer: &'static str,
+    /// Render function. MUST apply redaction via `Redactor::default_enabled()` on `surface::EXPORT`.
+    pub render: fn(&Trajectory) -> String,
+}
+
+/// Returns every trajectory export format compiled into this build.
+///
+/// This is the single source of truth for the redaction conformance test, `--list-formats`,
+/// and CLI dispatch. Feature-gated formats (csv, html, mermaid) appear only when the
+/// corresponding Cargo feature is enabled.
+///
+/// When adding a new exporter:
+/// 1. Implement `TrajectoryExporter` with mandatory `Redactor::default_enabled()` redaction.
+/// 2. Add an `ExportFormat` entry here (feature-gated if behind a Cargo feature).
+/// 3. Document the format and its tier in `docs/spec-export.md`.
+/// 4. The shared conformance test in `tests/export_redaction_conformance.rs` will cover it automatically.
+pub fn registry() -> Vec<ExportFormat> {
+    let mut formats = vec![ExportFormat {
+        name: "markdown",
+        tier: StabilityTier::Stable,
+        consumer: "docs, PR review, human readers",
+        render: MarkdownExporter::export,
+    }];
+
+    #[cfg(feature = "csv-export")]
+    formats.push(ExportFormat {
+        name: "csv",
+        tier: StabilityTier::Stable,
+        consumer: "spreadsheets, jq pipelines, tabular tools",
+        render: CsvExporter::export,
+    });
+
+    #[cfg(feature = "html-export")]
+    formats.push(ExportFormat {
+        name: "html",
+        tier: StabilityTier::Stable,
+        consumer: "self-contained browser view, shared notebooks",
+        render: HtmlExporter::export,
+    });
+
+    #[cfg(feature = "mermaid-export")]
+    formats.push(ExportFormat {
+        name: "mermaid",
+        tier: StabilityTier::Experimental,
+        consumer: "Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live)",
+        render: MermaidExporter::export,
+    });
+
+    formats
+}
 
 /// A contract for types that can convert a [`Trajectory`] into a specialized string format.
 ///

--- a/tests/bench_inspect.rs
+++ b/tests/bench_inspect.rs
@@ -2522,3 +2522,28 @@ fn inspect_displays_submission_class_and_warning_for_test_only_patches() {
         "expected stdout to contain eval gaming warning; got:\n{stdout}"
     );
 }
+
+#[test]
+fn list_formats_enumerates_compiled_in_formats_with_tier() {
+    // The discoverability affordance from docs/spec-export.md: operators can list every
+    // export format compiled into the build with its stability tier and consumer, without
+    // reading source. `markdown` is always compiled in, so this is feature-independent.
+    let out = Command::new(binary_path())
+        .args(["bench", "inspect", "--list-formats"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "--list-formats should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("markdown"),
+        "expected `markdown` in --list-formats output; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("stable"),
+        "expected a stability tier in --list-formats output; got:\n{stdout}"
+    );
+}

--- a/tests/export_redaction_conformance.rs
+++ b/tests/export_redaction_conformance.rs
@@ -1,0 +1,86 @@
+//! Shared conformance tests for all registered trajectory exporters.
+//!
+//! These tests enforce the two invariants in docs/spec-export.md:
+//!   1. Every exporter in the registry redacts secrets (no raw credential may appear in output).
+//!   2. The spec document mentions every format name and stability tier declared in the registry.
+//!
+//! Adding an exporter that skips redaction, or forgetting to document it in spec-export.md,
+//! fails CI here.
+
+use maxwells_daemon::model::Message;
+use maxwells_daemon::trajectory::Trajectory;
+use maxwells_daemon::trajectory::export::registry;
+
+/// A real-looking GitHub personal access token used as a canary secret in the fixture.
+const CANARY_TOKEN: &str = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcde012345";
+
+fn fixture_trajectory() -> Trajectory {
+    let mut t = Trajectory::new();
+    t.info.task = Some(format!("Fix tests using token {CANARY_TOKEN}"));
+    t.info.outcome = Some(format!("submitted with key {CANARY_TOKEN}"));
+    t.record_message(&Message::system(format!(
+        "You are an agent. Secret: {CANARY_TOKEN}"
+    )));
+    t.record_message(&Message::user(format!(
+        "Hello agent, use {CANARY_TOKEN} to authenticate"
+    )));
+    t.record_message(&Message::assistant(format!(
+        "Authenticated with {CANARY_TOKEN}, proceeding"
+    )));
+    t
+}
+
+#[test]
+fn all_registered_exporters_redact_secrets() {
+    let traj = fixture_trajectory();
+    let formats = registry();
+    assert!(
+        !formats.is_empty(),
+        "registry() returned no exporters — expected at least MarkdownExporter"
+    );
+    for fmt in &formats {
+        let output = (fmt.render)(&traj);
+        assert!(
+            !output.contains(CANARY_TOKEN),
+            "Exporter '{}' (tier: {}) leaked raw secret token in output.\n\
+             Every exporter MUST apply Redactor::default_enabled() on surface::EXPORT.\n\
+             Output (first 400 chars):\n{}",
+            fmt.name,
+            fmt.tier.as_str(),
+            &output[..output.len().min(400)]
+        );
+        assert!(
+            output.contains("[REDACTED:"),
+            "Exporter '{}' (tier: {}) produced no redaction markers — \
+             expected [REDACTED:...] tokens where the secret appeared.\n\
+             Output (first 400 chars):\n{}",
+            fmt.name,
+            fmt.tier.as_str(),
+            &output[..output.len().min(400)]
+        );
+    }
+}
+
+#[test]
+fn spec_documents_every_registered_format() {
+    let formats = registry();
+    let spec = match std::fs::read_to_string("docs/spec-export.md") {
+        Ok(s) => s,
+        Err(e) => panic!("docs/spec-export.md must exist (see issue #516): {e}"),
+    };
+    for fmt in &formats {
+        assert!(
+            spec.contains(fmt.name),
+            "docs/spec-export.md does not mention format name '{}'. \
+             Every registered exporter must be documented in the spec.",
+            fmt.name
+        );
+        assert!(
+            spec.contains(fmt.tier.as_str()),
+            "docs/spec-export.md does not mention stability tier '{}' (used by format '{}'). \
+             The spec must define and use both stability tiers.",
+            fmt.tier.as_str(),
+            fmt.name
+        );
+    }
+}

--- a/tests/export_redaction_conformance.rs
+++ b/tests/export_redaction_conformance.rs
@@ -64,9 +64,15 @@ fn all_registered_exporters_redact_secrets() {
 #[test]
 fn spec_documents_every_registered_format() {
     let formats = registry();
-    let spec = match std::fs::read_to_string("docs/spec-export.md") {
+    // Resolve relative to the crate root so the test passes regardless of the working
+    // directory the test runner is invoked from.
+    let spec_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("docs/spec-export.md");
+    let spec = match std::fs::read_to_string(&spec_path) {
         Ok(s) => s,
-        Err(e) => panic!("docs/spec-export.md must exist (see issue #516): {e}"),
+        Err(e) => panic!(
+            "docs/spec-export.md must exist at {} (see issue #516): {e}",
+            spec_path.display()
+        ),
     };
     for fmt in &formats {
         assert!(


### PR DESCRIPTION
## Summary

This PR establishes a formal contract for trajectory export formats by introducing a centralized registry, stability tiers, and a conformance test suite. It enables operators to discover available export formats at runtime and ensures all exporters apply mandatory secret redaction before emitting output.

## Key Changes

- **Export format registry** (`src/trajectory/export.rs`): Added `ExportFormat` struct and `registry()` function as the single source of truth for all compiled-in exporters. Each format declares its name, stability tier (`Stable` / `Experimental`), intended consumer, and render function.

- **Stability tiers** (`src/trajectory/export.rs`): Introduced `StabilityTier` enum to distinguish between `stable` formats (schema/layout changes require documented version bumps) and `experimental` formats (may change without notice).

- **Conformance test** (`tests/export_redaction_conformance.rs`): Added shared test suite that:
  - Verifies every registered exporter redacts secrets (no raw credentials leak)
  - Confirms the spec document mentions every registered format and tier
  - Runs with `--all-features` to cover all feature-gated exporters

- **CLI `--list-formats` flag** (`src/cli/args.rs`, `src/cli/mod.rs`): Operators can now enumerate all export formats compiled into the current build without reading source, showing name, stability tier, and intended consumer in a scripting-friendly format.

- **Export spec document** (`docs/spec-export.md`): Comprehensive specification governing:
  - Supported formats (markdown, csv, html, mermaid) with their stability tiers and Cargo features
  - Mandatory redaction invariant that all exporters must satisfy
  - Stability tier definitions and change policies
  - Acceptance bar for new exporters (registration, redaction, CI green, spec update)
  - Relationship to the artifact contract (exports are human/integration views, not versioned machine artifacts)

- **Registry-driven dispatch** (`src/cli/mod.rs`): Refactored `bench_inspect_export()` to dispatch through the registry, ensuring all exporters are covered by the conformance test and reducing duplication.

## Notable Implementation Details

- The `render` function pointer in `ExportFormat` ensures the registry stays in sync with trait implementations without duplicating redaction logic.
- Feature-gated formats (csv, html, mermaid) appear in the registry only when their Cargo feature is enabled.
- The conformance test uses a fixture trajectory containing a canary GitHub token (`ghp_*`) to verify redaction is applied.
- The spec explicitly states that exports are NOT versioned machine artifacts and must not be used as input to `bench evaluate`, `bench compare`, or other commands expecting versioned artifacts.

https://claude.ai/code/session_016oZyWBtNoqauA2tYZ3gTWr