### PR TITLE
⚡ Bolt: Optimize normalize_search_text allocations

### DIFF
--- a/src/skills.rs
+++ b/src/skills.rs
@@ -540,16 +540,27 @@ fn searchable_tokens(name: &str, description: &str) -> BTreeSet<String> {
         .collect()
 }
 
+/// Normalizes search text.
+///
+/// ⚡ Bolt Optimization:
+/// By tracking word boundaries dynamically, this optimization avoids
+/// the allocation of an intermediate `Vec<_>` and a secondary `String` join,
+/// eliminating heap allocations per tokenized string.
 fn normalize_search_text(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
+    let mut space = false;
     for ch in text.chars() {
         if ch.is_ascii_alphanumeric() || ch == '$' || ch == '@' || ch == '/' {
+            if space && !out.is_empty() {
+                out.push(' ');
+            }
             out.push(ch.to_ascii_lowercase());
+            space = false;
         } else {
-            out.push(' ');
+            space = true;
         }
     }
-    out.split_whitespace().collect::<Vec<_>>().join(" ")
+    out
 }
 
 fn is_stopword(token: &str) -> bool {


### PR DESCRIPTION
💡 What: Removed intermediate `.collect::<Vec<_>>().join(" ")` in `normalize_search_text` by tracking word boundaries dynamically.
🎯 Why: The original approach required allocating a `String`, parsing it into a temporary `Vec`, and allocating a final `String` join.
📊 Impact: Eliminates a heap `Vec` allocation and a second `String` allocation for every tokenized search query.
🔬 Measurement: Run tests via `cargo test --lib skills` to verify identical search normalization logic.

---
*PR created automatically by Jules for task [3414768555953785547](https://jules.google.com/task/3414768555953785547) started by @madmax983*