### PR TITLE
👺 Havoc: Fix Poisoning Panic on fork drift_steps unwrap

### DIFF
--- a/src/run/fork.rs
+++ b/src/run/fork.rs
@@ -614,7 +614,7 @@ pub async fn run(args: ForkCmd) -> Result<(), Error> {
     let run_result = agent.run().await;
 
     // Report if any drift steps occurred during the deterministic prefix (though we exit 9 early if mismatch occurs)
-    let collected_drifts = drift_steps.lock().unwrap().clone();
+    let collected_drifts = drift_steps.lock().unwrap_or_else(std::sync::PoisonError::into_inner).clone();
     if !collected_drifts.is_empty() {
         tracing::warn!("Replay drift detected during deterministic prefix phase");
     }


### PR DESCRIPTION
* 🧨 **The Trigger:** If the inner deterministic evaluation fails/panics while processing replay traces, the `drift_steps` Mutex poisons. The outer process attempts `.unwrap()` on line 617, causing an unrecoverable secondary crash.
* 📉 **The Stack Trace:** None available (simulated Mutex panic).
* 🧪 **Reproduction:** Intentionally poison `drift_steps` inside `src/run/fork.rs` and observe the subsequent unwrap crash instead of recovering gracefully.
* 😈 **Comment:** You assumed Mutexes never poison in Rust. You forgot that panics propagate, and unwrapping poisoned mutexes turns a localized thread crash into a systemic system failure.

---
*PR created automatically by Jules for task [3815495813552794974](https://jules.google.com/task/3815495813552794974) started by @madmax983*