### PR TITLE
🌟 Nova: Add finetune-export format for trajectory outputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+finetune-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
 

--- a/docs/spec-export.md
+++ b/docs/spec-export.md
@@ -171,3 +171,5 @@ an exporter. Each **must** satisfy this bar before merging:
 - Choosing the concrete CLI surface, trait shape, or Cargo feature-flag strategy beyond
   what is already implemented.
 - Live streaming or real-time export from in-flight sweeps.
+finetune
+experimental

--- a/docs/spec-export.md
+++ b/docs/spec-export.md
@@ -34,6 +34,7 @@ max bench inspect --list-formats
 | `csv` | stable | `csv-export` | spreadsheets, jq pipelines, tabular tools |
 | `html` | stable | `html-export` | self-contained browser view, shared notebooks |
 | `mermaid` | experimental | `mermaid-export` | Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live) |
+| `finetune` | experimental | `finetune-export` | JSONL fine-tuning format for model training platforms |
 
 Feature-gated formats require rebuilding with the corresponding feature:
 
@@ -171,5 +172,3 @@ an exporter. Each **must** satisfy this bar before merging:
 - Choosing the concrete CLI surface, trait shape, or Cargo feature-flag strategy beyond
   what is already implemented.
 - Live streaming or real-time export from in-flight sweeps.
-finetune
-experimental

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -95,6 +95,14 @@ pub fn registry() -> Vec<ExportFormat> {
         render: MermaidExporter::export,
     });
 
+    #[cfg(feature = "finetune-export")]
+    formats.push(ExportFormat {
+        name: "finetune",
+        tier: StabilityTier::Experimental,
+        consumer: "JSONL fine-tuning format for model training platforms",
+        render: FinetuneExporter::export,
+    });
+
     formats
 }
 
@@ -109,6 +117,7 @@ pub const FEATURE_GATED_FORMATS: &[(&str, &str)] = &[
     ("csv", "csv-export"),
     ("html", "html-export"),
     ("mermaid", "mermaid-export"),
+    ("finetune", "finetune-export"),
 ];
 
 /// Returns `true` if `name` is a trajectory export format known to this codebase,
@@ -166,7 +175,32 @@ pub struct MermaidExporter;
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
+#[cfg(feature = "finetune-export")]
+pub struct FinetuneExporter;
+
 use std::fmt::Write;
+
+#[cfg(feature = "finetune-export")]
+impl TrajectoryExporter for FinetuneExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+
+        let mut messages = Vec::new();
+        for msg in &trajectory.messages {
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            messages.push(serde_json::json!({
+                "role": msg.role,
+                "content": content
+            }));
+        }
+
+        let dataset_row = serde_json::json!({
+            "messages": messages
+        });
+
+        serde_json::to_string(&dataset_row).unwrap_or_else(|_| String::new()) + "\n"
+    }
+}
 
 #[cfg(feature = "csv-export")]
 impl TrajectoryExporter for CsvExporter {
@@ -452,5 +486,27 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+
+    #[cfg(feature = "finetune-export")]
+    #[test]
+    fn test_finetune_export_format() {
+        let mut t = Trajectory::new();
+        t.record_message(&Message::system("Sys prompt"));
+        t.record_message(&Message::user("User prompt"));
+        t.record_message(&Message::assistant("Assistant reply"));
+
+        let jsonl = FinetuneExporter::export(&t);
+        let parsed: serde_json::Value = serde_json::from_str(&jsonl).unwrap_or_else(|_| serde_json::json!({}));
+
+        assert!(parsed.get("messages").is_some());
+        let msgs = parsed["messages"].as_array().map_or(&[] as &[serde_json::Value], |v| v.as_slice());
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0]["role"], "system");
+        assert_eq!(msgs[0]["content"], "Sys prompt");
+        assert_eq!(msgs[1]["role"], "user");
+        assert_eq!(msgs[1]["content"], "User prompt");
+        assert_eq!(msgs[2]["role"], "assistant");
+        assert_eq!(msgs[2]["content"], "Assistant reply");
     }
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -497,10 +497,13 @@ mod tests {
         t.record_message(&Message::assistant("Assistant reply"));
 
         let jsonl = FinetuneExporter::export(&t);
-        let parsed: serde_json::Value = serde_json::from_str(&jsonl).unwrap_or_else(|_| serde_json::json!({}));
+        let parsed: serde_json::Value =
+            serde_json::from_str(&jsonl).unwrap_or_else(|_| serde_json::json!({}));
 
         assert!(parsed.get("messages").is_some());
-        let msgs = parsed["messages"].as_array().map_or(&[] as &[serde_json::Value], |v| v.as_slice());
+        let msgs = parsed["messages"]
+            .as_array()
+            .map_or(&[] as &[serde_json::Value], |v| v.as_slice());
         assert_eq!(msgs.len(), 3);
         assert_eq!(msgs[0]["role"], "system");
         assert_eq!(msgs[0]["content"], "Sys prompt");


### PR DESCRIPTION
💡 The Spark: I noticed we record incredibly valuable agent trajectories but don't easily allow users to train their own open-source models on them.
🚀 The Feature: Implemented `FinetuneExporter` to directly dump trajectories in a JSONL format suitable for model fine-tuning.
🔮 The Potential: Opens the door for an entire ecosystem of user-trained SWE models built from our agent's successful runs.
⚠️ Risk: Low. Isolated in `src/trajectory/export.rs` behind a `finetune-export` cargo feature flag.

---
*PR created automatically by Jules for task [4208535909466420189](https://jules.google.com/task/4208535909466420189) started by @madmax983*