### PR TITLE
🎨 Mosaic: UI Polish for [cli/inspect]

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3878,9 +3878,18 @@ fn parse_breakdown_selection(
 fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
     if i.list_formats {
         use crate::trajectory::export::registry;
+        use comfy_table::{modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Table};
+
+        let mut table = Table::new();
+        table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Format", "Tier", "Consumer"]);
+
         for fmt in registry() {
-            println!("{:<12}{:<14}{}", fmt.name, fmt.tier.as_str(), fmt.consumer);
+            table.add_row(vec![fmt.name, fmt.tier.as_str(), fmt.consumer]);
         }
+        println!("{table}");
         return Ok(());
     }
 


### PR DESCRIPTION
* 🖌️ **Before:** The `--list-formats` command outputs raw unformatted text rows separated by spaces without any headers.
* ✨ **After:** The `--list-formats` command outputs a clear and readable `comfy-table` with `Format`, `Tier`, and `Consumer` headers.
* 🖼️ **Visuals:** Replaced raw `println!` lines with a rounded UTF-8 table.

---
*PR created automatically by Jules for task [14788473201921328301](https://jules.google.com/task/14788473201921328301) started by @madmax983*