### PR TITLE
🎨 Mosaic: UI Polish for Catalog CLI

### DIFF
--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -1,6 +1,6 @@
 use super::args::CatalogCmd;
 use crate::error::Error;
-use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+use comfy_table::{Cell, Color, Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 use serde::Serialize;
 
 pub const STAGES: &[&str] = &["preflight", "run", "inspect", "analyze", "publish"];
@@ -515,10 +515,34 @@ pub fn run_catalog(cmd: CatalogCmd) -> Result<(), Error> {
     table
         .load_preset(UTF8_FULL)
         .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_header(["Command", "Summary", "Cost", "Stage"]);
+        .set_header([
+            Cell::new("Command").fg(Color::Cyan),
+            Cell::new("Summary").fg(Color::Cyan),
+            Cell::new("Cost").fg(Color::Cyan),
+            Cell::new("Stage").fg(Color::Cyan),
+        ]);
 
     for entry in &filtered {
-        table.add_row([entry.path, entry.summary, entry.cost_tier, entry.stage]);
+        let cost_color = if entry.cost_tier == "free" {
+            Color::Green
+        } else {
+            Color::Red
+        };
+
+        let stage_color = match entry.stage {
+            "preflight" => Color::Blue,
+            "run" => Color::Magenta,
+            "analyze" => Color::Yellow,
+            "publish" => Color::Green,
+            _ => Color::White,
+        };
+
+        table.add_row([
+            Cell::new(entry.path).fg(Color::Yellow),
+            Cell::new(entry.summary),
+            Cell::new(entry.cost_tier).fg(cost_color),
+            Cell::new(entry.stage).fg(stage_color),
+        ]);
     }
 
     println!("{table}");

--- a/tests/catalog_render.rs
+++ b/tests/catalog_render.rs
@@ -1,0 +1,32 @@
+use maxwells_daemon::cli::args::CatalogCmd;
+use maxwells_daemon::cli::catalog::run_catalog;
+
+#[test]
+fn test_catalog_render() {
+    let cmd = CatalogCmd {
+        free_only: false,
+        stage: None,
+        format: "text".to_string(),
+    };
+    let _ = run_catalog(cmd);
+}
+
+#[test]
+fn test_catalog_render_json() {
+    let cmd = CatalogCmd {
+        free_only: false,
+        stage: None,
+        format: "json".to_string(),
+    };
+    let _ = run_catalog(cmd);
+}
+
+#[test]
+fn test_catalog_render_filtered() {
+    let cmd = CatalogCmd {
+        free_only: true,
+        stage: Some("preflight".to_string()),
+        format: "text".to_string(),
+    };
+    let _ = run_catalog(cmd);
+}


### PR DESCRIPTION
🖌️ **Before:** The command output for `cargo run -- catalog` showed a plain black and white table with no visual hierarchy, making it harder to scan commands and their costs/stages.
✨ **After:** The CLI now outputs a beautifully formatted table where the header pops in cyan, commands in yellow, and costs/stages are color-coded (e.g., green for free, red for paid) to follow the Z-pattern scanning layout.
🖼️ **Visuals:** Added `comfy-table` Cell coloring to highlight the differences in command types and costs at a glance.

---
*PR created automatically by Jules for task [9767187617724388111](https://jules.google.com/task/9767187617724388111) started by @madmax983*