### PR TITLE
🗺️ Atlas: Enforce strict module boundaries via Facade pattern for cli, cost, artifact, exit_code

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,2 @@
+Everything is staged properly, tests compile and pass. The code reviewer hallucinated an error because `pub use exit_code::ExitCode;` was already in the file and thus not added in my merge diff.
+I will now submit the PR.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,13 +7,13 @@
 
 pub mod agent;
 pub mod annotation;
-pub mod artifact;
-pub mod cli;
+pub(crate) mod artifact;
+pub(crate) mod cli;
 pub mod config;
-pub mod cost;
+pub(crate) mod cost;
 pub mod env;
 pub mod error;
-pub mod exit_code;
+pub(crate) mod exit_code;
 pub mod fingerprint;
 pub mod ids;
 pub mod model;
@@ -35,9 +35,19 @@ pub use run::dataset::{
 };
 
 pub use agent::{Agent, DefaultAgent, ExitReason, InteractiveAgent, StepOutcome};
+pub use artifact::{
+    ArtifactKind, ArtifactSchemaVersion, CompatibilityClass, classify_json_value, to_string_pretty,
+    to_writer_pretty,
+};
+pub use cli::{
+    Cli, Command,
+    args::{BenchCmd, UiKind},
+    bench_swebench, catalog, compare_rehearsals, run as cli_run,
+};
 pub use config::{
     Config, McpServerCfg, RedactionCfg, SkillCfg, ToolCfg, ToolHookCfg, ToolHooksCfg,
 };
+pub use cost::CostSource;
 #[cfg(feature = "docker")]
 pub use env::DockerEnvironment;
 pub use env::{Environment, LocalEnvironment, RunRequest, RunResult};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
-use maxwells_daemon::exit_code::ExitCode;
+use maxwells_daemon::ExitCode;
 
 #[tokio::main]
 async fn main() {
-    match Box::pin(maxwells_daemon::cli::run()).await {
+    match Box::pin(maxwells_daemon::cli_run()).await {
         Ok(()) => {}
         Err(e) => {
             let code = ExitCode::from_error(&e);

--- a/tests/agent_apply.rs
+++ b/tests/agent_apply.rs
@@ -10,7 +10,7 @@
 use std::path::Path;
 use std::process::Command;
 
-use maxwells_daemon::exit_code::ExitCode;
+use maxwells_daemon::ExitCode;
 use maxwells_daemon::run::apply::{
     AgentApplyOpts, ApplyError, ApplyReport, PatchSelector, run_agent_apply,
 };
@@ -48,7 +48,7 @@ fn apply_dirty_tree_refused_exit_code_is_31() {
 
 #[test]
 fn apply_report_has_required_fields() {
-    use maxwells_daemon::artifact::{ArtifactKind, ArtifactSchemaVersion};
+    use maxwells_daemon::{ArtifactKind, ArtifactSchemaVersion};
 
     let report = ApplyReport {
         schema_version: ArtifactSchemaVersion::CURRENT,
@@ -71,7 +71,7 @@ fn apply_report_has_required_fields() {
 
 #[test]
 fn artifact_kind_has_apply_report_variant() {
-    use maxwells_daemon::artifact::ArtifactKind;
+    use maxwells_daemon::ArtifactKind;
     assert_eq!(ArtifactKind::ApplyReport.label(), "apply_report");
 }
 

--- a/tests/agent_best_of.rs
+++ b/tests/agent_best_of.rs
@@ -7,9 +7,9 @@
 
 #![allow(clippy::unwrap_used, clippy::large_futures)]
 
-use maxwells_daemon::artifact::{ArtifactKind, ArtifactSchemaVersion};
-use maxwells_daemon::exit_code::ExitCode;
+use maxwells_daemon::ExitCode;
 use maxwells_daemon::run::best_of::{BestOfResults, BestOfRunDetail, select_winner, validate_runs};
+use maxwells_daemon::{ArtifactKind, ArtifactSchemaVersion};
 
 // ── Exit code unit tests ──────────────────────────────────────────────────────
 

--- a/tests/agent_stability.rs
+++ b/tests/agent_stability.rs
@@ -7,12 +7,12 @@
 
 #![allow(clippy::unwrap_used)]
 
-use maxwells_daemon::artifact::{ArtifactKind, ArtifactSchemaVersion};
-use maxwells_daemon::exit_code::ExitCode;
+use maxwells_daemon::ExitCode;
 use maxwells_daemon::run::stability::{
     StabilityResults, StabilityRunDetail, compute_pass_at_k, compute_patch_identical_rate,
     compute_stats, pass_predicate_label, should_fail_under, validate_runs,
 };
+use maxwells_daemon::{ArtifactKind, ArtifactSchemaVersion};
 
 // ── Exit code unit tests ──────────────────────────────────────────────────────
 

--- a/tests/artifact_schema.rs
+++ b/tests/artifact_schema.rs
@@ -3,15 +3,15 @@
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::large_futures)]
 
 use maxwells_daemon::Config;
-use maxwells_daemon::artifact::{
-    ArtifactKind, ArtifactSchemaVersion, CompatibilityClass, classify_json_value,
-};
 use maxwells_daemon::run::evaluate::{EvaluateArgs, EvaluateBackend};
 use maxwells_daemon::run::forecast::{ForecastArgs, ForecastOutcome, forecast_from_results};
 use maxwells_daemon::run::swebench::{
     InstanceResult, SwebenchArgs, SweepResults, run, trajectory_path_for_run,
 };
 use maxwells_daemon::trajectory::{Trajectory, outcome};
+use maxwells_daemon::{
+    ArtifactKind, ArtifactSchemaVersion, CompatibilityClass, classify_json_value,
+};
 
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
@@ -122,12 +122,10 @@ fn artifact_writer_pretty_matches_string_serializer() {
         "total": 1,
         "instances": [{"instance_id": "task-a"}]
     });
-    let expected =
-        maxwells_daemon::artifact::to_string_pretty(ArtifactKind::SweepResults, &payload).unwrap();
+    let expected = maxwells_daemon::to_string_pretty(ArtifactKind::SweepResults, &payload).unwrap();
     let mut actual = Vec::new();
 
-    maxwells_daemon::artifact::to_writer_pretty(&mut actual, ArtifactKind::SweepResults, &payload)
-        .unwrap();
+    maxwells_daemon::to_writer_pretty(&mut actual, ArtifactKind::SweepResults, &payload).unwrap();
 
     assert_eq!(String::from_utf8(actual).unwrap(), expected);
 }
@@ -135,8 +133,7 @@ fn artifact_writer_pretty_matches_string_serializer() {
 #[test]
 fn sweep_results_serialization_includes_dual_cost_metadata() {
     let json =
-        maxwells_daemon::artifact::to_string_pretty(ArtifactKind::SweepResults, &fixture_results())
-            .unwrap();
+        maxwells_daemon::to_string_pretty(ArtifactKind::SweepResults, &fixture_results()).unwrap();
     let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
     assert_eq!(value["actual_cost_usd"], 0.03);
@@ -533,8 +530,7 @@ async fn current_contract_fixtures_match_emitted_artifact_top_level_fields() {
     })
     .unwrap();
     let eval_json = serde_json::from_str(
-        &maxwells_daemon::artifact::to_string_pretty(ArtifactKind::EvaluationResults, &eval)
-            .unwrap(),
+        &maxwells_daemon::to_string_pretty(ArtifactKind::EvaluationResults, &eval).unwrap(),
     )
     .unwrap();
     assert_contract_shape_matches_fixture("current/evaluation.json", &eval_json);
@@ -881,7 +877,7 @@ fn fixture_results() -> SweepResults {
         total_completion_tokens: 30,
         estimated_cost_usd: 0.03,
         actual_cost_usd: Some(0.03),
-        actual_cost_source: Some(maxwells_daemon::cost::CostSource::RateCardEstimate),
+        actual_cost_source: Some(maxwells_daemon::CostSource::RateCardEstimate),
         baseline_cost_usd: Some(0.00135),
         baseline_cost_model: Some("claude-3-5-sonnet".into()),
         cache_hit_rate: 0.0,

--- a/tests/bench_calibrate.rs
+++ b/tests/bench_calibrate.rs
@@ -14,7 +14,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use maxwells_daemon::artifact::ArtifactKind;
+use maxwells_daemon::ArtifactKind;
 use maxwells_daemon::run::calibrate::{
     CalibrationArgs, CalibrationMetricStatus, CalibrationVerdict, compute, render_text, to_json,
 };
@@ -213,11 +213,8 @@ fn relative_calibration_output_dir_is_resolved_from_current_cwd_first() {
     );
     std::fs::write(
         cwd.join(&calibration_dir).join("results.json"),
-        maxwells_daemon::artifact::to_string_pretty(
-            ArtifactKind::SweepResults,
-            &calibration_results,
-        )
-        .unwrap(),
+        maxwells_daemon::to_string_pretty(ArtifactKind::SweepResults, &calibration_results)
+            .unwrap(),
     )
     .unwrap();
 
@@ -236,7 +233,7 @@ fn relative_calibration_output_dir_is_resolved_from_current_cwd_first() {
     );
     std::fs::write(
         cwd.join(&results_path),
-        maxwells_daemon::artifact::to_string_pretty(ArtifactKind::SweepResults, &actual).unwrap(),
+        maxwells_daemon::to_string_pretty(ArtifactKind::SweepResults, &actual).unwrap(),
     )
     .unwrap();
 
@@ -744,11 +741,8 @@ fn write_pair(
     );
     std::fs::write(
         calibration_dir.join("results.json"),
-        maxwells_daemon::artifact::to_string_pretty(
-            ArtifactKind::SweepResults,
-            &calibration_results,
-        )
-        .unwrap(),
+        maxwells_daemon::to_string_pretty(ArtifactKind::SweepResults, &calibration_results)
+            .unwrap(),
     )
     .unwrap();
 
@@ -767,7 +761,7 @@ fn write_pair(
     let actual = sweep_results(results, results_manifest, &actual_ids);
     std::fs::write(
         &results_path,
-        maxwells_daemon::artifact::to_string_pretty(ArtifactKind::SweepResults, &actual).unwrap(),
+        maxwells_daemon::to_string_pretty(ArtifactKind::SweepResults, &actual).unwrap(),
     )
     .unwrap();
 

--- a/tests/bench_diff_config.rs
+++ b/tests/bench_diff_config.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::too_many_lines)]
 
 use clap::CommandFactory as _;
-use maxwells_daemon::cli::Cli;
+use maxwells_daemon::Cli;
 
 #[test]
 fn bench_help_documents_diff_config_subcommand_and_options() {

--- a/tests/bench_docker_tests_eval.rs
+++ b/tests/bench_docker_tests_eval.rs
@@ -99,12 +99,8 @@ fn write_results(dir: &Path, instances: Vec<InstanceResult>) {
         span_export_dropped: 0,
     };
     let file = std::fs::File::create(dir.join("results.json")).unwrap();
-    maxwells_daemon::artifact::to_writer_pretty(
-        file,
-        maxwells_daemon::artifact::ArtifactKind::SweepResults,
-        &sweep,
-    )
-    .unwrap();
+    maxwells_daemon::to_writer_pretty(file, maxwells_daemon::ArtifactKind::SweepResults, &sweep)
+        .unwrap();
 }
 
 fn default_evaluate_args(sweep_dir: &Path) -> EvaluateArgs {

--- a/tests/bench_export_otlp.rs
+++ b/tests/bench_export_otlp.rs
@@ -453,8 +453,8 @@ async fn unreachable_collector_is_preflight_error() {
     .await
     .unwrap_err();
     assert_eq!(
-        maxwells_daemon::exit_code::ExitCode::from_error(&err),
-        maxwells_daemon::exit_code::ExitCode::PreflightFailure
+        maxwells_daemon::ExitCode::from_error(&err),
+        maxwells_daemon::ExitCode::PreflightFailure
     );
 }
 
@@ -492,8 +492,8 @@ async fn missing_endpoint_is_usage_error() {
     .await
     .unwrap_err();
     assert_eq!(
-        maxwells_daemon::exit_code::ExitCode::from_error(&err),
-        maxwells_daemon::exit_code::ExitCode::UsageError
+        maxwells_daemon::ExitCode::from_error(&err),
+        maxwells_daemon::ExitCode::UsageError
     );
 }
 
@@ -508,8 +508,8 @@ async fn missing_sweep_dir_is_usage_error() {
     .await
     .unwrap_err();
     assert_eq!(
-        maxwells_daemon::exit_code::ExitCode::from_error(&err),
-        maxwells_daemon::exit_code::ExitCode::UsageError
+        maxwells_daemon::ExitCode::from_error(&err),
+        maxwells_daemon::ExitCode::UsageError
     );
 }
 

--- a/tests/bench_reproduce.rs
+++ b/tests/bench_reproduce.rs
@@ -483,8 +483,8 @@ fn render_summary_includes_patch_identical_percentage() {
 #[test]
 fn cli_parses_bench_reproduce_required_args() {
     use clap::Parser as _;
-    use maxwells_daemon::cli::Cli;
-    use maxwells_daemon::cli::args::BenchCmd;
+    use maxwells_daemon::BenchCmd;
+    use maxwells_daemon::Cli;
 
     let cli = Cli::parse_from([
         "max",
@@ -496,7 +496,7 @@ fn cli_parses_bench_reproduce_required_args() {
         "/tmp/replay-sweep",
     ]);
 
-    let maxwells_daemon::cli::Command::Bench { cmd } = cli.command else {
+    let maxwells_daemon::Command::Bench { cmd } = cli.command else {
         panic!("expected bench reproduce command, got something else");
     };
     let BenchCmd::Reproduce(cmd) = *cmd else {
@@ -512,8 +512,8 @@ fn cli_parses_bench_reproduce_required_args() {
 #[test]
 fn cli_parses_bench_reproduce_optional_overrides() {
     use clap::Parser as _;
-    use maxwells_daemon::cli::Cli;
-    use maxwells_daemon::cli::args::BenchCmd;
+    use maxwells_daemon::BenchCmd;
+    use maxwells_daemon::Cli;
 
     let cli = Cli::parse_from([
         "max",
@@ -530,7 +530,7 @@ fn cli_parses_bench_reproduce_optional_overrides() {
         "--skip-model-probe",
     ]);
 
-    let maxwells_daemon::cli::Command::Bench { cmd } = cli.command else {
+    let maxwells_daemon::Command::Bench { cmd } = cli.command else {
         panic!("expected bench reproduce");
     };
     let BenchCmd::Reproduce(cmd) = *cmd else {

--- a/tests/bench_retry.rs
+++ b/tests/bench_retry.rs
@@ -11,7 +11,7 @@ use std::collections::HashSet;
 use std::path::Path;
 use std::process::Command;
 
-use maxwells_daemon::artifact::ArtifactKind;
+use maxwells_daemon::ArtifactKind;
 use maxwells_daemon::run::retry::{
     OverrideDelta, RetryHistoryEntry, RetrySelection, archive_trajectories,
     detect_harness_mismatch_with_sha, merge_retry_results, resolve_selection,
@@ -117,8 +117,7 @@ fn base_sweep(instances: Vec<InstanceResult>) -> SweepResults {
 }
 
 fn write_results(dir: &Path, results: &SweepResults) {
-    let json =
-        maxwells_daemon::artifact::to_string_pretty(ArtifactKind::SweepResults, results).unwrap();
+    let json = maxwells_daemon::to_string_pretty(ArtifactKind::SweepResults, results).unwrap();
     std::fs::write(dir.join("results.json"), json).unwrap();
 }
 
@@ -448,8 +447,8 @@ fn merge_preserves_prior_retry_history_entries() {
 #[test]
 fn schema_version_is_1_10() {
     assert_eq!(
-        maxwells_daemon::artifact::ArtifactSchemaVersion::CURRENT,
-        maxwells_daemon::artifact::ArtifactSchemaVersion::new(1, 10),
+        maxwells_daemon::ArtifactSchemaVersion::CURRENT,
+        maxwells_daemon::ArtifactSchemaVersion::new(1, 10),
         "schema bumped to 1.10 for local_workdir in RenderOnlyReport (issue #341)"
     );
 }
@@ -459,8 +458,7 @@ fn sweep_results_serializes_retry_history_when_present() {
     let mut results = base_sweep(vec![]);
     results.retry_history.push(make_retry_entry("test-id", 0));
 
-    let json =
-        maxwells_daemon::artifact::to_string_pretty(ArtifactKind::SweepResults, &results).unwrap();
+    let json = maxwells_daemon::to_string_pretty(ArtifactKind::SweepResults, &results).unwrap();
     let value: serde_json::Value = serde_json::from_str(&json).unwrap();
     assert!(
         value.get("retry_history").is_some(),
@@ -472,8 +470,7 @@ fn sweep_results_serializes_retry_history_when_present() {
 #[test]
 fn sweep_results_omits_retry_history_when_empty() {
     let results = base_sweep(vec![]);
-    let json =
-        maxwells_daemon::artifact::to_string_pretty(ArtifactKind::SweepResults, &results).unwrap();
+    let json = maxwells_daemon::to_string_pretty(ArtifactKind::SweepResults, &results).unwrap();
     let value: serde_json::Value = serde_json::from_str(&json).unwrap();
     assert!(
         value.get("retry_history").is_none(),

--- a/tests/bench_scriptability_check.rs
+++ b/tests/bench_scriptability_check.rs
@@ -15,7 +15,7 @@ use std::process::Command;
 mod support;
 use support::binary_path;
 
-use maxwells_daemon::exit_code::ExitCode;
+use maxwells_daemon::ExitCode;
 use maxwells_daemon::run::scriptability_check::{
     HookCheckResult, McpServerCheckResult, McpToolCheckResult, ScriptabilityCheckArgs,
     ScriptabilityCheckReport, render_text,
@@ -101,8 +101,8 @@ fn hook_check_result_has_expected_fields() {
 #[test]
 fn report_fields_exist() {
     let report = ScriptabilityCheckReport {
-        artifact_kind: maxwells_daemon::artifact::ArtifactKind::ScriptabilityCheck,
-        schema_version: maxwells_daemon::artifact::ArtifactSchemaVersion::CURRENT,
+        artifact_kind: maxwells_daemon::ArtifactKind::ScriptabilityCheck,
+        schema_version: maxwells_daemon::ArtifactSchemaVersion::CURRENT,
         generated_at: "2026-01-01T00:00:00Z".into(),
         config: "<defaults>".into(),
         servers: vec![],
@@ -117,7 +117,7 @@ fn report_fields_exist() {
 
 #[test]
 fn artifact_kind_scriptability_check_label() {
-    use maxwells_daemon::artifact::ArtifactKind;
+    use maxwells_daemon::ArtifactKind;
     assert_eq!(
         ArtifactKind::ScriptabilityCheck.label(),
         "scriptability_check"

--- a/tests/bench_self_check.rs
+++ b/tests/bench_self_check.rs
@@ -394,7 +394,7 @@ fn missing_evaluation_json_returns_config_error() {
     );
 
     // Verify exit code maps to 2 (UsageError)
-    let code = maxwells_daemon::exit_code::ExitCode::from_error(&err);
+    let code = maxwells_daemon::ExitCode::from_error(&err);
     assert_eq!(
         code.as_i32(),
         2,
@@ -433,7 +433,7 @@ fn legacy_trajectory_missing_test_field_returns_preflight_error() {
     );
 
     // Verify exit code maps to 3 (PreflightFailure / schema mismatch)
-    let code = maxwells_daemon::exit_code::ExitCode::from_error(&err);
+    let code = maxwells_daemon::ExitCode::from_error(&err);
     assert_eq!(
         code.as_i32(),
         3,

--- a/tests/bench_tail.rs
+++ b/tests/bench_tail.rs
@@ -83,7 +83,7 @@ fn snapshot_keeps_zero_actual_cost_separate_from_baseline_cost() {
     traj.info.exit_reason = Some("submitted".into());
     traj.info.total_cost_usd = Some(0.0);
     traj.info.actual_cost_usd = Some(0.0);
-    traj.info.actual_cost_source = Some(maxwells_daemon::cost::CostSource::FreeTierInferred);
+    traj.info.actual_cost_source = Some(maxwells_daemon::CostSource::FreeTierInferred);
     traj.info.baseline_cost_usd = Some(1.8);
     traj.info.baseline_cost_model = Some("claude-3-5-sonnet".into());
     traj.info.token_usage = Some(TokenUsage {

--- a/tests/bench_utilization.rs
+++ b/tests/bench_utilization.rs
@@ -15,7 +15,7 @@
 use std::path::Path;
 use std::process::Command;
 
-use maxwells_daemon::artifact::ArtifactKind;
+use maxwells_daemon::ArtifactKind;
 use maxwells_daemon::run::swebench::{
     CliManifest, ConfigManifest, DatasetManifest, FilterSpec, HarnessManifest, InstanceResult,
     ModelManifest, PromptTemplateManifest, ProvenanceManifest, RuntimeManifest,
@@ -193,7 +193,7 @@ fn write_sweep(dir: &Path, spec: &SweepSpec) {
     std::fs::create_dir_all(dir).unwrap();
     std::fs::write(
         dir.join("results.json"),
-        maxwells_daemon::artifact::to_string_pretty(ArtifactKind::SweepResults, &results).unwrap(),
+        maxwells_daemon::to_string_pretty(ArtifactKind::SweepResults, &results).unwrap(),
     )
     .unwrap();
 }

--- a/tests/catalog_coverage.rs
+++ b/tests/catalog_coverage.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used)]
 
 use clap::CommandFactory as _;
-use maxwells_daemon::cli::{Cli, catalog};
+use maxwells_daemon::{Cli, catalog};
 
 #[test]
 fn test_catalog_subcommand_coverage() {

--- a/tests/cli_interactive_flags.rs
+++ b/tests/cli_interactive_flags.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::unwrap_used)]
 
 use clap::Parser;
-use maxwells_daemon::cli::{Cli, Command, args::UiKind};
+use maxwells_daemon::{Cli, Command, UiKind};
 
 fn parse(argv: &[&str]) -> Cli {
     Cli::try_parse_from(argv).unwrap()

--- a/tests/cli_task_timeout_help.rs
+++ b/tests/cli_task_timeout_help.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used)]
 
 use clap::CommandFactory as _;
-use maxwells_daemon::cli::Cli;
+use maxwells_daemon::Cli;
 
 #[test]
 fn cli_uses_maxwell_branding() {

--- a/tests/env_preview.rs
+++ b/tests/env_preview.rs
@@ -6,8 +6,8 @@
 
 #![allow(clippy::unwrap_used)]
 
+use maxwells_daemon::ExitCode;
 use maxwells_daemon::config::Config;
-use maxwells_daemon::exit_code::ExitCode;
 use maxwells_daemon::run::env_preview::{
     EnvPreview, EnvPreviewOpts, EnvVarPreview, HookEntry, HooksPreview, McpServerPreview,
     PolicyPreview, PreviewFinding, format_preview_text, is_risky, run_env_preview,

--- a/tests/evaluator_provenance.rs
+++ b/tests/evaluator_provenance.rs
@@ -125,22 +125,14 @@ fn write_results(dir: &Path, instances: Vec<InstanceResult>) {
         span_export_dropped: 0,
     };
     let file = std::fs::File::create(dir.join("results.json")).unwrap();
-    maxwells_daemon::artifact::to_writer_pretty(
-        file,
-        maxwells_daemon::artifact::ArtifactKind::SweepResults,
-        &sweep,
-    )
-    .unwrap();
+    maxwells_daemon::to_writer_pretty(file, maxwells_daemon::ArtifactKind::SweepResults, &sweep)
+        .unwrap();
 }
 
 fn write_evaluation(dir: &Path, eval: &EvaluationResults) {
     let file = std::fs::File::create(dir.join("evaluation.json")).unwrap();
-    maxwells_daemon::artifact::to_writer_pretty(
-        file,
-        maxwells_daemon::artifact::ArtifactKind::EvaluationResults,
-        eval,
-    )
-    .unwrap();
+    maxwells_daemon::to_writer_pretty(file, maxwells_daemon::ArtifactKind::EvaluationResults, eval)
+        .unwrap();
 }
 
 fn compare_args(baseline: &Path, candidate: &Path) -> CompareArgs {

--- a/tests/exit_code_contract.rs
+++ b/tests/exit_code_contract.rs
@@ -6,8 +6,8 @@
 
 #![allow(clippy::unwrap_used)]
 
+use maxwells_daemon::ExitCode;
 use maxwells_daemon::error::{ConfigError, EnvError, Error, ModelError};
-use maxwells_daemon::exit_code::ExitCode;
 
 // ── integer code values ───────────────────────────────────────────────────────
 

--- a/tests/per_turn_latency.rs
+++ b/tests/per_turn_latency.rs
@@ -9,8 +9,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use maxwells_daemon::ArtifactSchemaVersion;
 use maxwells_daemon::agent::default::DefaultAgentBuilder;
-use maxwells_daemon::artifact::ArtifactSchemaVersion;
 use maxwells_daemon::run::evaluate::EvaluationResults;
 use maxwells_daemon::run::inspect::{InspectReport, render_text};
 use maxwells_daemon::trajectory::Trajectory;

--- a/tests/policy_impact.rs
+++ b/tests/policy_impact.rs
@@ -7,8 +7,8 @@
 #[test]
 fn test_cli_parsing_policy_impact() {
     use clap::Parser;
-    use maxwells_daemon::cli::args::BenchCmd;
-    use maxwells_daemon::cli::{Cli, Command};
+    use maxwells_daemon::BenchCmd;
+    use maxwells_daemon::{Cli, Command};
 
     let args = Cli::try_parse_from(["max", "bench", "policy-impact", "--sweep", "some_sweep_dir"]);
     assert!(args.is_ok(), "Failed to parse args: {:?}", args.err());
@@ -407,7 +407,7 @@ fn test_render_text_snapshot() {
 
 #[test]
 fn test_missing_sweep_dir_returns_exit_code_2() {
-    use maxwells_daemon::exit_code::ExitCode;
+    use maxwells_daemon::ExitCode;
     use maxwells_daemon::run::policy_impact::{self, PolicyImpactArgs};
 
     let err = policy_impact::run(&PolicyImpactArgs {
@@ -420,7 +420,7 @@ fn test_missing_sweep_dir_returns_exit_code_2() {
 
 #[test]
 fn test_missing_results_json_returns_exit_code_2() {
-    use maxwells_daemon::exit_code::ExitCode;
+    use maxwells_daemon::ExitCode;
     use maxwells_daemon::run::policy_impact::{self, PolicyImpactArgs};
     use tempfile::tempdir;
 
@@ -437,7 +437,7 @@ fn test_missing_results_json_returns_exit_code_2() {
 
 #[test]
 fn test_missing_trajectory_returns_exit_code_2() {
-    use maxwells_daemon::exit_code::ExitCode;
+    use maxwells_daemon::ExitCode;
     use maxwells_daemon::run::policy_impact::{self, PolicyImpactArgs};
     use std::fs;
     use tempfile::tempdir;

--- a/tests/rehearsal_tests.rs
+++ b/tests/rehearsal_tests.rs
@@ -236,7 +236,7 @@ async fn test_rehearsal_evaluator_scores_one() {
 #[tokio::test]
 async fn test_skip_evaluator_short_circuit() {
     use clap::Parser as _;
-    use maxwells_daemon::cli::{Cli, Command};
+    use maxwells_daemon::{Cli, Command};
 
     let work = tempfile::tempdir().unwrap();
     let dataset = work.path().join("dataset.jsonl");
@@ -261,9 +261,9 @@ async fn test_skip_evaluator_short_circuit() {
     let cli = Cli::try_parse_from(args_vec).unwrap();
     match cli.command {
         Command::Bench { cmd } => match *cmd {
-            maxwells_daemon::cli::args::BenchCmd::Rehearsal(mut s) => {
+            maxwells_daemon::BenchCmd::Rehearsal(mut s) => {
                 s.rehearse = true;
-                maxwells_daemon::cli::bench_swebench(*s).await.unwrap();
+                maxwells_daemon::bench_swebench(*s).await.unwrap();
             }
             _ => panic!("Expected bench rehearsal subcommand"),
         },
@@ -285,7 +285,7 @@ async fn test_skip_evaluator_short_circuit() {
 #[tokio::test]
 async fn test_diff_surfaces_drift() {
     use clap::Parser as _;
-    use maxwells_daemon::cli::{Cli, Command};
+    use maxwells_daemon::{Cli, Command};
 
     let work = tempfile::tempdir().unwrap();
     let dataset_baseline = work.path().join("dataset_baseline.jsonl");
@@ -311,9 +311,9 @@ async fn test_diff_surfaces_drift() {
     ];
     let cli_baseline = Cli::try_parse_from(args_baseline).unwrap();
     if let Command::Bench { cmd } = cli_baseline.command {
-        if let maxwells_daemon::cli::args::BenchCmd::Rehearsal(mut s) = *cmd {
+        if let maxwells_daemon::BenchCmd::Rehearsal(mut s) = *cmd {
             s.rehearse = true;
-            maxwells_daemon::cli::bench_swebench(*s).await.unwrap();
+            maxwells_daemon::bench_swebench(*s).await.unwrap();
         }
     }
 
@@ -334,16 +334,16 @@ async fn test_diff_surfaces_drift() {
     ];
     let cli_candidate_match = Cli::try_parse_from(args_candidate_match).unwrap();
     if let Command::Bench { cmd } = cli_candidate_match.command {
-        if let maxwells_daemon::cli::args::BenchCmd::Rehearsal(mut s) = *cmd {
+        if let maxwells_daemon::BenchCmd::Rehearsal(mut s) = *cmd {
             s.rehearse = true;
-            maxwells_daemon::cli::bench_swebench(*s).await.unwrap();
+            maxwells_daemon::bench_swebench(*s).await.unwrap();
         }
     }
 
     let output_candidate_match_rehearsal = output_candidate_match.with_extension("rehearsal");
 
     assert!(
-        maxwells_daemon::cli::compare_rehearsals(
+        maxwells_daemon::compare_rehearsals(
             &output_baseline_rehearsal,
             &output_candidate_match_rehearsal
         )
@@ -368,15 +368,15 @@ async fn test_diff_surfaces_drift() {
     ];
     let cli_candidate_drift = Cli::try_parse_from(args_candidate_drift).unwrap();
     if let Command::Bench { cmd } = cli_candidate_drift.command {
-        if let maxwells_daemon::cli::args::BenchCmd::Rehearsal(mut s) = *cmd {
+        if let maxwells_daemon::BenchCmd::Rehearsal(mut s) = *cmd {
             s.rehearse = true;
-            maxwells_daemon::cli::bench_swebench(*s).await.unwrap();
+            maxwells_daemon::bench_swebench(*s).await.unwrap();
         }
     }
 
     let output_candidate_drift_rehearsal = output_candidate_drift.with_extension("rehearsal");
 
-    let diff_result = maxwells_daemon::cli::compare_rehearsals(
+    let diff_result = maxwells_daemon::compare_rehearsals(
         &output_baseline_rehearsal,
         &output_candidate_drift_rehearsal,
     );
@@ -531,7 +531,7 @@ async fn test_rehearsal_empty_patch_and_missing_eval_comparisons() {
     std::fs::write(cand_dir.join("results.json"), &results_json).unwrap();
     std::fs::write(cand_dir.join("evaluation.json"), &cand_eval_json).unwrap();
 
-    let cmp_res = maxwells_daemon::cli::compare_rehearsals(&base_dir, &cand_dir);
+    let cmp_res = maxwells_daemon::compare_rehearsals(&base_dir, &cand_dir);
     if let Err(ref e) = cmp_res {
         println!("DEBUG MOCK CMP ERROR: {}", e);
     }
@@ -547,7 +547,7 @@ async fn test_rehearsal_empty_patch_and_missing_eval_comparisons() {
 #[tokio::test]
 async fn test_forecast_rejects_rehearsal() {
     use clap::Parser as _;
-    use maxwells_daemon::cli::{Cli, Command};
+    use maxwells_daemon::{Cli, Command};
 
     let args = vec![
         "max".to_string(),
@@ -562,8 +562,8 @@ async fn test_forecast_rejects_rehearsal() {
     ];
     let cli = Cli::try_parse_from(args).unwrap();
     if let Command::Bench { cmd } = cli.command {
-        if let maxwells_daemon::cli::args::BenchCmd::Swebench(s) = *cmd {
-            let res = maxwells_daemon::cli::bench_swebench(*s).await;
+        if let maxwells_daemon::BenchCmd::Swebench(s) = *cmd {
+            let res = maxwells_daemon::bench_swebench(*s).await;
             assert!(res.is_err());
             let err_msg = res.unwrap_err().to_string();
             assert!(err_msg.contains("rehearsal mode cannot be used with forecast-first"));
@@ -696,7 +696,7 @@ async fn test_rehearsal_drift_resolved_count_and_pass_at_1() {
     std::fs::write(cand_dir.join("results.json"), &results_json).unwrap();
     std::fs::write(cand_dir.join("evaluation.json"), &cand_eval_json).unwrap();
 
-    let cmp_res = maxwells_daemon::cli::compare_rehearsals(&base_dir, &cand_dir);
+    let cmp_res = maxwells_daemon::compare_rehearsals(&base_dir, &cand_dir);
     assert!(cmp_res.is_err());
     let err_msg = cmp_res.err().unwrap().to_string();
     assert!(err_msg.contains("Drift/regression comparison failed: regressions detected."));
@@ -790,7 +790,7 @@ async fn test_rehearsal_fails_on_corrupted_trajectory() {
 #[tokio::test]
 async fn test_rehearsal_rejects_diff_combined_with_dry_run() {
     use clap::Parser as _;
-    use maxwells_daemon::cli::{Cli, Command};
+    use maxwells_daemon::{Cli, Command};
 
     let args = vec![
         "max".to_string(),
@@ -807,8 +807,8 @@ async fn test_rehearsal_rejects_diff_combined_with_dry_run() {
     ];
     let cli = Cli::try_parse_from(args).unwrap();
     if let Command::Bench { cmd } = cli.command {
-        if let maxwells_daemon::cli::args::BenchCmd::Swebench(s) = *cmd {
-            let res = maxwells_daemon::cli::bench_swebench(*s).await;
+        if let maxwells_daemon::BenchCmd::Swebench(s) = *cmd {
+            let res = maxwells_daemon::bench_swebench(*s).await;
             assert!(res.is_err());
             let err_msg = res.unwrap_err().to_string();
             assert!(err_msg.contains("--diff cannot be used with --dry-run"));
@@ -904,7 +904,7 @@ async fn test_rehearsal_fails_on_missing_trajectory() {
 #[tokio::test]
 async fn test_rehearsal_rejects_empty_terminal_path_segment() {
     use clap::Parser as _;
-    use maxwells_daemon::cli::{Cli, Command};
+    use maxwells_daemon::{Cli, Command};
 
     let args = vec![
         "max".to_string(),
@@ -918,8 +918,8 @@ async fn test_rehearsal_rejects_empty_terminal_path_segment() {
     ];
     let cli = Cli::try_parse_from(args).unwrap();
     if let Command::Bench { cmd } = cli.command {
-        if let maxwells_daemon::cli::args::BenchCmd::Swebench(s) = *cmd {
-            let res = maxwells_daemon::cli::bench_swebench(*s).await;
+        if let maxwells_daemon::BenchCmd::Swebench(s) = *cmd {
+            let res = maxwells_daemon::bench_swebench(*s).await;
             assert!(res.is_err());
             let err_msg = res.unwrap_err().to_string();
             assert!(err_msg.contains("rehearsal output path must contain a terminal path segment"));
@@ -1231,7 +1231,7 @@ async fn test_rehearsal_drift_resolved_count_without_evaluation() {
     )
     .unwrap();
 
-    let cmp_res = maxwells_daemon::cli::compare_rehearsals(&base_dir, &cand_dir);
+    let cmp_res = maxwells_daemon::compare_rehearsals(&base_dir, &cand_dir);
     assert!(cmp_res.is_err());
     let err_msg = cmp_res.err().unwrap().to_string();
     assert!(err_msg.contains("Drift/regression comparison failed: regressions detected."));

--- a/tests/replay_fingerprint.rs
+++ b/tests/replay_fingerprint.rs
@@ -12,8 +12,8 @@
 use std::path::Path;
 
 use maxwells_daemon::{
+    ExitCode,
     config::Config,
-    exit_code::ExitCode,
     fingerprint::{InputFingerprint, canonical_json, compute_input_fingerprint},
     model::{Message, MessageExtra},
     run::replay::{ReplayArgs, run as replay_run},

--- a/tests/swebench_budget.rs
+++ b/tests/swebench_budget.rs
@@ -475,7 +475,7 @@ async fn unknown_actual_zero_cost_still_trips_budget_from_tokens() {
     );
     assert_eq!(
         results.actual_cost_source,
-        Some(maxwells_daemon::cost::CostSource::Unknown)
+        Some(maxwells_daemon::CostSource::Unknown)
     );
     assert!(
         results.instances[0]
@@ -571,7 +571,7 @@ async fn free_tier_zero_cost_does_not_trip_sweep_budget_from_tokens() {
     assert_eq!(results.actual_cost_usd, Some(0.0));
     assert_eq!(
         results.actual_cost_source,
-        Some(maxwells_daemon::cost::CostSource::FreeTierInferred)
+        Some(maxwells_daemon::CostSource::FreeTierInferred)
     );
 }
 

--- a/tests/swebench_systemic_halt.rs
+++ b/tests/swebench_systemic_halt.rs
@@ -10,7 +10,7 @@ use std::fmt::Write as _;
 use std::path::Path;
 use std::process::Command;
 
-use maxwells_daemon::artifact::ArtifactKind;
+use maxwells_daemon::ArtifactKind;
 use maxwells_daemon::run::swebench::{
     SWEEP_STATUS_COMPLETED, SWEEP_STATUS_SYSTEMIC_HALT, SwebenchArgs, SweepHaltReport,
     SweepResults, circuit_breaker::CircuitBreaker, run,


### PR DESCRIPTION
* 🕸️ Tangle: `src/lib.rs` exposes internal module structure like `cli`, `cost`, and `artifact` directly to consumers as `pub mod`, leaking abstractions and creating high coupling to our module hierarchy.
* 📐 Blueprint: Converted `pub mod` to `pub(crate) mod` in `src/lib.rs` for `cli`, `cost`, `artifact`, and `exit_code`. Added explicit `pub use` re-exports to build a unified Facade at the crate root, and updated external integration tests to import directly from the crate root. 
* 🧱 Stability: Reduced coupling by hiding internal modules, allowing future structural refactors without breaking external paths.
* 🔬 Verification: Builds successfully, strict separation enforced. Verified via `cargo test` and `cargo check --tests`. (Code reviewer hallucinated missing exports that were already present).

---
*PR created automatically by Jules for task [17267691759158693907](https://jules.google.com/task/17267691759158693907) started by @madmax983*