### PR TITLE
⚒️ Forge: Implement Display and FromStr for Role

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,5 @@
+1. **Add Display and FromStr to Role:** In `src/model/mod.rs`, implement `std::fmt::Display` and `std::str::FromStr` for `Role` so it can be parsed to and serialized from a string naturally (`system`, `user`, `assistant`, `tool`).
+2. **Refactor trajectory parsing:** In `src/trajectory/mod.rs`, replace the manual `match rec.role.as_str() { ... }` parsing with `rec.role.parse().unwrap_or(Role::User)`.
+3. **Refactor trajectory serialization:** In `src/trajectory/mod.rs`, remove `role_to_string` and replace `role_to_string(m.role)` with `m.role.to_string()`.
+4. **Refactor fingerprint JSON:** In `src/fingerprint.rs`, replace the manual match inside `role_to_json_str` with `serde_json::Value::String(role.to_string())`.
+5. **Run tests & clippy:** Ensure `cargo fmt`, `cargo clippy`, and `cargo test` pass.

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -140,16 +140,7 @@ pub fn cap_canonical(s: &str, cap: usize) -> (String, bool) {
 }
 
 fn role_to_json_str(role: crate::model::Role) -> serde_json::Value {
-    use crate::model::Role;
-    serde_json::Value::String(
-        match role {
-            Role::System => "system",
-            Role::User => "user",
-            Role::Assistant => "assistant",
-            Role::Tool => "tool",
-        }
-        .to_owned(),
-    )
+    serde_json::Value::String(role.to_string())
 }
 
 #[cfg(test)]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -30,6 +30,31 @@ pub enum Role {
     Tool,
 }
 
+impl std::fmt::Display for Role {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::System => write!(f, "system"),
+            Self::User => write!(f, "user"),
+            Self::Assistant => write!(f, "assistant"),
+            Self::Tool => write!(f, "tool"),
+        }
+    }
+}
+
+impl std::str::FromStr for Role {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "system" => Ok(Self::System),
+            "assistant" => Ok(Self::Assistant),
+            "tool" => Ok(Self::Tool),
+            "user" => Ok(Self::User),
+            _ => Err(()),
+        }
+    }
+}
+
 /// Advisory: tells the backend whether this message's content is worth
 /// keeping warm in a prompt cache, and whether a breakpoint marker belongs
 /// here.

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -812,7 +812,7 @@ impl Trajectory {
     /// ```
     pub fn record_message(&mut self, m: &Message) {
         self.messages.push(MessageRecord {
-            role: role_to_string(m.role),
+            role: m.role.to_string(),
             content: m.content.clone(),
             extra: m.extra.clone(),
         });
@@ -831,7 +831,7 @@ impl Trajectory {
     /// ```
     pub fn record_with_extra(&mut self, m: &Message, extra: MessageExtra) {
         self.messages.push(MessageRecord {
-            role: role_to_string(m.role),
+            role: m.role.to_string(),
             content: m.content.clone(),
             extra,
         });
@@ -903,12 +903,7 @@ impl Trajectory {
         self.messages
             .iter()
             .map(|rec| {
-                let role = match rec.role.as_str() {
-                    "system" => Role::System,
-                    "assistant" => Role::Assistant,
-                    "tool" => Role::Tool,
-                    _ => Role::User,
-                };
+                let role = rec.role.parse().unwrap_or(Role::User);
                 Message {
                     role,
                     content: rec.content.clone(),
@@ -999,15 +994,6 @@ pub fn load_all_trajectories_for_instance(
         }
     }
     trajs
-}
-
-fn role_to_string(r: crate::model::Role) -> String {
-    match r {
-        crate::model::Role::System => "system".into(),
-        crate::model::Role::User => "user".into(),
-        crate::model::Role::Assistant => "assistant".into(),
-        crate::model::Role::Tool => "tool".into(),
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**🦠 Smell:** Manual string conversion logic for `Role` (`role_to_string` and `role_to_json_str` and inline `match` blocks) repeated in multiple places, such as `src/trajectory/mod.rs` and `src/fingerprint.rs`.
**✨ Solution:** Implement `std::fmt::Display` and `std::str::FromStr` directly on the `Role` enum in `src/model/mod.rs` and refactored call sites to use standard `.to_string()` and `.parse()` methods. The `FromStr` correctly uses `_ => Err(())` and uses `.unwrap_or(Role::User)` at call-sites to preserve original fallback behavior.
**🧼 Benefit:** Removes boilerplate code, centralizes string conversion logic inside the model module, adheres to standard Rust idiomatic usage, and improves overall code readability and maintainability.
**🛡️ Verification:** Unit tests, linting (`clippy`), and formatting passed with no behavior changes.

---
*PR created automatically by Jules for task [6671490325247251179](https://jules.google.com/task/6671490325247251179) started by @madmax983*