### PR TITLE
👺 Havoc: Prevent OOM from Unbounded Pipes

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -334,15 +334,19 @@ where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut chunk = [0u8; 8192];
+    const MAX_BUFFER: usize = 5 * 1024 * 1024;
     loop {
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {
             return Ok(());
         }
-        buffer
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .extend_from_slice(&chunk[..n]);
+        let mut b = buffer.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if b.len() + n <= MAX_BUFFER {
+            b.extend_from_slice(&chunk[..n]);
+        } else if b.len() < MAX_BUFFER {
+            let space = MAX_BUFFER - b.len();
+            b.extend_from_slice(&chunk[..space]);
+        }
     }
 }
 

--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -255,15 +255,19 @@ where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut chunk = [0u8; 8192];
+    const MAX_BUFFER: usize = 5 * 1024 * 1024;
     loop {
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {
             return Ok(());
         }
-        buffer
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .extend_from_slice(&chunk[..n]);
+        let mut b = buffer.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if b.len() + n <= MAX_BUFFER {
+            b.extend_from_slice(&chunk[..n]);
+        } else if b.len() < MAX_BUFFER {
+            let space = MAX_BUFFER - b.len();
+            b.extend_from_slice(&chunk[..space]);
+        }
     }
 }
 

--- a/tests/chaos_havoc.rs
+++ b/tests/chaos_havoc.rs
@@ -1,0 +1,19 @@
+use maxwells_daemon::env::{Environment, LocalEnvironment, RunRequest};
+use std::time::Duration;
+
+#[tokio::test]
+async fn havoc_env_oom_is_bounded() {
+    let mut env = LocalEnvironment::new();
+    let req = RunRequest {
+        command: "yes".to_string(),
+        timeout: Duration::from_secs(2),
+        cancellation: None,
+        env: Default::default(),
+        cwd: None,
+        stdin: None,
+    };
+
+    let result = env.run(req).await.unwrap();
+    assert!(result.timed_out);
+    assert!(result.stdout.len() <= 5 * 1024 * 1024 + 8192, "Buffer exceeded 5MB! Length: {}", result.stdout.len());
+}


### PR DESCRIPTION
* 🧨 **The Trigger:** Invoking a command like `yes` that emits gigabytes of text without exiting to standard output causes the internal pipe collector in the execution environment to buffer everything into RAM, leading to memory exhaustion (OOM).
* 📉 **The Stack Trace:** None available (simulated memory exhaustion).
* 🧪 **Reproduction:** Run a LocalEnvironment with `yes` bounded by a task timeout; observer unbounded memory consumption.
* 😈 **Comment:** You assumed the buffer would never be larger than RAM. You were wrong.

---
*PR created automatically by Jules for task [4066625422474787929](https://jules.google.com/task/4066625422474787929) started by @madmax983*