### PR TITLE
🌟 Nova: BashExporter for Trajectories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+bash-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
 

--- a/docs/spec-export.md
+++ b/docs/spec-export.md
@@ -34,6 +34,7 @@ max bench inspect --list-formats
 | `csv` | stable | `csv-export` | spreadsheets, jq pipelines, tabular tools |
 | `html` | stable | `html-export` | self-contained browser view, shared notebooks |
 | `mermaid` | experimental | `mermaid-export` | Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live) |
+| `bash` | stable | `bash-export` | reproducibility testing, local script execution |
 
 Feature-gated formats require rebuilding with the corresponding feature:
 

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -95,6 +95,14 @@ pub fn registry() -> Vec<ExportFormat> {
         render: MermaidExporter::export,
     });
 
+    #[cfg(feature = "bash-export")]
+    formats.push(ExportFormat {
+        name: "bash",
+        tier: StabilityTier::Stable,
+        consumer: "reproducibility testing, local script execution",
+        render: BashExporter::export,
+    });
+
     formats
 }
 
@@ -109,6 +117,7 @@ pub const FEATURE_GATED_FORMATS: &[(&str, &str)] = &[
     ("csv", "csv-export"),
     ("html", "html-export"),
     ("mermaid", "mermaid-export"),
+    ("bash", "bash-export"),
 ];
 
 /// Returns `true` if `name` is a trajectory export format known to this codebase,
@@ -165,6 +174,32 @@ pub struct MermaidExporter;
 
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
+
+#[cfg(feature = "bash-export")]
+pub struct BashExporter;
+
+#[cfg(feature = "bash-export")]
+impl TrajectoryExporter for BashExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut script = String::new();
+        script.push_str("#!/usr/bin/env bash\n");
+        script.push_str("# Trajectory Bash Export\n\n");
+        script.push_str("set -e\n\n");
+
+        for msg in &trajectory.messages {
+            if msg.role == "assistant" {
+                let action = crate::agent::parse::extract_action(&msg.content);
+                if let crate::agent::parse::Action::Bash(cmd) = action {
+                    let redacted = redactor.redact_text(&cmd, surface::EXPORT).text;
+                    script.push_str(&redacted);
+                    script.push('\n');
+                }
+            }
+        }
+        script
+    }
+}
 
 use std::fmt::Write;
 
@@ -452,5 +487,15 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+
+    #[cfg(feature = "bash-export")]
+    #[test]
+    fn test_bash_export_format() {
+        let mut t = Trajectory::new();
+        t.record_message(&Message::assistant("I will run this:\n```bash\nls -l\n```"));
+        let bash = BashExporter::export(&t);
+        assert!(bash.starts_with("#!/usr/bin/env bash"));
+        assert!(bash.contains("ls -l"));
     }
 }

--- a/tests/export_redaction_conformance.rs
+++ b/tests/export_redaction_conformance.rs
@@ -27,6 +27,9 @@ fn fixture_trajectory() -> Trajectory {
     t.record_message(&Message::assistant(format!(
         "Authenticated with {CANARY_TOKEN}, proceeding"
     )));
+    t.record_message(&Message::assistant(format!(
+        "I will now run a command:\n```bash\necho {CANARY_TOKEN} > secret.txt\n```"
+    )));
     t
 }
 


### PR DESCRIPTION
💡 **The Spark:** "I noticed we capture trajectories with shell commands, but there's no way to easily 'eject' those commands into a reproducible shell script."
🚀 **The Feature:** "Implemented `BashExporter` format for `bench inspect`."
🔮 **The Potential:** "Could be used to convert an agent's successful workflow into an automated bash script, effectively compiling AI into traditional automation."
⚠️ **Risk:** "Low. Isolated in `src/trajectory/export.rs`."

---
*PR created automatically by Jules for task [13125931631517537605](https://jules.google.com/task/13125931631517537605) started by @madmax983*