### PR TITLE
⚡ Bolt: Remove intermediate Vec allocation in search text normalization

### DIFF
--- a/src/skills.rs
+++ b/src/skills.rs
@@ -540,16 +540,27 @@ fn searchable_tokens(name: &str, description: &str) -> BTreeSet<String> {
         .collect()
 }
 
+/// Normalizes search text for fuzzy matching.
+///
+/// ⚡ Bolt Optimization:
+/// Avoids intermediate `Vec` allocations and `.split_whitespace().join(" ")` by tracking
+/// whitespace needs inline and collapsing contiguous non-alphanumeric characters directly
+/// into a single space during the initial iteration.
 fn normalize_search_text(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
+    let mut needs_space = false;
     for ch in text.chars() {
         if ch.is_ascii_alphanumeric() || ch == '$' || ch == '@' || ch == '/' {
+            if needs_space && !out.is_empty() {
+                out.push(' ');
+            }
             out.push(ch.to_ascii_lowercase());
+            needs_space = false;
         } else {
-            out.push(' ');
+            needs_space = true;
         }
     }
-    out.split_whitespace().collect::<Vec<_>>().join(" ")
+    out
 }
 
 fn is_stopword(token: &str) -> bool {


### PR DESCRIPTION
💡 What: Optimized `normalize_search_text` to process characters and whitespace within a single pass, avoiding the `.split_whitespace().collect::<Vec<_>>().join(" ")` chain.
🎯 Why: The previous implementation created an intermediate string, allocated a temporary `Vec` on the heap to store string slices, and then allocated a final string during the join operation.
📊 Impact: Eliminates 1 intermediate heap allocation (`Vec<_>`) and reduces memory copying.
🔭 Measurement: Run `cargo test --lib skills` and observe it passes correctly while skipping intermediate allocations on this code path.

---
*PR created automatically by Jules for task [15724982873313802913](https://jules.google.com/task/15724982873313802913) started by @madmax983*