### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,12 @@
+1. **Understand the Goal**: Sentry focuses on adding test coverage for untested logic. I found that `src/cost.rs` contains the `is_free_tier_model` function and `estimate_cost_usd` function, both of which lack tests. In fact, `cargo test --lib cost` shows no tests for `cost.rs` itself (it runs tests defined in other files that happen to use `cost.rs` logic maybe? No, `cargo test --lib cost` ran 26 tests, but none were inside `src/cost.rs`). Wait, there is no `mod tests` block in `src/cost.rs`.
+2. **Review `src/cost.rs`**:
+   - `CostSource` enum: has `label()` and `combine()` methods.
+   - `estimate_cost_usd`: calculates USD based on token counts and model name (applying anthropic cache multipliers).
+   - `is_free_tier_model`: checks if model string ends with `:free`.
+3. **Plan**:
+   - Add a `#[cfg(test)] mod tests` block at the bottom of `src/cost.rs`.
+   - Add a test for `CostSource::combine` to cover all combinations.
+   - Add a test for `estimate_cost_usd` to verify costs with and without anthropic multipliers.
+   - Add a test for `is_free_tier_model` to verify edge cases (like `anthropic/model:free`, `model:free`, `regular-model`, `model:free-tier`).
+4. **Pre-commit**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+5. **Submit PR**: Title "🛡️ Sentry: [test coverage improvement]" and include the target, risk, strategy, and verification command.

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -96,3 +96,69 @@ pub fn is_free_tier_model(model: &str) -> bool {
         .is_some_and(|name| name.ends_with(":free"))
         || model.ends_with(":free")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cost_source_combine() {
+        assert_eq!(
+            CostSource::ProviderReported.combine(CostSource::FreeTierInferred),
+            CostSource::ProviderReported
+        );
+        assert_eq!(
+            CostSource::FreeTierInferred.combine(CostSource::ProviderReported),
+            CostSource::ProviderReported
+        );
+        assert_eq!(
+            CostSource::FreeTierInferred.combine(CostSource::FreeTierInferred),
+            CostSource::FreeTierInferred
+        );
+        assert_eq!(
+            CostSource::Unknown.combine(CostSource::ProviderReported),
+            CostSource::Unknown
+        );
+        assert_eq!(
+            CostSource::ProviderReported.combine(CostSource::Unknown),
+            CostSource::Unknown
+        );
+        assert_eq!(
+            CostSource::RateCardEstimate.combine(CostSource::ProviderReported),
+            CostSource::RateCardEstimate
+        );
+        assert_eq!(
+            CostSource::ProviderReported.combine(CostSource::RateCardEstimate),
+            CostSource::RateCardEstimate
+        );
+    }
+
+    #[test]
+    fn test_is_free_tier_model() {
+        assert!(is_free_tier_model("anthropic/claude:free"));
+        assert!(is_free_tier_model("claude:free"));
+        assert!(!is_free_tier_model("claude:free-tier"));
+        assert!(!is_free_tier_model("claude-free"));
+    }
+
+    #[test]
+    #[allow(clippy::suboptimal_flops)]
+    fn test_estimate_cost_usd_anthropic() {
+        let cost = estimate_cost_usd(
+            1_000_000,
+            1_000_000,
+            1_000_000,
+            1_000_000,
+            "claude-3-5-sonnet-20240620",
+        );
+        let expected = 3.0 + (3.0 * 0.10) + (3.0 * 1.25) + 15.0;
+        assert!((cost - expected).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_estimate_cost_usd_other() {
+        let cost = estimate_cost_usd(1_000_000, 1_000_000, 1_000_000, 1_000_000, "gpt-4o");
+        let expected = 3.0 + 3.0 + 3.0 + 15.0;
+        assert!((cost - expected).abs() < f64::EPSILON);
+    }
+}


### PR DESCRIPTION
🎯 Target: `src/cost.rs` methods `CostSource::combine`, `estimate_cost_usd`, and `is_free_tier_model`.
💣 Risk: Cost estimation could incorrectly use cache multipliers for non-Anthropic models. `is_free_tier_model` could misidentify models.
🧪 Strategy: Added unit tests validating the cost estimator with and without Anthropic cache multipliers, `CostSource` combinations, and free-tier detection logic.
🔭 Verification: `cargo test --lib cost`

---
*PR created automatically by Jules for task [2537935380230826677](https://jules.google.com/task/2537935380230826677) started by @madmax983*