### PR TITLE
🎨 Mosaic: UI Polish for Agent CLI Output

### DIFF
--- a/src/run/agent_profile.rs
+++ b/src/run/agent_profile.rs
@@ -228,6 +228,8 @@ fn compute_pct(stage_ms: Option<u64>, total_ms: Option<u64>) -> Option<u8> {
 
 // ── text formatting ───────────────────────────────────────────────────────────
 
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+
 pub fn format_text(report: &AgentProfileReport) -> String {
     let mut out = String::new();
 
@@ -263,14 +265,24 @@ pub fn format_text(report: &AgentProfileReport) -> String {
         "\n── Token Usage ──────────────────────────────────────────"
     );
     let tu = &report.token_usage;
-    let _ = writeln!(out, "  prompt:          {:>8}", tu.prompt_tokens);
-    let _ = writeln!(out, "  cache-read:      {:>8}", tu.cache_read_tokens);
-    let _ = writeln!(out, "  cache-creation:  {:>8}", tu.cache_creation_tokens);
-    let _ = writeln!(out, "  completion:      {:>8}", tu.completion_tokens);
+    let mut token_table = Table::new();
+    token_table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(["Type", "Tokens"]);
+    let prompt_tokens = tu.prompt_tokens.to_string();
+    let cache_read_tokens = tu.cache_read_tokens.to_string();
+    let cache_creation_tokens = tu.cache_creation_tokens.to_string();
+    let completion_tokens = tu.completion_tokens.to_string();
+    token_table.add_row(["prompt", prompt_tokens.as_str()]);
+    token_table.add_row(["cache-read", cache_read_tokens.as_str()]);
+    token_table.add_row(["cache-creation", cache_creation_tokens.as_str()]);
+    token_table.add_row(["completion", completion_tokens.as_str()]);
     let total =
         tu.prompt_tokens + tu.cache_read_tokens + tu.cache_creation_tokens + tu.completion_tokens;
-    let _ = writeln!(out, "  ─────────────────────────");
-    let _ = writeln!(out, "  total:           {total:>8}");
+    let total_str = total.to_string();
+    token_table.add_row(["total", total_str.as_str()]);
+    let _ = writeln!(out, "{token_table}");
 
     // Stage breakdown
     let _ = writeln!(
@@ -278,44 +290,42 @@ pub fn format_text(report: &AgentProfileReport) -> String {
         "\n── Stage Breakdown ──────────────────────────────────────"
     );
     let sb = &report.stage_breakdown;
-    let _ = writeln!(out, "  {:<10} {:>10}   {:>5}", "stage", "ms", "share");
-    let _ = writeln!(out, "  {}", "─".repeat(30));
-    let _ = writeln!(
-        out,
-        "  {:<10} {:>10}   {:>5}",
-        "model",
-        fmt_ms(sb.model_ms),
-        fmt_pct(sb.model_pct)
-    );
-    let _ = writeln!(
-        out,
-        "  {:<10} {:>10}   {:>5}",
-        "tool",
-        fmt_ms(sb.tool_ms),
-        fmt_pct(sb.tool_pct)
-    );
-    let _ = writeln!(
-        out,
-        "  {:<10} {:>10}   {:>5}",
-        "harness",
-        fmt_ms(sb.harness_ms),
-        fmt_pct(sb.harness_pct)
-    );
+    let mut stage_table = Table::new();
+    stage_table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(["stage", "ms", "share"]);
+
+    let model_ms = fmt_ms(sb.model_ms);
+    let model_pct = fmt_pct(sb.model_pct);
+    stage_table.add_row(["model", model_ms.as_str(), model_pct.as_str()]);
+
+    let tool_ms = fmt_ms(sb.tool_ms);
+    let tool_pct = fmt_pct(sb.tool_pct);
+    stage_table.add_row(["tool", tool_ms.as_str(), tool_pct.as_str()]);
+
+    let harness_ms = fmt_ms(sb.harness_ms);
+    let harness_pct = fmt_pct(sb.harness_pct);
+    stage_table.add_row(["harness", harness_ms.as_str(), harness_pct.as_str()]);
+
+    let _ = writeln!(out, "{stage_table}");
 
     // Action mix
     let _ = writeln!(
         out,
         "\n── Action Mix ───────────────────────────────────────────"
     );
-    let _ = writeln!(out, "  {:<10} {:>6}   {:>6}", "class", "count", "share");
-    let _ = writeln!(out, "  {}", "─".repeat(28));
+    let mut mix_table = Table::new();
+    mix_table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(["class", "count", "share"]);
     for (name, entry) in &report.action_mix {
-        let _ = writeln!(
-            out,
-            "  {:<10} {:>6}   {:>5.1}%",
-            name, entry.count, entry.share_pct
-        );
+        let count_str = entry.count.to_string();
+        let share_str = format!("{:.1}%", entry.share_pct);
+        mix_table.add_row([name.as_str(), count_str.as_str(), share_str.as_str()]);
     }
+    let _ = writeln!(out, "{mix_table}");
 
     out
 }

--- a/src/run/agent_runs.rs
+++ b/src/run/agent_runs.rs
@@ -352,6 +352,8 @@ fn failure_category_label_str(fc: FailureCategory) -> String {
 
 const TASK_DISPLAY_LEN: usize = 40;
 
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+
 pub fn format_text(report: &AgentRunsReport) -> String {
     let mut out = String::new();
 
@@ -367,13 +369,19 @@ pub fn format_text(report: &AgentRunsReport) -> String {
         return out;
     }
 
-    // Header row — outcome needs ≥20 chars (step_limit_reached=18), failure_category ≥26 (history_compaction_failed=25)
-    let _ = writeln!(
-        out,
-        "{:<42} {:<20} {:<26} {:>6} {:>10} {:>9} model",
-        "task", "outcome", "failure_category", "steps", "duration", "cost_usd"
-    );
-    let _ = writeln!(out, "{}", "─".repeat(126));
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header([
+            "task",
+            "outcome",
+            "failure_category",
+            "steps",
+            "duration",
+            "cost_usd",
+            "model",
+        ]);
 
     for row in &report.rows {
         let task_raw = row
@@ -395,14 +403,18 @@ pub fn format_text(report: &AgentRunsReport) -> String {
             .map_or_else(|| "-".to_owned(), |c| format!("${c:.4}"));
         let model = row.model.as_deref().unwrap_or("");
 
-        let _ = writeln!(
-            out,
-            "{task:<42} {outcome:<20} {failure:<26} {steps:>6} {dur:>10} {cost:>9} {model}"
-        );
+        table.add_row([
+            task.as_str(),
+            outcome,
+            failure,
+            steps.as_str(),
+            dur.as_str(),
+            cost.as_str(),
+            model,
+        ]);
     }
 
-    // Footer
-    let _ = writeln!(out, "{}", "─".repeat(126));
+    let _ = writeln!(out, "{table}");
 
     // Outcome breakdown
     let outcome_parts: Vec<String> = report

--- a/src/run/config_resolve.rs
+++ b/src/run/config_resolve.rs
@@ -402,6 +402,8 @@ fn redact_value(value: Value, redactor: &Redactor) -> Value {
     }
 }
 
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+
 // ── Text formatter ────────────────────────────────────────────────────────────
 
 /// Render a [`ConfigResolveReport`] as human-readable text (the `--format text` output).
@@ -410,11 +412,13 @@ pub fn format_text(report: &ConfigResolveReport) -> String {
     use std::fmt::Write as _;
     let mut out = String::new();
 
-    let _ = writeln!(out, "=== agent config resolve (no model call made) ===");
-    let _ = writeln!(out);
+    let _ = writeln!(out, "=== agent config resolve (no model call made) ===\n");
 
-    let _ = writeln!(out, "{:<42} {:<32} Layer", "Field", "Value");
-    let _ = writeln!(out, "{}", "-".repeat(82));
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(["Field", "Value", "Layer"]);
 
     for field in &report.fields {
         let value_str = json_value_display(&field.value);
@@ -424,10 +428,11 @@ pub fn format_text(report: &ConfigResolveReport) -> String {
             ProvenanceLayer::Env => "env",
             ProvenanceLayer::Flag => "flag",
         };
-        let _ = writeln!(out, "{:<42} {:<32} {}", field.key, value_str, layer_str);
+        table.add_row([field.key.as_str(), value_str.as_str(), layer_str]);
     }
 
-    let _ = writeln!(out);
+    let _ = writeln!(out, "{table}\n");
+
     if report.hazards.is_empty() {
         let _ = writeln!(out, "--- Hazards: NONE ---");
     } else {


### PR DESCRIPTION
* 🖌️ **Before**: The output for `agent config resolve`, `agent runs`, and `agent profile` produced giant text walls using manual spacing.
* ✨ **After**: Rewritten the `format_text` functions across these files to utilize `comfy_table` with `presets::UTF8_FULL` and `modifiers::UTF8_ROUND_CORNERS`.
* 🖼️ **Visuals**: The output now looks like structured dashboards rather than log files, increasing readability and visual hierarchy.

---
*PR created automatically by Jules for task [635662533010518744](https://jules.google.com/task/635662533010518744) started by @madmax983*