### PR TITLE
🌟 Nova: ChatML Trajectory Exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ markdown-export = []
 html-export = []
 webhook = []
 csv-export = []
+chatml-export = []
 mermaid-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]

--- a/docs/spec-export.md
+++ b/docs/spec-export.md
@@ -32,6 +32,7 @@ max bench inspect --list-formats
 |--------|---------------|---------------|------------------------------|
 | `markdown` | stable | always compiled | docs, PR review, human readers |
 | `csv` | stable | `csv-export` | spreadsheets, jq pipelines, tabular tools |
+| `chatml`      | Experimental | ChatML dataset format for LLM fine-tuning (`<|im_start|>...`). |
 | `html` | stable | `html-export` | self-contained browser view, shared notebooks |
 | `mermaid` | experimental | `mermaid-export` | Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live) |
 

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -95,6 +95,14 @@ pub fn registry() -> Vec<ExportFormat> {
         render: MermaidExporter::export,
     });
 
+    #[cfg(feature = "chatml-export")]
+    formats.push(ExportFormat {
+        name: "chatml",
+        tier: StabilityTier::Experimental,
+        consumer: "LLM fine-tuning datasets, tokenizers",
+        render: ChatMlExporter::export,
+    });
+
     formats
 }
 
@@ -109,6 +117,7 @@ pub const FEATURE_GATED_FORMATS: &[(&str, &str)] = &[
     ("csv", "csv-export"),
     ("html", "html-export"),
     ("mermaid", "mermaid-export"),
+    ("chatml", "chatml-export"),
 ];
 
 /// Returns `true` if `name` is a trajectory export format known to this codebase,
@@ -452,5 +461,58 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+}
+
+/// An exporter that renders the trajectory into the ChatML format.
+///
+/// ChatML is commonly used for LLM fine-tuning and inference pipelines.
+/// Format: `<|im_start|>role\ncontent<|im_end|>\n`
+pub struct ChatMlExporter;
+
+impl TrajectoryExporter for ChatMlExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        use std::fmt::Write;
+        let mut out = String::new();
+        let redactor = Redactor::default_enabled();
+
+        for msg in &trajectory.messages {
+            let role = redactor.redact_text(&msg.role, surface::EXPORT).text;
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            let _ = write!(out, "<|im_start|>{role}\n{content}<|im_end|>\n");
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod chatml_tests {
+    use super::*;
+    use crate::trajectory::MessageRecord;
+
+    #[test]
+    fn test_chatml_export_format() {
+        let traj = Trajectory {
+            messages: vec![
+                MessageRecord {
+                    role: "system".to_string(),
+                    content: "You are a helpful assistant.".to_string(),
+                    extra: Default::default(),
+                },
+                MessageRecord {
+                    role: "user".to_string(),
+                    content: "Hello!".to_string(),
+                    extra: Default::default(),
+                },
+            ],
+            ..Trajectory::default()
+        };
+
+        let result = ChatMlExporter::export(&traj);
+        assert_eq!(
+            result,
+            "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nHello!<|im_end|>\n"
+        );
     }
 }


### PR DESCRIPTION
💡 **The Spark:** "I noticed we support exporting trajectories for humans (markdown) and generic parsers (csv), but we don't have a format specifically tailored for LLM datasets."
🚀 **The Feature:** "Implemented `ChatMlExporter` (behind the `chatml-export` feature) that formats message histories directly into ChatML (`<|im_start|>role...<|im_end|>`)."
🔮 **The Potential:** "Could be used to seamlessly export redacted, filtered trajectories directly into a format ready for fine-tuning models or multi-turn prompt inference."
⚠️ **Risk:** "Low. Purely additive and completely isolated in `src/trajectory/export.rs` behind a new cargo feature flag."

---
*PR created automatically by Jules for task [9917073842962748537](https://jules.google.com/task/9917073842962748537) started by @madmax983*