### PR TITLE
🌟 Nova: JUnit Trajectory Export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+junit-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
 

--- a/docs/spec-export.md
+++ b/docs/spec-export.md
@@ -34,6 +34,7 @@ max bench inspect --list-formats
 | `csv` | stable | `csv-export` | spreadsheets, jq pipelines, tabular tools |
 | `html` | stable | `html-export` | self-contained browser view, shared notebooks |
 | `mermaid` | experimental | `mermaid-export` | Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live) |
+| `junit` | experimental | `junit-export` | CI pipelines (GitLab, Jenkins, GitHub Actions) |
 
 Feature-gated formats require rebuilding with the corresponding feature:
 
@@ -121,6 +122,7 @@ markdown    stable        docs, PR review, human readers
 csv         stable        spreadsheets, jq pipelines, tabular tools
 html        stable        self-contained browser view, shared notebooks
 mermaid     experimental  Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live)
+junit       experimental  CI pipelines (GitLab, Jenkins, GitHub Actions)
 ```
 
 The output lists only formats compiled into the running binary (feature-gated formats

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -95,6 +95,14 @@ pub fn registry() -> Vec<ExportFormat> {
         render: MermaidExporter::export,
     });
 
+    #[cfg(feature = "junit-export")]
+    formats.push(ExportFormat {
+        name: "junit",
+        tier: StabilityTier::Experimental,
+        consumer: "CI pipelines (GitLab, Jenkins, GitHub Actions)",
+        render: JunitExporter::export,
+    });
+
     formats
 }
 
@@ -109,6 +117,7 @@ pub const FEATURE_GATED_FORMATS: &[(&str, &str)] = &[
     ("csv", "csv-export"),
     ("html", "html-export"),
     ("mermaid", "mermaid-export"),
+    ("junit", "junit-export"),
 ];
 
 /// Returns `true` if `name` is a trajectory export format known to this codebase,
@@ -165,6 +174,56 @@ pub struct MermaidExporter;
 
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
+
+#[cfg(feature = "junit-export")]
+pub struct JunitExporter;
+
+#[cfg(feature = "junit-export")]
+impl TrajectoryExporter for JunitExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut xml = String::new();
+
+        let task = trajectory.info.task.as_deref().unwrap_or("Unknown Task");
+        let task_safe = redactor
+            .redact_text(task, surface::EXPORT)
+            .text
+            .replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+            .replace('"', "&quot;")
+            .replace('\'', "&apos;");
+
+        let outcome = trajectory.info.outcome.as_deref().unwrap_or("unknown");
+        let outcome_safe = redactor
+            .redact_text(outcome, surface::EXPORT)
+            .text
+            .replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+            .replace('"', "&quot;")
+            .replace('\'', "&apos;");
+
+        let name = "Agent Trajectory";
+        let failures = i32::from(outcome == "error");
+
+        xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites>\n");
+        let _ = write!(
+            xml,
+            "  <testsuite name=\"{name}\" tests=\"1\" failures=\"{failures}\">\n    <testcase classname=\"Agent\" name=\"{task_safe}\">"
+        );
+
+        if failures > 0 {
+            let _ = write!(
+                xml,
+                "\n      <failure message=\"{outcome_safe}\">Outcome: {outcome_safe}</failure>"
+            );
+        }
+
+        xml.push_str("\n    </testcase>\n  </testsuite>\n</testsuites>\n");
+        xml
+    }
+}
 
 use std::fmt::Write;
 
@@ -452,5 +511,31 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+
+    #[cfg(feature = "junit-export")]
+    #[test]
+    fn test_junit_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        let xml = JunitExporter::export(&t);
+
+        assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        assert!(xml.contains("<testsuites>"));
+        assert!(xml.contains("<testsuite name=\"Agent Trajectory\" tests=\"1\" failures=\"0\">"));
+        assert!(xml.contains("<testcase classname=\"Agent\" name=\"Add a feature\">"));
+        assert!(!xml.contains("<failure"));
+
+        let mut t_err = Trajectory::new();
+        t_err.info.task = Some("Trigger error".to_string());
+        t_err.info.outcome = Some("error".to_string());
+
+        let xml_err = JunitExporter::export(&t_err);
+        assert!(
+            xml_err.contains("<testsuite name=\"Agent Trajectory\" tests=\"1\" failures=\"1\">")
+        );
+        assert!(xml_err.contains("<failure message=\"error\">Outcome: error</failure>"));
     }
 }


### PR DESCRIPTION
💡 The Spark: Many CI platforms natively parse JUnit XML. Currently trajectories are exported as md, html, etc. A JUnit exporter allows CI pipelines to directly surface agent runs as tests.
🚀 The Feature: Add `junit-export` feature and `JunitExporter` that translates trajectory outcomes into JUnit XML schema.
🔮 The Potential: Any maxwells-daemon user running agents in CI can now drop `--format junit > report.xml` to immediately integrate with Jenkins, GitLab, or GitHub Actions test reporting.
⚠️ Risk: Very low. Hidden behind its own `junit-export` feature.

---
*PR created automatically by Jules for task [8179116759896593491](https://jules.google.com/task/8179116759896593491) started by @madmax983*