### PR TITLE
🌟 Nova: JSON Trajectory Exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ markdown-export = []
 html-export = []
 webhook = []
 csv-export = []
+json-export = []
 mermaid-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]

--- a/docs/spec-export.md
+++ b/docs/spec-export.md
@@ -32,6 +32,7 @@ max bench inspect --list-formats
 |--------|---------------|---------------|------------------------------|
 | `markdown` | stable | always compiled | docs, PR review, human readers |
 | `csv` | stable | `csv-export` | spreadsheets, jq pipelines, tabular tools |
+| `messages-json` | stable | `json-export` | json parsers, JQ scripts, pipeline integration |
 | `html` | stable | `html-export` | self-contained browser view, shared notebooks |
 | `mermaid` | experimental | `mermaid-export` | Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live) |
 

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -87,6 +87,14 @@ pub fn registry() -> Vec<ExportFormat> {
         render: HtmlExporter::export,
     });
 
+    #[cfg(feature = "json-export")]
+    formats.push(ExportFormat {
+        name: "messages-json",
+        tier: StabilityTier::Stable,
+        consumer: "json parsers, JQ scripts, pipeline integration",
+        render: JsonExporter::export,
+    });
+
     #[cfg(feature = "mermaid-export")]
     formats.push(ExportFormat {
         name: "mermaid",
@@ -107,6 +115,7 @@ pub fn registry() -> Vec<ExportFormat> {
 /// but present here so the CLI can still route it and explain how to enable it.
 pub const FEATURE_GATED_FORMATS: &[(&str, &str)] = &[
     ("csv", "csv-export"),
+    ("messages-json", "json-export"),
     ("html", "html-export"),
     ("mermaid", "mermaid-export"),
 ];
@@ -160,6 +169,9 @@ pub struct MarkdownExporter;
 #[cfg(feature = "csv-export")]
 pub struct CsvExporter;
 
+#[cfg(feature = "json-export")]
+pub struct JsonExporter;
+
 #[cfg(feature = "mermaid-export")]
 pub struct MermaidExporter;
 
@@ -167,6 +179,27 @@ pub struct MermaidExporter;
 pub struct HtmlExporter;
 
 use std::fmt::Write;
+
+#[cfg(feature = "json-export")]
+impl TrajectoryExporter for JsonExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+
+        let messages: Vec<serde_json::Value> = trajectory
+            .messages
+            .iter()
+            .map(|msg| {
+                let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+                serde_json::json!({
+                    "role": msg.role,
+                    "content": content
+                })
+            })
+            .collect();
+
+        serde_json::to_string_pretty(&messages).unwrap_or_else(|_| "[]".to_string())
+    }
+}
 
 #[cfg(feature = "csv-export")]
 impl TrajectoryExporter for CsvExporter {
@@ -386,6 +419,25 @@ mod tests {
         assert!(md.contains("Hello agent"));
         assert!(md.contains("### Assistant"));
         assert!(md.contains("Hello user"));
+    }
+
+    #[cfg(feature = "json-export")]
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn test_json_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent"));
+
+        let json_out = JsonExporter::export(&t);
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_out).unwrap();
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0]["role"], "system");
+        assert_eq!(parsed[0]["content"], "System prompt");
+        assert_eq!(parsed[1]["role"], "user");
+        assert_eq!(parsed[1]["content"], "Hello agent");
     }
 
     #[cfg(feature = "csv-export")]


### PR DESCRIPTION
💡 **The Spark**: I noticed we have several exporters (Markdown, CSV, HTML, Mermaid) but no clean, redacted JSON exporter for downstream tools that prefer JSON over CSV for nested parsing.
🚀 **The Feature**: Implemented `JsonExporter` trait behind a `json-export` feature, named `messages-json` to avoid colliding with `bench inspect --format json`.
🔮 **The Potential**: Could be used for directly piping redacted trajectory messages into JSON pipelines, JQ scripts, or dataset builders without dealing with the full, dense `.traj.json` format.
⚠️ **Risk**: Low. Isolated behind the `json-export` feature flag in `src/trajectory/export.rs`.

---
*PR created automatically by Jules for task [16330301371106790033](https://jules.google.com/task/16330301371106790033) started by @madmax983*