### PR TITLE
🗺️ Atlas: Refactor TraceId and SpanId into NewTypes

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -41,6 +41,8 @@ macro_rules! string_id {
 
 string_id!(ContainerId);
 string_id!(TaskId);
+string_id!(TraceId);
+string_id!(SpanId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]

--- a/src/run/export_otlp.rs
+++ b/src/run/export_otlp.rs
@@ -236,7 +236,7 @@ pub fn reconstruct(sweep_dir: &Path) -> Result<Reconstructed, Error> {
 fn reconstruct_instance(
     sweep_dir: &Path,
     sweep_id: &str,
-    sweep_span_id: &str,
+    sweep_span_id: &crate::ids::SpanId,
     last_run: u32,
     sweep_start_nanos: u64,
     sweep_end_nanos: u64,

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -192,7 +192,7 @@ pub struct InspectReport {
     /// 32 lowercase hex chars. Deep-link to the operator's observability backend
     /// via their dashboard's trace search. `None` when OTLP was not enabled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub trace_id: Option<String>,
+    pub trace_id: Option<crate::ids::TraceId>,
     /// Metadata recording how this trajectory was forked from a parent run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fork_lineage: Option<crate::trajectory::ForkLineage>,

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -209,7 +209,7 @@ pub struct MiniArgs {
     /// is active. Written into `trajectory.info.trace_id` before the first
     /// save so the trajectory and its span share the same correlation key.
     /// `None` when OTLP is not configured.
-    pub trace_id: Option<String>,
+    pub trace_id: Option<crate::ids::TraceId>,
     /// Optional webhook URL for per-step push streaming (issue #324).
     /// When `Some`, each `StreamEvent` is POSTed as a JSON envelope to this
     /// URL by a background task.  Absent = no background task spawned.

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -426,7 +426,7 @@ pub struct InstanceResult {
     /// 32 lowercase hex chars (128-bit). Set when `--otlp-endpoint` is active
     /// (or `OTEL_EXPORTER_OTLP_ENDPOINT` is set). `None` otherwise.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub trace_id: Option<String>,
+    pub trace_id: Option<crate::ids::TraceId>,
 }
 
 /// Selection criteria recorded in a retry history entry.
@@ -2826,7 +2826,8 @@ pub async fn run(mut args: SwebenchArgs) -> Result<SweepResults, Error> {
             if needs_generated_id {
                 ir.trace_id = Some(crate::telemetry::new_trace_id(&ir.instance_id, &sweep_id));
             }
-            let trace_id = ir.trace_id.as_deref().unwrap_or_default();
+            let empty_trace_id = crate::ids::TraceId::new("");
+            let trace_id = ir.trace_id.as_ref().unwrap_or(&empty_trace_id);
             // Run indices are 1-based (the sweep loop runs `for run_index in 1..=reruns`).
             // Use reruns=1 as the default; if the instance ran multiple times take the last.
             let last_run_index = args.reruns.max(1);
@@ -3733,7 +3734,7 @@ struct CancelledWaitContext<'a> {
     attempts: u32,
     retry_reasons: &'a [FailureCategory],
     current: Option<InstanceResult>,
-    trace_id: Option<String>,
+    trace_id: Option<crate::ids::TraceId>,
 }
 
 fn cancelled_wait_result(ctx: CancelledWaitContext<'_>) -> InstanceResult {
@@ -3743,7 +3744,7 @@ fn cancelled_wait_result(ctx: CancelledWaitContext<'_>) -> InstanceResult {
         ctx.run_index,
         ctx.task,
         ctx.model_name,
-        ctx.trace_id.as_deref(),
+        ctx.trace_id.as_ref(),
     );
     let mut result = ctx.current.unwrap_or_else(|| InstanceResult {
         instance_id: ctx.instance_id.to_owned(),
@@ -3801,7 +3802,7 @@ fn persist_cancelled_wait_trajectory(
     run_index: u32,
     task: &str,
     model_name: &str,
-    trace_id: Option<&str>,
+    trace_id: Option<&crate::ids::TraceId>,
 ) {
     let traj_path = trajectory_path_for_run(output_dir, instance_id, run_index);
     let mut trajectory = std::fs::read_to_string(&traj_path)
@@ -3830,7 +3831,7 @@ fn persist_cancelled_wait_trajectory(
     trajectory.info.duration_secs.get_or_insert(0.0);
     trajectory.info.steps.get_or_insert(0);
     if trajectory.info.trace_id.is_none() {
-        trajectory.info.trace_id = trace_id.map(str::to_owned);
+        trajectory.info.trace_id = trace_id.cloned();
     }
 
     if let Some(parent) = traj_path.parent() {
@@ -4655,7 +4656,7 @@ struct RunOneParams {
     resume_from: Option<crate::trajectory::Trajectory>,
     /// OTel trace ID to embed in the trajectory and instance result.
     /// `None` when OTLP export is not configured.
-    trace_id: Option<String>,
+    trace_id: Option<crate::ids::TraceId>,
     rehearse: bool,
     /// Optional append-only JSONL stream target forwarded to mini runs.
     event_log: Option<PathBuf>,

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -28,10 +28,10 @@ use sha2::{Digest, Sha256};
 // ---------------------------------------------------------------------------
 
 /// A 128-bit OTel trace ID encoded as 32 lowercase hex chars.
-pub type TraceId = String;
+use crate::ids::{TraceId, SpanId};
 
-/// A 64-bit OTel span ID encoded as 16 lowercase hex chars.
-pub type SpanId = String;
+
+
 
 /// Generates a deterministic but collision-resistant 128-bit trace ID by
 /// hashing `instance_id + sweep_id + monotonic_nanos`.
@@ -44,7 +44,7 @@ pub fn new_trace_id(instance_id: &str, sweep_id: &str) -> TraceId {
     // Use the first 16 bytes (128 bits) as the trace ID.
     let mut bytes = [0u8; 16];
     bytes.copy_from_slice(&hash[..16]);
-    format!("{:032x}", u128::from_be_bytes(bytes))
+    TraceId::new(format!("{:032x}", u128::from_be_bytes(bytes)))
 }
 
 /// Generates a 64-bit span ID by taking the first 8 bytes of a SHA-256 hash.
@@ -52,11 +52,11 @@ pub fn new_span_id(salt: &str, trace_id: &TraceId) -> SpanId {
     let mut hasher = Sha256::new();
     hasher.update(salt.as_bytes());
     hasher.update(b"\x01");
-    hasher.update(trace_id.as_bytes());
+    hasher.update(trace_id.as_str().as_bytes());
     let hash = hasher.finalize();
     let mut bytes = [0u8; 8];
     bytes.copy_from_slice(&hash[..8]);
-    format!("{:016x}", u64::from_be_bytes(bytes))
+    SpanId::new(format!("{:016x}", u64::from_be_bytes(bytes)))
 }
 
 fn now_unix_nanos() -> u64 {
@@ -348,9 +348,9 @@ fn bool_attr(key: &str, val: bool) -> serde_json::Value {
 
 #[allow(clippy::too_many_arguments)]
 fn span_json(
-    trace_id: &str,
-    span_id: &str,
-    parent_span_id: Option<&str>,
+    trace_id: &crate::ids::TraceId,
+    span_id: &SpanId,
+    parent_span_id: Option<&SpanId>,
     name: &str,
     start_nanos: u64,
     end_nanos: u64,
@@ -417,8 +417,8 @@ fn u64_to_i64(v: u64) -> i64 {
 
 fn build_instance_spans(
     sweep_id: &str,
-    sweep_trace_id: &str,
-    sweep_span_id: &str,
+    sweep_trace_id: &crate::ids::TraceId,
+    sweep_span_id: &crate::ids::SpanId,
     inst: &InstanceSpanData,
 ) -> Vec<serde_json::Value> {
     let inst_span_id = new_span_id(&format!("inst_{}", inst.instance_id), &inst.trace_id);
@@ -876,8 +876,8 @@ pub(crate) mod build {
     /// when a trajectory is available.
     #[allow(clippy::too_many_arguments)]
     pub fn instance_span_data_from_result(
-        trace_id: &str,
-        sweep_span_id: &str,
+        trace_id: &crate::ids::TraceId,
+        sweep_span_id: &crate::ids::SpanId,
         instance_id: &str,
         repo: &str,
         result: &crate::run::swebench::InstanceResult,
@@ -886,8 +886,8 @@ pub(crate) mod build {
         end_nanos: u64,
     ) -> InstanceSpanData {
         InstanceSpanData {
-            trace_id: trace_id.to_owned(),
-            sweep_span_id: sweep_span_id.to_owned(),
+            trace_id: trace_id.clone(),
+            sweep_span_id: sweep_span_id.clone(),
             instance_id: instance_id.to_owned(),
             repo: repo.to_owned(),
             outcome: result.outcome.as_deref().unwrap_or("unknown").to_owned(),
@@ -907,8 +907,8 @@ pub(crate) mod build {
     /// never placed in span attributes — only numeric counters, exit codes,
     /// and model metadata.
     pub fn instance_span_data_from_trajectory(
-        trace_id: &str,
-        sweep_span_id: &str,
+        trace_id: &crate::ids::TraceId,
+        sweep_span_id: &crate::ids::SpanId,
         instance_id: &str,
         repo: &str,
         traj: &Trajectory,
@@ -1021,8 +1021,8 @@ pub(crate) mod build {
         }
 
         InstanceSpanData {
-            trace_id: trace_id.to_owned(),
-            sweep_span_id: sweep_span_id.to_owned(),
+            trace_id: trace_id.clone(),
+            sweep_span_id: sweep_span_id.clone(),
             instance_id: instance_id.to_owned(),
             repo: repo.to_owned(),
             outcome,
@@ -1138,16 +1138,16 @@ mod tests {
     #[test]
     fn trace_id_is_32_hex_chars() {
         let tid = new_trace_id("django__django__1234", "sweep-abc");
-        assert_eq!(tid.len(), 32);
-        assert!(tid.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(tid.as_str().len(), 32);
+        assert!(tid.as_str().chars().all(|c| c.is_ascii_hexdigit()));
     }
 
     #[test]
     fn span_id_is_16_hex_chars() {
         let tid = new_trace_id("repo__issue__1", "sweep-xyz");
         let sid = new_span_id("sweep_span", &tid);
-        assert_eq!(sid.len(), 16);
-        assert!(sid.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(sid.as_str().len(), 16);
+        assert!(sid.as_str().chars().all(|c| c.is_ascii_hexdigit()));
     }
 
     #[test]

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -667,7 +667,7 @@ pub struct TrajectoryInfo {
     /// spans in the operator's observability backend.
     /// `None` for sweeps run without OTLP export.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub trace_id: Option<String>,
+    pub trace_id: Option<crate::ids::TraceId>,
     /// Absolute canonicalized local working directory for the agent run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub local_workdir: Option<String>,

--- a/tests/otlp_traces.rs
+++ b/tests/otlp_traces.rs
@@ -191,7 +191,7 @@ fn instance_result_has_trace_id() {
         trace_id: Some("deadbeef00000000deadbeef00000000".into()),
     };
     assert_eq!(
-        ir.trace_id.as_deref(),
+        ir.trace_id.as_ref().map(maxwells_daemon::ids::TraceId::as_str),
         Some("deadbeef00000000deadbeef00000000")
     );
 }
@@ -207,7 +207,7 @@ fn trajectory_info_has_trace_id() {
         ..Default::default()
     };
     assert_eq!(
-        info.trace_id.as_deref(),
+        info.trace_id.as_ref().map(maxwells_daemon::ids::TraceId::as_str),
         Some("aabbccdd00000000aabbccdd00000000")
     );
 }
@@ -223,7 +223,7 @@ fn trajectory_trace_id_serialises_and_deserialises() {
     let json = serde_json::to_string(&traj).unwrap();
     let decoded: Trajectory = serde_json::from_str(&json).unwrap();
     assert_eq!(
-        decoded.info.trace_id.as_deref(),
+        decoded.info.trace_id.as_ref().map(maxwells_daemon::ids::TraceId::as_str),
         Some("cafebabe00000000cafebabe00000000")
     );
 }
@@ -420,7 +420,7 @@ async fn trace_id_written_to_instance_result_and_trajectory() {
             "instance {} missing trace_id",
             inst.instance_id
         );
-        let tid = inst.trace_id.as_deref().unwrap();
+        let tid = inst.trace_id.as_ref().map(maxwells_daemon::ids::TraceId::as_str).unwrap();
         assert_eq!(tid.len(), 32, "trace_id must be 32 hex chars, got: {tid}");
         assert!(
             tid.chars().all(|c| c.is_ascii_hexdigit()),


### PR DESCRIPTION
- 🕸️ Tangle: `TraceId` and `SpanId` were defined as plain `String` aliases (`Primitive Obsession`), which could lead to accidental mix-ups with other strings.
- 📐 Blueprint: Introduced strongly-typed NewTypes using the `string_id!` macro for `TraceId` and `SpanId`, propagating them through `telemetry` and `trajectory` modules.
- 🧱 Stability: Strict separation enforced at compile time, preventing accidental implicit conversions while serializing transparently.
- 🔭 Verification: Builds successfully and passes all tests across the workspace.

---
*PR created automatically by Jules for task [7733233708674683579](https://jules.google.com/task/7733233708674683579) started by @madmax983*