### PR TITLE
Add comprehensive failure_category reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,12 +437,18 @@ instead of dollars to ride out. Tiny mercy.
 | Docker run fails before the agent starts | Docker is unavailable or the binary lacks the `docker` feature | Start Docker, or use `--env local`; build with the Docker feature before selecting `--env docker` |
 | Smoke run cannot write artifacts | Output directory is unwritable | Choose a writable `--output` path, for example `runs/quickstart` inside the repo |
 | `bench doctor` reports dataset read/parse errors | The `--dataset-path` value is missing, points at a directory, or is not JSONL | Pass a readable SWE-bench JSONL file and rerun `bench doctor --skip-model-probe` |
+| `bench inspect` shows an unfamiliar `failure_category` string | Trajectory from a newer harness version, or an unclassified failure | See [`docs/failure-categories.md`](docs/failure-categories.md) for the full reference and triage runbook |
 
 ## Advanced Specs
 
 Start with the first-run path above, then use these deeper specs once you have
 a valid trajectory in hand:
 
+- [`failure-category reference`](docs/failure-categories.md): every
+  `failure_category` string, its definition, typical triggers, recommended
+  operator action, systemic-halt status, and a worked triage example. The
+  canonical vocabulary index for `bench triage`, `bench inspect`, `bench tail`,
+  and the circuit breaker.
 - [`mini --resume`](docs/spec-mini-resume.md): continue an interrupted
   single-task run from its persisted checkpoint — no token replay, prefix
   trusted verbatim, resume history recorded in the trajectory manifest.

--- a/docs/artifact-contract.md
+++ b/docs/artifact-contract.md
@@ -55,21 +55,9 @@ Any future schema change needs either a documented no-bump rationale in the rele
 ## Trajectory `failure_category` values
 
 The `info.failure_category` field in a trajectory artifact uses a stable string
-taxonomy.  Readers should treat unrecognised values as `unknown`.
-
-| Value              | Meaning                                                                 |
-|--------------------|-------------------------------------------------------------------------|
-| `step_limit`       | Agent exhausted the configured step budget.                             |
-| `patch_empty`      | Agent submitted but the patch was empty or only whitespace.             |
-| `patch_invalid`    | Captured patch failed `git apply --check` validation.                   |
-| `env_setup`        | Environment setup failed (Docker, container, tooling).                  |
-| `model_api`        | Persistent model API error (auth, quota, wrong model name).             |
-| `model_parse`      | Model response could not be parsed.                                     |
-| `wallclock_timeout`| Run exceeded the per-task wallclock timeout.                            |
-| `budget_halt`      | Run was skipped / halted due to a cost cap.                             |
-| `cancelled`        | Run was cancelled by operator (SIGINT / `--cancel-deadline`).           |
-| `agent_stagnation` | Stagnation detector tripped: same action repeated K times in W steps.   |
-| `unknown`          | Catch-all for unclassified failures.                                    |
+taxonomy.  Readers should treat unrecognised values as `unknown`.  The
+**canonical reference** for all values, their definitions, triage actions, and
+compatibility policy is [`docs/failure-categories.md`](failure-categories.md).
 
 ### `agent_stagnation` diagnostics
 

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -78,7 +78,9 @@ line without inspecting the integer exit code.
 
 For sweep commands the per-instance `failure_category` field in trajectory
 JSON files carries fine-grained information; the process exit code gives the
-coarse sweep-level result.
+coarse sweep-level result.  See [`docs/failure-categories.md`](failure-categories.md)
+for the complete reference of every `failure_category` value, its definition,
+and the recommended triage action.
 
 ## Per-Command Outcome Class Table
 

--- a/docs/failure-categories.md
+++ b/docs/failure-categories.md
@@ -1,0 +1,564 @@
+# Failure Category Reference and Triage Runbook
+
+Every trajectory produced by the harness carries a `failure_category` field in
+its `info` block when `outcome` is `error`.  This string drives
+[`bench triage`](spec-triage.md), [`bench compare`](spec-evaluation.md), the
+[systemic-halt circuit breaker](spec-systemic-halt.md), nightly-smoke auto-issues,
+and the failure mix in [`bench tail`](spec-tail.md).
+
+This page is the single canonical reference for every `failure_category` value:
+what it means, why you see it, what to do next, and how it integrates with the
+commands that consume it.
+
+See also: [`docs/exit-codes.md`](exit-codes.md) for coarse sweep-level outcome
+classes, [`docs/artifact-contract.md`](artifact-contract.md) for the full
+trajectory schema.
+
+---
+
+## How to Read This Reference
+
+Each entry below covers one operator-visible `failure_category` string and
+answers these questions:
+
+| Field | Meaning |
+|---|---|
+| **JSON string** | The exact value you see in `failure_category` and in `bench inspect` / `bench triage` output |
+| **Definition** | What the category means in one paragraph |
+| **You will see this when…** | Typical triggering conditions |
+| **Recommended action** | What to do next |
+| **Systemic-halt actionable** | Whether this category counts toward the [circuit-breaker threshold](spec-systemic-halt.md) |
+| **Partial patch preserved** | Whether the harness writes a patch file when this category fires |
+| **Typical sweep outcome class** | The most common process exit code from [`docs/exit-codes.md`](exit-codes.md) when this category dominates a sweep |
+
+---
+
+## Category Entries
+
+### `env_setup`
+
+| | |
+|---|---|
+| **JSON string** | `env_setup` |
+| **Systemic-halt actionable** | **Yes** |
+| **Partial patch preserved** | No |
+| **Typical sweep outcome class** | `systemic_halt` (11) when dominant; `success` (0) otherwise |
+
+**Definition.** The environment setup phase failed before the agent loop
+started. The harness attempted to prepare the task workspace — pulling a Docker
+image, cloning the repository, or running environment installation steps — and
+the preparation did not complete successfully.  No agent turns were executed.
+
+**You will see this when…**
+- The Docker daemon is not running or the socket is not accessible.
+- The Docker image tag does not exist or the pull times out.
+- The task dataset specifies a repository that cannot be cloned (private, moved, or removed).
+- The container fails to start or the environment setup script exits non-zero.
+- Network access to the container registry is blocked.
+
+**Recommended action.**
+1. Run `bench doctor` to verify Docker availability and connectivity.
+2. Check that the container image exists and is pullable: `docker pull <image>`.
+3. Review `bench inspect <sweep_dir> --instance <id>` for the specific error message.
+4. If `env_setup` is dominant across instances, the circuit breaker may trip with exit 11 (`systemic_halt`).  Halt reports are in `halt-report.json`.
+5. Use `bench retry` to rerun only affected instances after fixing the infrastructure issue.
+
+---
+
+### `model_api`
+
+| | |
+|---|---|
+| **JSON string** | `model_api` |
+| **Systemic-halt actionable** | **Yes** |
+| **Partial patch preserved** | No |
+| **Typical sweep outcome class** | `systemic_halt` (11) when dominant; `success` (0) otherwise |
+
+**Definition.** The model API returned repeated, non-transient errors during the
+agent loop.  The harness retried according to its retry policy and ultimately
+gave up because every attempt failed.
+
+**You will see this when…**
+- The `ANTHROPIC_API_KEY` (or equivalent provider key) is invalid, expired, or missing.
+- The account's token quota or rate limit is exhausted at the project level.
+- The configured model name does not exist or has been deprecated.
+- The model API endpoint is unreachable (network outage, firewall rule).
+- A provider-side outage causes all calls to fail.
+
+**Recommended action.**
+1. Verify the API key: `echo $ANTHROPIC_API_KEY | wc -c` and confirm it is set in the environment.
+2. Check the provider dashboard for quota or outage notices.
+3. Confirm the model name in your config matches a currently-available model: `bench doctor --skip-docker`.
+4. Run `bench inspect <sweep_dir> --instance <id>` to see the raw API error text.
+5. After fixing the credential issue, use `bench retry` or `bench swebench --resume` to continue.
+
+---
+
+### `model_parse`
+
+| | |
+|---|---|
+| **JSON string** | `model_parse` |
+| **Systemic-halt actionable** | No |
+| **Partial patch preserved** | No |
+| **Typical sweep outcome class** | `success` (0) |
+
+**Definition.** The harness repeatedly received a response from the model API
+that it could not parse into a valid agent action.  The model produced output but
+it was structurally incompatible with the expected tool-call or action format.
+
+**You will see this when…**
+- You switch to a model that uses a different response format from the one the harness expects.
+- The model produces free-form prose instead of structured tool calls (prompt mismatch).
+- The model API returns valid JSON but with an unexpected schema (provider-side format change).
+- The model is severely truncating its responses due to a context-length edge case.
+
+**Recommended action.**
+1. Confirm you are using a model supported by this harness version.
+2. Check [`bench inspect`](spec-inspect.md) on a failing instance to see the raw model output.
+3. If you recently changed the model name, verify format compatibility.
+4. File a bug report if a previously-working model starts producing this category.
+
+---
+
+### `step_limit`
+
+| | |
+|---|---|
+| **JSON string** | `step_limit` |
+| **Systemic-halt actionable** | No |
+| **Partial patch preserved** | No |
+| **Typical sweep outcome class** | `success` (0) |
+
+**Definition.** The agent exhausted its configured maximum step budget
+(`agent.step_limit`) without submitting a result.  The agent loop ran to
+completion — no infrastructure failure occurred — but the agent did not reach a
+terminal submission within the allotted turns.
+
+**You will see this when…**
+- Tasks are more complex than the configured step limit allows.
+- The step limit is deliberately set low for budget-testing purposes.
+- The agent is spending many turns on unproductive exploration.
+- You see `step_limit` paired with high `cost_usd` per instance in `bench tail`.
+
+**Recommended action.**
+1. Run `bench triage` to identify which instance clusters produce `step_limit` most often.
+2. Inspect representative instances with `bench inspect` to understand where the agent stalls.
+3. Increase `agent.step_limit` in your config if the tasks genuinely require more turns.
+4. Consider prompt improvements to guide the agent to submit earlier.
+
+---
+
+### `cost_limit`
+
+| | |
+|---|---|
+| **JSON string** | `cost_limit` |
+| **Systemic-halt actionable** | No |
+| **Partial patch preserved** | No |
+| **Typical sweep outcome class** | `success` (0); `budget_halt` (5) when the sweep-level cap is also hit |
+
+**Definition.** The per-task cost ceiling was reached before the task could
+complete.  The harness stopped dispatching new turns and recorded the instance
+as failed.
+
+**You will see this when…**
+- `--cost-limit-usd` (per-task) is set too low for the model and task complexity.
+- You are intentionally running with a tight per-task cap for cost exploration.
+- Token usage per turn is unusually high (e.g., long file reads, verbose tool output).
+
+**Recommended action.**
+1. Review per-task cost in `bench tail` or `bench inspect` to understand typical spend.
+2. Increase the per-task cost limit or switch to a cheaper model.
+3. Use `bench forecast` to project total cost before raising limits.
+
+---
+
+### `budget_exhausted`
+
+| | |
+|---|---|
+| **JSON string** | `budget_exhausted` |
+| **Systemic-halt actionable** | No |
+| **Partial patch preserved** | **Yes** — any patch accumulated before the cap fired is preserved |
+| **Typical sweep outcome class** | `budget_halt` (5) when the sweep-level cost cap terminates the run; `success` (0) for per-task cap |
+
+**Definition.** The per-task USD ceiling was reached mid-loop.  Unlike
+`cost_limit` (which prevents new turns from starting), `budget_exhausted` fires
+inside an active turn: the harness terminated the agent and preserved any partial
+patch that had accumulated before the cap fired.
+
+**You will see this when…**
+- The per-task budget was consumed partway through an agent turn.
+- A single very expensive model call pushed the instance over its ceiling.
+- The sweep-level cost cap (`--sweep-cost-limit-usd`) is hit, causing remaining instances to be skipped.
+
+**Recommended action.**
+1. Inspect the preserved partial patch via `bench inspect` — it may still be useful.
+2. Check `bench tail` cost burn per instance to calibrate the ceiling.
+3. Increase the per-task ceiling or use `bench forecast` to size the budget before re-running.
+4. Use `bench retry` to attempt only the budget-exhausted instances with a higher ceiling.
+
+---
+
+### `wallclock_timeout`
+
+| | |
+|---|---|
+| **JSON string** | `wallclock_timeout` |
+| **Systemic-halt actionable** | No |
+| **Partial patch preserved** | No |
+| **Typical sweep outcome class** | `success` (0) |
+
+**Definition.** The per-task real-time execution limit (`task_timeout_secs`) was
+exceeded.  The harness killed the agent turn after the configured wall-clock
+duration regardless of progress.
+
+**You will see this when…**
+- Tool calls block for an unexpectedly long time (slow network, large file I/O).
+- The model API has unusually high latency (provider-side degradation).
+- The Docker container starts slowly (image layer hydration on first run).
+- `task_timeout_secs` is set too low for the model and task combination.
+
+**Recommended action.**
+1. Check provider status for API latency anomalies.
+2. Increase `task_timeout_secs` in your config.
+3. Use `bench inspect` to see at which step the timeout occurred.
+4. If timeouts are rare, they may be noise; if they dominate, investigate infrastructure latency.
+
+---
+
+### `agent_internal`
+
+| | |
+|---|---|
+| **JSON string** | `agent_internal` |
+| **Systemic-halt actionable** | No |
+| **Partial patch preserved** | No |
+| **Typical sweep outcome class** | `internal_error` (1) in severe / sweep-halting cases; `success` (0) otherwise |
+
+**Definition.** An internal logic error occurred within the agent harness itself.
+This category indicates a bug in the harness code, not in the model, the
+environment, or the task.
+
+**You will see this when…**
+- A harness code path hits an unexpected state or invariant violation.
+- A JSON deserialization error occurs on internal data (not model output).
+- A file I/O error prevents trajectory writing mid-run.
+
+**Recommended action.**
+1. Use `bench inspect` to retrieve the error message and stack details.
+2. Report the issue with the full trajectory and the harness version.
+3. Use `bench bundle` to capture the sweep artifacts for a bug report.
+4. Consider pinning the harness to a known-good version while the fix is applied.
+
+---
+
+### `patch_apply_invalid`
+
+| | |
+|---|---|
+| **JSON string** | `patch_apply_invalid` |
+| **Systemic-halt actionable** | No |
+| **Partial patch preserved** | **Yes** — the invalid patch file is written for inspection |
+| **Typical sweep outcome class** | `success` (0) |
+
+**Definition.** The agent produced a patch that failed `git apply --check`
+validation at capture time.  The patch file is written to disk so you can
+inspect it, but the harness records the instance as failed because the patch
+cannot be applied cleanly.
+
+**You will see this when…**
+- The agent generates a diff against a different base commit than the one in the repo.
+- The agent produces syntactically malformed unified diff output.
+- The patch includes hunks that conflict with files already modified by an earlier step.
+- You use `agent apply` on an incompatible tree (use `apply_check_failed`, exit 29, for that scenario).
+
+**Recommended action.**
+1. Inspect the invalid patch: `bench inspect <sweep_dir> --instance <id> --show-patch`.
+2. Check the base commit the agent was working against.
+3. Review the agent's final diff-generation step in the trajectory.
+4. If systematic, investigate the model's patch-formatting capability.
+
+---
+
+### `patch_empty`
+
+| | |
+|---|---|
+| **JSON string** | `patch_empty` |
+| **Systemic-halt actionable** | No |
+| **Partial patch preserved** | No |
+| **Typical sweep outcome class** | `success` (0) |
+
+**Definition.** The agent submitted but the captured diff was empty (zero bytes
+or whitespace only).  The agent called the submission tool but no file changes
+were recorded.
+
+**You will see this when…**
+- The agent submitted without making any edits to the codebase.
+- All edits the agent made were reverted before submission.
+- The agent's edits were to a file outside the repository root (not tracked by git).
+- A shell command the agent ran cleaned up its own changes.
+
+**Recommended action.**
+1. Review the trajectory with `bench inspect` to find where the agent submitted and whether it made edits.
+2. Check if the task explicitly requires no code change (rare but possible).
+3. If systematic, investigate whether the agent is skipping the edit step.
+
+---
+
+### `secret_leak_detected`
+
+| | |
+|---|---|
+| **JSON string** | `secret_leak_detected` |
+| **Systemic-halt actionable** | No |
+| **Partial patch preserved** | No — submission is rejected |
+| **Typical sweep outcome class** | `verification_failure` (7) for `mini`; `success` (0) for `bench swebench` |
+
+**Definition.** A configured secret literal was found in a submission artifact
+(patch, trajectory, or output file).  The harness blocked the submission and
+recorded the instance as failed to prevent credential exposure.
+
+**You will see this when…**
+- The agent incorporates an API key or password into generated code or test files.
+- A configured `secret_literals` entry matches a substring of the patch.
+- The model echoes a secret from its context window into a tool call argument.
+
+**Recommended action.**
+1. Run `agent redact-check` to verify your secret literals configuration is correct.
+2. Run `agent redact-audit` on the sweep directory to locate any exposed secrets.
+3. Review the task and model prompt to understand why the secret appeared in the output.
+4. See [`docs/spec-secret-redaction.md`](spec-secret-redaction.md) for the full redaction policy.
+
+---
+
+### `agent_stagnation`
+
+| | |
+|---|---|
+| **JSON string** | `agent_stagnation` |
+| **Systemic-halt actionable** | No |
+| **Partial patch preserved** | No |
+| **Typical sweep outcome class** | `agent_stagnation` (12) for `mini`; `success` (0) for `bench swebench` |
+
+**Definition.** The stagnation detector fired: the agent repeated the same
+action at least K times within a trailing window of W steps.  The harness halted
+the run rather than let the agent loop indefinitely.
+
+When `failure_category` is `agent_stagnation`, `info.other["stagnation"]`
+contains a diagnostic object:
+
+```json
+{
+  "action_hash":  "<32-hex-char SHA-256 prefix of canonical action>",
+  "count":        4,
+  "window":       8,
+  "step_indices": [2, 4, 6, 8]
+}
+```
+
+**You will see this when…**
+- The agent retries the same failing command repeatedly without adjusting its strategy.
+- A tool always returns the same error, and the agent does not adapt.
+- The model lacks enough context variety to break out of a loop.
+
+**Recommended action.**
+1. Use `bench inspect` on the stagnating instance to see which action repeated.
+2. Review the `stagnation` diagnostic object to identify the repeated step indices.
+3. Use `bench stagnation-report` for cross-sweep aggregation of stagnation patterns.
+4. Adjust the prompt or the stagnation window (`agent.stagnation_window`, `agent.stagnation_count`) if needed.
+5. See [`docs/spec-stagnation.md`](spec-stagnation.md) for the full detection rule and config reference.
+
+---
+
+### `history_compaction_failed`
+
+| | |
+|---|---|
+| **JSON string** | `history_compaction_failed` |
+| **Systemic-halt actionable** | **Yes** |
+| **Partial patch preserved** | No |
+| **Typical sweep outcome class** | `systemic_halt` (11) when dominant; `success` (0) otherwise |
+
+**Definition.** The trajectory history could not be compacted to fit within
+`history_max_input_tokens` even after eliding all older observations.  The
+harness terminates the run rather than sending an oversized prompt or triggering
+a provider context-length error.
+
+**You will see this when…**
+- The task requires a very long context (many files, large diffs, long tool output).
+- `history_max_input_tokens` is configured too low for the model's context window.
+- A single tool call returns an extremely large response that cannot be elided.
+- You are using a model with a smaller context window than the task demands.
+
+**Recommended action.**
+1. Increase `history_max_input_tokens` in your config to match the model's context window.
+2. Check `bench inspect` to identify which observation caused the overflow.
+3. Consider switching to a model with a larger context window.
+4. Tune tool verbosity to reduce output size per step.
+5. If this category dominates a sweep, the circuit breaker may trip (exit 11); see `halt-report.json`.
+
+---
+
+### `read_only_violation`
+
+| | |
+|---|---|
+| **JSON string** | `read_only_violation` |
+| **Systemic-halt actionable** | No |
+| **Partial patch preserved** | No |
+| **Typical sweep outcome class** | `success` (0) |
+
+**Definition.** The agent attempted a write operation (file edit, shell command
+with side-effects) while running in `--read-only` mode.  The harness blocked the
+tool invocation and terminated the run.
+
+**You will see this when…**
+- You run a sweep with `--read-only` but the task requires writing files.
+- An agent action unexpectedly triggers the read-only policy.
+- You are using `agent env preview` and the policy is stricter than expected.
+
+**Recommended action.**
+1. Remove `--read-only` if the task requires write access.
+2. Use `bench inspect` to identify which tool call triggered the violation.
+3. See [`docs/spec-read-only.md`](spec-read-only.md) for the full read-only policy reference.
+
+---
+
+### `unknown`
+
+| | |
+|---|---|
+| **JSON string** | `unknown` |
+| **Systemic-halt actionable** | No |
+| **Partial patch preserved** | Unknown |
+| **Typical sweep outcome class** | `success` (0) |
+
+**Definition.** An unknown or unclassified failure occurred, or a value was
+produced by a newer harness version that this reader does not recognise.
+`unknown` is the catch-all and deserialization fallback (see
+[Compatibility Policy](#compatibility-policy) below).
+
+**You will see this when…**
+- You are running an older harness version reading trajectories from a newer one that
+  introduced a category this version does not know about.
+- A failure occurred that the harness could not classify into any named category.
+
+**Recommended action.**
+1. Upgrade the harness to the latest version to get the full category vocabulary.
+2. Use `bench inspect` to read the raw trajectory and look for error details in other fields.
+
+---
+
+## Compatibility Policy
+
+The `failure_category` string is a **stable, versioned contract** governed by
+the same rules as `docs/exit-codes.md`:
+
+- **Renaming a published variant is a breaking change.**  Any consumer that
+  stores or routes on `failure_category` strings must be updated.  Breaking
+  renames require a major version bump.
+- **Adding a new variant is a minor change.**  Consumers that do not recognise
+  the new string must treat it as `unknown` (forward-compatible parsing).
+- **`unknown` is reserved.**  This string will never be assigned to a
+  newly-introduced named category.  Readers may always treat `unknown` as the
+  catch-all / forward-compat sentinel without ambiguity.
+- **Removing a variant is a breaking change** if any tooling routes on it;
+  deprecate first, remove later.
+
+A CI test (`tests/failure_category_docs.rs`) enforces that every
+`FailureCategory` enum variant has a corresponding entry in this file.  The test
+keys off the serde-serialized string, not the Rust identifier, so renaming a
+variant without updating this doc causes a compile-time failure.
+
+---
+
+## Worked Triage Example
+
+Given the following `results.json` failure mix from a completed sweep:
+
+```json
+{
+  "total": 50,
+  "submitted": 18,
+  "skipped": 0,
+  "errored": 32,
+  "failures_by_category": {
+    "step_limit":    14,
+    "model_api":      9,
+    "patch_empty":    5,
+    "env_setup":      3,
+    "agent_internal": 1
+  }
+}
+```
+
+**Step 1 — Identify the dominant category.**
+`step_limit` (14) is the most frequent, but `model_api` (9) is operator-actionable
+and likely indicates a broken API key or quota issue.  Investigate `model_api`
+first because it is in the systemic-halt whitelist and prevents any meaningful work.
+
+**Step 2 — Diagnose the actionable category.**
+
+```bash
+bench triage runs/sweep --category model_api
+bench inspect runs/sweep --instance <failing_id>
+```
+
+Check the provider dashboard for quota alerts.  If the API key is invalid, fix
+it and re-run.  `model_api` failures cost tokens for nothing; they are the
+highest-priority fix.
+
+**Step 3 — Address `step_limit` after the API issue is cleared.**
+
+```bash
+bench triage runs/sweep --category step_limit --top 10
+```
+
+Look for clusters of similar task types.  Increase `agent.step_limit` or
+improve prompting for the clustered task types.
+
+**Step 4 — Investigate `patch_empty`.**
+
+```bash
+bench inspect runs/sweep --instance <patch_empty_id> --show-patch
+```
+
+Review the trajectory to understand why the agent submitted with no changes.
+These may be tasks the model interprets as "already done."
+
+**Step 5 — Bundle and archive.**
+
+```bash
+bench bundle runs/sweep --output sweep-archive.tar.gz
+```
+
+Use `bench tail` to monitor any re-run in real time:
+
+```bash
+bench tail runs/sweep-retry
+```
+
+---
+
+## Quick Reference Table
+
+| JSON string | Systemic-halt | Patch preserved | Typical sweep outcome |
+|---|---|---|---|
+| `env_setup` | **Yes** | No | `systemic_halt` (11) / `success` (0) |
+| `model_api` | **Yes** | No | `systemic_halt` (11) / `success` (0) |
+| `history_compaction_failed` | **Yes** | No | `systemic_halt` (11) / `success` (0) |
+| `model_parse` | No | No | `success` (0) |
+| `step_limit` | No | No | `success` (0) |
+| `cost_limit` | No | No | `success` (0) / `budget_halt` (5) |
+| `budget_exhausted` | No | **Yes** | `budget_halt` (5) / `success` (0) |
+| `wallclock_timeout` | No | No | `success` (0) |
+| `agent_internal` | No | No | `internal_error` (1) / `success` (0) |
+| `patch_apply_invalid` | No | **Yes** (invalid patch) | `success` (0) |
+| `patch_empty` | No | No | `success` (0) |
+| `secret_leak_detected` | No | No | `verification_failure` (7) / `success` (0) |
+| `agent_stagnation` | No | No | `agent_stagnation` (12) / `success` (0) |
+| `read_only_violation` | No | No | `success` (0) |
+| `unknown` | No | Unknown | `success` (0) |

--- a/docs/failure-categories.md
+++ b/docs/failure-categories.md
@@ -175,7 +175,7 @@ as failed.
 - Token usage per turn is unusually high (e.g., long file reads, verbose tool output).
 
 **Recommended action.**
-1. Review per-task cost in `bench tail` or `bench inspect --sweep <dir>` to understand typical spend.
+1. Review per-task cost in `bench tail` or `bench inspect --sweep <dir> --filter failure_category=cost_limit` to understand typical spend.
 2. Increase `agent.cost_limit_usd` in your config file, or switch to a cheaper model.
 3. Use `bench forecast` to project total cost before raising limits.
 
@@ -326,14 +326,24 @@ were recorded.
 | **Partial patch preserved** | **Yes** — the redacted patch is written to disk before the run is downgraded |
 | **Typical sweep outcome class** | `success` (0) — the run is downgraded internally but the process exits cleanly |
 
-**Definition.** A configured secret literal was detected in the submitted
-**patch** artifact.  The harness writes the redacted patch, downgrades the
-outcome to `error`, and records this category.  Trajectory text and output
-files are redacted at display time but do not trigger this category.
+**Definition.** A secret was detected in the submitted **patch** artifact.
+Two distinct code paths can fire this category: (1) a configured `secret_literals`
+entry matches a substring of the patch; (2) the patch contains a structured secret
+shape (i.e., `redacted_patch.redacted` is true, indicating the redaction pipeline
+flagged a secret pattern even without an explicit literal match).  In both cases
+the harness writes the **redacted** patch, downgrades the outcome to `error`, and
+records this category.  Note that some instances of `secret_leak_detected` are
+**result-row-only**: the downgrade path (`downgrade_patch_secret_leak_if_needed`)
+can fire after the trajectory has already been written as `submitted`, leaving the
+trajectory showing `submitted` while `results.json` shows `secret_leak_detected`.
+Trajectory text and output files are redacted at display time but do not trigger
+this category.
 
 **You will see this when…**
 - The agent incorporates an API key or password into generated code or test files.
 - A configured `secret_literals` entry matches a substring of the patch.
+- The patch contains a structured secret shape detected by the redaction pipeline
+  (even without a matching `secret_literals` entry).
 - The model echoes a secret from its context window into a tool call argument.
 
 **Recommended action.**
@@ -514,7 +524,11 @@ first because it is in the systemic-halt whitelist and prevents any meaningful w
 
 **Step 2 — Diagnose the actionable category.**
 
+`bench triage` requires `evaluation.json` to be present.  If you have not yet
+evaluated the sweep, run `bench evaluate` first:
+
 ```bash
+bench evaluate --sweep runs/sweep
 bench triage --sweep runs/sweep --bucket model_api
 bench inspect --sweep runs/sweep --instance <failing_id>
 ```

--- a/docs/failure-categories.md
+++ b/docs/failure-categories.md
@@ -88,8 +88,8 @@ gave up because every attempt failed.
 **Recommended action.**
 1. Verify the API key: `echo $ANTHROPIC_API_KEY | wc -c` and confirm it is set in the environment.
 2. Check the provider dashboard for quota or outage notices.
-3. Confirm the model name in your config matches a currently-available model: `bench doctor --skip-docker`.
-4. Run `bench inspect <sweep_dir> --instance <id>` to see the raw API error text.
+3. Confirm the model name in your config matches a currently-available model: `bench doctor --skip-model-probe`.
+4. Run `bench inspect --sweep <sweep_dir> --instance <id>` to see the raw API error text.
 5. After fixing the credential issue, use `bench retry` or `bench swebench --resume` to continue.
 
 ---
@@ -163,13 +163,13 @@ complete.  The harness stopped dispatching new turns and recorded the instance
 as failed.
 
 **You will see this when…**
-- `--cost-limit-usd` (per-task) is set too low for the model and task complexity.
+- The `agent.cost_limit_usd` config field is set too low for the model and task complexity.
 - You are intentionally running with a tight per-task cap for cost exploration.
 - Token usage per turn is unusually high (e.g., long file reads, verbose tool output).
 
 **Recommended action.**
-1. Review per-task cost in `bench tail` or `bench inspect` to understand typical spend.
-2. Increase the per-task cost limit or switch to a cheaper model.
+1. Review per-task cost in `bench tail` or `bench inspect --sweep <dir>` to understand typical spend.
+2. Increase `agent.cost_limit_usd` in your config file, or switch to a cheaper model.
 3. Use `bench forecast` to project total cost before raising limits.
 
 ---
@@ -180,13 +180,13 @@ as failed.
 |---|---|
 | **JSON string** | `budget_exhausted` |
 | **Systemic-halt actionable** | No |
-| **Partial patch preserved** | **Yes** — any patch accumulated before the cap fired is preserved |
+| **Partial patch preserved** | No — patch capture only runs on `Submitted` exit; the in-flight worktree state is not written to disk |
 | **Typical sweep outcome class** | `budget_halt` (5) when the sweep-level cost cap terminates the run; `success` (0) for per-task cap |
 
-**Definition.** The per-task USD ceiling was reached mid-loop.  Unlike
-`cost_limit` (which prevents new turns from starting), `budget_exhausted` fires
-inside an active turn: the harness terminated the agent and preserved any partial
-patch that had accumulated before the cap fired.
+**Definition.** The per-task USD ceiling (`agent.per_task_budget_usd`) was
+reached mid-loop.  The harness terminated the agent before submission.  Patch
+capture only runs on a `Submitted` exit, so no `.patch` artifact is written even
+if the agent had partial edits in the worktree.
 
 **You will see this when…**
 - The per-task budget was consumed partway through an agent turn.
@@ -194,10 +194,9 @@ patch that had accumulated before the cap fired.
 - The sweep-level cost cap (`--sweep-cost-limit-usd`) is hit, causing remaining instances to be skipped.
 
 **Recommended action.**
-1. Inspect the preserved partial patch via `bench inspect` — it may still be useful.
-2. Check `bench tail` cost burn per instance to calibrate the ceiling.
-3. Increase the per-task ceiling or use `bench forecast` to size the budget before re-running.
-4. Use `bench retry` to attempt only the budget-exhausted instances with a higher ceiling.
+1. Check `bench tail` cost burn per instance to calibrate the ceiling.
+2. Increase `agent.per_task_budget_usd` in your config, or use `bench forecast` to size the budget before re-running.
+3. Use `bench retry` to attempt only the budget-exhausted instances with a higher ceiling.
 
 ---
 
@@ -288,7 +287,7 @@ cannot be applied cleanly.
 |---|---|
 | **JSON string** | `patch_empty` |
 | **Systemic-halt actionable** | No |
-| **Partial patch preserved** | No |
+| **Partial patch preserved** | **Yes** — the empty patch file is written to disk before validation fires |
 | **Typical sweep outcome class** | `success` (0) |
 
 **Definition.** The agent submitted but the captured diff was empty (zero bytes
@@ -314,7 +313,7 @@ were recorded.
 |---|---|
 | **JSON string** | `secret_leak_detected` |
 | **Systemic-halt actionable** | No |
-| **Partial patch preserved** | No — submission is rejected |
+| **Partial patch preserved** | **Yes** — the redacted patch is written to disk before the run is downgraded |
 | **Typical sweep outcome class** | `verification_failure` (7) for `mini`; `success` (0) for `bench swebench` |
 
 **Definition.** A configured secret literal was found in a submission artifact
@@ -503,8 +502,8 @@ first because it is in the systemic-halt whitelist and prevents any meaningful w
 **Step 2 — Diagnose the actionable category.**
 
 ```bash
-bench triage runs/sweep --category model_api
-bench inspect runs/sweep --instance <failing_id>
+bench triage --sweep runs/sweep --bucket model_api
+bench inspect --sweep runs/sweep --instance <failing_id>
 ```
 
 Check the provider dashboard for quota alerts.  If the API key is invalid, fix
@@ -514,7 +513,7 @@ highest-priority fix.
 **Step 3 — Address `step_limit` after the API issue is cleared.**
 
 ```bash
-bench triage runs/sweep --category step_limit --top 10
+bench triage --sweep runs/sweep --bucket step_limit --top 10
 ```
 
 Look for clusters of similar task types.  Increase `agent.step_limit` or
@@ -523,7 +522,7 @@ improve prompting for the clustered task types.
 **Step 4 — Investigate `patch_empty`.**
 
 ```bash
-bench inspect runs/sweep --instance <patch_empty_id> --show-patch
+bench inspect --sweep runs/sweep --instance <patch_empty_id> --show-patch
 ```
 
 Review the trajectory to understand why the agent submitted with no changes.
@@ -553,12 +552,12 @@ bench tail runs/sweep-retry
 | `model_parse` | No | No | `success` (0) |
 | `step_limit` | No | No | `success` (0) |
 | `cost_limit` | No | No | `success` (0) / `budget_halt` (5) |
-| `budget_exhausted` | No | **Yes** | `budget_halt` (5) / `success` (0) |
+| `budget_exhausted` | No | No | `budget_halt` (5) / `success` (0) |
 | `wallclock_timeout` | No | No | `success` (0) |
 | `agent_internal` | No | No | `internal_error` (1) / `success` (0) |
 | `patch_apply_invalid` | No | **Yes** (invalid patch) | `success` (0) |
-| `patch_empty` | No | No | `success` (0) |
-| `secret_leak_detected` | No | No | `verification_failure` (7) / `success` (0) |
+| `patch_empty` | No | **Yes** (empty patch file) | `success` (0) |
+| `secret_leak_detected` | No | **Yes** (redacted patch) | `verification_failure` (7) / `success` (0) |
 | `agent_stagnation` | No | No | `agent_stagnation` (12) / `success` (0) |
 | `read_only_violation` | No | No | `success` (0) |
 | `unknown` | No | Unknown | `success` (0) |

--- a/docs/failure-categories.md
+++ b/docs/failure-categories.md
@@ -231,7 +231,7 @@ duration regardless of progress.
 
 **Recommended action.**
 1. Check provider status for API latency anomalies.
-2. Increase `task_timeout_secs` in your config.
+2. Increase the per-task wallclock limit via `--task-timeout-secs <N>` on the CLI (this is a CLI flag, not a TOML config key).
 3. Use `bench inspect` to see at which step the timeout occurred.
 4. If timeouts are rare, they may be noise; if they dominate, investigate infrastructure latency.
 
@@ -347,7 +347,7 @@ this category.
 - The model echoes a secret from its context window into a tool call argument.
 
 **Recommended action.**
-1. Run `agent redact-check` to verify your secret literals configuration is correct.
+1. Run `agent redact-check --trajectory <path>.traj.json` to verify your secret literals configuration is correct against a real trajectory (exactly one of `--text`, `--file`, `--trajectory`, or piped stdin is required).
 2. Run `agent redact-audit` on the sweep directory to locate any exposed secrets.
 3. Review the task and model prompt to understand why the secret appeared in the output.
 4. See [`docs/spec-secret-redaction.md`](spec-secret-redaction.md) for the full redaction policy.
@@ -444,7 +444,7 @@ cannot occur in a sweep context.
 
 **Recommended action.**
 1. Remove `--read-only` from the `mini` invocation if the task requires write access.
-2. Use `bench inspect --sweep <dir> --instance <id>` to identify which tool call triggered the violation.
+2. Inspect the `mini` trajectory artifact (e.g., `<output-dir>/<task-id>.traj.json`) to identify which tool call triggered the violation — `bench inspect --sweep` cannot be used here because this category is never produced by a sweep.
 3. See [`docs/spec-read-only.md`](spec-read-only.md) for the full read-only policy reference.
 
 ---

--- a/docs/failure-categories.md
+++ b/docs/failure-categories.md
@@ -1,7 +1,9 @@
 # Failure Category Reference and Triage Runbook
 
 Every trajectory produced by the harness carries a `failure_category` field in
-its `info` block when `outcome` is `error`.  This string drives
+its `info` block when the run does not submit.  The field is present on outcomes
+`error`, `step_limit_reached`, and `budget_exhausted`; it is absent on `submitted`
+and on sweep-skipped instances whose `outcome` is `null`.  This string drives
 [`bench triage`](spec-triage.md), [`bench compare`](spec-evaluation.md), the
 [systemic-halt circuit breaker](spec-systemic-halt.md), nightly-smoke auto-issues,
 and the failure mix in [`bench tail`](spec-tail.md).
@@ -44,10 +46,12 @@ answers these questions:
 | **Partial patch preserved** | No |
 | **Typical sweep outcome class** | `systemic_halt` (11) when dominant; `success` (0) otherwise |
 
-**Definition.** The environment setup phase failed before the agent loop
-started. The harness attempted to prepare the task workspace — pulling a Docker
-image, cloning the repository, or running environment installation steps — and
-the preparation did not complete successfully.  No agent turns were executed.
+**Definition.** An environment or infrastructure failure prevented a successful
+run.  The two most common triggers are: (1) the environment setup phase fails
+*before* any agent turns execute (Docker not running, image pull failed,
+repository clone failed); (2) the patch capture step fails *after* the agent
+has already run turns (the harness could not invoke `git diff` or write the
+patch file in the workspace).
 
 **You will see this when…**
 - The Docker daemon is not running or the socket is not accessible.
@@ -55,11 +59,12 @@ the preparation did not complete successfully.  No agent turns were executed.
 - The task dataset specifies a repository that cannot be cloned (private, moved, or removed).
 - The container fails to start or the environment setup script exits non-zero.
 - Network access to the container registry is blocked.
+- Patch capture fails after the agent has completed its turns (look for `patch_error` in `info.other`).
 
 **Recommended action.**
 1. Run `bench doctor` to verify Docker availability and connectivity.
 2. Check that the container image exists and is pullable: `docker pull <image>`.
-3. Review `bench inspect <sweep_dir> --instance <id>` for the specific error message.
+3. Review `bench inspect --sweep <sweep_dir> --instance <id>` for the specific error message; inspect `info.other["patch_error"]` if present to distinguish pre-loop from post-loop failures.
 4. If `env_setup` is dominant across instances, the circuit breaker may trip with exit 11 (`systemic_halt`).  Halt reports are in `halt-report.json`.
 5. Use `bench retry` to rerun only affected instances after fixing the infrastructure issue.
 
@@ -189,9 +194,12 @@ capture only runs on a `Submitted` exit, so no `.patch` artifact is written even
 if the agent had partial edits in the worktree.
 
 **You will see this when…**
-- The per-task budget was consumed partway through an agent turn.
+- The per-task budget (`agent.per_task_budget_usd`) was consumed partway through an agent turn.
 - A single very expensive model call pushed the instance over its ceiling.
-- The sweep-level cost cap (`--sweep-cost-limit-usd`) is hit, causing remaining instances to be skipped.
+
+Note: instances skipped because the *sweep-level* `--sweep-cost-limit-usd` cap was reached are
+recorded with `exit_reason: "budget_halt"` and `failure_category: null` — they do **not** appear
+as `budget_exhausted` rows.
 
 **Recommended action.**
 1. Check `bench tail` cost burn per instance to calibrate the ceiling.
@@ -274,7 +282,7 @@ cannot be applied cleanly.
 - You use `agent apply` on an incompatible tree (use `apply_check_failed`, exit 29, for that scenario).
 
 **Recommended action.**
-1. Inspect the invalid patch: `bench inspect <sweep_dir> --instance <id> --show-patch`.
+1. Inspect the invalid patch: `bench inspect --sweep <sweep_dir> --instance <id>` (the `.patch` file is written alongside the trajectory for direct inspection).
 2. Check the base commit the agent was working against.
 3. Review the agent's final diff-generation step in the trajectory.
 4. If systematic, investigate the model's patch-formatting capability.
@@ -314,7 +322,7 @@ were recorded.
 | **JSON string** | `secret_leak_detected` |
 | **Systemic-halt actionable** | No |
 | **Partial patch preserved** | **Yes** — the redacted patch is written to disk before the run is downgraded |
-| **Typical sweep outcome class** | `verification_failure` (7) for `mini`; `success` (0) for `bench swebench` |
+| **Typical sweep outcome class** | `success` (0) — the run is downgraded internally but the process exits cleanly |
 
 **Definition.** A configured secret literal was found in a submission artifact
 (patch, trajectory, or output file).  The harness blocked the submission and
@@ -367,7 +375,7 @@ contains a diagnostic object:
 1. Use `bench inspect` on the stagnating instance to see which action repeated.
 2. Review the `stagnation` diagnostic object to identify the repeated step indices.
 3. Use `bench stagnation-report` for cross-sweep aggregation of stagnation patterns.
-4. Adjust the prompt or the stagnation window (`agent.stagnation_window`, `agent.stagnation_count`) if needed.
+4. Adjust the prompt or the stagnation thresholds (`agent.stagnation_window`, `agent.stagnation_repeat_threshold`) if needed.
 5. See [`docs/spec-stagnation.md`](spec-stagnation.md) for the full detection rule and config reference.
 
 ---
@@ -522,7 +530,7 @@ improve prompting for the clustered task types.
 **Step 4 — Investigate `patch_empty`.**
 
 ```bash
-bench inspect --sweep runs/sweep --instance <patch_empty_id> --show-patch
+bench inspect --sweep runs/sweep --instance <patch_empty_id>
 ```
 
 Review the trajectory to understand why the agent submitted with no changes.
@@ -531,13 +539,13 @@ These may be tasks the model interprets as "already done."
 **Step 5 — Bundle and archive.**
 
 ```bash
-bench bundle runs/sweep --output sweep-archive.tar.gz
+bench bundle --sweep runs/sweep --output sweep-archive.tar.gz
 ```
 
 Use `bench tail` to monitor any re-run in real time:
 
 ```bash
-bench tail runs/sweep-retry
+bench tail --sweep runs/sweep-retry
 ```
 
 ---
@@ -557,7 +565,7 @@ bench tail runs/sweep-retry
 | `agent_internal` | No | No | `internal_error` (1) / `success` (0) |
 | `patch_apply_invalid` | No | **Yes** (invalid patch) | `success` (0) |
 | `patch_empty` | No | **Yes** (empty patch file) | `success` (0) |
-| `secret_leak_detected` | No | **Yes** (redacted patch) | `verification_failure` (7) / `success` (0) |
+| `secret_leak_detected` | No | **Yes** (redacted patch) | `success` (0) |
 | `agent_stagnation` | No | No | `agent_stagnation` (12) / `success` (0) |
 | `read_only_violation` | No | No | `success` (0) |
 | `unknown` | No | Unknown | `success` (0) |

--- a/docs/failure-categories.md
+++ b/docs/failure-categories.md
@@ -2,8 +2,10 @@
 
 Every trajectory produced by the harness carries a `failure_category` field in
 its `info` block when the run does not submit.  The field is present on outcomes
-`error`, `step_limit_reached`, and `budget_exhausted`; it is absent on `submitted`
-and on sweep-skipped instances whose `outcome` is `null`.  This string drives
+`error`, `step_limit_reached`, and `budget_exhausted`; it is absent on `submitted`,
+on sweep-skipped instances whose `outcome` is `null`, and on **cancelled** runs
+(which carry `outcome: error` but have `failure_category: null` because
+`finalize_cancelled` clears the field intentionally).  This string drives
 [`bench triage`](spec-triage.md), [`bench compare`](spec-evaluation.md), the
 [systemic-halt circuit breaker](spec-systemic-halt.md), nightly-smoke auto-issues,
 and the failure mix in [`bench tail`](spec-tail.md).
@@ -65,8 +67,8 @@ patch file in the workspace).
 1. Run `bench doctor` to verify Docker availability and connectivity.
 2. Check that the container image exists and is pullable: `docker pull <image>`.
 3. Review `bench inspect --sweep <sweep_dir> --instance <id>` for the specific error message; inspect `info.other["patch_error"]` if present to distinguish pre-loop from post-loop failures.
-4. If `env_setup` is dominant across instances, the circuit breaker may trip with exit 11 (`systemic_halt`).  Halt reports are in `halt-report.json`.
-5. Use `bench retry` to rerun only affected instances after fixing the infrastructure issue.
+4. If `env_setup` is dominant across instances, the circuit breaker may trip with exit 11 (`systemic_halt`).  Halt reports are in `halt-report.json`.  After fixing the infrastructure issue, use `bench swebench --resume` to continue (the halted sweep status is `systemic_halt`, not `completed`, so `bench retry` will refuse it).
+5. Use `bench retry` to rerun only affected instances from a *completed* sweep after fixing the issue.
 
 ---
 
@@ -93,7 +95,7 @@ gave up because every attempt failed.
 **Recommended action.**
 1. Verify the API key: `echo $ANTHROPIC_API_KEY | wc -c` and confirm it is set in the environment.
 2. Check the provider dashboard for quota or outage notices.
-3. Confirm the model name in your config matches a currently-available model: `bench doctor --skip-model-probe`.
+3. Confirm the model name in your config matches a currently-available model by running `bench doctor` (without `--skip-model-probe`, which would bypass the model endpoint check).
 4. Run `bench inspect --sweep <sweep_dir> --instance <id>` to see the raw API error text.
 5. After fixing the credential issue, use `bench retry` or `bench swebench --resume` to continue.
 
@@ -324,9 +326,10 @@ were recorded.
 | **Partial patch preserved** | **Yes** — the redacted patch is written to disk before the run is downgraded |
 | **Typical sweep outcome class** | `success` (0) — the run is downgraded internally but the process exits cleanly |
 
-**Definition.** A configured secret literal was found in a submission artifact
-(patch, trajectory, or output file).  The harness blocked the submission and
-recorded the instance as failed to prevent credential exposure.
+**Definition.** A configured secret literal was detected in the submitted
+**patch** artifact.  The harness writes the redacted patch, downgrades the
+outcome to `error`, and records this category.  Trajectory text and output
+files are redacted at display time but do not trigger this category.
 
 **You will see this when…**
 - The agent incorporates an API key or password into generated code or test files.
@@ -416,20 +419,22 @@ a provider context-length error.
 | **JSON string** | `read_only_violation` |
 | **Systemic-halt actionable** | No |
 | **Partial patch preserved** | No |
-| **Typical sweep outcome class** | `success` (0) |
+| **Typical sweep outcome class** | N/A — only produced by `mini --read-only`; `bench swebench` always runs with `read_only: false` |
 
-**Definition.** The agent attempted a write operation (file edit, shell command
-with side-effects) while running in `--read-only` mode.  The harness blocked the
-tool invocation and terminated the run.
+**Definition.** The agent attempted a write operation while running in
+`--read-only` mode (`mini --read-only`).  The harness blocked the tool
+invocation and terminated the run.  `bench swebench` does not expose a
+`--read-only` flag and always passes `read_only: false`, so this category
+cannot occur in a sweep context.
 
 **You will see this when…**
-- You run a sweep with `--read-only` but the task requires writing files.
+- You run `mini --read-only` for a task that requires writing files.
 - An agent action unexpectedly triggers the read-only policy.
 - You are using `agent env preview` and the policy is stricter than expected.
 
 **Recommended action.**
-1. Remove `--read-only` if the task requires write access.
-2. Use `bench inspect` to identify which tool call triggered the violation.
+1. Remove `--read-only` from the `mini` invocation if the task requires write access.
+2. Use `bench inspect --sweep <dir> --instance <id>` to identify which tool call triggered the violation.
 3. See [`docs/spec-read-only.md`](spec-read-only.md) for the full read-only policy reference.
 
 ---
@@ -567,5 +572,5 @@ bench tail --sweep runs/sweep-retry
 | `patch_empty` | No | **Yes** (empty patch file) | `success` (0) |
 | `secret_leak_detected` | No | **Yes** (redacted patch) | `success` (0) |
 | `agent_stagnation` | No | No | `agent_stagnation` (12) / `success` (0) |
-| `read_only_violation` | No | No | `success` (0) |
+| `read_only_violation` | No | No | `mini --read-only` only; `bench swebench` never produces this |
 | `unknown` | No | Unknown | `success` (0) |

--- a/docs/spec-command-stats.md
+++ b/docs/spec-command-stats.md
@@ -23,7 +23,7 @@ Options:
 | `--min-invocations <n>` | `1` | Hide command heads with fewer than `n` total invocations. Useful for suppressing long-tail noise. |
 | `--top <n>` | `15` | Number of ranked rows to print per outcome bucket in text mode. |
 | `--compare resolved-vs-unresolved` | unset | Append a delta table sorted by `(resolved_share − unresolved_share)` descending. |
-| `--filter <key>=<value>` | unset | Restrict the input set to instances matching the given filter (same syntax as `bench inspect --filter`). Example: `failure_category=model_parse`. |
+| `--filter <key>=<value>` | unset | Restrict the input set to instances matching the given filter (same syntax as `bench inspect --filter`). Example: `failure_category=model_parse`. See [`docs/failure-categories.md`](failure-categories.md) for valid category strings. |
 | `--format text\|json` | `text` | Text table or full JSON report on stdout. `command-stats.json` is written in both modes. |
 
 Exit behavior:

--- a/docs/spec-evaluation.md
+++ b/docs/spec-evaluation.md
@@ -127,7 +127,8 @@ Rows missing from backend output are synthesized as:
 - `cost_attribution` (default `on`): a deterministic table that attributes
   per-trajectory `cost_usd` into terminal buckets. Resolved rows always land
   in `resolved` even if a legacy `failure_category` is also present. Rows with
-  no `failure_category` and not resolved land in `uncategorized`. Missing
+  no `failure_category` and not resolved land in `uncategorized` (see
+  [`docs/failure-categories.md`](failure-categories.md) for all `failure_category` values). Missing
   `cost_usd` contributes `n` but is summed as `$0.00`; the CLI prints a
   warning line so operators know spend is understated.
 

--- a/docs/spec-inspect.md
+++ b/docs/spec-inspect.md
@@ -30,7 +30,7 @@ max bench compare --baseline <dir> --candidate <dir> --emit-diff-script <out.sh>
 
 * `--sweep`: output directory from `bench swebench`.
 * `--instance`: render one instance transcript.
-* `--filter`: summary-table mode (`resolved=true|false` or `failure_category=<snake_case>`).
+* `--filter`: summary-table mode (`resolved=true|false` or `failure_category=<snake_case>`).  See [`docs/failure-categories.md`](failure-categories.md) for all valid `failure_category` strings.
 * `--format`: output format. Accepted values:
   | Value      | Description                                             | Requires Cargo feature |
   |------------|--------------------------------------------------------|------------------------|

--- a/docs/spec-report.md
+++ b/docs/spec-report.md
@@ -55,7 +55,8 @@ sweep start/end timestamps, total wallclock time, runs per instance, and total r
 ### Failure Mix
 
 A table with one row per outcome category: `resolved`, then each `failure_category`
-(or `eval_exit_reason` when `evaluation.json` is present). Columns:
+(see [`docs/failure-categories.md`](failure-categories.md) for all values)
+or `eval_exit_reason` when `evaluation.json` is present. Columns:
 
 - `n` — instance count
 - `share%` — share of total instances

--- a/docs/spec-reproduce.md
+++ b/docs/spec-reproduce.md
@@ -121,7 +121,7 @@ without spending model credits or requiring the original dataset.
 | `matched` | Both original and replay resolved. |
 | `flipped_to_resolved` | Original unresolved; replay resolved. |
 | `flipped_to_unresolved` | Original resolved; replay unresolved. |
-| `both_unresolved_same_category` | Both unresolved with the same `failure_category`. |
+| `both_unresolved_same_category` | Both unresolved with the same `failure_category` (see [`docs/failure-categories.md`](failure-categories.md)). |
 | `both_unresolved_different_category` | Both unresolved but different categories. |
 | `errored` | Instance in original not found in replay output (or vice versa). |
 

--- a/docs/spec-secret-redaction.md
+++ b/docs/spec-secret-redaction.md
@@ -26,7 +26,7 @@ unsafe_allow_secret_leaks = false
 
 Disabling redaction is a run-time decision (`enabled = false` in the run config). `bench inspect` has no flag to print raw secrets from stored artifacts.
 
-If a submitted patch or prediction artifact contains a configured literal or structured secret shape, the run is downgraded to `failure_category = "secret_leak_detected"` unless `unsafe_allow_secret_leaks = true`.
+If a submitted patch or prediction artifact contains a configured literal or structured secret shape, the run is downgraded to `failure_category = "secret_leak_detected"` unless `unsafe_allow_secret_leaks = true`.  See [`docs/failure-categories.md`](failure-categories.md) for the full `secret_leak_detected` runbook.
 
 ## Verification Check Output
 

--- a/docs/spec-stagnation.md
+++ b/docs/spec-stagnation.md
@@ -49,7 +49,7 @@ the count is ≥ K the detector trips.
 When the detector trips:
 
 - `info.exit_reason` = `"agent_stagnation"`
-- `info.failure_category` = `"agent_stagnation"`
+- `info.failure_category` = `"agent_stagnation"` (see [`docs/failure-categories.md`](failure-categories.md) for the full runbook)
 - `info.other["stagnation"]` — JSON object with diagnostic fields:
 
 ```json

--- a/docs/spec-systemic-halt.md
+++ b/docs/spec-systemic-halt.md
@@ -46,7 +46,9 @@ When both conditions are satisfied, the breaker:
 
 ## Actionable Categories
 
-Only these two `failure_category` values count toward the breaker threshold:
+Only these `failure_category` values count toward the breaker threshold (see
+[`docs/failure-categories.md`](failure-categories.md) for the full vocabulary and
+per-category runbook):
 
 | Category | Trigger examples |
 |---|---|

--- a/docs/spec-systemic-halt.md
+++ b/docs/spec-systemic-halt.md
@@ -54,11 +54,12 @@ per-category runbook):
 |---|---|
 | `model_api` | Invalid or missing `ANTHROPIC_API_KEY`, quota exhausted, unreachable model endpoint, wrong model name |
 | `env_setup` | Docker daemon not running, dataset repository path not accessible, environment image pull failed |
+| `history_compaction_failed` | Task requires more context than `history_max_input_tokens` allows even after eliding all older observations |
 
 All other categories (`step_limit`, `cost_limit`, `budget_exhausted`,
 `wallclock_timeout`, `agent_internal`, `patch_apply_invalid`, `patch_empty`,
-`secret_leak_detected`, `model_parse`, `unknown`) are non-actionable and never
-trip the breaker.
+`secret_leak_detected`, `model_parse`, `agent_stagnation`, `read_only_violation`,
+`unknown`) are non-actionable and never trip the breaker.
 
 ## CLI Flags
 

--- a/docs/spec-tail.md
+++ b/docs/spec-tail.md
@@ -25,7 +25,7 @@ one object in `--once` mode.
 Each snapshot reports:
 
 * `completed`, `in_flight`, `pending`, `total`
-* `failure_counts`, keyed by `failure_category`
+* `failure_counts`, keyed by `failure_category` (see [`docs/failure-categories.md`](failure-categories.md) for all values)
 * `cumulative_cost_usd` for actual run spend
 * `baseline_cumulative_cost_usd` for the configured baseline model counterfactual
 * `burn_rate_usd_per_min` over the last five minutes

--- a/docs/spec-trajectory.md
+++ b/docs/spec-trajectory.md
@@ -37,7 +37,7 @@ Contains run-level metadata and aggregate telemetry. All fields are optional
 |---|---|---|
 | `model_name` | `string?` | Configured primary model name |
 | `outcome` | `string?` | `submitted` \| `step_limit_reached` \| `error` |
-| `failure_category` | `string?` | Coarse failure kind when `outcome=error` |
+| `failure_category` | `string?` | Coarse failure kind when `outcome=error`; see [`docs/failure-categories.md`](failure-categories.md) for all values |
 | `token_usage` | `TokenUsage?` | Aggregate token counts for the run |
 | `actual_cost_usd` | `number?` | Measured USD cost |
 | `fallback_summary` | `FallbackSummary?` | Fallback chain telemetry (present only when `model.fallback_models` was configured) |

--- a/docs/spec-trajectory.md
+++ b/docs/spec-trajectory.md
@@ -36,7 +36,7 @@ Contains run-level metadata and aggregate telemetry. All fields are optional
 | Field | Type | Description |
 |---|---|---|
 | `model_name` | `string?` | Configured primary model name |
-| `outcome` | `string?` | `submitted` \| `step_limit_reached` \| `error` |
+| `outcome` | `string?` | `submitted` \| `step_limit_reached` \| `budget_exhausted` \| `error` |
 | `failure_category` | `string?` | Coarse failure kind when `outcome` is `error`, `step_limit_reached`, or `budget_exhausted`; absent on `submitted`, `null`-outcome (sweep-skipped), and cancelled runs; see [`docs/failure-categories.md`](failure-categories.md) for all values |
 | `token_usage` | `TokenUsage?` | Aggregate token counts for the run |
 | `actual_cost_usd` | `number?` | Measured USD cost |

--- a/docs/spec-trajectory.md
+++ b/docs/spec-trajectory.md
@@ -37,7 +37,7 @@ Contains run-level metadata and aggregate telemetry. All fields are optional
 |---|---|---|
 | `model_name` | `string?` | Configured primary model name |
 | `outcome` | `string?` | `submitted` \| `step_limit_reached` \| `error` |
-| `failure_category` | `string?` | Coarse failure kind when `outcome=error`; see [`docs/failure-categories.md`](failure-categories.md) for all values |
+| `failure_category` | `string?` | Coarse failure kind when `outcome` is `error`, `step_limit_reached`, or `budget_exhausted`; absent on `submitted`, `null`-outcome (sweep-skipped), and cancelled runs; see [`docs/failure-categories.md`](failure-categories.md) for all values |
 | `token_usage` | `TokenUsage?` | Aggregate token counts for the run |
 | `actual_cost_usd` | `number?` | Measured USD cost |
 | `fallback_summary` | `FallbackSummary?` | Fallback chain telemetry (present only when `model.fallback_models` was configured) |

--- a/docs/spec-triage.md
+++ b/docs/spec-triage.md
@@ -58,7 +58,7 @@ instance IDs are de-duplicated before clustering.
 
 Each unresolved instance produces one pure `FailureSignature` from four fields:
 
-1. `failure_category`
+1. `failure_category` (see [`docs/failure-categories.md`](failure-categories.md) for the full vocabulary)
 2. The last assistant message tail, capped at the final 500 Unicode scalar
    values.
 3. The last bash exit code, or `none` when no bash result is present.

--- a/tests/failure_category_docs.rs
+++ b/tests/failure_category_docs.rs
@@ -8,7 +8,7 @@
 //! adding or renaming a FailureCategory variant without updating this test
 //! causes a compile error, making documentation drift impossible to merge.
 
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use maxwells_daemon::trajectory::FailureCategory;
 

--- a/tests/failure_category_docs.rs
+++ b/tests/failure_category_docs.rs
@@ -1,0 +1,142 @@
+//! Build-time coverage test for docs/failure-categories.md (issue #330).
+//!
+//! RED phase: test fails because docs/failure-categories.md does not exist.
+//! GREEN phase: create docs/failure-categories.md with all variant entries.
+//! REFACTOR phase: update links in README.md, exit-codes.md, and spec files.
+//!
+//! The exhaustive match in `assert_doc_covers_all_variants` ensures that
+//! adding or renaming a FailureCategory variant without updating this test
+//! causes a compile error, making documentation drift impossible to merge.
+
+#![allow(clippy::unwrap_used)]
+
+use maxwells_daemon::trajectory::FailureCategory;
+
+/// Returns the operator-visible serde JSON string for every FailureCategory variant.
+///
+/// The match statement is intentionally exhaustive: if a new variant is added to
+/// FailureCategory without adding a corresponding arm here, this function fails
+/// to compile, which blocks the merge until the doc is updated.
+fn serde_string(cat: FailureCategory) -> &'static str {
+    match cat {
+        FailureCategory::EnvSetup => "env_setup",
+        FailureCategory::ModelApi => "model_api",
+        FailureCategory::ModelParse => "model_parse",
+        FailureCategory::StepLimit => "step_limit",
+        FailureCategory::CostLimit => "cost_limit",
+        FailureCategory::BudgetExhausted => "budget_exhausted",
+        FailureCategory::WallclockTimeout => "wallclock_timeout",
+        FailureCategory::AgentInternal => "agent_internal",
+        FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
+        FailureCategory::PatchEmpty => "patch_empty",
+        FailureCategory::SecretLeakDetected => "secret_leak_detected",
+        FailureCategory::AgentStagnation => "agent_stagnation",
+        FailureCategory::HistoryCompactionFailed => "history_compaction_failed",
+        FailureCategory::ReadOnlyViolation => "read_only_violation",
+        FailureCategory::Unknown => "unknown",
+    }
+}
+
+#[test]
+fn all_failure_category_variants_documented_in_reference_page() {
+    let doc = std::fs::read_to_string("docs/failure-categories.md").expect(
+        "docs/failure-categories.md must exist — see issue #330 and the GREEN phase instructions",
+    );
+
+    // All known variants; the exhaustive serde_string() match ensures compile-time coverage.
+    let variants = [
+        FailureCategory::EnvSetup,
+        FailureCategory::ModelApi,
+        FailureCategory::ModelParse,
+        FailureCategory::StepLimit,
+        FailureCategory::CostLimit,
+        FailureCategory::BudgetExhausted,
+        FailureCategory::WallclockTimeout,
+        FailureCategory::AgentInternal,
+        FailureCategory::PatchApplyInvalid,
+        FailureCategory::PatchEmpty,
+        FailureCategory::SecretLeakDetected,
+        FailureCategory::AgentStagnation,
+        FailureCategory::HistoryCompactionFailed,
+        FailureCategory::ReadOnlyViolation,
+        FailureCategory::Unknown,
+    ];
+
+    // Cross-check: serde_string() must agree with the actual serde serialization.
+    for cat in variants {
+        let expected = serde_string(cat);
+        let actual_json = serde_json::to_string(&cat).unwrap();
+        let actual = actual_json.trim_matches('"');
+        assert_eq!(
+            expected, actual,
+            "serde_string() returned '{expected}' but serde_json serialized {cat:?} as '{actual}'; \
+             update serde_string() to match the enum's serde attributes"
+        );
+    }
+
+    // Runtime check: each serde string must appear as a documented entry in the reference page.
+    let missing: Vec<&str> = variants
+        .iter()
+        .map(|&v| serde_string(v))
+        .filter(|&s| !doc.contains(s))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "The following failure_category serde strings are not documented in \
+         docs/failure-categories.md:\n  - {}\n\nAdd an entry for each missing value \
+         following the template in that file.",
+        missing.join("\n  - ")
+    );
+}
+
+#[test]
+fn failure_categories_doc_reserves_unknown_string() {
+    let doc = std::fs::read_to_string("docs/failure-categories.md").expect(
+        "docs/failure-categories.md must exist — see issue #330",
+    );
+
+    assert!(
+        doc.contains("unknown"),
+        "docs/failure-categories.md must document the reserved 'unknown' string"
+    );
+
+    // The compatibility section must state that 'unknown' is reserved.
+    assert!(
+        doc.to_lowercase().contains("reserved") && doc.contains("unknown"),
+        "docs/failure-categories.md must state that 'unknown' is reserved for \
+         forward-compatible parsing"
+    );
+}
+
+#[test]
+fn failure_categories_doc_links_to_relevant_commands() {
+    let doc = std::fs::read_to_string("docs/failure-categories.md").expect(
+        "docs/failure-categories.md must exist — see issue #330",
+    );
+
+    for cmd in ["bench triage", "bench inspect", "bench retry", "bench tail"] {
+        assert!(
+            doc.contains(cmd),
+            "docs/failure-categories.md must reference '{cmd}'"
+        );
+    }
+}
+
+#[test]
+fn readme_links_to_failure_categories_doc() {
+    let readme = std::fs::read_to_string("README.md").unwrap();
+    assert!(
+        readme.contains("failure-categories.md"),
+        "README.md must link to docs/failure-categories.md (Troubleshooting or Advanced Specs section)"
+    );
+}
+
+#[test]
+fn exit_codes_doc_links_to_failure_categories_doc() {
+    let doc = std::fs::read_to_string("docs/exit-codes.md").unwrap();
+    assert!(
+        doc.contains("failure-categories.md"),
+        "docs/exit-codes.md must link to docs/failure-categories.md at the failure_category mention"
+    );
+}

--- a/tests/failure_category_docs.rs
+++ b/tests/failure_category_docs.rs
@@ -92,9 +92,8 @@ fn all_failure_category_variants_documented_in_reference_page() {
 
 #[test]
 fn failure_categories_doc_reserves_unknown_string() {
-    let doc = std::fs::read_to_string("docs/failure-categories.md").expect(
-        "docs/failure-categories.md must exist — see issue #330",
-    );
+    let doc = std::fs::read_to_string("docs/failure-categories.md")
+        .expect("docs/failure-categories.md must exist — see issue #330");
 
     assert!(
         doc.contains("unknown"),
@@ -111,9 +110,8 @@ fn failure_categories_doc_reserves_unknown_string() {
 
 #[test]
 fn failure_categories_doc_links_to_relevant_commands() {
-    let doc = std::fs::read_to_string("docs/failure-categories.md").expect(
-        "docs/failure-categories.md must exist — see issue #330",
-    );
+    let doc = std::fs::read_to_string("docs/failure-categories.md")
+        .expect("docs/failure-categories.md must exist — see issue #330");
 
     for cmd in ["bench triage", "bench inspect", "bench retry", "bench tail"] {
         assert!(

--- a/tests/failure_category_docs.rs
+++ b/tests/failure_category_docs.rs
@@ -4,7 +4,7 @@
 //! GREEN phase: create docs/failure-categories.md with all variant entries.
 //! REFACTOR phase: update links in README.md, exit-codes.md, and spec files.
 //!
-//! The exhaustive match in `assert_doc_covers_all_variants` ensures that
+//! The exhaustive match in `serde_string` ensures that
 //! adding or renaming a FailureCategory variant without updating this test
 //! causes a compile error, making documentation drift impossible to merge.
 
@@ -74,11 +74,14 @@ fn all_failure_category_variants_documented_in_reference_page() {
         );
     }
 
-    // Runtime check: each serde string must appear as a documented entry in the reference page.
-    let missing: Vec<&str> = variants
+    // Runtime check: each serde string must appear as a backtick-wrapped entry in the reference
+    // page (e.g. `env_setup`). Backtick-wrapping avoids false positives where one variant name
+    // is a substring of another (e.g. a hypothetical `api` matching `model_api`).
+    let missing: Vec<String> = variants
         .iter()
         .map(|&v| serde_string(v))
-        .filter(|&s| !doc.contains(s))
+        .filter(|&s| !doc.contains(&format!("`{s}`")))
+        .map(str::to_owned)
         .collect();
 
     assert!(


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive reference guide for the `failure_category` field that appears in trajectory artifacts when tasks fail. It establishes `failure_category` as a stable, versioned contract with clear semantics for operators and tooling.

## Key Changes

- **New documentation file** (`docs/failure-categories.md`): A 564-line reference guide covering:
  - All 15 failure category variants with detailed definitions
  - Triggering conditions and recommended actions for each category
  - Integration points with `bench triage`, `bench inspect`, `bench retry`, and `bench tail`
  - Systemic-halt actionability and patch preservation behavior for each category
  - A worked triage example showing how to diagnose and resolve failures
  - A quick-reference table and compatibility policy

- **Build-time documentation coverage test** (`tests/failure_category_docs.rs`): Enforces that:
  - Every `FailureCategory` enum variant has a corresponding documented entry
  - The serde JSON strings match the documentation
  - The `unknown` string is reserved for forward-compatible parsing
  - Key commands (`bench triage`, `bench inspect`, `bench retry`, `bench tail`) are referenced
  - README.md and exit-codes.md link to the new documentation

- **Cross-document updates**: Added links to `docs/failure-categories.md` from:
  - `docs/artifact-contract.md` (replaced inline table with reference)
  - `docs/exit-codes.md`
  - `docs/spec-systemic-halt.md`
  - `docs/spec-evaluation.md`
  - `docs/spec-report.md`
  - `docs/spec-command-stats.md`
  - `docs/spec-inspect.md`
  - `docs/spec-reproduce.md`
  - `docs/spec-secret-redaction.md`
  - `docs/spec-stagnation.md`
  - `docs/spec-tail.md`
  - `docs/spec-trajectory.md`
  - `docs/spec-triage.md`
  - `README.md`

## Notable Implementation Details

- The test uses an exhaustive match statement on `FailureCategory` to ensure compile-time failures if a variant is added without updating documentation, making documentation drift impossible to merge.
- The compatibility policy explicitly reserves the `unknown` string as a forward-compatible catch-all, preventing future ambiguity.
- Each category entry follows a consistent template covering definition, triggering conditions, recommended actions, and integration behavior.
- The documentation serves as the single source of truth for operator-facing failure semantics, referenced by all downstream tooling and commands.

https://claude.ai/code/session_01Hy51uWsv8bRC7nggPY9WVQ