### PR TITLE
⚡ Bolt: Optimize normalize_search_text by removing intermediate Vec allocation

### DIFF
--- a/src/skills.rs
+++ b/src/skills.rs
@@ -540,16 +540,26 @@ fn searchable_tokens(name: &str, description: &str) -> BTreeSet<String> {
         .collect()
 }
 
+/// Normalizes search text by converting to lowercase, keeping specific punctuation,
+/// and collapsing multiple spaces into one.
+///
+/// **Optimization (Bolt):** Eliminates an intermediate `.collect::<Vec<_>>()` allocation
+/// by deduplicating spaces inline during the single character iteration.
 fn normalize_search_text(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
+    let mut last_was_space = true;
     for ch in text.chars() {
         if ch.is_ascii_alphanumeric() || ch == '$' || ch == '@' || ch == '/' {
+            if last_was_space && !out.is_empty() {
+                out.push(' ');
+            }
             out.push(ch.to_ascii_lowercase());
+            last_was_space = false;
         } else {
-            out.push(' ');
+            last_was_space = true;
         }
     }
-    out.split_whitespace().collect::<Vec<_>>().join(" ")
+    out
 }
 
 fn is_stopword(token: &str) -> bool {


### PR DESCRIPTION
- 💡 What: Replaced an intermediate `.split_whitespace().collect::<Vec<_>>().join(" ")` chain with inline space deduplication inside `normalize_search_text`.
- 🎯 Why: The previous implementation created an unnecessary intermediate vector on the heap just to collapse spaces, which was an avoidable overhead.
- 📊 Impact: Eliminates a heap allocation (`Vec`) during search text normalization for skills.
- 🔬 Measurement: Run `cargo test` to ensure functionality is preserved. Compile and check `clippy` for correctness.

---
*PR created automatically by Jules for task [14642557240188233695](https://jules.google.com/task/14642557240188233695) started by @madmax983*