### PR TITLE
🛡️ Sentry: Add test for custom headers in SweepWebhookSink

### DIFF
--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -606,6 +606,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn custom_headers_appear_in_request() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{addr}");
+
+        let headers = vec![("X-Test-Header".to_owned(), "hello-world".to_owned())];
+        let sink =
+            SweepWebhookSink::new(url, &headers, Redactor::disabled(), "s".to_owned()).unwrap();
+
+        sink.emit(SweepNotificationEvent::SweepStarted {
+            total_instances: 5,
+            model: "test-model".to_owned(),
+        });
+
+        let socket = accept(&listener).await;
+        let request = read_http(socket).await;
+        let lower = request.to_ascii_lowercase();
+        assert!(
+            lower.contains("x-test-header: hello-world"),
+            "custom header not found in: {request}"
+        );
+    }
+
+    #[tokio::test]
     async fn invalid_header_name_rejected_at_construction() {
         let err = SweepWebhookSink::new(
             "http://127.0.0.1:1".to_owned(),


### PR DESCRIPTION
🎯 Target: src/stream/sweep_webhook.rs (SweepWebhookSink implementation)
💣 Risk: Custom HTTP headers provided to `SweepWebhookSink::new()` could be silently dropped during configuration, failing to inject necessary authorization or tracking metadata without warning operators.
🧪 Strategy: Added `custom_headers_appear_in_request` test that spawns a local server, instantiates a sink with a custom header, triggers a webhook event, and asserts the header is present in the received HTTP request.
🔬 Verification: `cargo test --lib stream::sweep_webhook`

---
*PR created automatically by Jules for task [5511606770321133233](https://jules.google.com/task/5511606770321133233) started by @madmax983*