### PR TITLE
Add `bench variance` command for flakiness classification

### DIFF
--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -76,6 +76,7 @@ pub enum ArtifactKind {
     EvalParityReport,
     AgentRunsReport,
     MiniResult,
+    BenchVarianceReport,
 }
 
 impl ArtifactKind {
@@ -109,6 +110,7 @@ impl ArtifactKind {
             Self::EvalParityReport => "eval_parity_report",
             Self::AgentRunsReport => "agent_runs_report",
             Self::MiniResult => "mini_result",
+            Self::BenchVarianceReport => "bench_variance_report",
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1334,6 +1334,8 @@ pub enum BenchCmd {
     Utilization(UtilizationCmd),
     /// Backfill OTLP traces from a completed sweep directory to a collector (zero model cost: reads only on-disk artifacts).
     ExportOtlp(ExportOtlpCmd),
+    /// Classify per-instance flakiness from a rerun sweep (zero cost: reads only on-disk artifacts).
+    Variance(BenchVarianceCmd),
 }
 
 /// `bench export-otlp` — re-export reconstructed sweep + instance spans from a
@@ -1948,6 +1950,30 @@ pub struct BudgetFitCmd {
     /// May be specified multiple times.
     #[arg(long = "filter", value_name = "KEY=VALUE", action = clap::ArgAction::Append)]
     pub filter: Vec<String>,
+}
+
+/// `bench variance` — classify per-instance flakiness from a rerun sweep (zero-cost: reads only on-disk artifacts).
+#[derive(Debug, Args)]
+pub struct BenchVarianceCmd {
+    /// Completed rerun sweep directory produced by `bench swebench --reruns N`.
+    #[arg(long)]
+    pub sweep: std::path::PathBuf,
+
+    /// Output format: `text` (default) or `json`.
+    #[arg(long, default_value = "text", value_name = "FMT")]
+    pub format: String,
+
+    /// Target CI half-width for recommended rerun count (e.g. `0.05` for ±5%).
+    #[arg(long, value_name = "WIDTH")]
+    pub ci_width: Option<f64>,
+
+    /// Instance-id substring filter. May be specified multiple times.
+    #[arg(long = "filter", value_name = "SUBSTRING", action = clap::ArgAction::Append)]
+    pub filter: Vec<String>,
+
+    /// Show only instances of this stability class: `always_resolved`, `always_failed`, or `flaky`.
+    #[arg(long, value_name = "CLASS")]
+    pub class: Option<String>,
 }
 
 /// `bench ladder` — resolved-rate and cost trend across sweeps (zero-cost: reads only on-disk artifacts).

--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -194,6 +194,12 @@ pub fn entries() -> &'static [CatalogEntry] {
             stage: "analyze",
         },
         CatalogEntry {
+            path: "bench variance",
+            summary: "Classify per-instance flakiness from a rerun sweep (zero cost)",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
             path: "bench bundle",
             summary: "Export or verify a portable, redacted sweep archive",
             cost_tier: "free",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -139,6 +139,7 @@ pub async fn run() -> Result<(), Error> {
             args::BenchCmd::EvalParity(p) => bench_eval_parity(p),
             args::BenchCmd::Utilization(u) => bench_utilization(u),
             args::BenchCmd::ExportOtlp(c) => Box::pin(bench_export_otlp(c)).await,
+            args::BenchCmd::Variance(v) => bench_variance(v),
         },
         Command::Agent { cmd } => match *cmd {
             args::AgentCmd::SkillsPreview(s) => agent_skills_preview_cmd(&s),
@@ -4292,6 +4293,37 @@ fn bench_budget_fit(b: args::BudgetFitCmd) -> Result<(), Error> {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
         print!("{}", crate::run::budget_fit::render_text(&report));
+    }
+    Ok(())
+}
+
+fn bench_variance(v: args::BenchVarianceCmd) -> Result<(), Error> {
+    let is_json = match v.format.as_str() {
+        "text" => false,
+        "json" => true,
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "bench variance: unknown --format `{other}` (expected `text` or `json`)"
+            ))));
+        }
+    };
+    let args = crate::run::variance::BenchVarianceArgs {
+        sweep_dir: v.sweep,
+        ci_width: v.ci_width,
+        filter: v.filter,
+        class: v.class,
+    };
+    let report = crate::run::variance::compute_variance(&args)?;
+    if is_json {
+        println!(
+            "{}",
+            crate::artifact::to_string_pretty(
+                crate::artifact::ArtifactKind::BenchVarianceReport,
+                &report,
+            )?
+        );
+    } else {
+        print!("{}", crate::run::variance::render_text(&report));
     }
     Ok(())
 }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -80,4 +80,5 @@ pub mod triage;
 pub mod triage_diff;
 pub mod ui;
 pub mod utilization;
+pub mod variance;
 pub mod watch;

--- a/src/run/variance.rs
+++ b/src/run/variance.rs
@@ -2,7 +2,11 @@
 //!
 //! Read-only: never re-runs instances, never calls a model, never modifies input sweeps.
 
-#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
 
 use std::path::PathBuf;
 
@@ -167,8 +171,11 @@ fn compute_noise_summary(instances: &[InstanceVariance], ci_width: Option<f64>) 
     let flaky_share = f64::from(flaky_count) / n_f;
 
     let pass_at_k = instances.iter().filter(|i| i.resolved_slots > 0).count() as f64 / n_f;
-    let all_of_k =
-        instances.iter().filter(|i| i.resolved_slots == i.total_slots).count() as f64 / n_f;
+    let all_of_k = instances
+        .iter()
+        .filter(|i| i.resolved_slots == i.total_slots)
+        .count() as f64
+        / n_f;
 
     let total_resolved: u64 = instances.iter().map(|i| u64::from(i.resolved_slots)).sum();
     let total_slots: u64 = instances.iter().map(|i| u64::from(i.total_slots)).sum();
@@ -181,9 +188,8 @@ fn compute_noise_summary(instances: &[InstanceVariance], ci_width: Option<f64>) 
 
     let (ci_lower, ci_upper) = wilson_ci(pass_at_1, total_slots);
 
-    let recommended_reruns = ci_width.and_then(|w| {
-        compute_recommended_reruns(pass_at_1, n, w, total_slots)
-    });
+    let recommended_reruns =
+        ci_width.and_then(|w| compute_recommended_reruns(pass_at_1, n, w, total_slots));
 
     NoiseSummary {
         flaky_count,
@@ -205,8 +211,7 @@ fn wilson_ci(p: f64, n: u64) -> (f64, f64) {
     let n_f = n as f64;
     let z2 = Z * Z;
     let center = (p + z2 / (2.0 * n_f)) / (1.0 + z2 / n_f);
-    let half = Z * (p * (1.0 - p) / n_f + z2 / (4.0 * n_f * n_f)).sqrt()
-        / (1.0 + z2 / n_f);
+    let half = Z * (p * (1.0 - p) / n_f + z2 / (4.0 * n_f * n_f)).sqrt() / (1.0 + z2 / n_f);
     let lower = (center - half).max(0.0);
     let upper = (center + half).min(1.0);
     (lower, upper)
@@ -246,10 +251,26 @@ pub fn render_text(report: &BenchVarianceReport) -> String {
     let _ = writeln!(s, "## Noise Summary");
     let _ = writeln!(s, "  flaky_count:    {}", noise.flaky_count);
     let _ = writeln!(s, "  flaky_share:    {:.3}", noise.flaky_share);
-    let _ = writeln!(s, "  pass_at_k:      {:.3}  (best-case: any slot resolved)", noise.pass_at_k);
-    let _ = writeln!(s, "  all_of_k:       {:.3}  (worst-case: all slots resolved)", noise.all_of_k);
-    let _ = writeln!(s, "  pass_at_1:      {:.3}  (per-slot pass rate)", noise.pass_at_1);
-    let _ = writeln!(s, "  CI 95%:         [{:.3}, {:.3}]", noise.ci_lower, noise.ci_upper);
+    let _ = writeln!(
+        s,
+        "  pass_at_k:      {:.3}  (best-case: any slot resolved)",
+        noise.pass_at_k
+    );
+    let _ = writeln!(
+        s,
+        "  all_of_k:       {:.3}  (worst-case: all slots resolved)",
+        noise.all_of_k
+    );
+    let _ = writeln!(
+        s,
+        "  pass_at_1:      {:.3}  (per-slot pass rate)",
+        noise.pass_at_1
+    );
+    let _ = writeln!(
+        s,
+        "  CI 95%:         [{:.3}, {:.3}]",
+        noise.ci_lower, noise.ci_upper
+    );
     if let Some(rec) = noise.recommended_reruns {
         let _ = writeln!(s, "  recommended_reruns: {rec}");
     }

--- a/src/run/variance.rs
+++ b/src/run/variance.rs
@@ -1,0 +1,278 @@
+//! `bench variance` — classify per-instance flakiness from rerun sweeps.
+//!
+//! Read-only: never re-runs instances, never calls a model, never modifies input sweeps.
+
+#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Error;
+use crate::run::compare::load_sweep;
+
+// ── public types ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StabilityClass {
+    AlwaysResolved,
+    AlwaysFailed,
+    Flaky,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstanceVariance {
+    pub instance_id: String,
+    pub resolved_slots: u32,
+    pub total_slots: u32,
+    pub stability_class: StabilityClass,
+}
+
+/// Sweep-wide noise metrics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NoiseSummary {
+    /// Number of flaky instances (resolved some but not all slots).
+    pub flaky_count: u32,
+    /// Fraction of instances that are flaky.
+    pub flaky_share: f64,
+    /// Best-case pass rate: fraction of instances with at least one resolved slot.
+    pub pass_at_k: f64,
+    /// Worst-case pass rate: fraction of instances where all slots resolved.
+    pub all_of_k: f64,
+    /// Per-slot pass rate: total_resolved / total_slots.
+    pub pass_at_1: f64,
+    /// Wilson 95% CI lower bound for pass_at_1.
+    pub ci_lower: f64,
+    /// Wilson 95% CI upper bound for pass_at_1.
+    pub ci_upper: f64,
+    /// Recommended reruns per instance to achieve target CI half-width. None when not requested
+    /// or when current reruns already suffice.
+    pub recommended_reruns: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchVarianceReport {
+    pub instances: Vec<InstanceVariance>,
+    pub noise: NoiseSummary,
+}
+
+#[derive(Debug, Clone)]
+pub struct BenchVarianceArgs {
+    pub sweep_dir: PathBuf,
+    /// Target CI half-width for recommended rerun count calculation.
+    pub ci_width: Option<f64>,
+    /// Instance-id substring filters (currently unused, reserved for future use).
+    pub filter: Vec<String>,
+    /// Stability class filter: "flaky", "always_resolved", or "always_failed".
+    pub class: Option<String>,
+}
+
+// ── entry point ───────────────────────────────────────────────────────────────
+
+pub fn compute_variance(args: &BenchVarianceArgs) -> Result<BenchVarianceReport, Error> {
+    let class_filter: Option<StabilityClass> = match args.class.as_deref() {
+        None => None,
+        Some("flaky") => Some(StabilityClass::Flaky),
+        Some("always_resolved") => Some(StabilityClass::AlwaysResolved),
+        Some("always_failed") => Some(StabilityClass::AlwaysFailed),
+        Some(other) => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "bench variance: invalid --class '{other}'; \
+                 valid values: always_resolved, always_failed, flaky"
+            ))));
+        }
+    };
+
+    let results_path = args.sweep_dir.join("results.json");
+    if !results_path.exists() {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "bench variance: results.json not found in {}; \
+             this command requires a completed sweep directory",
+            args.sweep_dir.display()
+        ))));
+    }
+
+    let loaded = load_sweep(&args.sweep_dir)?;
+
+    let mut instances: Vec<_> = loaded.instances.values().collect();
+    instances.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
+
+    let max_runs = instances.iter().map(|i| i.runs).max().unwrap_or(0);
+    if max_runs <= 1 {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(
+            "bench variance: sweep contains only single-slot runs; \
+             this command requires a rerun sweep (--reruns N with N > 1) \
+             so that each instance has multiple runs to compare"
+                .into(),
+        )));
+    }
+
+    let all_variance: Vec<InstanceVariance> = instances
+        .iter()
+        .map(|inst| InstanceVariance {
+            instance_id: inst.instance_id.clone(),
+            resolved_slots: inst.resolved_count,
+            total_slots: inst.runs,
+            stability_class: classify(inst.resolved_count, inst.runs),
+        })
+        .collect();
+
+    let noise = compute_noise_summary(&all_variance, args.ci_width);
+
+    let filtered_instances: Vec<InstanceVariance> = match &class_filter {
+        None => all_variance,
+        Some(cls) => all_variance
+            .into_iter()
+            .filter(|i| &i.stability_class == cls)
+            .collect(),
+    };
+
+    Ok(BenchVarianceReport {
+        instances: filtered_instances,
+        noise,
+    })
+}
+
+fn classify(resolved_slots: u32, total_slots: u32) -> StabilityClass {
+    if resolved_slots == 0 {
+        StabilityClass::AlwaysFailed
+    } else if resolved_slots == total_slots {
+        StabilityClass::AlwaysResolved
+    } else {
+        StabilityClass::Flaky
+    }
+}
+
+fn compute_noise_summary(instances: &[InstanceVariance], ci_width: Option<f64>) -> NoiseSummary {
+    let n = instances.len();
+    if n == 0 {
+        return NoiseSummary {
+            flaky_count: 0,
+            flaky_share: 0.0,
+            pass_at_k: 0.0,
+            all_of_k: 0.0,
+            pass_at_1: 0.0,
+            ci_lower: 0.0,
+            ci_upper: 0.0,
+            recommended_reruns: None,
+        };
+    }
+
+    let n_f = n as f64;
+    let flaky_count = instances
+        .iter()
+        .filter(|i| i.stability_class == StabilityClass::Flaky)
+        .count() as u32;
+    let flaky_share = f64::from(flaky_count) / n_f;
+
+    let pass_at_k = instances.iter().filter(|i| i.resolved_slots > 0).count() as f64 / n_f;
+    let all_of_k =
+        instances.iter().filter(|i| i.resolved_slots == i.total_slots).count() as f64 / n_f;
+
+    let total_resolved: u64 = instances.iter().map(|i| u64::from(i.resolved_slots)).sum();
+    let total_slots: u64 = instances.iter().map(|i| u64::from(i.total_slots)).sum();
+
+    let pass_at_1 = if total_slots > 0 {
+        total_resolved as f64 / total_slots as f64
+    } else {
+        0.0
+    };
+
+    let (ci_lower, ci_upper) = wilson_ci(pass_at_1, total_slots);
+
+    let recommended_reruns = ci_width.and_then(|w| {
+        compute_recommended_reruns(pass_at_1, n, w, total_slots)
+    });
+
+    NoiseSummary {
+        flaky_count,
+        flaky_share,
+        pass_at_k,
+        all_of_k,
+        pass_at_1,
+        ci_lower,
+        ci_upper,
+        recommended_reruns,
+    }
+}
+
+fn wilson_ci(p: f64, n: u64) -> (f64, f64) {
+    if n == 0 {
+        return (0.0, 1.0);
+    }
+    const Z: f64 = 1.96;
+    let n_f = n as f64;
+    let z2 = Z * Z;
+    let center = (p + z2 / (2.0 * n_f)) / (1.0 + z2 / n_f);
+    let half = Z * (p * (1.0 - p) / n_f + z2 / (4.0 * n_f * n_f)).sqrt()
+        / (1.0 + z2 / n_f);
+    let lower = (center - half).max(0.0);
+    let upper = (center + half).min(1.0);
+    (lower, upper)
+}
+
+fn compute_recommended_reruns(
+    pass_at_1: f64,
+    n_instances: usize,
+    ci_width: f64,
+    current_total_slots: u64,
+) -> Option<u32> {
+    let variance = pass_at_1 * (1.0 - pass_at_1);
+    if variance < 1e-12 {
+        return None;
+    }
+    const Z: f64 = 1.96;
+    let n_required = (Z / ci_width).powi(2) * variance;
+    let avg_current = current_total_slots as f64 / n_instances as f64;
+    let k_required = (n_required / n_instances as f64).ceil() as u32;
+    if k_required as f64 <= avg_current {
+        None
+    } else {
+        Some(k_required)
+    }
+}
+
+// ── text rendering ────────────────────────────────────────────────────────────
+
+pub fn render_text(report: &BenchVarianceReport) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::new();
+
+    let _ = writeln!(s, "# Bench Variance Report");
+    let _ = writeln!(s);
+
+    let noise = &report.noise;
+    let _ = writeln!(s, "## Noise Summary");
+    let _ = writeln!(s, "  flaky_count:    {}", noise.flaky_count);
+    let _ = writeln!(s, "  flaky_share:    {:.3}", noise.flaky_share);
+    let _ = writeln!(s, "  pass_at_k:      {:.3}  (best-case: any slot resolved)", noise.pass_at_k);
+    let _ = writeln!(s, "  all_of_k:       {:.3}  (worst-case: all slots resolved)", noise.all_of_k);
+    let _ = writeln!(s, "  pass_at_1:      {:.3}  (per-slot pass rate)", noise.pass_at_1);
+    let _ = writeln!(s, "  CI 95%:         [{:.3}, {:.3}]", noise.ci_lower, noise.ci_upper);
+    if let Some(rec) = noise.recommended_reruns {
+        let _ = writeln!(s, "  recommended_reruns: {rec}");
+    }
+    let _ = writeln!(s);
+
+    let _ = writeln!(s, "## Instances ({})", report.instances.len());
+    let _ = writeln!(
+        s,
+        "  {:<40}  {:<8}  {:<5}  {}",
+        "INSTANCE_ID", "RESOLVED", "TOTAL", "CLASS"
+    );
+    let _ = writeln!(s, "  {}", "-".repeat(78));
+    for inst in &report.instances {
+        let class_label = match inst.stability_class {
+            StabilityClass::AlwaysResolved => "always_resolved",
+            StabilityClass::AlwaysFailed => "always_failed",
+            StabilityClass::Flaky => "flaky",
+        };
+        let _ = writeln!(
+            s,
+            "  {:<40}  {:<8}  {:<5}  {}",
+            inst.instance_id, inst.resolved_slots, inst.total_slots, class_label
+        );
+    }
+    s
+}

--- a/src/run/variance.rs
+++ b/src/run/variance.rs
@@ -108,14 +108,15 @@ pub fn compute_variance(args: &BenchVarianceArgs) -> Result<BenchVarianceReport,
         ))));
     }
 
-    let explicit_status: Option<String> = std::fs::read_to_string(&results_path)
+    let results_json: Option<serde_json::Value> = std::fs::read_to_string(&results_path)
         .ok()
-        .and_then(|t| serde_json::from_str::<serde_json::Value>(&t).ok())
-        .and_then(|v| {
-            v.get("sweep_status")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_owned)
-        });
+        .and_then(|t| serde_json::from_str(&t).ok());
+
+    let explicit_status: Option<String> = results_json.as_ref().and_then(|v| {
+        v.get("sweep_status")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned)
+    });
     if let Some(ref s) = explicit_status {
         if s != crate::run::swebench::SWEEP_STATUS_COMPLETED {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
@@ -123,6 +124,17 @@ pub fn compute_variance(args: &BenchVarianceArgs) -> Result<BenchVarianceReport,
                  flakiness metrics over partial sweeps are misleading"
             ))));
         }
+    }
+
+    let budget_halted = results_json
+        .as_ref()
+        .and_then(|v| v.get("budget_halted").and_then(serde_json::Value::as_u64))
+        .unwrap_or(0);
+    if budget_halted > 0 {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "bench variance: sweep had {budget_halted} budget-halted instance(s); \
+             budget-halted slots appear as failed runs and bias flakiness metrics"
+        ))));
     }
 
     let loaded = load_sweep(&args.sweep_dir)?;

--- a/src/run/variance.rs
+++ b/src/run/variance.rs
@@ -15,6 +15,8 @@ use serde::{Deserialize, Serialize};
 use crate::error::Error;
 use crate::run::compare::load_sweep;
 
+const Z95: f64 = 1.96;
+
 // ── public types ──────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -66,7 +68,7 @@ pub struct BenchVarianceArgs {
     pub sweep_dir: PathBuf,
     /// Target CI half-width for recommended rerun count calculation.
     pub ci_width: Option<f64>,
-    /// Instance-id substring filters (currently unused, reserved for future use).
+    /// Instance-id substring filters. An instance is kept when its id contains any filter string.
     pub filter: Vec<String>,
     /// Stability class filter: "flaky", "always_resolved", or "always_failed".
     pub class: Option<String>,
@@ -75,6 +77,14 @@ pub struct BenchVarianceArgs {
 // ── entry point ───────────────────────────────────────────────────────────────
 
 pub fn compute_variance(args: &BenchVarianceArgs) -> Result<BenchVarianceReport, Error> {
+    if let Some(w) = args.ci_width {
+        if !w.is_finite() || w <= 0.0 {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "bench variance: --ci-width must be a finite, strictly positive value, got {w}"
+            ))));
+        }
+    }
+
     let class_filter: Option<StabilityClass> = match args.class.as_deref() {
         None => None,
         Some("flaky") => Some(StabilityClass::Flaky),
@@ -124,13 +134,25 @@ pub fn compute_variance(args: &BenchVarianceArgs) -> Result<BenchVarianceReport,
 
     let noise = compute_noise_summary(&all_variance, args.ci_width);
 
-    let filtered_instances: Vec<InstanceVariance> = match &class_filter {
-        None => all_variance,
-        Some(cls) => all_variance
-            .into_iter()
-            .filter(|i| &i.stability_class == cls)
-            .collect(),
-    };
+    let filtered_instances: Vec<InstanceVariance> = all_variance
+        .into_iter()
+        .filter(|i| {
+            if let Some(cls) = &class_filter {
+                if &i.stability_class != cls {
+                    return false;
+                }
+            }
+            if !args.filter.is_empty()
+                && !args
+                    .filter
+                    .iter()
+                    .any(|f| i.instance_id.contains(f.as_str()))
+            {
+                return false;
+            }
+            true
+        })
+        .collect();
 
     Ok(BenchVarianceReport {
         instances: filtered_instances,
@@ -207,11 +229,10 @@ fn wilson_ci(p: f64, n: u64) -> (f64, f64) {
     if n == 0 {
         return (0.0, 1.0);
     }
-    const Z: f64 = 1.96;
     let n_f = n as f64;
-    let z2 = Z * Z;
+    let z2 = Z95 * Z95;
     let center = (p + z2 / (2.0 * n_f)) / (1.0 + z2 / n_f);
-    let half = Z * (p * (1.0 - p) / n_f + z2 / (4.0 * n_f * n_f)).sqrt() / (1.0 + z2 / n_f);
+    let half = Z95 * (p * (1.0 - p) / n_f + z2 / (4.0 * n_f * n_f)).sqrt() / (1.0 + z2 / n_f);
     let lower = (center - half).max(0.0);
     let upper = (center + half).min(1.0);
     (lower, upper)
@@ -227,11 +248,10 @@ fn compute_recommended_reruns(
     if variance < 1e-12 {
         return None;
     }
-    const Z: f64 = 1.96;
-    let n_required = (Z / ci_width).powi(2) * variance;
+    let n_required = (Z95 / ci_width).powi(2) * variance;
     let avg_current = current_total_slots as f64 / n_instances as f64;
     let k_required = (n_required / n_instances as f64).ceil() as u32;
-    if k_required as f64 <= avg_current {
+    if f64::from(k_required) <= avg_current {
         None
     } else {
         Some(k_required)
@@ -279,8 +299,8 @@ pub fn render_text(report: &BenchVarianceReport) -> String {
     let _ = writeln!(s, "## Instances ({})", report.instances.len());
     let _ = writeln!(
         s,
-        "  {:<40}  {:<8}  {:<5}  {}",
-        "INSTANCE_ID", "RESOLVED", "TOTAL", "CLASS"
+        "  {:<40}  {:<8}  {:<5}  CLASS",
+        "INSTANCE_ID", "RESOLVED", "TOTAL"
     );
     let _ = writeln!(s, "  {}", "-".repeat(78));
     for inst in &report.instances {

--- a/src/run/variance.rs
+++ b/src/run/variance.rs
@@ -5,7 +5,8 @@
 #![allow(
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
-    clippy::cast_sign_loss
+    clippy::cast_sign_loss,
+    clippy::too_many_lines
 )]
 
 use std::path::PathBuf;
@@ -107,7 +108,38 @@ pub fn compute_variance(args: &BenchVarianceArgs) -> Result<BenchVarianceReport,
         ))));
     }
 
+    let explicit_status: Option<String> = std::fs::read_to_string(&results_path)
+        .ok()
+        .and_then(|t| serde_json::from_str::<serde_json::Value>(&t).ok())
+        .and_then(|v| {
+            v.get("sweep_status")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        });
+    if let Some(ref s) = explicit_status {
+        if s != crate::run::swebench::SWEEP_STATUS_COMPLETED {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "bench variance: sweep status is '{s}', not 'completed'; \
+                 flakiness metrics over partial sweeps are misleading"
+            ))));
+        }
+    }
+
     let loaded = load_sweep(&args.sweep_dir)?;
+
+    if explicit_status.is_none() {
+        let finished = loaded
+            .manifest
+            .as_ref()
+            .and_then(|m| m.runtime.finished_at_utc.as_ref());
+        if finished.is_none() {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(
+                "bench variance: legacy results.json lacks sweep_status and \
+                 manifest.runtime.finished_at_utc; cannot confirm sweep completed"
+                    .into(),
+            )));
+        }
+    }
 
     let mut instances: Vec<_> = loaded.instances.values().collect();
     instances.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
@@ -244,13 +276,17 @@ fn compute_recommended_reruns(
     ci_width: f64,
     current_total_slots: u64,
 ) -> Option<u32> {
-    let variance = pass_at_1 * (1.0 - pass_at_1);
-    if variance < 1e-12 {
+    let (ci_lo, ci_hi) = wilson_ci(pass_at_1, current_total_slots);
+    if (ci_hi - ci_lo) / 2.0 <= ci_width {
         return None;
     }
-    let n_required = (Z95 / ci_width).powi(2) * variance;
-    let avg_current = current_total_slots as f64 / n_instances as f64;
+    // For p=0 or p=1 the observed variance is 0, but the CI may still be wide
+    // for small n. Use worst-case variance (p=0.5) for a conservative recommendation.
+    let variance = pass_at_1 * (1.0 - pass_at_1);
+    let effective_variance = if variance < 1e-12 { 0.25 } else { variance };
+    let n_required = (Z95 / ci_width).powi(2) * effective_variance;
     let k_required = (n_required / n_instances as f64).ceil() as u32;
+    let avg_current = current_total_slots as f64 / n_instances as f64;
     if f64::from(k_required) <= avg_current {
         None
     } else {

--- a/src/run/variance.rs
+++ b/src/run/variance.rs
@@ -141,7 +141,7 @@ pub fn compute_variance(args: &BenchVarianceArgs) -> Result<BenchVarianceReport,
         }
     }
 
-    let mut instances: Vec<_> = loaded.instances.values().collect();
+    let mut instances: Vec<_> = loaded.instances.values().filter(|i| i.runs > 1).collect();
     instances.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
 
     let max_runs = instances.iter().map(|i| i.runs).max().unwrap_or(0);

--- a/tests/bench_variance.rs
+++ b/tests/bench_variance.rs
@@ -1,0 +1,780 @@
+//! `bench variance` — tests covering all AC items from issue #524.
+//!
+//! Red → Green → Refactor TDD cycle.
+//!
+//! AC items covered:
+//! AC1: rejects single-slot sweeps (runs <= 1) with non-zero exit and clear message
+//! AC2: per-instance stability class: always_resolved, always_failed, flaky
+//! AC3: sweep-wide noise metrics: flaky count/share, pass_at_k, all_of_k, CI
+//! AC4: recommended rerun count for --ci-width target
+//! AC5: --format text|json; JSON is schema-versioned
+//! AC6: --filter and --class selectors
+//! AC7: reads only on-disk artifacts ($0 cost — no model or network calls)
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::too_many_lines,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::items_after_statements
+)]
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use maxwells_daemon::run::swebench::{
+    CliManifest, ConfigManifest, DatasetManifest, HarnessManifest, InstanceResult, ModelManifest,
+    PromptTemplateManifest, ProvenanceManifest, RuntimeManifest, SweepResults,
+    SWEEP_STATUS_COMPLETED,
+};
+use maxwells_daemon::run::variance::{BenchVarianceArgs, StabilityClass, compute_variance};
+use maxwells_daemon::trajectory::outcome;
+
+mod support;
+use support::binary_path;
+
+// ── fixture helpers ───────────────────────────────────────────────────────────
+
+fn rerun_instance(id: &str, runs: u32, resolved_count: u32) -> InstanceResult {
+    let pass_at_1 = {
+        // simulate: first slot resolved if any resolved
+        resolved_count > 0
+    };
+    InstanceResult {
+        instance_id: id.into(),
+        exit_reason: if resolved_count > 0 {
+            "submitted".into()
+        } else {
+            "error".into()
+        },
+        outcome: Some(if resolved_count > 0 {
+            outcome::SUBMITTED.into()
+        } else {
+            outcome::ERROR.into()
+        }),
+        failure_category: None,
+        steps: Some(10),
+        cost_usd: Some(0.01),
+        prompt_tokens: Some(500),
+        cache_read_tokens: Some(0),
+        cache_creation_tokens: Some(0),
+        completion_tokens: Some(100),
+        duration_secs: Some(5.0),
+        error: None,
+        github_pr_error: None,
+        patch_present: resolved_count > 0,
+        non_empty_patch: resolved_count > 0,
+        attempts: 1,
+        retry_reasons: Vec::new(),
+        runs,
+        resolved_count,
+        pass_at_1,
+        tests_run_before_submit: false,
+        last_tests_passed: None,
+        fallback_count: None,
+        final_model: None,
+        retry_id: None,
+        previous_failure_category: None,
+        trace_id: None,
+    }
+}
+
+fn make_manifest() -> ProvenanceManifest {
+    let argv = vec![
+        "max".into(),
+        "bench".into(),
+        "swebench".into(),
+        "--reruns".into(),
+        "3".into(),
+    ];
+    ProvenanceManifest {
+        purpose: None,
+        harness: HarnessManifest {
+            name: "maxwells-daemon".into(),
+            version: "0.1.0-test".into(),
+            git_sha: Some("deadbeef".into()),
+            git_dirty: Some(false),
+            git_resolution: "exact".into(),
+        },
+        dataset: DatasetManifest {
+            path: "tests/fixtures/test.jsonl".into(),
+            sha256: "abc123".into(),
+            instance_count: 3,
+            filter_spec: None,
+            ..Default::default()
+        },
+        prompt_template: PromptTemplateManifest {
+            source: "inline".into(),
+            path: None,
+            sha256: "tpl123".into(),
+        },
+        config: ConfigManifest {
+            resolved: "default".into(),
+            overlay_paths: Vec::new(),
+        },
+        model: ModelManifest {
+            name: "claude-opus-4-7".into(),
+            backend: "litellm".into(),
+            backend_version: None,
+            base_url: None,
+        },
+        runtime: RuntimeManifest {
+            started_at_utc: "2026-05-01T00:00:00Z".into(),
+            finished_at_utc: Some("2026-05-01T00:10:00Z".into()),
+            host_os: "linux".into(),
+            resume_mode: false,
+            rust_version: Some("rustc 1.85.0".into()),
+        },
+        cli: CliManifest { argv },
+        chaos_fail_every: 0,
+        circuit_breaker: None,
+        source: None,
+        import_predictions_path: None,
+        import_predictions_sha256: None,
+        reproduced_from: None,
+    }
+}
+
+fn write_results(dir: &Path, instances: Vec<InstanceResult>) {
+    let total = instances.len();
+    let manifest = make_manifest();
+    let pass_at_k = if total > 0 {
+        instances.iter().filter(|i| i.resolved_count > 0).count() as f64 / total as f64
+    } else {
+        0.0
+    };
+    let submitted = instances
+        .iter()
+        .filter(|r| r.outcome.as_deref() == Some(outcome::SUBMITTED))
+        .count();
+    let errored = instances
+        .iter()
+        .filter(|r| r.outcome.as_deref() == Some(outcome::ERROR))
+        .count();
+    let failures_by_category = BTreeMap::new();
+    let sweep = SweepResults {
+        total,
+        sweep_status: SWEEP_STATUS_COMPLETED.into(),
+        cancelled_at: None,
+        cancel_deadline_at: None,
+        cancel_exit_code: None,
+        completed: total,
+        in_flight_at_cancel: 0,
+        not_started: 0,
+        submitted,
+        submitted_with_tests: 0,
+        skipped: 0,
+        errored,
+        failures_by_category,
+        budget_halted: 0,
+        with_patch: submitted,
+        patch_empty: 0,
+        patch_apply_invalid: 0,
+        github_pr_failures: 0,
+        total_prompt_tokens: 0,
+        total_cache_read_tokens: 0,
+        total_cache_creation_tokens: 0,
+        total_completion_tokens: 0,
+        estimated_cost_usd: 0.03,
+        actual_cost_usd: Some(0.03),
+        actual_cost_source: None,
+        baseline_cost_usd: None,
+        baseline_cost_model: None,
+        cache_hit_rate: 0.0,
+        retries: 0,
+        retried_instances: 0,
+        pass_at_k,
+        filter_spec: Default::default(),
+        manifest: Some(manifest),
+        cost_limit_usd: None,
+        instances,
+        rate_limit_events: None,
+        total_fallbacks: 0,
+        model_mix: BTreeMap::new(),
+        systemic_halt_category: None,
+        retry_history: vec![],
+        partial: 0,
+        span_export_dropped: 0,
+    };
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(
+        dir.join("results.json"),
+        serde_json::to_string_pretty(&sweep).unwrap(),
+    )
+    .unwrap();
+}
+
+// ── AC1: rejects single-slot sweeps ──────────────────────────────────────────
+
+#[test]
+fn ac1_rejects_single_slot_sweep() {
+    let dir = tempfile::tempdir().unwrap();
+    // Write a sweep where all instances have runs == 1 (single slot)
+    write_results(
+        dir.path(),
+        vec![rerun_instance("task-a", 1, 1), rerun_instance("task-b", 1, 0)],
+    );
+
+    let result = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec![],
+        class: None,
+    });
+
+    let err = result.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("single") || msg.contains("rerun") || msg.contains("slots") || msg.contains("runs"),
+        "expected single-slot rejection message, got: {msg}"
+    );
+}
+
+#[test]
+fn ac1_rejects_missing_results_json() {
+    let dir = tempfile::tempdir().unwrap();
+    // No results.json — should fail with a clear error
+    let result = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec![],
+        class: None,
+    });
+    assert!(result.is_err(), "expected error for missing results.json");
+}
+
+// ── AC2: per-instance stability classes ───────────────────────────────────────
+
+#[test]
+fn ac2_always_resolved_classification() {
+    let dir = tempfile::tempdir().unwrap();
+    // Instance resolved all 3 slots → always_resolved
+    write_results(dir.path(), vec![rerun_instance("task-a", 3, 3)]);
+
+    let report = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec![],
+        class: None,
+    })
+    .unwrap();
+
+    assert_eq!(report.instances.len(), 1);
+    let inst = &report.instances[0];
+    assert_eq!(inst.instance_id, "task-a");
+    assert_eq!(inst.resolved_slots, 3);
+    assert_eq!(inst.total_slots, 3);
+    assert_eq!(inst.stability_class, StabilityClass::AlwaysResolved);
+}
+
+#[test]
+fn ac2_always_failed_classification() {
+    let dir = tempfile::tempdir().unwrap();
+    // Instance resolved 0 of 3 slots → always_failed
+    write_results(dir.path(), vec![rerun_instance("task-a", 3, 0)]);
+
+    let report = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec![],
+        class: None,
+    })
+    .unwrap();
+
+    let inst = &report.instances[0];
+    assert_eq!(inst.stability_class, StabilityClass::AlwaysFailed);
+}
+
+#[test]
+fn ac2_flaky_classification() {
+    let dir = tempfile::tempdir().unwrap();
+    // Instance resolved 2 of 4 slots → flaky
+    write_results(dir.path(), vec![rerun_instance("task-a", 4, 2)]);
+
+    let report = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec![],
+        class: None,
+    })
+    .unwrap();
+
+    let inst = &report.instances[0];
+    assert_eq!(inst.stability_class, StabilityClass::Flaky);
+}
+
+#[test]
+fn ac2_mixed_classes_in_one_sweep() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results(
+        dir.path(),
+        vec![
+            rerun_instance("always-resolved", 3, 3),
+            rerun_instance("always-failed", 3, 0),
+            rerun_instance("flaky", 3, 1),
+        ],
+    );
+
+    let report = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec![],
+        class: None,
+    })
+    .unwrap();
+
+    assert_eq!(report.instances.len(), 3);
+
+    let find = |id: &str| {
+        report
+            .instances
+            .iter()
+            .find(|i| i.instance_id == id)
+            .unwrap()
+    };
+    assert_eq!(find("always-resolved").stability_class, StabilityClass::AlwaysResolved);
+    assert_eq!(find("always-failed").stability_class, StabilityClass::AlwaysFailed);
+    assert_eq!(find("flaky").stability_class, StabilityClass::Flaky);
+}
+
+// ── AC3: sweep-wide noise metrics ─────────────────────────────────────────────
+
+#[test]
+fn ac3_noise_metrics_all_resolved() {
+    let dir = tempfile::tempdir().unwrap();
+    // All 3 instances always resolved
+    write_results(
+        dir.path(),
+        vec![
+            rerun_instance("a", 3, 3),
+            rerun_instance("b", 3, 3),
+            rerun_instance("c", 3, 3),
+        ],
+    );
+
+    let report = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec![],
+        class: None,
+    })
+    .unwrap();
+
+    let noise = &report.noise;
+    assert_eq!(noise.flaky_count, 0);
+    assert!((noise.flaky_share - 0.0).abs() < 1e-9);
+    assert!((noise.pass_at_k - 1.0).abs() < 1e-9, "pass_at_k={}", noise.pass_at_k);
+    assert!((noise.all_of_k - 1.0).abs() < 1e-9, "all_of_k={}", noise.all_of_k);
+    assert!((noise.pass_at_1 - 1.0).abs() < 1e-9, "pass_at_1={}", noise.pass_at_1);
+    // CI must include 1.0 when all pass
+    assert!(noise.ci_upper >= 1.0 - 1e-9, "ci_upper={}", noise.ci_upper);
+    // Wilson CI lower for p=1, n=9 slots is ~0.70; check it's meaningfully high
+    assert!(noise.ci_lower >= 0.6, "ci_lower should be high, got {}", noise.ci_lower);
+}
+
+#[test]
+fn ac3_noise_metrics_mixed() {
+    let dir = tempfile::tempdir().unwrap();
+    // 3 instances, 3 slots each: always_resolved, always_failed, flaky(1/3)
+    write_results(
+        dir.path(),
+        vec![
+            rerun_instance("always-resolved", 3, 3),
+            rerun_instance("always-failed", 3, 0),
+            rerun_instance("flaky", 3, 1),
+        ],
+    );
+
+    let report = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec![],
+        class: None,
+    })
+    .unwrap();
+
+    let noise = &report.noise;
+    // 1 flaky instance out of 3
+    assert_eq!(noise.flaky_count, 1);
+    assert!((noise.flaky_share - 1.0 / 3.0).abs() < 1e-9, "flaky_share={}", noise.flaky_share);
+    // pass_at_k (any-of-k): always_resolved and flaky both have resolved_count > 0 → 2/3
+    assert!((noise.pass_at_k - 2.0 / 3.0).abs() < 1e-9, "pass_at_k={}", noise.pass_at_k);
+    // all_of_k: only always_resolved has resolved_count == runs → 1/3
+    assert!((noise.all_of_k - 1.0 / 3.0).abs() < 1e-9, "all_of_k={}", noise.all_of_k);
+    // pass_at_1 (per-slot): total_resolved/total_slots = (3+0+1)/9 = 4/9
+    let expected_pass_at_1 = 4.0 / 9.0;
+    assert!(
+        (noise.pass_at_1 - expected_pass_at_1).abs() < 1e-9,
+        "pass_at_1={} expected={}",
+        noise.pass_at_1,
+        expected_pass_at_1
+    );
+    // CI bounds should be non-NaN and within [0,1]
+    assert!(noise.ci_lower >= 0.0 && noise.ci_lower <= 1.0);
+    assert!(noise.ci_upper >= 0.0 && noise.ci_upper <= 1.0);
+    assert!(noise.ci_lower <= noise.ci_upper);
+    // CI should contain the estimate
+    assert!(noise.ci_lower <= noise.pass_at_1 + 1e-9);
+    assert!(noise.ci_upper >= noise.pass_at_1 - 1e-9);
+}
+
+#[test]
+fn ac3_spread_between_best_and_worst_case() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results(
+        dir.path(),
+        vec![
+            rerun_instance("a", 5, 5), // always resolved
+            rerun_instance("b", 5, 3), // flaky
+            rerun_instance("c", 5, 0), // always failed
+        ],
+    );
+
+    let report = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec![],
+        class: None,
+    })
+    .unwrap();
+
+    let noise = &report.noise;
+    // pass_at_k (any-of-k, best-case): a and b both have any resolved → 2/3
+    assert!((noise.pass_at_k - 2.0 / 3.0).abs() < 1e-9);
+    // all_of_k (all-of-k, worst-case): only a has all resolved → 1/3
+    assert!((noise.all_of_k - 1.0 / 3.0).abs() < 1e-9);
+    // Spread = pass_at_k - all_of_k = 1/3
+    assert!(noise.pass_at_k > noise.all_of_k);
+}
+
+// ── AC4: recommended rerun count ─────────────────────────────────────────────
+
+#[test]
+fn ac4_recommended_reruns_for_ci_width() {
+    let dir = tempfile::tempdir().unwrap();
+    // p ≈ 0.5, high variance → many reruns needed
+    write_results(
+        dir.path(),
+        vec![
+            rerun_instance("a", 2, 1),
+            rerun_instance("b", 2, 1),
+            rerun_instance("c", 2, 1),
+            rerun_instance("d", 2, 1),
+        ],
+    );
+
+    let report = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: Some(0.05), // narrow target: 5% half-width
+        filter: vec![],
+        class: None,
+    })
+    .unwrap();
+
+    // With p=0.5, need n >= (1.96/0.05)^2 * 0.25 ≈ 384 slots
+    // With 4 instances, that's ceil(384/4) = 96 reruns per instance minimum
+    // So recommended should be > current reruns (2) when ci_width=0.05
+    assert!(
+        report.noise.recommended_reruns.is_some(),
+        "expected a recommended rerun count"
+    );
+    let rec = report.noise.recommended_reruns.unwrap();
+    assert!(rec > 2, "recommended reruns ({rec}) should exceed current 2 for such a narrow CI target");
+}
+
+#[test]
+fn ac4_current_reruns_already_sufficient() {
+    let dir = tempfile::tempdir().unwrap();
+    // With 100 instances at 5 reruns each, p=1.0 → CI is very tight
+    let instances: Vec<InstanceResult> = (0..100)
+        .map(|i| rerun_instance(&format!("task-{i}"), 5, 5))
+        .collect();
+    write_results(dir.path(), instances);
+
+    let report = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: Some(0.10), // generous: 10% half-width
+        filter: vec![],
+        class: None,
+    })
+    .unwrap();
+
+    // With p=1.0, variance is 0, so CI width is 0 → current reruns suffice
+    // recommended_reruns should be None or 1
+    if let Some(rec) = report.noise.recommended_reruns {
+        assert!(
+            rec <= 5,
+            "recommended reruns ({rec}) should not exceed current 5 when CI already sufficient"
+        );
+    }
+}
+
+// ── AC5: --format text|json ───────────────────────────────────────────────────
+
+#[test]
+fn ac5_json_output_is_schema_versioned() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results(
+        dir.path(),
+        vec![
+            rerun_instance("a", 3, 3),
+            rerun_instance("b", 3, 1),
+        ],
+    );
+
+    // Call binary with --format json
+    let output = std::process::Command::new(binary_path())
+        .args(["bench", "variance", "--sweep"])
+        .arg(dir.path())
+        .args(["--format", "json"])
+        .output()
+        .expect("failed to run max binary");
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, got {}: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let val: serde_json::Value = serde_json::from_str(&stdout)
+        .expect("JSON output should be valid JSON");
+
+    // Must have schema_version and artifact_kind fields
+    assert!(
+        val.get("schema_version").is_some(),
+        "JSON must have schema_version, got: {stdout}"
+    );
+    assert!(
+        val.get("artifact_kind").is_some(),
+        "JSON must have artifact_kind, got: {stdout}"
+    );
+    assert_eq!(
+        val["artifact_kind"].as_str().unwrap(),
+        "bench_variance_report",
+        "artifact_kind must be bench_variance_report"
+    );
+    // Must have instances and noise fields
+    assert!(val.get("instances").is_some());
+    assert!(val.get("noise").is_some());
+}
+
+#[test]
+fn ac5_text_output_contains_stability_classes() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results(
+        dir.path(),
+        vec![
+            rerun_instance("always-resolved", 3, 3),
+            rerun_instance("always-failed", 3, 0),
+            rerun_instance("flaky-instance", 3, 1),
+        ],
+    );
+
+    let output = std::process::Command::new(binary_path())
+        .args(["bench", "variance", "--sweep"])
+        .arg(dir.path())
+        .args(["--format", "text"])
+        .output()
+        .expect("failed to run max binary");
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("always_resolved") || stdout.contains("AlwaysResolved"),
+        "text output should mention always_resolved, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("always_failed") || stdout.contains("AlwaysFailed"),
+        "text output should mention always_failed, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("flaky"),
+        "text output should mention flaky, got: {stdout}"
+    );
+}
+
+#[test]
+fn ac5_invalid_format_exits_nonzero() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results(dir.path(), vec![rerun_instance("a", 3, 2)]);
+
+    let output = std::process::Command::new(binary_path())
+        .args(["bench", "variance", "--sweep"])
+        .arg(dir.path())
+        .args(["--format", "csv"])
+        .output()
+        .expect("failed to run max binary");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for invalid format"
+    );
+}
+
+// ── AC6: --filter and --class selectors ───────────────────────────────────────
+
+#[test]
+fn ac6_class_filter_flaky_only() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results(
+        dir.path(),
+        vec![
+            rerun_instance("always-resolved", 3, 3),
+            rerun_instance("always-failed", 3, 0),
+            rerun_instance("flaky-a", 3, 1),
+            rerun_instance("flaky-b", 3, 2),
+        ],
+    );
+
+    let report = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec![],
+        class: Some("flaky".into()),
+    })
+    .unwrap();
+
+    assert_eq!(
+        report.instances.len(),
+        2,
+        "expected 2 flaky instances, got {}",
+        report.instances.len()
+    );
+    for inst in &report.instances {
+        assert_eq!(
+            inst.stability_class,
+            StabilityClass::Flaky,
+            "class filter should only return flaky instances"
+        );
+    }
+}
+
+#[test]
+fn ac6_class_filter_always_resolved() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results(
+        dir.path(),
+        vec![
+            rerun_instance("a", 3, 3),
+            rerun_instance("b", 3, 0),
+            rerun_instance("c", 3, 2),
+        ],
+    );
+
+    let report = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec![],
+        class: Some("always_resolved".into()),
+    })
+    .unwrap();
+
+    assert_eq!(report.instances.len(), 1);
+    assert_eq!(report.instances[0].instance_id, "a");
+}
+
+#[test]
+fn ac6_invalid_class_returns_error() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results(dir.path(), vec![rerun_instance("a", 3, 2)]);
+
+    let result = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec![],
+        class: Some("unknown_class".into()),
+    });
+
+    assert!(result.is_err(), "invalid --class should return an error");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("unknown_class") || msg.contains("class") || msg.contains("invalid"),
+        "error message should mention the invalid class, got: {msg}"
+    );
+}
+
+#[test]
+fn ac6_cli_class_filter_via_binary() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results(
+        dir.path(),
+        vec![
+            rerun_instance("always-resolved", 3, 3),
+            rerun_instance("flaky", 3, 1),
+        ],
+    );
+
+    let output = std::process::Command::new(binary_path())
+        .args(["bench", "variance", "--sweep"])
+        .arg(dir.path())
+        .args(["--format", "json", "--class", "flaky"])
+        .output()
+        .expect("failed to run max binary");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let val: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let instances = val["instances"].as_array().unwrap();
+    assert_eq!(instances.len(), 1);
+    assert_eq!(instances[0]["instance_id"].as_str().unwrap(), "flaky");
+}
+
+// ── AC7: zero cost — reads only on-disk artifacts ─────────────────────────────
+
+#[test]
+fn ac7_cli_single_slot_exits_nonzero() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results(dir.path(), vec![rerun_instance("a", 1, 1)]);
+
+    let output = std::process::Command::new(binary_path())
+        .args(["bench", "variance", "--sweep"])
+        .arg(dir.path())
+        .output()
+        .expect("failed to run max binary");
+
+    assert!(
+        !output.status.success(),
+        "single-slot sweep must exit non-zero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("single") || stderr.contains("rerun") || stderr.contains("slot") || stderr.contains("runs"),
+        "error message should mention single-slot / rerun requirement, got: {stderr}"
+    );
+}
+
+#[test]
+fn ac7_reads_no_model_or_network() {
+    // Verify: the command completes successfully without any model API key set
+    let dir = tempfile::tempdir().unwrap();
+    write_results(
+        dir.path(),
+        vec![
+            rerun_instance("a", 3, 3),
+            rerun_instance("b", 3, 1),
+        ],
+    );
+
+    // Deliberately unset ANTHROPIC_API_KEY so any model call would fail
+    let output = std::process::Command::new(binary_path())
+        .args(["bench", "variance", "--sweep"])
+        .arg(dir.path())
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("LITELLM_KEY")
+        .output()
+        .expect("failed to run max binary");
+
+    assert!(
+        output.status.success(),
+        "variance must succeed without any API key (zero cost), stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/tests/bench_variance.rs
+++ b/tests/bench_variance.rs
@@ -275,6 +275,35 @@ fn ac1_rejects_incomplete_sweep() {
     );
 }
 
+#[test]
+fn ac1_excludes_single_slot_instances_in_mixed_sweep() {
+    let dir = tempfile::tempdir().unwrap();
+    // Mixed sweep: two 3-slot instances and one 1-slot instance
+    write_results(
+        dir.path(),
+        vec![
+            rerun_instance("multi-a", 3, 2),
+            rerun_instance("multi-b", 3, 3),
+            rerun_instance("single", 1, 1), // should be excluded
+        ],
+    );
+
+    let report = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec![],
+        class: None,
+    })
+    .unwrap();
+
+    // Only the two multi-slot instances should appear
+    assert_eq!(report.instances.len(), 2);
+    assert!(
+        report.instances.iter().all(|i| i.instance_id != "single"),
+        "single-slot instance must be excluded from variance analysis"
+    );
+}
+
 // ── AC2: per-instance stability classes ───────────────────────────────────────
 
 #[test]

--- a/tests/bench_variance.rs
+++ b/tests/bench_variance.rs
@@ -25,8 +25,8 @@ use std::path::Path;
 
 use maxwells_daemon::run::swebench::{
     CliManifest, ConfigManifest, DatasetManifest, HarnessManifest, InstanceResult, ModelManifest,
-    PromptTemplateManifest, ProvenanceManifest, RuntimeManifest, SweepResults,
-    SWEEP_STATUS_COMPLETED,
+    PromptTemplateManifest, ProvenanceManifest, RuntimeManifest, SWEEP_STATUS_COMPLETED,
+    SweepResults,
 };
 use maxwells_daemon::run::variance::{BenchVarianceArgs, StabilityClass, compute_variance};
 use maxwells_daemon::trajectory::outcome;
@@ -213,7 +213,10 @@ fn ac1_rejects_single_slot_sweep() {
     // Write a sweep where all instances have runs == 1 (single slot)
     write_results(
         dir.path(),
-        vec![rerun_instance("task-a", 1, 1), rerun_instance("task-b", 1, 0)],
+        vec![
+            rerun_instance("task-a", 1, 1),
+            rerun_instance("task-b", 1, 0),
+        ],
     );
 
     let result = compute_variance(&BenchVarianceArgs {
@@ -226,7 +229,10 @@ fn ac1_rejects_single_slot_sweep() {
     let err = result.unwrap_err();
     let msg = err.to_string();
     assert!(
-        msg.contains("single") || msg.contains("rerun") || msg.contains("slots") || msg.contains("runs"),
+        msg.contains("single")
+            || msg.contains("rerun")
+            || msg.contains("slots")
+            || msg.contains("runs"),
         "expected single-slot rejection message, got: {msg}"
     );
 }
@@ -333,8 +339,14 @@ fn ac2_mixed_classes_in_one_sweep() {
             .find(|i| i.instance_id == id)
             .unwrap()
     };
-    assert_eq!(find("always-resolved").stability_class, StabilityClass::AlwaysResolved);
-    assert_eq!(find("always-failed").stability_class, StabilityClass::AlwaysFailed);
+    assert_eq!(
+        find("always-resolved").stability_class,
+        StabilityClass::AlwaysResolved
+    );
+    assert_eq!(
+        find("always-failed").stability_class,
+        StabilityClass::AlwaysFailed
+    );
     assert_eq!(find("flaky").stability_class, StabilityClass::Flaky);
 }
 
@@ -364,13 +376,29 @@ fn ac3_noise_metrics_all_resolved() {
     let noise = &report.noise;
     assert_eq!(noise.flaky_count, 0);
     assert!((noise.flaky_share - 0.0).abs() < 1e-9);
-    assert!((noise.pass_at_k - 1.0).abs() < 1e-9, "pass_at_k={}", noise.pass_at_k);
-    assert!((noise.all_of_k - 1.0).abs() < 1e-9, "all_of_k={}", noise.all_of_k);
-    assert!((noise.pass_at_1 - 1.0).abs() < 1e-9, "pass_at_1={}", noise.pass_at_1);
+    assert!(
+        (noise.pass_at_k - 1.0).abs() < 1e-9,
+        "pass_at_k={}",
+        noise.pass_at_k
+    );
+    assert!(
+        (noise.all_of_k - 1.0).abs() < 1e-9,
+        "all_of_k={}",
+        noise.all_of_k
+    );
+    assert!(
+        (noise.pass_at_1 - 1.0).abs() < 1e-9,
+        "pass_at_1={}",
+        noise.pass_at_1
+    );
     // CI must include 1.0 when all pass
     assert!(noise.ci_upper >= 1.0 - 1e-9, "ci_upper={}", noise.ci_upper);
     // Wilson CI lower for p=1, n=9 slots is ~0.70; check it's meaningfully high
-    assert!(noise.ci_lower >= 0.6, "ci_lower should be high, got {}", noise.ci_lower);
+    assert!(
+        noise.ci_lower >= 0.6,
+        "ci_lower should be high, got {}",
+        noise.ci_lower
+    );
 }
 
 #[test]
@@ -397,11 +425,23 @@ fn ac3_noise_metrics_mixed() {
     let noise = &report.noise;
     // 1 flaky instance out of 3
     assert_eq!(noise.flaky_count, 1);
-    assert!((noise.flaky_share - 1.0 / 3.0).abs() < 1e-9, "flaky_share={}", noise.flaky_share);
+    assert!(
+        (noise.flaky_share - 1.0 / 3.0).abs() < 1e-9,
+        "flaky_share={}",
+        noise.flaky_share
+    );
     // pass_at_k (any-of-k): always_resolved and flaky both have resolved_count > 0 → 2/3
-    assert!((noise.pass_at_k - 2.0 / 3.0).abs() < 1e-9, "pass_at_k={}", noise.pass_at_k);
+    assert!(
+        (noise.pass_at_k - 2.0 / 3.0).abs() < 1e-9,
+        "pass_at_k={}",
+        noise.pass_at_k
+    );
     // all_of_k: only always_resolved has resolved_count == runs → 1/3
-    assert!((noise.all_of_k - 1.0 / 3.0).abs() < 1e-9, "all_of_k={}", noise.all_of_k);
+    assert!(
+        (noise.all_of_k - 1.0 / 3.0).abs() < 1e-9,
+        "all_of_k={}",
+        noise.all_of_k
+    );
     // pass_at_1 (per-slot): total_resolved/total_slots = (3+0+1)/9 = 4/9
     let expected_pass_at_1 = 4.0 / 9.0;
     assert!(
@@ -480,7 +520,10 @@ fn ac4_recommended_reruns_for_ci_width() {
         "expected a recommended rerun count"
     );
     let rec = report.noise.recommended_reruns.unwrap();
-    assert!(rec > 2, "recommended reruns ({rec}) should exceed current 2 for such a narrow CI target");
+    assert!(
+        rec > 2,
+        "recommended reruns ({rec}) should exceed current 2 for such a narrow CI target"
+    );
 }
 
 #[test]
@@ -517,10 +560,7 @@ fn ac5_json_output_is_schema_versioned() {
     let dir = tempfile::tempdir().unwrap();
     write_results(
         dir.path(),
-        vec![
-            rerun_instance("a", 3, 3),
-            rerun_instance("b", 3, 1),
-        ],
+        vec![rerun_instance("a", 3, 3), rerun_instance("b", 3, 1)],
     );
 
     // Call binary with --format json
@@ -539,8 +579,8 @@ fn ac5_json_output_is_schema_versioned() {
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let val: serde_json::Value = serde_json::from_str(&stdout)
-        .expect("JSON output should be valid JSON");
+    let val: serde_json::Value =
+        serde_json::from_str(&stdout).expect("JSON output should be valid JSON");
 
     // Must have schema_version and artifact_kind fields
     assert!(
@@ -746,7 +786,10 @@ fn ac7_cli_single_slot_exits_nonzero() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("single") || stderr.contains("rerun") || stderr.contains("slot") || stderr.contains("runs"),
+        stderr.contains("single")
+            || stderr.contains("rerun")
+            || stderr.contains("slot")
+            || stderr.contains("runs"),
         "error message should mention single-slot / rerun requirement, got: {stderr}"
     );
 }
@@ -757,10 +800,7 @@ fn ac7_reads_no_model_or_network() {
     let dir = tempfile::tempdir().unwrap();
     write_results(
         dir.path(),
-        vec![
-            rerun_instance("a", 3, 3),
-            rerun_instance("b", 3, 1),
-        ],
+        vec![rerun_instance("a", 3, 3), rerun_instance("b", 3, 1)],
     );
 
     // Deliberately unset ANTHROPIC_API_KEY so any model call would fail

--- a/tests/bench_variance.rs
+++ b/tests/bench_variance.rs
@@ -250,6 +250,31 @@ fn ac1_rejects_missing_results_json() {
     assert!(result.is_err(), "expected error for missing results.json");
 }
 
+#[test]
+fn ac1_rejects_incomplete_sweep() {
+    let dir = tempfile::tempdir().unwrap();
+    let cancelled = serde_json::json!({"total": 2, "sweep_status": "cancelled", "instances": []});
+    std::fs::write(
+        dir.path().join("results.json"),
+        serde_json::to_string(&cancelled).unwrap(),
+    )
+    .unwrap();
+
+    let result = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec![],
+        class: None,
+    });
+
+    assert!(result.is_err(), "expected error for cancelled sweep");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("cancelled") || msg.contains("completed") || msg.contains("status"),
+        "error should mention sweep status, got: {msg}"
+    );
+}
+
 // ── AC2: per-instance stability classes ───────────────────────────────────────
 
 #[test]
@@ -551,6 +576,34 @@ fn ac4_current_reruns_already_sufficient() {
             "recommended reruns ({rec}) should not exceed current 5 when CI already sufficient"
         );
     }
+}
+
+#[test]
+fn ac4_recommends_reruns_for_extreme_p_small_n() {
+    let dir = tempfile::tempdir().unwrap();
+    // 3 instances × 2 reruns, all pass → p=1.0 but only 6 total slots
+    write_results(
+        dir.path(),
+        vec![
+            rerun_instance("a", 2, 2),
+            rerun_instance("b", 2, 2),
+            rerun_instance("c", 2, 2),
+        ],
+    );
+
+    let report = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: Some(0.05),
+        filter: vec![],
+        class: None,
+    })
+    .unwrap();
+
+    // Wilson CI half-width for p=1, n=6 is ~0.20 >> 0.05 target
+    assert!(
+        report.noise.recommended_reruns.is_some(),
+        "should recommend reruns when p=1 but Wilson CI is still wide"
+    );
 }
 
 // ── AC5: --format text|json ───────────────────────────────────────────────────

--- a/tests/bench_variance.rs
+++ b/tests/bench_variance.rs
@@ -251,6 +251,36 @@ fn ac1_rejects_missing_results_json() {
 }
 
 #[test]
+fn ac1_rejects_budget_halted_sweep() {
+    let dir = tempfile::tempdir().unwrap();
+    let halted = serde_json::json!({
+        "total": 3,
+        "sweep_status": "completed",
+        "budget_halted": 2,
+        "instances": []
+    });
+    std::fs::write(
+        dir.path().join("results.json"),
+        serde_json::to_string(&halted).unwrap(),
+    )
+    .unwrap();
+
+    let result = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec![],
+        class: None,
+    });
+
+    assert!(result.is_err(), "expected error for budget-halted sweep");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("budget") || msg.contains("halted"),
+        "error should mention budget halt, got: {msg}"
+    );
+}
+
+#[test]
 fn ac1_rejects_incomplete_sweep() {
     let dir = tempfile::tempdir().unwrap();
     let cancelled = serde_json::json!({"total": 2, "sweep_status": "cancelled", "instances": []});

--- a/tests/bench_variance.rs
+++ b/tests/bench_variance.rs
@@ -767,6 +767,45 @@ fn ac6_cli_class_filter_via_binary() {
     assert_eq!(instances[0]["instance_id"].as_str().unwrap(), "flaky");
 }
 
+#[test]
+fn ac6_substring_filter() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results(
+        dir.path(),
+        vec![
+            rerun_instance("task-foo-1", 3, 1),
+            rerun_instance("task-bar-2", 3, 1),
+        ],
+    );
+
+    let report = compute_variance(&BenchVarianceArgs {
+        sweep_dir: dir.path().to_path_buf(),
+        ci_width: None,
+        filter: vec!["foo".into()],
+        class: None,
+    })
+    .unwrap();
+
+    assert_eq!(report.instances.len(), 1);
+    assert_eq!(report.instances[0].instance_id, "task-foo-1");
+}
+
+#[test]
+fn ac4_invalid_ci_width_returns_error() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results(dir.path(), vec![rerun_instance("a", 3, 2)]);
+
+    for bad in &[0.0_f64, -0.1, f64::NAN, f64::INFINITY] {
+        let result = compute_variance(&BenchVarianceArgs {
+            sweep_dir: dir.path().to_path_buf(),
+            ci_width: Some(*bad),
+            filter: vec![],
+            class: None,
+        });
+        assert!(result.is_err(), "expected error for ci_width={bad}, got ok");
+    }
+}
+
 // ── AC7: zero cost — reads only on-disk artifacts ─────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Implements the `bench variance` command to classify per-instance flakiness from rerun sweeps, enabling analysis of test stability without additional model or network calls. This addresses all acceptance criteria from issue #524.

## Key Changes

- **New `bench variance` command** (`src/cli/args.rs`, `src/cli/mod.rs`):
  - Accepts a completed sweep directory from `bench swebench --reruns N`
  - Supports `--format text|json` output with schema versioning
  - Supports `--class` filter (flaky, always_resolved, always_failed)
  - Supports `--ci-width` for recommended rerun count calculation
  - Validates that sweeps have multiple runs (rejects single-slot sweeps)

- **Core variance analysis module** (`src/run/variance.rs`):
  - `StabilityClass` enum: AlwaysResolved, AlwaysFailed, Flaky
  - `InstanceVariance`: per-instance resolved/total slots and classification
  - `NoiseSummary`: sweep-wide metrics including:
    - `flaky_count` and `flaky_share`: proportion of flaky instances
    - `pass_at_k`: best-case pass rate (any slot resolved)
    - `all_of_k`: worst-case pass rate (all slots resolved)
    - `pass_at_1`: per-slot pass rate with Wilson 95% CI bounds
    - `recommended_reruns`: calculated based on target CI half-width
  - `compute_variance()`: main entry point with class filtering
  - `wilson_ci()`: Wilson score interval for binomial confidence bounds
  - `render_text()`: human-readable text output

- **Comprehensive test suite** (`tests/bench_variance.rs`):
  - AC1: Validates rejection of single-slot sweeps with clear error messages
  - AC2: Tests per-instance stability classification (all three classes)
  - AC3: Validates sweep-wide noise metrics (flaky counts, pass rates, CI bounds)
  - AC4: Tests recommended rerun count calculation for target CI widths
  - AC5: Verifies JSON schema versioning and text output formatting
  - AC6: Tests `--class` and `--filter` selector functionality
  - AC7: Confirms zero-cost operation (no API keys required, reads only disk artifacts)

- **Integration updates**:
  - Added `BenchVarianceReport` artifact kind to `src/artifact.rs`
  - Registered command in CLI catalog (`src/cli/catalog.rs`)
  - Added variance module to `src/run/mod.rs`

## Notable Implementation Details

- **Zero-cost design**: Command reads only on-disk `results.json` artifacts; no model calls or network I/O
- **Robust statistics**: Uses Wilson score interval for accurate confidence bounds on binomial proportions
- **Flexible filtering**: Supports both per-instance class filtering and future instance-id substring filters
- **Schema versioning**: JSON output includes `schema_version` and `artifact_kind` for forward compatibility
- **Clear error messages**: Validates sweep structure and provides actionable guidance for invalid inputs

https://claude.ai/code/session_01W5KtBGRqxwNPdzeudrA9Gd