### PR TITLE
⚒️ Forge: Refactor ExitCode::from_error into From traits

### DIFF
--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -259,19 +259,20 @@ impl ExitCode {
             Self::Killed => "killed",
         }
     }
+}
 
-    /// Best-effort mapping from a runtime `Error` to the appropriate outcome class.
-    ///
-    /// A small number of outcomes (regression gate, sweep cancellation, budget-halt
-    /// forecast) are driven by explicit `process::exit` calls in the CLI layer and
-    /// do not go through this function. See `docs/exit-codes.md` for the full table.
-    #[must_use]
-    pub fn from_error(e: &Error) -> Self {
+/// Best-effort mapping from a runtime `Error` to the appropriate outcome class.
+///
+/// A small number of outcomes (regression gate, sweep cancellation, budget-halt
+/// forecast) are driven by explicit `process::exit` calls in the CLI layer and
+/// do not go through this conversion. See `docs/exit-codes.md` for the full table.
+impl From<&Error> for ExitCode {
+    fn from(e: &Error) -> Self {
         match e {
             Error::Preflight(_) => Self::PreflightFailure,
             Error::Config(_) => Self::UsageError,
             Error::VerificationFailed(..) => Self::VerificationFailure,
-            Error::Env(env_e) => Self::from_env_error(env_e),
+            Error::Env(env_e) => Self::from(env_e),
             Error::Model(model_e) => match model_e {
                 crate::error::ModelError::ReplayDrift(_) => Self::ReplayPromptDrift,
                 crate::error::ModelError::ScriptedResponsesExhausted(_) => {
@@ -301,8 +302,10 @@ impl ExitCode {
             },
         }
     }
+}
 
-    fn from_env_error(e: &EnvError) -> Self {
+impl From<&EnvError> for ExitCode {
+    fn from(e: &EnvError) -> Self {
         match e {
             EnvError::DockerNotInstalled
             | EnvError::DockerDaemonUnreachable(_)
@@ -323,7 +326,7 @@ mod tests {
     #[test]
     fn from_error_config_is_usage_error() {
         assert_eq!(
-            ExitCode::from_error(&Error::Config(ConfigError::Invalid("x".into()))),
+            ExitCode::from(&Error::Config(ConfigError::Invalid("x".into()))),
             ExitCode::UsageError
         );
     }
@@ -331,7 +334,7 @@ mod tests {
     #[test]
     fn from_error_preflight_is_preflight_failure() {
         assert_eq!(
-            ExitCode::from_error(&Error::Preflight("drift".into())),
+            ExitCode::from(&Error::Preflight("drift".into())),
             ExitCode::PreflightFailure
         );
     }
@@ -339,7 +342,7 @@ mod tests {
     #[test]
     fn from_error_verification_failed_is_verification_failure() {
         assert_eq!(
-            ExitCode::from_error(&Error::VerificationFailed(1, 2)),
+            ExitCode::from(&Error::VerificationFailed(1, 2)),
             ExitCode::VerificationFailure
         );
     }
@@ -347,7 +350,7 @@ mod tests {
     #[test]
     fn from_error_docker_not_installed_is_preflight_failure() {
         assert_eq!(
-            ExitCode::from_error(&Error::Env(EnvError::DockerNotInstalled)),
+            ExitCode::from(&Error::Env(EnvError::DockerNotInstalled)),
             ExitCode::PreflightFailure
         );
     }
@@ -355,7 +358,7 @@ mod tests {
     #[test]
     fn from_error_command_failed_is_task_unsuccessful() {
         assert_eq!(
-            ExitCode::from_error(&Error::Env(EnvError::CommandFailed("exit 1".into()))),
+            ExitCode::from(&Error::Env(EnvError::CommandFailed("exit 1".into()))),
             ExitCode::TaskUnsuccessful
         );
     }
@@ -363,7 +366,7 @@ mod tests {
     #[test]
     fn from_error_timeout_is_task_unsuccessful() {
         assert_eq!(
-            ExitCode::from_error(&Error::Env(EnvError::Timeout(
+            ExitCode::from(&Error::Env(EnvError::Timeout(
                 std::time::Duration::from_secs(1)
             ))),
             ExitCode::TaskUnsuccessful
@@ -373,7 +376,7 @@ mod tests {
     #[test]
     fn from_error_unexpected_exit_is_task_unsuccessful() {
         assert_eq!(
-            ExitCode::from_error(&Error::Env(EnvError::UnexpectedExit("1".into()))),
+            ExitCode::from(&Error::Env(EnvError::UnexpectedExit("1".into()))),
             ExitCode::TaskUnsuccessful
         );
     }
@@ -381,7 +384,7 @@ mod tests {
     #[test]
     fn from_error_docker_daemon_unreachable_is_preflight_failure() {
         assert_eq!(
-            ExitCode::from_error(&Error::Env(EnvError::DockerDaemonUnreachable(
+            ExitCode::from(&Error::Env(EnvError::DockerDaemonUnreachable(
                 "connection refused".into()
             ))),
             ExitCode::PreflightFailure
@@ -391,7 +394,7 @@ mod tests {
     #[test]
     fn from_error_container_start_failed_is_preflight_failure() {
         assert_eq!(
-            ExitCode::from_error(&Error::Env(EnvError::ContainerStartFailed(
+            ExitCode::from(&Error::Env(EnvError::ContainerStartFailed(
                 "image not found".into()
             ))),
             ExitCode::PreflightFailure
@@ -401,7 +404,7 @@ mod tests {
     #[test]
     fn from_error_env_io_is_task_unsuccessful() {
         assert_eq!(
-            ExitCode::from_error(&Error::Env(EnvError::Io(std::io::Error::other(
+            ExitCode::from(&Error::Env(EnvError::Io(std::io::Error::other(
                 "disk full"
             )))),
             ExitCode::TaskUnsuccessful
@@ -411,7 +414,7 @@ mod tests {
     #[test]
     fn from_error_model_is_task_unsuccessful() {
         assert_eq!(
-            ExitCode::from_error(&Error::Model(ModelError::Request("t/o".into()))),
+            ExitCode::from(&Error::Model(ModelError::Request("t/o".into()))),
             ExitCode::TaskUnsuccessful
         );
     }
@@ -419,7 +422,7 @@ mod tests {
     #[test]
     fn from_error_io_is_internal_error() {
         assert_eq!(
-            ExitCode::from_error(&Error::Io(std::io::Error::other("disk full"))),
+            ExitCode::from(&Error::Io(std::io::Error::other("disk full"))),
             ExitCode::InternalError
         );
     }
@@ -427,7 +430,7 @@ mod tests {
     #[test]
     fn from_error_replay_response_exhausted() {
         assert_eq!(
-            ExitCode::from_error(&Error::Model(ModelError::ScriptedResponsesExhausted(3))),
+            ExitCode::from(&Error::Model(ModelError::ScriptedResponsesExhausted(3))),
             ExitCode::ReplayResponseExhausted
         );
     }
@@ -435,7 +438,7 @@ mod tests {
     #[test]
     fn from_error_replay_unfingerprinted_legacy_is_usage_error() {
         assert_eq!(
-            ExitCode::from_error(&Error::Model(ModelError::ReplayUnfingerprintedLegacy(0))),
+            ExitCode::from(&Error::Model(ModelError::ReplayUnfingerprintedLegacy(0))),
             ExitCode::UsageError
         );
     }
@@ -444,7 +447,7 @@ mod tests {
     fn from_error_responses_exhausted_is_task_unsuccessful() {
         // Generic DeterministicModel exhaustion (non-replay) must not exit 10.
         assert_eq!(
-            ExitCode::from_error(&Error::Model(ModelError::ResponsesExhausted(0))),
+            ExitCode::from(&Error::Model(ModelError::ResponsesExhausted(0))),
             ExitCode::TaskUnsuccessful
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ async fn main() {
     match Box::pin(maxwells_daemon::cli::run()).await {
         Ok(()) => {}
         Err(e) => {
-            let code = ExitCode::from_error(&e);
+            let code = ExitCode::from(&e);
             eprintln!("outcome_class: {}", code.outcome_class());
             eprintln!("error: {e}");
             std::process::exit(code.as_i32());

--- a/src/run/suite.rs
+++ b/src/run/suite.rs
@@ -560,7 +560,7 @@ pub async fn run(args: SuiteArgs) -> Result<ExitCode, Error> {
             // Mini errored before writing a trajectory (env/preflight failure).
             let (failure_category, stop_reason) = match &run_outcome {
                 Err(e) => {
-                    let code = ExitCode::from_error(e);
+                    let code = ExitCode::from(e);
                     let cat = match code {
                         ExitCode::PreflightFailure => FailureCategory::EnvSetup,
                         _ => FailureCategory::AgentInternal,
@@ -616,7 +616,7 @@ pub async fn run(args: SuiteArgs) -> Result<ExitCode, Error> {
         // ── Propagate hard errors (env/preflight) that should stop the suite
         match &run_outcome {
             Err(e) if !is_verification_error => {
-                let code = ExitCode::from_error(e);
+                let code = ExitCode::from(e);
                 // Only halt on InternalError when no trajectory was written; if
                 // mini returned InternalError *after* writing a trajectory (e.g.
                 // a wallclock-timeout wrapper), it is a task-scoped failure and
@@ -705,13 +705,13 @@ fn classify_task_exit(
         // trajectory (e.g. post-save I/O failure), propagate that exit code.
         return match run_outcome {
             Ok(()) => ExitCode::Success,
-            Err(e) => ExitCode::from_error(e),
+            Err(e) => ExitCode::from(e),
         };
     }
     match run_outcome {
         Ok(()) => ExitCode::TaskUnsuccessful,
         Err(e) => {
-            let code = ExitCode::from_error(e);
+            let code = ExitCode::from(e);
             // Agent-loop terminal conditions (stagnation) and Trajectory-wrapper
             // errors (e.g. wallclock timeout maps to InternalError) are
             // task-level failures in the suite exit matrix (only 0/4/5/7 are

--- a/tests/bench_export_otlp.rs
+++ b/tests/bench_export_otlp.rs
@@ -453,7 +453,7 @@ async fn unreachable_collector_is_preflight_error() {
     .await
     .unwrap_err();
     assert_eq!(
-        maxwells_daemon::exit_code::ExitCode::from_error(&err),
+        maxwells_daemon::exit_code::ExitCode::from(&err),
         maxwells_daemon::exit_code::ExitCode::PreflightFailure
     );
 }
@@ -492,7 +492,7 @@ async fn missing_endpoint_is_usage_error() {
     .await
     .unwrap_err();
     assert_eq!(
-        maxwells_daemon::exit_code::ExitCode::from_error(&err),
+        maxwells_daemon::exit_code::ExitCode::from(&err),
         maxwells_daemon::exit_code::ExitCode::UsageError
     );
 }
@@ -508,7 +508,7 @@ async fn missing_sweep_dir_is_usage_error() {
     .await
     .unwrap_err();
     assert_eq!(
-        maxwells_daemon::exit_code::ExitCode::from_error(&err),
+        maxwells_daemon::exit_code::ExitCode::from(&err),
         maxwells_daemon::exit_code::ExitCode::UsageError
     );
 }

--- a/tests/bench_self_check.rs
+++ b/tests/bench_self_check.rs
@@ -394,7 +394,7 @@ fn missing_evaluation_json_returns_config_error() {
     );
 
     // Verify exit code maps to 2 (UsageError)
-    let code = maxwells_daemon::exit_code::ExitCode::from_error(&err);
+    let code = maxwells_daemon::exit_code::ExitCode::from(&err);
     assert_eq!(
         code.as_i32(),
         2,
@@ -433,7 +433,7 @@ fn legacy_trajectory_missing_test_field_returns_preflight_error() {
     );
 
     // Verify exit code maps to 3 (PreflightFailure / schema mismatch)
-    let code = maxwells_daemon::exit_code::ExitCode::from_error(&err);
+    let code = maxwells_daemon::exit_code::ExitCode::from(&err);
     assert_eq!(
         code.as_i32(),
         3,

--- a/tests/exit_code_contract.rs
+++ b/tests/exit_code_contract.rs
@@ -209,61 +209,61 @@ fn all_variants_have_unique_outcome_classes() {
 #[test]
 fn config_error_maps_to_usage_error() {
     let e = Error::Config(ConfigError::Invalid("bad flag".into()));
-    assert_eq!(ExitCode::from_error(&e), ExitCode::UsageError);
+    assert_eq!(ExitCode::from(&e), ExitCode::UsageError);
 }
 
 #[test]
 fn config_not_found_maps_to_usage_error() {
     let e = Error::Config(ConfigError::NotFound("cfg.toml".into()));
-    assert_eq!(ExitCode::from_error(&e), ExitCode::UsageError);
+    assert_eq!(ExitCode::from(&e), ExitCode::UsageError);
 }
 
 #[test]
 fn verification_failed_maps_to_verification_failure() {
     let e = Error::VerificationFailed(1, 3);
-    assert_eq!(ExitCode::from_error(&e), ExitCode::VerificationFailure);
+    assert_eq!(ExitCode::from(&e), ExitCode::VerificationFailure);
 }
 
 #[test]
 fn model_api_error_maps_to_task_unsuccessful() {
     let e = Error::Model(ModelError::Request("timeout".into()));
-    assert_eq!(ExitCode::from_error(&e), ExitCode::TaskUnsuccessful);
+    assert_eq!(ExitCode::from(&e), ExitCode::TaskUnsuccessful);
 }
 
 #[test]
 fn model_malformed_maps_to_task_unsuccessful() {
     let e = Error::Model(ModelError::Malformed("no json".into()));
-    assert_eq!(ExitCode::from_error(&e), ExitCode::TaskUnsuccessful);
+    assert_eq!(ExitCode::from(&e), ExitCode::TaskUnsuccessful);
 }
 
 #[test]
 fn docker_not_installed_maps_to_preflight_failure() {
     let e = Error::Env(EnvError::DockerNotInstalled);
-    assert_eq!(ExitCode::from_error(&e), ExitCode::PreflightFailure);
+    assert_eq!(ExitCode::from(&e), ExitCode::PreflightFailure);
 }
 
 #[test]
 fn docker_daemon_unreachable_maps_to_preflight_failure() {
     let e = Error::Env(EnvError::DockerDaemonUnreachable("socket closed".into()));
-    assert_eq!(ExitCode::from_error(&e), ExitCode::PreflightFailure);
+    assert_eq!(ExitCode::from(&e), ExitCode::PreflightFailure);
 }
 
 #[test]
 fn container_start_failed_maps_to_preflight_failure() {
     let e = Error::Env(EnvError::ContainerStartFailed("oom".into()));
-    assert_eq!(ExitCode::from_error(&e), ExitCode::PreflightFailure);
+    assert_eq!(ExitCode::from(&e), ExitCode::PreflightFailure);
 }
 
 #[test]
 fn env_command_failed_maps_to_task_unsuccessful() {
     let e = Error::Env(EnvError::CommandFailed("exit 1".into()));
-    assert_eq!(ExitCode::from_error(&e), ExitCode::TaskUnsuccessful);
+    assert_eq!(ExitCode::from(&e), ExitCode::TaskUnsuccessful);
 }
 
 #[test]
 fn env_timeout_maps_to_task_unsuccessful() {
     let e = Error::Env(EnvError::Timeout(std::time::Duration::from_secs(60)));
-    assert_eq!(ExitCode::from_error(&e), ExitCode::TaskUnsuccessful);
+    assert_eq!(ExitCode::from(&e), ExitCode::TaskUnsuccessful);
 }
 
 #[test]
@@ -272,7 +272,7 @@ fn io_error_maps_to_internal_error() {
         std::io::ErrorKind::NotFound,
         "file gone",
     ));
-    assert_eq!(ExitCode::from_error(&e), ExitCode::InternalError);
+    assert_eq!(ExitCode::from(&e), ExitCode::InternalError);
 }
 
 #[test]
@@ -280,19 +280,19 @@ fn json_error_maps_to_internal_error() {
     let e: Error = serde_json::from_str::<serde_json::Value>("not json")
         .unwrap_err()
         .into();
-    assert_eq!(ExitCode::from_error(&e), ExitCode::InternalError);
+    assert_eq!(ExitCode::from(&e), ExitCode::InternalError);
 }
 
 #[test]
 fn trajectory_error_maps_to_internal_error() {
     let e = Error::Trajectory("corrupt file".into());
-    assert_eq!(ExitCode::from_error(&e), ExitCode::InternalError);
+    assert_eq!(ExitCode::from(&e), ExitCode::InternalError);
 }
 
 #[test]
 fn github_error_maps_to_internal_error() {
     let e = Error::Github("api 500".into());
-    assert_eq!(ExitCode::from_error(&e), ExitCode::InternalError);
+    assert_eq!(ExitCode::from(&e), ExitCode::InternalError);
 }
 
 #[test]
@@ -301,7 +301,7 @@ fn template_error_maps_to_internal_error() {
         minijinja::ErrorKind::InvalidOperation,
         "render failed",
     ));
-    assert_eq!(ExitCode::from_error(&e), ExitCode::InternalError);
+    assert_eq!(ExitCode::from(&e), ExitCode::InternalError);
 }
 
 // ── cross-surface consistency ─────────────────────────────────────────────────
@@ -438,7 +438,7 @@ fn text_and_numeric_surfaces_agree_for_every_error_variant() {
     ];
 
     for (expected_class, e) in error_cases {
-        let code = ExitCode::from_error(&e);
+        let code = ExitCode::from(&e);
         assert_eq!(
             code.outcome_class(),
             expected_class,
@@ -516,11 +516,11 @@ fn preflight_probe_errors_map_to_preflight_failure() {
     for msg in cases {
         let e = Error::Env(EnvError::DockerDaemonUnreachable(msg.into()));
         assert_eq!(
-            ExitCode::from_error(&e),
+            ExitCode::from(&e),
             ExitCode::PreflightFailure,
             "message {msg:?} should map to PreflightFailure"
         );
-        assert_eq!(ExitCode::from_error(&e).as_i32(), 3);
+        assert_eq!(ExitCode::from(&e).as_i32(), 3);
     }
 }
 
@@ -532,6 +532,6 @@ fn model_probe_failure_maps_to_preflight_failure() {
     let e = Error::Env(EnvError::DockerDaemonUnreachable(
         "preflight: model probe failed: 401 unauthorized".into(),
     ));
-    assert_eq!(ExitCode::from_error(&e), ExitCode::PreflightFailure);
-    assert_eq!(ExitCode::from_error(&e).as_i32(), 3);
+    assert_eq!(ExitCode::from(&e), ExitCode::PreflightFailure);
+    assert_eq!(ExitCode::from(&e).as_i32(), 3);
 }

--- a/tests/policy_impact.rs
+++ b/tests/policy_impact.rs
@@ -414,7 +414,7 @@ fn test_missing_sweep_dir_returns_exit_code_2() {
         sweep_dir: std::path::PathBuf::from("does_not_exist_at_all_999888"),
     });
     assert!(err.is_err());
-    let code = ExitCode::from_error(&err.unwrap_err());
+    let code = ExitCode::from(&err.unwrap_err());
     assert_eq!(code, ExitCode::UsageError);
 }
 
@@ -431,7 +431,7 @@ fn test_missing_results_json_returns_exit_code_2() {
         sweep_dir: sweep_dir.to_path_buf(),
     });
     assert!(err.is_err());
-    let code = ExitCode::from_error(&err.unwrap_err());
+    let code = ExitCode::from(&err.unwrap_err());
     assert_eq!(code, ExitCode::UsageError);
 }
 
@@ -466,6 +466,6 @@ fn test_missing_trajectory_returns_exit_code_2() {
         sweep_dir: sweep_dir.to_path_buf(),
     });
     assert!(err.is_err());
-    let code = ExitCode::from_error(&err.unwrap_err());
+    let code = ExitCode::from(&err.unwrap_err());
     assert_eq!(code, ExitCode::UsageError);
 }

--- a/tests/replay_fingerprint.rs
+++ b/tests/replay_fingerprint.rs
@@ -254,7 +254,7 @@ async fn prompt_drift_exits_drift_code_at_step_zero() {
     let result = replay_run(args).await;
     assert!(result.is_err(), "should fail on drift");
     assert_eq!(
-        ExitCode::from_error(&result.unwrap_err()),
+        ExitCode::from(&result.unwrap_err()),
         ExitCode::ReplayPromptDrift
     );
 


### PR DESCRIPTION
🚰 Smell: `ExitCode::from_error` and `ExitCode::from_env_error` re-implement standard conversion logic instead of using idiomatic Rust `From` traits.
✨ Solution: Replaced `ExitCode::from_error` and `ExitCode::from_env_error` with `impl From<&Error> for ExitCode` and `impl From<&EnvError> for ExitCode`, and updated all callers.
🧼 Benefit: Aligns with idiomatic Rust patterns (using standard traits over custom methods) and improves readability.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [2999460725703724900](https://jules.google.com/task/2999460725703724900) started by @madmax983*