### PR TITLE
Add --result-format json to max mini for machine-readable output

### DIFF
--- a/docs/spec-mini-result-format.md
+++ b/docs/spec-mini-result-format.md
@@ -1,0 +1,122 @@
+# `mini --result-format json` — Machine-Readable Run Result
+
+**Issue:** #537  
+**Status:** Implemented  
+**Complexity tier:** S
+
+## Problem
+
+`max mini` is the entry point for single-task runs and the README's primary persona
+("operators who own the SWE agent loop"). Yet on completion it emits nothing
+machine-readable to stdout — only a `.traj.json` on disk plus tracing logs on stderr.
+To learn the outcome, cost, or patch location a CI wrapper must reconstruct the
+trajectory path and parse the full `mini-swe-agent-1.1` schema. The sweep path already
+ships machine-readable summaries; this closes the single-task parity gap.
+
+## Usage
+
+```
+max mini --task "<TASK>" --result-format json [OTHER FLAGS]
+```
+
+Add `--result-format json` to any existing `max mini` invocation. The flag is strictly
+additive; omitting it preserves today's behaviour exactly.
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--result-format text\|json` | Output format for the run result. Default: `text` (no change). |
+
+## JSON output (`--result-format json`)
+
+Exactly one schema-versioned JSON object is printed to stdout after a terminal run.
+All human/log text (tracing, progress, stderr diagnostics) continues to go to stderr,
+so stdout is clean JSON with no leading noise.
+
+### Schema
+
+```json
+{
+  "artifact_kind": "mini_result",
+  "schema_version": { "major": 1, "minor": 10 },
+  "outcome": "submitted",
+  "exit_code": 0,
+  "exit_outcome_class": "success",
+  "total_cost_usd": 0.0012,
+  "steps": 3,
+  "input_tokens": 8420,
+  "output_tokens": 213,
+  "trajectory_path": "/runs/fix-the-bug.traj.json",
+  "patch_path": null,
+  "failure_category": null
+}
+```
+
+### Field reference
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `artifact_kind` | string | Always `"mini_result"`. |
+| `schema_version` | object | `{ "major": N, "minor": N }` — version when binary was built. |
+| `outcome` | string \| null | From `trajectory.info.outcome` (e.g. `"submitted"`, `"error"`). |
+| `exit_code` | integer | Numeric exit code the process produces (0, 7, …). |
+| `exit_outcome_class` | string | Stable class label (e.g. `"success"`, `"verification_failure"`). |
+| `total_cost_usd` | number \| null | Actual + baseline cost. `null` when not captured (deterministic/free runs). |
+| `steps` | integer \| null | Number of agent steps taken. |
+| `input_tokens` | integer \| null | Prompt tokens (`token_usage.prompt_tokens`). `null` when not captured. |
+| `output_tokens` | integer \| null | Completion tokens (`token_usage.completion_tokens`). `null` when not captured. |
+| `trajectory_path` | string | Absolute path to the written `.traj.json` file. |
+| `patch_path` | string \| null | Absolute path to the `.patch` file, or `null` when no patch was captured (no `--open-pr` flags). |
+| `failure_category` | string \| null | Machine-readable failure category (see `FailureCategory` enum). `null` on success. |
+
+### Emission scope
+
+The JSON object is emitted **only** for:
+
+1. **Submitted runs** — `mini::run` returns `Ok(())` and `trajectory.info.outcome == "submitted"`.
+2. **Verification-failure runs** — `mini::run` returns `Err(VerificationFailed)` (exit code 7).
+
+It is **not** emitted for:
+- Runs that return `Ok(())` but did not submit (step-limit, budget-exhausted, stagnation, user-interrupt).
+  These are operator-actionable signals; the trajectory is the authoritative record.
+- Hard errors before a trajectory exists (env setup, model API failure, pre-trajectory I/O).
+  For those the process exits with the appropriate `outcome_class` printed to stderr.
+
+### Redaction guarantee
+
+All string fields in the JSON object pass through the active `Redactor` policy
+(same surface as `trajectory` artifacts — consistent with `agent skills-preview --format json`).
+Numbers, booleans, `schema_version`, and JSON structure keys are never altered.
+This guarantees that `secret_literals` and `custom_patterns` configured in
+`[redaction]` cannot leak via stdout.
+
+### Schema compatibility
+
+The `mini_result` artifact follows the same additive-only minor-version contract as all
+other harness artifacts. New fields may be added in minor releases; consumers must accept
+unknown additive fields in the current major version.
+
+## Exit codes
+
+| Code | Class | Condition |
+|------|-------|-----------|
+| `0` | `success` | Agent submitted and all verify checks passed (or no checks configured). |
+| `4` | `task_unsuccessful` | Agent hit step limit, budget, or env error. No JSON emitted. |
+| `7` | `verification_failure` | Agent submitted but at least one `--verify` check failed. JSON emitted. |
+| `12` | `agent_stagnation` | Stagnation detected. No JSON emitted. |
+
+## Falsifiable success metric
+
+```sh
+max mini --task "fix the typo" --result-format json | jq -e '.outcome'
+```
+
+Exits 0 and prints the outcome string in one invocation, with zero post-run file lookups.
+
+## Out of scope
+
+- Per-step streaming (already served by `--stream`, `--event-log`, `--webhook-url`).
+- Multi-run listing / summarisation (tracked by #509).
+- Any change to the on-disk `mini-swe-agent-1.1` trajectory schema.
+- A JSON result for the `bench` sweep path (already has `bench tail --once --format json`).

--- a/docs/spec-mini-result-format.md
+++ b/docs/spec-mini-result-format.md
@@ -89,7 +89,16 @@ It is **not** emitted for:
 The flag is honored on the standard, `--resume`, and `--continue` mini paths.
 When `--open-pr` / `--github-pr-dry-run` is combined with `--result-format json`,
 the human-facing PR URL / dry-run plan is written to **stderr** instead of stdout
-so that stdout remains exactly one JSON object.
+so that stdout remains exactly one JSON object. If the PR publish itself fails
+(e.g. missing token), the result object is still emitted and its
+`exit_code` / `exit_outcome_class` reflect that publish failure — a run error
+takes precedence, otherwise the publish error, otherwise success — so the JSON
+never reports success for a command that exits non-zero.
+
+`--result-format json` is rejected (usage error) when combined with `--ui ratatui`,
+because the dashboard renders to stdout. The hidden `--deterministic-responses`
+test hook is likewise rejected with `--driver codex|claude-code`, which shell out
+to a real agent and ignore scripted responses.
 
 ### Redaction guarantee
 

--- a/docs/spec-mini-result-format.md
+++ b/docs/spec-mini-result-format.md
@@ -72,16 +72,24 @@ so stdout is clean JSON with no leading noise.
 
 ### Emission scope
 
-The JSON object is emitted **only** for:
+The object is emitted **only when the agent submitted a patch** — i.e. the
+written trajectory records `outcome == "submitted"`. This single condition
+covers both contract cases:
 
-1. **Submitted runs** — `mini::run` returns `Ok(())` and `trajectory.info.outcome == "submitted"`.
-2. **Verification-failure runs** — `mini::run` returns `Err(VerificationFailed)` (exit code 7).
+1. **Submitted + verified** — `mini::run` returns `Ok(())`, exit code `0`.
+2. **Submitted + verification failed** — `mini::run` returns `Err(VerificationFailed)`, exit code `7`.
 
 It is **not** emitted for:
-- Runs that return `Ok(())` but did not submit (step-limit, budget-exhausted, stagnation, user-interrupt).
-  These are operator-actionable signals; the trajectory is the authoritative record.
+- Runs that did not submit (step-limit, budget-exhausted, stagnation, user-interrupt) —
+  even if a `--verify` check fails on such a run (the trajectory outcome is not
+  `submitted`, so no result object is printed). These are represented only by the trajectory.
 - Hard errors before a trajectory exists (env setup, model API failure, pre-trajectory I/O).
   For those the process exits with the appropriate `outcome_class` printed to stderr.
+
+The flag is honored on the standard, `--resume`, and `--continue` mini paths.
+When `--open-pr` / `--github-pr-dry-run` is combined with `--result-format json`,
+the human-facing PR URL / dry-run plan is written to **stderr** instead of stdout
+so that stdout remains exactly one JSON object.
 
 ### Redaction guarantee
 

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -75,6 +75,7 @@ pub enum ArtifactKind {
     AgentProfileReport,
     EvalParityReport,
     AgentRunsReport,
+    MiniResult,
 }
 
 impl ArtifactKind {
@@ -107,6 +108,7 @@ impl ArtifactKind {
             Self::AgentProfileReport => "agent_profile_report",
             Self::EvalParityReport => "eval_parity_report",
             Self::AgentRunsReport => "agent_runs_report",
+            Self::MiniResult => "mini_result",
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1083,6 +1083,21 @@ pub struct MiniCmd {
     /// trajectory is reproducible.
     #[arg(long, value_name = "N", default_value_t = 0)]
     pub chaos_fail_every: u32,
+
+    /// Output format for the run result on stdout. `text` (default) preserves
+    /// today's output — no structured output. `json` prints exactly one
+    /// schema-versioned JSON object to stdout on completion (submitted or
+    /// verification-failure); all human/log text goes to stderr.
+    /// Has no effect for hard errors before a trajectory exists.
+    #[arg(long, value_enum, default_value_t = crate::run::mini::ResultFormat::Text)]
+    pub result_format: crate::run::mini::ResultFormat,
+
+    /// Hidden test/CI hook: scripted model responses (repeatable; one response
+    /// per assistant turn), bypassing the real model API. Identical to the
+    /// mechanism used internally by `max hello-world`. Lets CI drive
+    /// `--result-format json` deterministically without a real API key.
+    #[arg(long = "deterministic-responses", value_name = "RESPONSE", hide = true)]
+    pub deterministic_responses: Vec<String>,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1041,6 +1041,17 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
     let traj_path = m.output.join(format!("{trajectory_name}.traj.json"));
     // patch_path is only set when github-pr flags are active (same gating as patch_capture).
     let patch_path = github_pr.as_ref().map(|o| o.patch_path.clone());
+    // The scripted-model hook only affects the builtin loop; external drivers
+    // shell out to a real agent and ignore it, which would silently make a paid
+    // call despite the documented "bypasses the model API" guarantee.
+    if !m.deterministic_responses.is_empty() && m.driver != crate::run::mini::RunDriver::Builtin {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(
+            "--deterministic-responses is only honored by the builtin driver; \
+             external drivers (--driver codex|claude-code) shell out to a real agent \
+             and ignore scripted responses"
+                .into(),
+        )));
+    }
     let scripted = if m.deterministic_responses.is_empty() {
         None
     } else {
@@ -1081,31 +1092,34 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         issue_provenance,
     };
     let run_result = crate::run::mini::run(args).await;
-    // Emit the machine-readable result BEFORE attempting any GitHub PR publish.
-    // A submitted run's trajectory and patch already exist on disk, so a later
-    // PR-publish error (missing token, API failure) must not suppress the JSON
-    // stdout contract the caller asked for.
-    emit_mini_result(
-        result_format,
-        &run_result,
-        &traj_path,
-        patch_path.as_deref(),
-        &redactor,
-    )?;
-    // Only publish when the run succeeded or failed at verification — those are
-    // the two cases where the trajectory and patch are guaranteed on disk.
-    // For other errors (env setup, model API, pre-trajectory I/O) propagate
-    // immediately so the real failure isn't masked by a trajectory-read error.
+    // Attempt the GitHub PR publish only when the run succeeded or failed at
+    // verification — those are the two cases where the trajectory and patch are
+    // guaranteed on disk. Capture the result instead of early-returning so the
+    // JSON result object can both always emit AND fold the publish failure into
+    // its effective exit code.
     let is_verification_failure =
         matches!(run_result, Err(crate::error::Error::VerificationFailed(..)));
-    if run_result.is_ok() || is_verification_failure {
+    let publish_result = if run_result.is_ok() || is_verification_failure {
         maybe_publish_mini_github_pr(
             github_pr,
             result_format == crate::run::mini::ResultFormat::Json,
         )
-        .await?;
-    }
+        .await
+    } else {
+        Ok(())
+    };
+    emit_mini_result(
+        result_format,
+        &run_result,
+        &publish_result,
+        &traj_path,
+        patch_path.as_deref(),
+        &redactor,
+    )?;
+    // Propagate the run error first (it determines the JSON exit code), then any
+    // publish error. This ordering matches emit_mini_result's exit-code precedence.
     run_result?;
+    publish_result?;
     Ok(())
 }
 
@@ -1530,11 +1544,13 @@ async fn mini_resume_cmd(
         continue_from: None,
         issue_provenance,
     };
-    // Resume never captures a patch (patch_capture: None), so patch_path is None.
+    // Resume never captures a patch (patch_capture: None) and never publishes a PR.
     let run_result = crate::run::mini::run(args).await;
+    let no_publish: Result<(), Error> = Ok(());
     emit_mini_result(
         result_format,
         &run_result,
+        &no_publish,
         &result_traj_path,
         None,
         &redactor,
@@ -1819,11 +1835,13 @@ async fn mini_continue_cmd(
         parent_sweep_run_id: None,
         issue_provenance: None,
     };
-    // Continue never captures a patch (patch_capture: None), so patch_path is None.
+    // Continue never captures a patch (patch_capture: None) and never publishes a PR.
     let run_result = crate::run::mini::run(args).await;
+    let no_publish: Result<(), Error> = Ok(());
     emit_mini_result(
         result_format,
         &run_result,
+        &no_publish,
         &result_traj_path,
         None,
         &redactor,
@@ -2537,13 +2555,19 @@ struct TrajectoryInfoOnly {
 
 /// Emit a machine-readable run result to stdout when `--result-format json` is active.
 ///
-/// Called after `mini::run` and the optional GitHub PR publish; `run_result?` comes after.
-/// Emission scope (from AC4): only for `Ok(())` (submitted) and `VerificationFailed` —
-/// the two cases where the trajectory and patch are guaranteed on disk.
-/// For any other `Err`, silently return `Ok(())` so `run_result?` propagates the real error.
+/// Emission scope: only when the trajectory records `outcome == "submitted"`,
+/// covering a clean submit (exit 0) and a submitted-then-verification-failed run
+/// (exit 7). Hard errors before a trajectory exists, and unsubmitted runs (step
+/// limit, budget, stagnation), print no result object.
+///
+/// The reported `exit_code`/`exit_outcome_class` reflect the **effective** final
+/// exit: a run error takes precedence (it is propagated first by the caller),
+/// otherwise a GitHub PR-publish error, otherwise success. This keeps the JSON
+/// honest even when `--open-pr` publishing fails after a successful submit.
 fn emit_mini_result(
     format: crate::run::mini::ResultFormat,
     run_result: &Result<(), Error>,
+    publish_result: &Result<(), Error>,
     traj_path: &std::path::Path,
     patch_path: Option<&std::path::Path>,
     redactor: &crate::redaction::Redactor,
@@ -2551,24 +2575,25 @@ fn emit_mini_result(
     if format != crate::run::mini::ResultFormat::Json {
         return Ok(());
     }
-    let exit_code = match run_result {
-        Ok(()) => crate::exit_code::ExitCode::Success,
-        Err(e) if matches!(e, Error::VerificationFailed(..)) => {
-            crate::exit_code::ExitCode::from_error(e)
-        }
-        Err(_) => return Ok(()), // hard error — no object; run_result? handles it
+    // Only Ok and VerificationFailed guarantee a trajectory (and patch) on disk.
+    // Any other run error is a hard pre-/mid-trajectory failure → no result object;
+    // the caller's `run_result?` propagates it and `main` prints the outcome class.
+    if !(run_result.is_ok() || matches!(run_result, Err(Error::VerificationFailed(..)))) {
+        return Ok(());
+    }
+    // Effective exit code: run error first (caller propagates it before the publish
+    // error), then a publish error, otherwise success.
+    let exit_code = match (run_result, publish_result) {
+        (Err(e), _) | (Ok(()), Err(e)) => crate::exit_code::ExitCode::from_error(e),
+        (Ok(()), Ok(())) => crate::exit_code::ExitCode::Success,
     };
     // Deserialize only the `info` block (see TrajectoryInfoOnly) to avoid
     // loading the full message history just to read summary fields.
     let traj_json = std::fs::read_to_string(traj_path).map_err(Error::Io)?;
     let traj: TrajectoryInfoOnly = serde_json::from_str(&traj_json).map_err(Error::Json)?;
-    // Only emit when the agent actually submitted a patch. This is the unifying
-    // condition behind both contract cases: a clean submit (outcome=submitted,
-    // exit 0) and a submitted-then-verification-failed run (outcome=submitted,
-    // exit 7). Runs that returned Ok without submitting (step-limit, budget) and
-    // runs where a `--verify` check fails on an *unsubmitted* run (outcome still
-    // step_limit_reached/etc., yet mini::run returns VerificationFailed) are
-    // represented only by the trajectory, not by a stdout result object.
+    // Only emit when the agent actually submitted a patch — the unifying condition
+    // behind both contract cases. Unsubmitted runs (incl. a `--verify` failure on a
+    // step-limit/budget run) are represented only by the trajectory.
     if traj.info.outcome.as_deref() != Some(crate::trajectory::outcome::SUBMITTED) {
         return Ok(());
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1036,6 +1036,7 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
 
     // Capture state needed for --result-format json before MiniArgs consumes fields.
     let result_format = m.result_format;
+    reject_json_with_ratatui(result_format, interactive_mode)?;
     let redactor = crate::redaction::Redactor::from_config_lossy(&cfg.root.redaction);
     let traj_path = m.output.join(format!("{trajectory_name}.traj.json"));
     // patch_path is only set when github-pr flags are active (same gating as patch_capture).
@@ -1080,6 +1081,17 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         issue_provenance,
     };
     let run_result = crate::run::mini::run(args).await;
+    // Emit the machine-readable result BEFORE attempting any GitHub PR publish.
+    // A submitted run's trajectory and patch already exist on disk, so a later
+    // PR-publish error (missing token, API failure) must not suppress the JSON
+    // stdout contract the caller asked for.
+    emit_mini_result(
+        result_format,
+        &run_result,
+        &traj_path,
+        patch_path.as_deref(),
+        &redactor,
+    )?;
     // Only publish when the run succeeded or failed at verification — those are
     // the two cases where the trajectory and patch are guaranteed on disk.
     // For other errors (env setup, model API, pre-trajectory I/O) propagate
@@ -1093,13 +1105,6 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         )
         .await?;
     }
-    emit_mini_result(
-        result_format,
-        &run_result,
-        &traj_path,
-        patch_path.as_deref(),
-        &redactor,
-    )?;
     run_result?;
     Ok(())
 }
@@ -1483,8 +1488,14 @@ async fn mini_resume_cmd(
 
     // Capture --result-format state before MiniArgs consumes cfg/output fields.
     let result_format = m.result_format;
+    reject_json_with_ratatui(result_format, interactive_mode)?;
     let redactor = crate::redaction::Redactor::from_config_lossy(&cfg.root.redaction);
     let result_traj_path = traj_output_dir.join(format!("{traj_stem}.traj.json"));
+    let scripted = if m.deterministic_responses.is_empty() {
+        None
+    } else {
+        Some(m.deterministic_responses.clone())
+    };
 
     let args = crate::run::mini::MiniArgs {
         task,
@@ -1495,7 +1506,7 @@ async fn mini_resume_cmd(
         driver_isolated: false,
         output_dir: traj_output_dir,
         trajectory_name: traj_stem,
-        deterministic_responses: None,
+        deterministic_responses: scripted,
         deterministic_usage_per_call: None,
         task_timeout_secs: m.task_timeout_secs,
         cancellation: None,
@@ -1766,8 +1777,14 @@ async fn mini_continue_cmd(
 
     // Capture --result-format state before MiniArgs consumes cfg/output fields.
     let result_format = m.result_format;
+    reject_json_with_ratatui(result_format, interactive_mode)?;
     let redactor = crate::redaction::Redactor::from_config_lossy(&cfg.root.redaction);
     let result_traj_path = output_dir.join(format!("{child_traj_name}.traj.json"));
+    let scripted = if m.deterministic_responses.is_empty() {
+        None
+    } else {
+        Some(m.deterministic_responses.clone())
+    };
 
     let args = crate::run::mini::MiniArgs {
         task: follow_up_task,
@@ -1778,7 +1795,7 @@ async fn mini_continue_cmd(
         driver_isolated: false,
         output_dir,
         trajectory_name: child_traj_name,
-        deterministic_responses: None,
+        deterministic_responses: scripted,
         deterministic_usage_per_call: None,
         task_timeout_secs: effective_task_timeout,
         cancellation: None,
@@ -2481,6 +2498,33 @@ fn validate_observation_head_ratio(value: f64) -> Result<(), Error> {
             "--observation-head-ratio must be a finite value in [0,1], got {value}"
         ))))
     }
+}
+
+/// Reject `--result-format json` combined with the ratatui dashboard UI.
+///
+/// The ratatui dashboard enters the alternate screen and renders to
+/// `std::io::stdout()` (see `agent::confirm_tui`), which would interleave
+/// terminal-control bytes with the JSON result and break the clean-stdout
+/// contract. The two modes are fundamentally incompatible, so reject early.
+fn reject_json_with_ratatui(
+    result_format: crate::run::mini::ResultFormat,
+    interactive_mode: crate::run::mini::InteractiveMode,
+) -> Result<(), Error> {
+    use crate::run::mini::{InteractiveMode, ResultFormat};
+    if result_format == ResultFormat::Json
+        && matches!(
+            interactive_mode,
+            InteractiveMode::Ratatui | InteractiveMode::RatatuiMonitor
+        )
+    {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(
+            "--result-format json cannot be combined with --ui ratatui; the dashboard \
+             renders to stdout and would corrupt the JSON result stream. Use the default \
+             --ui stderr."
+                .into(),
+        )));
+    }
+    Ok(())
 }
 
 /// Lightweight view over a trajectory file that deserializes only the `info`

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1033,6 +1033,24 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
 
     let verification_checks = parse_verify_checks(&m.verify)?;
     let interactive_mode = resolve_interactive_mode(m.interactive, m.yolo, m.ui);
+
+    // Capture state needed for --result-format json before MiniArgs consumes fields.
+    let result_format = m.result_format;
+    let redactor =
+        crate::redaction::Redactor::from_config_lossy(&cfg.root.redaction);
+    let traj_path = m
+        .output
+        .join(format!("{trajectory_name}.traj.json"));
+    // patch_path is only set when github-pr flags are active (same gating as patch_capture).
+    let patch_path = github_pr
+        .as_ref()
+        .map(|o| o.patch_path.clone());
+    let scripted = if m.deterministic_responses.is_empty() {
+        None
+    } else {
+        Some(m.deterministic_responses.clone())
+    };
+
     let args = crate::run::mini::MiniArgs {
         task,
         extra_context: m.extra_context,
@@ -1042,7 +1060,7 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
         driver_isolated: m.driver_isolated,
         output_dir: m.output,
         trajectory_name,
-        deterministic_responses: None,
+        deterministic_responses: scripted,
         deterministic_usage_per_call: None,
         task_timeout_secs: m.task_timeout_secs,
         cancellation: None,
@@ -1076,6 +1094,13 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
     if run_result.is_ok() || is_verification_failure {
         maybe_publish_mini_github_pr(github_pr).await?;
     }
+    emit_mini_result(
+        result_format,
+        &run_result,
+        &traj_path,
+        patch_path.as_deref(),
+        &redactor,
+    )?;
     run_result?;
     Ok(())
 }
@@ -2429,6 +2454,55 @@ fn validate_observation_head_ratio(value: f64) -> Result<(), Error> {
             "--observation-head-ratio must be a finite value in [0,1], got {value}"
         ))))
     }
+}
+
+/// Emit a machine-readable run result to stdout when `--result-format json` is active.
+///
+/// Called after `mini::run` and the optional GitHub PR publish; `run_result?` comes after.
+/// Emission scope (from AC4): only for `Ok(())` (submitted) and `VerificationFailed` —
+/// the two cases where the trajectory and patch are guaranteed on disk.
+/// For any other `Err`, silently return `Ok(())` so `run_result?` propagates the real error.
+fn emit_mini_result(
+    format: crate::run::mini::ResultFormat,
+    run_result: &Result<(), Error>,
+    traj_path: &std::path::Path,
+    patch_path: Option<&std::path::Path>,
+    redactor: &crate::redaction::Redactor,
+) -> Result<(), Error> {
+    if format != crate::run::mini::ResultFormat::Json {
+        return Ok(());
+    }
+    let exit_code = match run_result {
+        Ok(()) => crate::exit_code::ExitCode::Success,
+        Err(e) if matches!(e, Error::VerificationFailed(..)) => {
+            crate::exit_code::ExitCode::from_error(e)
+        }
+        Err(_) => return Ok(()), // hard error — no object; run_result? handles it
+    };
+    // Load the trajectory that mini::run just wrote to disk.
+    let traj_json = std::fs::read_to_string(traj_path).map_err(Error::Io)?;
+    let traj: crate::trajectory::Trajectory =
+        serde_json::from_str(&traj_json).map_err(Error::Json)?;
+    // For a plain Ok(()) run, only emit if the trajectory records "submitted".
+    // Stagnation / step-limit / budget-exhausted runs return Ok but are not submitted;
+    // those do not emit a result object (would be noisy and the trajectory is the record).
+    if run_result.is_ok()
+        && traj.info.outcome.as_deref() != Some(crate::trajectory::outcome::SUBMITTED)
+    {
+        return Ok(());
+    }
+    let effective_patch = patch_path.filter(|p| p.exists());
+    let result = crate::run::mini_result::MiniResult::from_trajectory_info(
+        &traj.info,
+        exit_code,
+        traj_path,
+        effective_patch,
+    );
+    let json = result
+        .to_redacted_json(redactor)
+        .map_err(Error::Json)?;
+    println!("{json}");
+    Ok(())
 }
 
 #[allow(clippy::single_option_map)]
@@ -7201,6 +7275,8 @@ mod tests {
             webhook_headers: vec![],
             no_step_persist: false,
             chaos_fail_every: 0,
+            result_format: crate::run::mini::ResultFormat::Text,
+            deterministic_responses: vec![],
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1036,15 +1036,10 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
 
     // Capture state needed for --result-format json before MiniArgs consumes fields.
     let result_format = m.result_format;
-    let redactor =
-        crate::redaction::Redactor::from_config_lossy(&cfg.root.redaction);
-    let traj_path = m
-        .output
-        .join(format!("{trajectory_name}.traj.json"));
+    let redactor = crate::redaction::Redactor::from_config_lossy(&cfg.root.redaction);
+    let traj_path = m.output.join(format!("{trajectory_name}.traj.json"));
     // patch_path is only set when github-pr flags are active (same gating as patch_capture).
-    let patch_path = github_pr
-        .as_ref()
-        .map(|o| o.patch_path.clone());
+    let patch_path = github_pr.as_ref().map(|o| o.patch_path.clone());
     let scripted = if m.deterministic_responses.is_empty() {
         None
     } else {
@@ -2479,10 +2474,14 @@ fn emit_mini_result(
         }
         Err(_) => return Ok(()), // hard error — no object; run_result? handles it
     };
-    // Load the trajectory that mini::run just wrote to disk.
+    // Deserialize only the `info` block: a trajectory carries the full message
+    // history and tool outputs (potentially megabytes) that we never read here.
+    #[derive(serde::Deserialize)]
+    struct TrajectoryInfoOnly {
+        info: crate::trajectory::TrajectoryInfo,
+    }
     let traj_json = std::fs::read_to_string(traj_path).map_err(Error::Io)?;
-    let traj: crate::trajectory::Trajectory =
-        serde_json::from_str(&traj_json).map_err(Error::Json)?;
+    let traj: TrajectoryInfoOnly = serde_json::from_str(&traj_json).map_err(Error::Json)?;
     // For a plain Ok(()) run, only emit if the trajectory records "submitted".
     // Stagnation / step-limit / budget-exhausted runs return Ok but are not submitted;
     // those do not emit a result object (would be noisy and the trajectory is the record).
@@ -2491,16 +2490,22 @@ fn emit_mini_result(
     {
         return Ok(());
     }
-    let effective_patch = patch_path.filter(|p| p.exists());
+    // The spec promises absolute paths. Canonicalize where possible (the files
+    // exist on disk by this point); fall back to the as-given path if the
+    // filesystem call fails so we never panic on an unusual path.
+    let abs_traj_path = traj_path
+        .canonicalize()
+        .unwrap_or_else(|_| traj_path.to_path_buf());
+    let abs_patch_path = patch_path
+        .filter(|p| p.exists())
+        .and_then(|p| p.canonicalize().ok());
     let result = crate::run::mini_result::MiniResult::from_trajectory_info(
         &traj.info,
         exit_code,
-        traj_path,
-        effective_patch,
+        &abs_traj_path,
+        abs_patch_path.as_deref(),
     );
-    let json = result
-        .to_redacted_json(redactor)
-        .map_err(Error::Json)?;
+    let json = result.to_redacted_json(redactor).map_err(Error::Json)?;
     println!("{json}");
     Ok(())
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1087,7 +1087,11 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
     let is_verification_failure =
         matches!(run_result, Err(crate::error::Error::VerificationFailed(..)));
     if run_result.is_ok() || is_verification_failure {
-        maybe_publish_mini_github_pr(github_pr).await?;
+        maybe_publish_mini_github_pr(
+            github_pr,
+            result_format == crate::run::mini::ResultFormat::Json,
+        )
+        .await?;
     }
     emit_mini_result(
         result_format,
@@ -1477,6 +1481,11 @@ async fn mini_resume_cmd(
         }
     });
 
+    // Capture --result-format state before MiniArgs consumes cfg/output fields.
+    let result_format = m.result_format;
+    let redactor = crate::redaction::Redactor::from_config_lossy(&cfg.root.redaction);
+    let result_traj_path = traj_output_dir.join(format!("{traj_stem}.traj.json"));
+
     let args = crate::run::mini::MiniArgs {
         task,
         extra_context: m.extra_context,
@@ -1510,7 +1519,16 @@ async fn mini_resume_cmd(
         continue_from: None,
         issue_provenance,
     };
-    crate::run::mini::run(args).await
+    // Resume never captures a patch (patch_capture: None), so patch_path is None.
+    let run_result = crate::run::mini::run(args).await;
+    emit_mini_result(
+        result_format,
+        &run_result,
+        &result_traj_path,
+        None,
+        &redactor,
+    )?;
+    run_result
 }
 
 /// Validate `traj` for `--continue` and exit the process on the first violation.
@@ -1746,6 +1764,11 @@ async fn mini_continue_cmd(
     let verification_checks = parse_verify_checks(&m.verify)?;
     let interactive_mode = resolve_interactive_mode(m.interactive, m.yolo, m.ui);
 
+    // Capture --result-format state before MiniArgs consumes cfg/output fields.
+    let result_format = m.result_format;
+    let redactor = crate::redaction::Redactor::from_config_lossy(&cfg.root.redaction);
+    let result_traj_path = output_dir.join(format!("{child_traj_name}.traj.json"));
+
     let args = crate::run::mini::MiniArgs {
         task: follow_up_task,
         extra_context: m.extra_context,
@@ -1779,7 +1802,16 @@ async fn mini_continue_cmd(
         parent_sweep_run_id: None,
         issue_provenance: None,
     };
-    crate::run::mini::run(args).await
+    // Continue never captures a patch (patch_capture: None), so patch_path is None.
+    let run_result = crate::run::mini::run(args).await;
+    emit_mini_result(
+        result_format,
+        &run_result,
+        &result_traj_path,
+        None,
+        &redactor,
+    )?;
+    run_result
 }
 
 fn apply_read_only_policy(m: &args::MiniCmd, cfg: &Config) -> Result<(), Error> {
@@ -2451,6 +2483,14 @@ fn validate_observation_head_ratio(value: f64) -> Result<(), Error> {
     }
 }
 
+/// Lightweight view over a trajectory file that deserializes only the `info`
+/// block. A trajectory carries the full message history and tool outputs
+/// (potentially megabytes) that `emit_mini_result` never reads.
+#[derive(serde::Deserialize)]
+struct TrajectoryInfoOnly {
+    info: crate::trajectory::TrajectoryInfo,
+}
+
 /// Emit a machine-readable run result to stdout when `--result-format json` is active.
 ///
 /// Called after `mini::run` and the optional GitHub PR publish; `run_result?` comes after.
@@ -2474,20 +2514,18 @@ fn emit_mini_result(
         }
         Err(_) => return Ok(()), // hard error — no object; run_result? handles it
     };
-    // Deserialize only the `info` block: a trajectory carries the full message
-    // history and tool outputs (potentially megabytes) that we never read here.
-    #[derive(serde::Deserialize)]
-    struct TrajectoryInfoOnly {
-        info: crate::trajectory::TrajectoryInfo,
-    }
+    // Deserialize only the `info` block (see TrajectoryInfoOnly) to avoid
+    // loading the full message history just to read summary fields.
     let traj_json = std::fs::read_to_string(traj_path).map_err(Error::Io)?;
     let traj: TrajectoryInfoOnly = serde_json::from_str(&traj_json).map_err(Error::Json)?;
-    // For a plain Ok(()) run, only emit if the trajectory records "submitted".
-    // Stagnation / step-limit / budget-exhausted runs return Ok but are not submitted;
-    // those do not emit a result object (would be noisy and the trajectory is the record).
-    if run_result.is_ok()
-        && traj.info.outcome.as_deref() != Some(crate::trajectory::outcome::SUBMITTED)
-    {
+    // Only emit when the agent actually submitted a patch. This is the unifying
+    // condition behind both contract cases: a clean submit (outcome=submitted,
+    // exit 0) and a submitted-then-verification-failed run (outcome=submitted,
+    // exit 7). Runs that returned Ok without submitting (step-limit, budget) and
+    // runs where a `--verify` check fails on an *unsubmitted* run (outcome still
+    // step_limit_reached/etc., yet mini::run returns VerificationFailed) are
+    // represented only by the trajectory, not by a stdout result object.
+    if traj.info.outcome.as_deref() != Some(crate::trajectory::outcome::SUBMITTED) {
         return Ok(());
     }
     // The spec promises absolute paths. Canonicalize where possible (the files
@@ -2613,23 +2651,37 @@ fn trajectory_submitted(path: &std::path::Path) -> Result<bool, Error> {
     Ok(trajectory.info.outcome.as_deref() == Some(crate::trajectory::outcome::SUBMITTED))
 }
 
-async fn publish_github_pr(options: crate::run::github_pr::GithubPrOptions) -> Result<(), Error> {
+async fn publish_github_pr(
+    options: crate::run::github_pr::GithubPrOptions,
+    to_stderr: bool,
+) -> Result<(), Error> {
     let result = crate::run::github_pr::publish(options).await?;
+    // When the run result is being emitted as JSON, this human-facing PR text
+    // must not pollute stdout — stdout has to be exactly one JSON object.
     if let Some(output) = result.dry_run_output {
-        print!("{output}");
+        if to_stderr {
+            eprint!("{output}");
+        } else {
+            print!("{output}");
+        }
     } else if let Some(url) = result.url {
-        println!("github_pr_url: {url}");
+        if to_stderr {
+            eprintln!("github_pr_url: {url}");
+        } else {
+            println!("github_pr_url: {url}");
+        }
     }
     Ok(())
 }
 
 async fn maybe_publish_mini_github_pr(
     github_pr: Option<crate::run::github_pr::GithubPrOptions>,
+    json_result_mode: bool,
 ) -> Result<(), Error> {
     if let Some(options) = github_pr {
         let traj_path = options.trajectory_ref.clone();
         if trajectory_submitted(std::path::Path::new(&traj_path))? {
-            publish_github_pr(options).await?;
+            publish_github_pr(options, json_result_mode).await?;
         } else {
             tracing::info!(trajectory = %traj_path, "github PR skipped because run did not submit");
         }
@@ -7135,34 +7187,40 @@ mod tests {
         let patch = work.path().join("submitted.patch");
         std::fs::write(&patch, sample_patch()).unwrap();
 
-        maybe_publish_mini_github_pr(Some(crate::run::github_pr::GithubPrOptions {
-            target_repo: "madmax983/maxwells-daemon".into(),
-            target_branch: "trunk".into(),
-            task_id: "submitted".into(),
-            trajectory_ref: submitted.display().to_string(),
-            patch_path: patch,
-            branch_prefix: "max".into(),
-            token_env: "GITHUB_TOKEN".into(),
-            mode: PublishMode::DryRun,
-            timeout_secs: 30,
-            max_retries: 2,
-            backoff_base_ms: 250,
-            redaction: crate::config::RedactionCfg::default(),
-        }))
+        maybe_publish_mini_github_pr(
+            Some(crate::run::github_pr::GithubPrOptions {
+                target_repo: "madmax983/maxwells-daemon".into(),
+                target_branch: "trunk".into(),
+                task_id: "submitted".into(),
+                trajectory_ref: submitted.display().to_string(),
+                patch_path: patch,
+                branch_prefix: "max".into(),
+                token_env: "GITHUB_TOKEN".into(),
+                mode: PublishMode::DryRun,
+                timeout_secs: 30,
+                max_retries: 2,
+                backoff_base_ms: 250,
+                redaction: crate::config::RedactionCfg::default(),
+            }),
+            false,
+        )
         .await
         .unwrap();
 
         let errored = work.path().join("errored.traj.json");
         write_trajectory(&errored, Some(outcome::ERROR));
-        maybe_publish_mini_github_pr(Some(crate::run::github_pr::GithubPrOptions {
-            trajectory_ref: errored.display().to_string(),
-            patch_path: work.path().join("missing.patch"),
-            mode: PublishMode::DryRun,
-            ..github_options_for_cli_test()
-        }))
+        maybe_publish_mini_github_pr(
+            Some(crate::run::github_pr::GithubPrOptions {
+                trajectory_ref: errored.display().to_string(),
+                patch_path: work.path().join("missing.patch"),
+                mode: PublishMode::DryRun,
+                ..github_options_for_cli_test()
+            }),
+            false,
+        )
         .await
         .unwrap();
-        maybe_publish_mini_github_pr(None).await.unwrap();
+        maybe_publish_mini_github_pr(None, false).await.unwrap();
     }
 
     #[test]

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -106,6 +106,22 @@ pub enum PatchValidationFailure {
     ApplyFailed(String),
 }
 
+/// Output format for `mini --result-format`.
+///
+/// `Text` (default) preserves existing behaviour — nothing machine-readable is
+/// printed to stdout. `Json` emits exactly one schema-versioned JSON object
+/// to stdout after a terminal submitted or verification-failure run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+pub enum ResultFormat {
+    /// Default: no structured output on stdout; human/log text to stderr.
+    #[default]
+    Text,
+    /// Emit a single schema-versioned JSON object to stdout after the run
+    /// completes (submitted or verification-failure). All human/log text goes
+    /// to stderr so stdout is clean JSON with no leading noise.
+    Json,
+}
+
 /// Selects which agent backend drives a single-task run.
 ///
 /// The harness ships a built-in bash-first loop, but operators exploring

--- a/src/run/mini_result.rs
+++ b/src/run/mini_result.rs
@@ -1,0 +1,223 @@
+//! Machine-readable single-run result for `max mini --result-format json`.
+//!
+//! See `docs/spec-mini-result-format.md` for the full schema contract.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::artifact::ArtifactKind;
+use crate::exit_code::ExitCode;
+use crate::redaction::{Redactor, surface};
+use crate::trajectory::{FailureCategory, TokenUsage, TrajectoryInfo};
+
+/// Compact, schema-versioned single-run result emitted to stdout by
+/// `max mini --result-format json`.
+///
+/// The struct is flattened with an `ArtifactHeader` at serialisation time via
+/// `crate::artifact::to_string_pretty`, which prepends `artifact_kind` and
+/// `schema_version` into the top-level JSON object.
+#[derive(Debug, Serialize)]
+pub struct MiniResult {
+    /// High-level run outcome string from `trajectory.info.outcome`
+    /// (e.g. `"submitted"`, `"error"`, `"step_limit_reached"`).
+    pub outcome: Option<String>,
+    /// Numeric process exit code this run would produce.
+    pub exit_code: i32,
+    /// Stable string outcome-class label (e.g. `"success"`, `"verification_failure"`).
+    pub exit_outcome_class: String,
+    /// Total cost of the run in USD (actual + baseline). `null` when not captured.
+    pub total_cost_usd: Option<f64>,
+    /// Number of agent steps taken.
+    pub steps: Option<u32>,
+    /// Prompt (input) tokens consumed. `null` when not captured.
+    pub input_tokens: Option<u64>,
+    /// Completion (output) tokens consumed. `null` when not captured.
+    pub output_tokens: Option<u64>,
+    /// Absolute path of the written `.traj.json` trajectory file.
+    pub trajectory_path: String,
+    /// Absolute path of the written `.patch` file, or `null` when no patch
+    /// was captured (no `--github-pr` / `--open-pr` flags).
+    pub patch_path: Option<String>,
+    /// Machine-readable failure category. `null` on successful runs.
+    pub failure_category: Option<FailureCategory>,
+}
+
+impl MiniResult {
+    /// Build a `MiniResult` from a completed `TrajectoryInfo` and associated metadata.
+    ///
+    /// * `info` — the `.info` block of the just-written trajectory.
+    /// * `exit` — the `ExitCode` that the process will exit with.
+    /// * `traj_path` — absolute path to the `.traj.json` artifact.
+    /// * `patch_path` — path to the `.patch` artifact, if it was written.
+    pub fn from_trajectory_info(
+        info: &TrajectoryInfo,
+        exit: ExitCode,
+        traj_path: &Path,
+        patch_path: Option<&Path>,
+    ) -> Self {
+        let (input_tokens, output_tokens) = split_tokens(info.token_usage.as_ref());
+        Self {
+            outcome: info.outcome.clone(),
+            exit_code: exit.as_i32(),
+            exit_outcome_class: exit.outcome_class().to_owned(),
+            total_cost_usd: info.total_cost_usd,
+            steps: info.steps,
+            input_tokens,
+            output_tokens,
+            trajectory_path: traj_path.display().to_string(),
+            patch_path: patch_path.map(|p| p.display().to_string()),
+            failure_category: info.failure_category,
+        }
+    }
+
+    /// Serialize to indented JSON, redacting all string fields through the
+    /// active `Redactor` policy (consistent with `agent skills-preview --format json`).
+    ///
+    /// Numbers, booleans, and nested structure keys are never altered.
+    pub fn to_redacted_json(&self, redactor: &Redactor) -> Result<String, serde_json::Error> {
+        let raw = crate::artifact::to_string_pretty(ArtifactKind::MiniResult, self)?;
+        let mut value: serde_json::Value = serde_json::from_str(&raw)?;
+        redactor.redact_json_value(&mut value, surface::TRAJECTORY);
+        serde_json::to_string_pretty(&value)
+    }
+}
+
+fn split_tokens(usage: Option<&TokenUsage>) -> (Option<u64>, Option<u64>) {
+    match usage {
+        Some(u) => (Some(u.prompt_tokens), Some(u.completion_tokens)),
+        None => (None, None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use std::path::PathBuf;
+
+    use crate::config::RedactionCfg;
+    use crate::trajectory::{TokenUsage, TrajectoryInfo};
+
+    use super::*;
+
+    fn make_info(outcome: &str, steps: u32, cost: f64) -> TrajectoryInfo {
+        TrajectoryInfo {
+            outcome: Some(outcome.to_owned()),
+            steps: Some(steps),
+            total_cost_usd: Some(cost),
+            token_usage: Some(TokenUsage {
+                prompt_tokens: 10,
+                completion_tokens: 5,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn from_trajectory_info_maps_fields_correctly() {
+        let info = make_info("submitted", 3, 0.01);
+        let traj = PathBuf::from("/tmp/foo.traj.json");
+        let patch = PathBuf::from("/tmp/foo.patch");
+
+        let result = MiniResult::from_trajectory_info(
+            &info,
+            ExitCode::Success,
+            &traj,
+            Some(patch.as_path()),
+        );
+
+        assert_eq!(result.outcome.as_deref(), Some("submitted"));
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.exit_outcome_class, "success");
+        assert_eq!(result.total_cost_usd, Some(0.01));
+        assert_eq!(result.steps, Some(3));
+        assert_eq!(result.input_tokens, Some(10));
+        assert_eq!(result.output_tokens, Some(5));
+        assert_eq!(result.trajectory_path, "/tmp/foo.traj.json");
+        assert_eq!(result.patch_path.as_deref(), Some("/tmp/foo.patch"));
+        assert!(result.failure_category.is_none());
+    }
+
+    #[test]
+    fn from_trajectory_info_null_patch_when_no_patch() {
+        let info = make_info("submitted", 1, 0.0);
+        let traj = PathBuf::from("/tmp/foo.traj.json");
+
+        let result = MiniResult::from_trajectory_info(&info, ExitCode::Success, &traj, None);
+        assert!(result.patch_path.is_none());
+    }
+
+    #[test]
+    fn to_redacted_json_is_valid_json_with_required_keys() {
+        let info = make_info("submitted", 2, 0.005);
+        let traj = PathBuf::from("/tmp/test.traj.json");
+        let result = MiniResult::from_trajectory_info(&info, ExitCode::Success, &traj, None);
+
+        let redactor = Redactor::disabled();
+        let json_str = result.to_redacted_json(&redactor).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        assert!(parsed.is_object());
+        assert_eq!(parsed["artifact_kind"].as_str(), Some("mini_result"));
+        assert!(parsed["schema_version"].is_object());
+        assert!(parsed["outcome"].is_string());
+        assert!(parsed["exit_code"].is_number());
+        assert!(parsed["exit_outcome_class"].is_string());
+        assert!(parsed.get("total_cost_usd").is_some());
+        assert!(parsed.get("steps").is_some());
+        assert!(parsed.get("input_tokens").is_some());
+        assert!(parsed.get("output_tokens").is_some());
+        assert!(parsed["trajectory_path"].is_string());
+        assert!(parsed.get("patch_path").is_some());
+        assert!(parsed.get("failure_category").is_some());
+    }
+
+    #[test]
+    fn to_redacted_json_redacts_sensitive_trajectory_path() {
+        let info = make_info("submitted", 1, 0.0);
+        let traj = PathBuf::from("/home/alice/supersecrettoken/run.traj.json");
+        let result = MiniResult::from_trajectory_info(&info, ExitCode::Success, &traj, None);
+
+        let cfg = RedactionCfg {
+            enabled: true,
+            secret_literals: vec!["supersecrettoken".to_owned()],
+            ..Default::default()
+        };
+        let redactor = Redactor::from_config(&cfg).unwrap();
+        let json_str = result.to_redacted_json(&redactor).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        let traj_path_val = parsed["trajectory_path"].as_str().unwrap();
+        assert!(
+            !traj_path_val.contains("supersecrettoken"),
+            "secret must be redacted from trajectory_path; got: {traj_path_val}"
+        );
+        assert!(
+            traj_path_val.contains("[REDACTED:"),
+            "expected [REDACTED:...] marker; got: {traj_path_val}"
+        );
+    }
+
+    #[test]
+    fn split_tokens_none_when_no_usage() {
+        let (input, output) = split_tokens(None);
+        assert!(input.is_none());
+        assert!(output.is_none());
+    }
+
+    #[test]
+    fn split_tokens_extracts_prompt_and_completion() {
+        let usage = TokenUsage {
+            prompt_tokens: 42,
+            completion_tokens: 7,
+            cache_read_tokens: 1,
+            cache_creation_tokens: 2,
+        };
+        let (input, output) = split_tokens(Some(&usage));
+        assert_eq!(input, Some(42));
+        assert_eq!(output, Some(7));
+    }
+}

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -47,6 +47,7 @@ pub mod instance_history;
 pub mod ladder;
 pub mod matrix;
 pub mod mini;
+pub mod mini_result;
 pub mod near_miss;
 pub mod patch_stats;
 pub mod policy_check;

--- a/tests/mini_result_format.rs
+++ b/tests/mini_result_format.rs
@@ -17,8 +17,7 @@ use std::process::Stdio;
 
 mod support;
 
-const SUBMIT_RESPONSE: &str =
-    "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```";
+const SUBMIT_RESPONSE: &str = "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```";
 
 /// Run `max mini` with the deterministic scripted model and return (stdout, stderr, status).
 fn run_mini(extra_args: &[&str]) -> (String, String, std::process::ExitStatus) {
@@ -58,10 +57,9 @@ fn result_format_json_prints_valid_json_on_submit() {
         "expected exit 0; stderr:\n{stderr}\nstdout:\n{stdout}"
     );
     // AC1: stdout is valid JSON with no leading log noise
-    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
-        .unwrap_or_else(|e| {
-            panic!("stdout is not valid JSON: {e}\nstdout: {stdout}\nstderr: {stderr}")
-        });
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("stdout is not valid JSON: {e}\nstdout: {stdout}\nstderr: {stderr}")
+    });
     assert!(parsed.is_object(), "JSON output must be an object");
 }
 
@@ -69,8 +67,7 @@ fn result_format_json_prints_valid_json_on_submit() {
 fn result_format_json_contains_artifact_kind_and_schema_version() {
     let (stdout, _, status) = run_mini(&["--result-format", "json"]);
     assert!(status.success());
-    let parsed: serde_json::Value =
-        serde_json::from_str(stdout.trim()).expect("valid JSON");
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
     // AC6: versioned via ArtifactSchemaVersion
     assert_eq!(
         parsed["artifact_kind"].as_str(),
@@ -95,8 +92,7 @@ fn result_format_json_contains_artifact_kind_and_schema_version() {
 fn result_format_json_contains_all_required_keys() {
     let (stdout, _, status) = run_mini(&["--result-format", "json"]);
     assert!(status.success());
-    let parsed: serde_json::Value =
-        serde_json::from_str(stdout.trim()).expect("valid JSON");
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
     // AC3: required key presence
     let required = [
         "outcome",
@@ -107,8 +103,8 @@ fn result_format_json_contains_all_required_keys() {
         "input_tokens",
         "output_tokens",
         "trajectory_path",
-        "patch_path",         // nullable — key must exist
-        "failure_category",   // nullable — key must exist
+        "patch_path",       // nullable — key must exist
+        "failure_category", // nullable — key must exist
     ];
     for key in required {
         assert!(
@@ -122,8 +118,7 @@ fn result_format_json_contains_all_required_keys() {
 fn result_format_json_outcome_is_submitted_on_success() {
     let (stdout, _, status) = run_mini(&["--result-format", "json"]);
     assert!(status.success());
-    let parsed: serde_json::Value =
-        serde_json::from_str(stdout.trim()).expect("valid JSON");
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
     assert_eq!(
         parsed["outcome"].as_str(),
         Some("submitted"),
@@ -175,8 +170,8 @@ fn result_format_json_stdout_starts_with_brace_when_log_info() {
         "stdout must start with '{{' (no log noise); got: {trimmed:?}"
     );
     // Also must be valid JSON
-    let _: serde_json::Value = serde_json::from_str(trimmed)
-        .unwrap_or_else(|e| panic!("not valid JSON: {e}\n{trimmed}"));
+    let _: serde_json::Value =
+        serde_json::from_str(trimmed).unwrap_or_else(|e| panic!("not valid JSON: {e}\n{trimmed}"));
 }
 
 // ── AC2: default / `--result-format text` unchanged, stdout empty ────────────
@@ -229,7 +224,7 @@ fn result_format_json_emits_on_verification_failure() {
             "--result-format",
             "json",
             "--verify",
-            "always_fail:false",  // `false` exits 1 on every platform
+            "always_fail:false", // `false` exits 1 on every platform
         ])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -242,13 +237,13 @@ fn result_format_json_emits_on_verification_failure() {
     assert_eq!(
         out.status.code(),
         Some(7),
-        "expected exit 7 (verification_failure); got {:#?}\nstderr:\n{stderr}", out.status
+        "expected exit 7 (verification_failure); got {:#?}\nstderr:\n{stderr}",
+        out.status
     );
     // But stdout must still have the JSON result
-    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
-        .unwrap_or_else(|e| {
-            panic!("stdout is not valid JSON: {e}\nstdout: {stdout}\nstderr: {stderr}")
-        });
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("stdout is not valid JSON: {e}\nstdout: {stdout}\nstderr: {stderr}")
+    });
     assert_eq!(
         parsed["exit_code"].as_i64(),
         Some(7),
@@ -260,7 +255,9 @@ fn result_format_json_emits_on_verification_failure() {
         "exit_outcome_class must be 'verification_failure'"
     );
     // trajectory_path should reference an existing file
-    let traj = parsed["trajectory_path"].as_str().expect("trajectory_path is a string");
+    let traj = parsed["trajectory_path"]
+        .as_str()
+        .expect("trajectory_path is a string");
     assert!(
         std::path::Path::new(traj).exists(),
         "trajectory_path in JSON must point to an existing file: {traj}"

--- a/tests/mini_result_format.rs
+++ b/tests/mini_result_format.rs
@@ -263,3 +263,52 @@ fn result_format_json_emits_on_verification_failure() {
         "trajectory_path in JSON must point to an existing file: {traj}"
     );
 }
+
+// ── Emission scope: an unsubmitted run must not emit even if --verify fails ──
+
+#[test]
+fn result_format_json_suppressed_when_unsubmitted_verification_fails() {
+    // Agent does one non-submitting step, hits the step limit (outcome =
+    // step_limit_reached), then a failing --verify check makes mini::run return
+    // VerificationFailed. Because the run never submitted, no JSON result object
+    // should be printed — the trajectory is the authoritative record.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = support::command()
+        .args([
+            "--log",
+            "error",
+            "mini",
+            "--task",
+            "say hello",
+            "--env",
+            "local",
+            "--step-limit",
+            "1",
+            "--deterministic-responses",
+            "```bash\necho not-submitting-yet\n```",
+            "--output",
+            tmp.path().to_str().unwrap(),
+            "--result-format",
+            "json",
+            "--verify",
+            "always_fail:false",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn max mini");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    // Verification failure → exit 7.
+    assert_eq!(
+        out.status.code(),
+        Some(7),
+        "expected exit 7; stderr:\n{stderr}\nstdout:\n{stdout}"
+    );
+    // But no result object on stdout, since the run did not submit.
+    assert!(
+        stdout.trim().is_empty(),
+        "unsubmitted run must not emit a JSON result; got stdout: {stdout:?}"
+    );
+}

--- a/tests/mini_result_format.rs
+++ b/tests/mini_result_format.rs
@@ -359,3 +359,49 @@ fn result_format_json_rejected_with_ratatui_ui() {
         "error message should mention the ratatui conflict; got: {stderr}"
     );
 }
+
+// ── Incompatible combo: scripted responses are ignored by external drivers ───
+
+#[test]
+fn deterministic_responses_rejected_with_external_driver() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = support::command()
+        .args([
+            "--log",
+            "error",
+            "mini",
+            "--task",
+            "say hello",
+            "--env",
+            "local",
+            "--deterministic-responses",
+            SUBMIT_RESPONSE,
+            "--driver",
+            "codex",
+            "--output",
+            tmp.path().to_str().unwrap(),
+            "--result-format",
+            "json",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn max mini");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    // Usage error → exit 2; no JSON, and no real external agent invoked.
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected usage error exit 2; stderr:\n{stderr}\nstdout:\n{stdout}"
+    );
+    assert!(
+        stdout.trim().is_empty(),
+        "stdout must be empty when the combination is rejected; got: {stdout:?}"
+    );
+    assert!(
+        stderr.contains("deterministic-responses"),
+        "error message should mention deterministic-responses; got: {stderr}"
+    );
+}

--- a/tests/mini_result_format.rs
+++ b/tests/mini_result_format.rs
@@ -312,3 +312,50 @@ fn result_format_json_suppressed_when_unsubmitted_verification_fails() {
         "unsubmitted run must not emit a JSON result; got stdout: {stdout:?}"
     );
 }
+
+// ── Incompatible combo: ratatui dashboard renders to stdout, so reject ───────
+
+#[test]
+fn result_format_json_rejected_with_ratatui_ui() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = support::command()
+        .args([
+            "--log",
+            "error",
+            "mini",
+            "--task",
+            "say hello",
+            "--env",
+            "local",
+            "--deterministic-responses",
+            SUBMIT_RESPONSE,
+            "--output",
+            tmp.path().to_str().unwrap(),
+            "--result-format",
+            "json",
+            "--yolo",
+            "--ui",
+            "ratatui",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn max mini");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    // Usage error → exit 2; nothing on stdout (no half-rendered dashboard, no JSON).
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected usage error exit 2; stderr:\n{stderr}\nstdout:\n{stdout}"
+    );
+    assert!(
+        stdout.trim().is_empty(),
+        "stdout must be empty when the combination is rejected; got: {stdout:?}"
+    );
+    assert!(
+        stderr.contains("ratatui"),
+        "error message should mention the ratatui conflict; got: {stderr}"
+    );
+}

--- a/tests/mini_result_format.rs
+++ b/tests/mini_result_format.rs
@@ -1,0 +1,268 @@
+//! Integration tests for `max mini --result-format json` (issue #537).
+//!
+//! RED → GREEN → REFACTOR cycle.
+//!
+//! These tests spawn the compiled `max` binary as a subprocess and assert:
+//!  AC1 — stdout is exactly one JSON object; logs go to stderr.
+//!  AC2 — default / `--result-format text` produce no JSON on stdout.
+//!  AC3 — the JSON object includes all required keys.
+//!  AC4 — emitted for both submitted and verification-failure runs.
+//!  AC5 — string fields pass through the Redactor (no secret leaks).
+//!  AC6 — artifact is versioned with `schema_version` and `artifact_kind`.
+//!  AC7 — integration test pipes stdout through JSON parser (this file).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::process::Stdio;
+
+mod support;
+
+const SUBMIT_RESPONSE: &str =
+    "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n```\nok\n```";
+
+/// Run `max mini` with the deterministic scripted model and return (stdout, stderr, status).
+fn run_mini(extra_args: &[&str]) -> (String, String, std::process::ExitStatus) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = support::command()
+        .args([
+            "--log",
+            "error",
+            "mini",
+            "--task",
+            "say hello",
+            "--env",
+            "local",
+            "--deterministic-responses",
+            SUBMIT_RESPONSE,
+            "--output",
+            tmp.path().to_str().unwrap(),
+        ])
+        .args(extra_args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn max mini");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    (stdout, stderr, out.status)
+}
+
+// ── AC1 + AC3 + AC6 + AC7: submitted run produces valid, keyed JSON ─────────
+
+#[test]
+fn result_format_json_prints_valid_json_on_submit() {
+    let (stdout, stderr, status) = run_mini(&["--result-format", "json"]);
+    assert!(
+        status.success(),
+        "expected exit 0; stderr:\n{stderr}\nstdout:\n{stdout}"
+    );
+    // AC1: stdout is valid JSON with no leading log noise
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| {
+            panic!("stdout is not valid JSON: {e}\nstdout: {stdout}\nstderr: {stderr}")
+        });
+    assert!(parsed.is_object(), "JSON output must be an object");
+}
+
+#[test]
+fn result_format_json_contains_artifact_kind_and_schema_version() {
+    let (stdout, _, status) = run_mini(&["--result-format", "json"]);
+    assert!(status.success());
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("valid JSON");
+    // AC6: versioned via ArtifactSchemaVersion
+    assert_eq!(
+        parsed["artifact_kind"].as_str(),
+        Some("mini_result"),
+        "artifact_kind must be 'mini_result'"
+    );
+    assert!(
+        parsed["schema_version"].is_object(),
+        "schema_version must be an object"
+    );
+    assert!(
+        parsed["schema_version"]["major"].is_number(),
+        "schema_version.major must be a number"
+    );
+    assert!(
+        parsed["schema_version"]["minor"].is_number(),
+        "schema_version.minor must be a number"
+    );
+}
+
+#[test]
+fn result_format_json_contains_all_required_keys() {
+    let (stdout, _, status) = run_mini(&["--result-format", "json"]);
+    assert!(status.success());
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("valid JSON");
+    // AC3: required key presence
+    let required = [
+        "outcome",
+        "exit_code",
+        "exit_outcome_class",
+        "total_cost_usd",
+        "steps",
+        "input_tokens",
+        "output_tokens",
+        "trajectory_path",
+        "patch_path",         // nullable — key must exist
+        "failure_category",   // nullable — key must exist
+    ];
+    for key in required {
+        assert!(
+            parsed.get(key).is_some(),
+            "JSON result missing required key: {key}\nfull JSON: {parsed}"
+        );
+    }
+}
+
+#[test]
+fn result_format_json_outcome_is_submitted_on_success() {
+    let (stdout, _, status) = run_mini(&["--result-format", "json"]);
+    assert!(status.success());
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(
+        parsed["outcome"].as_str(),
+        Some("submitted"),
+        "outcome must be 'submitted' for a clean run"
+    );
+    assert_eq!(
+        parsed["exit_code"].as_i64(),
+        Some(0),
+        "exit_code must be 0 for a clean submitted run"
+    );
+    assert_eq!(
+        parsed["exit_outcome_class"].as_str(),
+        Some("success"),
+        "exit_outcome_class must be 'success' for a clean submitted run"
+    );
+}
+
+// ── AC1: stdout is clean — no leading log noise ───────────────────────────────
+
+#[test]
+fn result_format_json_stdout_starts_with_brace_when_log_info() {
+    // Even with verbose logging requested, stdout must be a clean JSON object
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = support::command()
+        .args([
+            "--log",
+            "info",
+            "mini",
+            "--task",
+            "say hello",
+            "--env",
+            "local",
+            "--deterministic-responses",
+            SUBMIT_RESPONSE,
+            "--output",
+            tmp.path().to_str().unwrap(),
+            "--result-format",
+            "json",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn max mini");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let trimmed = stdout.trim();
+    assert!(
+        trimmed.starts_with('{'),
+        "stdout must start with '{{' (no log noise); got: {trimmed:?}"
+    );
+    // Also must be valid JSON
+    let _: serde_json::Value = serde_json::from_str(trimmed)
+        .unwrap_or_else(|e| panic!("not valid JSON: {e}\n{trimmed}"));
+}
+
+// ── AC2: default / `--result-format text` unchanged, stdout empty ────────────
+
+#[test]
+fn result_format_text_produces_no_json_on_stdout() {
+    let (stdout, stderr, status) = run_mini(&["--result-format", "text"]);
+    assert!(
+        status.success(),
+        "expected exit 0; stderr:\n{stderr}\nstdout:\n{stdout}"
+    );
+    // AC2: text format must not print a JSON object to stdout
+    assert!(
+        stdout.trim().is_empty(),
+        "stdout must be empty in text mode; got: {stdout:?}"
+    );
+}
+
+#[test]
+fn default_result_format_produces_no_json_on_stdout() {
+    let (stdout, stderr, status) = run_mini(&[]);
+    assert!(
+        status.success(),
+        "expected exit 0; stderr:\n{stderr}\nstdout:\n{stdout}"
+    );
+    assert!(
+        stdout.trim().is_empty(),
+        "stdout must be empty in default (text) mode; got: {stdout:?}"
+    );
+}
+
+// ── AC4: verification-failure run also emits JSON ───────────────────────────
+
+#[test]
+fn result_format_json_emits_on_verification_failure() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = support::command()
+        .args([
+            "--log",
+            "error",
+            "mini",
+            "--task",
+            "say hello",
+            "--env",
+            "local",
+            "--deterministic-responses",
+            SUBMIT_RESPONSE,
+            "--output",
+            tmp.path().to_str().unwrap(),
+            "--result-format",
+            "json",
+            "--verify",
+            "always_fail:false",  // `false` exits 1 on every platform
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn max mini");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    // Process should exit non-zero (verification_failure = 7)
+    assert_eq!(
+        out.status.code(),
+        Some(7),
+        "expected exit 7 (verification_failure); got {:#?}\nstderr:\n{stderr}", out.status
+    );
+    // But stdout must still have the JSON result
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| {
+            panic!("stdout is not valid JSON: {e}\nstdout: {stdout}\nstderr: {stderr}")
+        });
+    assert_eq!(
+        parsed["exit_code"].as_i64(),
+        Some(7),
+        "exit_code must be 7 (VerificationFailure)"
+    );
+    assert_eq!(
+        parsed["exit_outcome_class"].as_str(),
+        Some("verification_failure"),
+        "exit_outcome_class must be 'verification_failure'"
+    );
+    // trajectory_path should reference an existing file
+    let traj = parsed["trajectory_path"].as_str().expect("trajectory_path is a string");
+    assert!(
+        std::path::Path::new(traj).exists(),
+        "trajectory_path in JSON must point to an existing file: {traj}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements issue #537 by adding a `--result-format json` flag to `max mini` that emits a schema-versioned JSON object to stdout containing the run result, cost, token usage, and artifact paths. This provides machine-readable output for CI/automation without requiring post-run trajectory file parsing.

## Key Changes

- **New `ResultFormat` enum** (`src/run/mini.rs`): Defines `Text` (default, no change) and `Json` output modes
- **New `MiniResult` struct** (`src/run/mini_result.rs`): Captures run outcome, exit code, cost, token usage, trajectory/patch paths, and failure category; includes redaction support for sensitive data
- **CLI flag** (`src/cli/args.rs`): Added `--result-format` flag with `text|json` options (default: `text`)
- **Result emission** (`src/cli/mod.rs`): New `emit_mini_result()` function that:
  - Only emits JSON for submitted runs or verification failures (when trajectory exists on disk)
  - Loads the trajectory and constructs a `MiniResult` from its metadata
  - Applies redaction to all string fields to prevent secret leaks
  - Prints clean JSON to stdout (all logs/diagnostics go to stderr)
- **Artifact versioning** (`src/artifact.rs`): Added `MiniResult` to `ArtifactKind` enum with schema version tracking
- **Comprehensive tests** (`tests/mini_result_format.rs`): 11 integration tests covering:
  - Valid JSON output with required keys (AC1, AC3, AC6, AC7)
  - Schema versioning and artifact kind (AC6)
  - Text mode unchanged behavior (AC2)
  - Verification failure runs emit JSON (AC4)
  - Redaction of sensitive data (AC5)
  - Clean stdout even with verbose logging

## Implementation Details

- JSON is only emitted for terminal states where the trajectory is guaranteed on disk: successful submission or verification failure (exit code 7)
- Non-submitted runs (step limit, budget exhausted, stagnation) return `Ok(())` but do not emit JSON—the trajectory is the authoritative record
- All string fields pass through the active `Redactor` policy, consistent with other artifact formats
- The `--deterministic-responses` flag (previously unused) is now wired through for testing/CI automation
- Patch path is only included when GitHub PR flags are active (same gating as patch capture)

https://claude.ai/code/session_01CCLXqGm8WFYZ6hXStJ6tLj