### PR TITLE
Implement per-tier extra_args validation and application in cascade

### DIFF
--- a/docs/spec-cascade.md
+++ b/docs/spec-cascade.md
@@ -1,0 +1,203 @@
+# `bench cascade` Spec
+
+`bench cascade` runs instances through an **ordered list of model tiers** and
+short-circuits each instance on the first tier that resolves it. Cheaper tiers
+run first; expensive premium-tier capacity is consumed only for instances that
+cheaper tiers cannot resolve.
+
+## CLI
+
+```bash
+max bench cascade \
+  --config cascade.toml \
+  --dataset-path data/swe-bench-verified.jsonl \
+  --output runs/cascade-2025-01 \
+  --eval-backend sb-cli \
+  --limit 50 \
+  --seed 42 \
+  --sweep-cost-limit-usd 50.00
+```
+
+Options:
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--config <path>` | required | TOML cascade manifest containing `[[tier]]` entries. |
+| `--dataset-path <file>` | required¹ | Local JSONL dataset file. |
+| `--dataset <alias>` | required¹ | Named SWE-bench alias (`verified`, `lite`, `full`). |
+| `--output <dir>` | required | Root output directory. Tier results land in `{output}/tier-{name}/`. |
+| `--eval-backend <backend>` | required² | Evaluation backend used for per-instance short-circuit (e.g. `sb-cli`). |
+| `--sweep-cost-limit-usd <f>` | unset | Shared USD ceiling across all tiers. Instances reached after the limit is exhausted are recorded as `skipped_budget`. |
+| `--resume` | off | Load existing `cascade.json` and skip completed instances. |
+| `--limit <n>` | unset | Keep at most N instances after filtering and sampling. |
+| `--sample <n>` | unset | Reproducibly random-subset to N instances (requires `--seed`). |
+| `--seed <n>` | unset | RNG seed for `--sample`. |
+| `--parallel <n>` | 4 | Worker parallelism per tier sweep. |
+| `--skip-preflight` | off | Skip startup preflight checks. |
+| `--skip-model-probe` | off | Skip model-endpoint probe during preflight. |
+
+¹ Exactly one of `--dataset-path` or `--dataset` must be provided.
+² A cascade requires an evaluation backend; `--eval-backend none` is rejected.
+
+## Manifest format
+
+```toml
+[[tier]]
+name = "haiku"
+model = "claude-haiku-4-5"
+step_limit = 20
+per_task_budget_usd = 0.10
+
+[[tier]]
+name = "sonnet"
+model = "claude-sonnet-4-6"
+step_limit = 40
+per_task_budget_usd = 0.50
+extra_args = ["--skip-patch-validation"]
+
+[[tier]]
+name = "opus"
+model = "claude-opus-4-8"
+step_limit = 80
+per_task_budget_usd = 2.00
+extra_args = ["--max-rpm", "500"]
+```
+
+Each `[[tier]]` entry supports:
+
+| Field | Required | Type | Meaning |
+| --- | --- | --- | --- |
+| `name` | yes | string | Unique tier name; used as the output subdirectory. Must not contain `/`, `\`, or `..`. |
+| `model` | yes | string | Model name passed to the sweep (e.g. `claude-opus-4-8`). |
+| `step_limit` | no | integer | Override the default agent step limit for this tier. |
+| `per_task_budget_usd` | no | float | Override per-task USD ceiling for this tier. |
+| `prompt_file` | no | path | TOML config file overlaid on defaults for this tier. |
+| `extra_args` | no | list of strings | Additional sweep args applied as overrides to this tier only (parsed as overrides). |
+
+### `extra_args` reference
+
+`extra_args` accepts a subset of sweep-level flags, applied per-tier in
+isolation. The same override semantics apply as for `bench matrix` arm
+`extra_args` (see `docs/spec-matrix.md`).
+
+| Arg | Type | Meaning |
+| --- | --- | --- |
+| `--skip-patch-validation` | flag | Skip `git apply --check` and empty-diff validation after patch capture. Useful for non-git or relaxed-validation tiers. |
+| `--max-rpm <n>` | integer | Per-tier aggregate request-rate ceiling (requests/min). |
+| `--max-input-tpm <n>` | integer | Per-tier aggregate input-token-rate ceiling (tokens/min). |
+
+**Isolation**: each tier's `extra_args` are applied exclusively to that tier's
+sweep run; args from one tier do not carry over to any other tier.
+
+**Precedence**: `extra_args` are applied after the dedicated tier fields
+(`model`, `step_limit`, `per_task_budget_usd`). If both a dedicated field and
+an `extra_args` entry target the same sweep setting, the dedicated field takes
+precedence at config-construction time; `extra_args` override sweep-level args
+applied afterward.
+
+**Fail-fast validation**: unrecognized or malformed `extra_args` entries cause
+the cascade to fail before any model budget is spent, with an error message that
+names the offending tier and arg.
+
+## Routing logic
+
+1. Instances are resolved once from the dataset before any tier runs.
+2. Tiers execute in definition order (tier 0 → tier 1 → … → tier N−1).
+3. After each tier's sweep, the evaluation backend scores outcomes.
+4. Instances resolved by tier k are **removed** from subsequent tiers.
+5. Instances not resolved after all tiers are recorded as exhausted.
+
+## Output artifacts
+
+After a run, the output directory contains:
+
+```
+{output}/
+  cascade.json              ← machine-readable state (updated after every tier)
+  cascade-summary.json      ← per-tier stats and cascade-wide summary
+  tier-{name}/              ← standard sweep artifacts for each tier
+    results.json
+    *.traj.json
+  …
+```
+
+### `cascade.json`
+
+```json
+{
+  "artifact_kind": "cascade",
+  "config_path": "cascade.toml",
+  "tier_names": ["haiku", "sonnet", "opus"],
+  "instance_ids": ["django__django-1234", "…"],
+  "filter_spec": { "original_count": 500, "selected_count": 50, "seed": 42 },
+  "cost_limit_usd": 50.0,
+  "instances": {
+    "django__django-1234": {
+      "resolving_tier": "haiku",
+      "total_cost_usd": 0.08,
+      "attempts": [
+        { "tier_name": "haiku", "model": "claude-haiku-4-5",
+          "outcome": "submitted", "eval_exit_reason": "resolved",
+          "cost_usd": 0.08, "steps": 12 }
+      ]
+    }
+  }
+}
+```
+
+#### `halted_reason` values
+
+| Value | Meaning |
+| --- | --- |
+| `skipped_budget` | Instance was not started because the shared cost limit was already reached. |
+| `eval_pending` | Model ran but the evaluator failed; will retry on `--resume`. |
+
+### `cascade-summary.json`
+
+```json
+{
+  "artifact_kind": "cascade-summary",
+  "tiers": [
+    { "name": "haiku", "model": "claude-haiku-4-5",
+      "instances_attempted": 50, "resolved": 20, "resolved_rate": 0.40,
+      "total_cost_usd": 4.00, "mean_cost_per_attempt_usd": 0.08,
+      "cost_per_resolved_usd": 0.20 }
+  ],
+  "cascade_resolved": 35,
+  "cascade_resolved_rate": 0.70,
+  "total_instances": 50,
+  "total_cost_usd": 12.50,
+  "cost_per_resolved_cascade_usd": 0.357,
+  "savings_vs_top_tier_only_usd": 37.50
+}
+```
+
+## Budget enforcement
+
+The `--sweep-cost-limit-usd` ceiling is **shared** across all tiers:
+
+1. Before each tier sweep, if `cumulative_cost >= limit`, remaining instances
+   for that tier are marked `skipped_budget`.
+2. There is no mid-sweep interruption — once a tier's sweep starts, it runs to
+   completion (or until its own per-task budget fires).
+3. Instances already evaluated as `eval_pending` bypass the budget guard — the
+   evaluator retry costs no model budget.
+
+## Resume behaviour
+
+`--resume` loads `cascade.json` and skips:
+- Instances already resolved (have `resolving_tier` set).
+- Instances where all tiers have already completed a non-skipped attempt.
+
+Instances with `halted_reason: "eval_pending"` are re-queued for evaluator
+retry (the inner sweep uses `resume: true` so model calls are not re-spent).
+
+## Graceful abort (Ctrl-C)
+
+When a cancellation signal arrives during a tier sweep:
+
+- The in-flight tier is allowed to finish current tasks (up to
+  `--cancel-deadline-secs`; default 60 s).
+- Unstarted instances for the cancelled tier are recorded and future tiers
+  are not started.
+- `--resume` can restart the experiment from where it left off.

--- a/src/run/cascade.rs
+++ b/src/run/cascade.rs
@@ -198,14 +198,12 @@ fn parse_extra_args(tier_name: &str, args: &[String]) -> Result<ExtraArgOverride
             "--max-rpm" => {
                 let val_str = args.get(i + 1).ok_or_else(|| {
                     Error::Config(ConfigError::Invalid(format!(
-                        "cascade tier {:?}: extra_arg `--max-rpm` requires a value",
-                        tier_name
+                        "cascade tier {tier_name:?}: extra_arg `--max-rpm` requires a value"
                     )))
                 })?;
                 let val: u32 = val_str.parse().map_err(|_| {
                     Error::Config(ConfigError::Invalid(format!(
-                        "cascade tier {:?}: extra_arg `--max-rpm` value {:?} is not a valid u32",
-                        tier_name, val_str
+                        "cascade tier {tier_name:?}: extra_arg `--max-rpm` value {val_str:?} is not a valid u32"
                     )))
                 })?;
                 overrides.max_rpm = Some(val);
@@ -214,14 +212,12 @@ fn parse_extra_args(tier_name: &str, args: &[String]) -> Result<ExtraArgOverride
             "--max-input-tpm" => {
                 let val_str = args.get(i + 1).ok_or_else(|| {
                     Error::Config(ConfigError::Invalid(format!(
-                        "cascade tier {:?}: extra_arg `--max-input-tpm` requires a value",
-                        tier_name
+                        "cascade tier {tier_name:?}: extra_arg `--max-input-tpm` requires a value"
                     )))
                 })?;
                 let val: u64 = val_str.parse().map_err(|_| {
                     Error::Config(ConfigError::Invalid(format!(
-                        "cascade tier {:?}: extra_arg `--max-input-tpm` value {:?} is not a valid u64",
-                        tier_name, val_str
+                        "cascade tier {tier_name:?}: extra_arg `--max-input-tpm` value {val_str:?} is not a valid u64"
                     )))
                 })?;
                 overrides.max_input_tpm = Some(val);
@@ -229,10 +225,9 @@ fn parse_extra_args(tier_name: &str, args: &[String]) -> Result<ExtraArgOverride
             }
             unknown => {
                 return Err(Error::Config(ConfigError::Invalid(format!(
-                    "cascade tier {:?}: unrecognized extra_arg {:?}; \
+                    "cascade tier {tier_name:?}: unrecognized extra_arg {unknown:?}; \
                      recognized args: --skip-patch-validation, \
-                     --max-rpm <n>, --max-input-tpm <n>",
-                    tier_name, unknown
+                     --max-rpm <n>, --max-input-tpm <n>"
                 ))));
             }
         }
@@ -248,12 +243,9 @@ fn apply_extra_arg_overrides(
     if overrides.skip_patch_validation {
         tier_args.skip_patch_validation = true;
     }
-    if let Some(rpm) = overrides.max_rpm {
-        tier_args.max_rpm = Some(rpm);
-    }
-    if let Some(tpm) = overrides.max_input_tpm {
-        tier_args.max_input_tpm = Some(tpm);
-    }
+    // extra_args take precedence; fall back to config-file rate limits (e.g. from prompt_file)
+    tier_args.max_rpm = overrides.max_rpm.or(tier_args.config.root.sweep.max_rpm);
+    tier_args.max_input_tpm = overrides.max_input_tpm.or(tier_args.config.root.sweep.max_input_tpm);
 }
 
 // ── Validation ────────────────────────────────────────────────────────────────

--- a/src/run/cascade.rs
+++ b/src/run/cascade.rs
@@ -245,7 +245,9 @@ fn apply_extra_arg_overrides(
     }
     // extra_args take precedence; fall back to config-file rate limits (e.g. from prompt_file)
     tier_args.max_rpm = overrides.max_rpm.or(tier_args.config.root.sweep.max_rpm);
-    tier_args.max_input_tpm = overrides.max_input_tpm.or(tier_args.config.root.sweep.max_input_tpm);
+    tier_args.max_input_tpm = overrides
+        .max_input_tpm
+        .or(tier_args.config.root.sweep.max_input_tpm);
 }
 
 // ── Validation ────────────────────────────────────────────────────────────────

--- a/src/run/cascade.rs
+++ b/src/run/cascade.rs
@@ -169,11 +169,99 @@ pub struct CascadeSummary {
     pub savings_vs_top_tier_only_usd: f64,
 }
 
+// ── extra_args parsing ────────────────────────────────────────────────────────
+
+/// Typed overrides derived from a tier's `extra_args` list.
+struct ExtraArgOverrides {
+    skip_patch_validation: bool,
+    max_rpm: Option<u32>,
+    max_input_tpm: Option<u64>,
+}
+
+/// Parse per-tier `extra_args` into typed overrides.
+///
+/// Fails with a usage error naming the offending tier and arg for any
+/// unrecognized or malformed entry.
+fn parse_extra_args(tier_name: &str, args: &[String]) -> Result<ExtraArgOverrides, Error> {
+    let mut overrides = ExtraArgOverrides {
+        skip_patch_validation: false,
+        max_rpm: None,
+        max_input_tpm: None,
+    };
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--skip-patch-validation" => {
+                overrides.skip_patch_validation = true;
+                i += 1;
+            }
+            "--max-rpm" => {
+                let val_str = args.get(i + 1).ok_or_else(|| {
+                    Error::Config(ConfigError::Invalid(format!(
+                        "cascade tier {:?}: extra_arg `--max-rpm` requires a value",
+                        tier_name
+                    )))
+                })?;
+                let val: u32 = val_str.parse().map_err(|_| {
+                    Error::Config(ConfigError::Invalid(format!(
+                        "cascade tier {:?}: extra_arg `--max-rpm` value {:?} is not a valid u32",
+                        tier_name, val_str
+                    )))
+                })?;
+                overrides.max_rpm = Some(val);
+                i += 2;
+            }
+            "--max-input-tpm" => {
+                let val_str = args.get(i + 1).ok_or_else(|| {
+                    Error::Config(ConfigError::Invalid(format!(
+                        "cascade tier {:?}: extra_arg `--max-input-tpm` requires a value",
+                        tier_name
+                    )))
+                })?;
+                let val: u64 = val_str.parse().map_err(|_| {
+                    Error::Config(ConfigError::Invalid(format!(
+                        "cascade tier {:?}: extra_arg `--max-input-tpm` value {:?} is not a valid u64",
+                        tier_name, val_str
+                    )))
+                })?;
+                overrides.max_input_tpm = Some(val);
+                i += 2;
+            }
+            unknown => {
+                return Err(Error::Config(ConfigError::Invalid(format!(
+                    "cascade tier {:?}: unrecognized extra_arg {:?}; \
+                     recognized args: --skip-patch-validation, \
+                     --max-rpm <n>, --max-input-tpm <n>",
+                    tier_name, unknown
+                ))));
+            }
+        }
+    }
+    Ok(overrides)
+}
+
+/// Apply parsed extra-arg overrides to a sweep-args struct.
+fn apply_extra_arg_overrides(
+    overrides: &ExtraArgOverrides,
+    tier_args: &mut crate::run::swebench::SwebenchArgs,
+) {
+    if overrides.skip_patch_validation {
+        tier_args.skip_patch_validation = true;
+    }
+    if let Some(rpm) = overrides.max_rpm {
+        tier_args.max_rpm = Some(rpm);
+    }
+    if let Some(tpm) = overrides.max_input_tpm {
+        tier_args.max_input_tpm = Some(tpm);
+    }
+}
+
 // ── Validation ────────────────────────────────────────────────────────────────
 
 /// Validate tier definitions before running.
 ///
-/// Rules: at least one tier, all names non-empty, no path separators, unique.
+/// Rules: at least one tier, all names non-empty, no path separators, unique,
+/// and all `extra_args` entries recognized.
 pub fn validate_tiers(tiers: &[TierDef]) -> Result<(), Error> {
     if tiers.is_empty() {
         return Err(Error::Config(ConfigError::Invalid(
@@ -203,6 +291,12 @@ pub fn validate_tiers(tiers: &[TierDef]) -> Result<(), Error> {
                 tier.name
             ))));
         }
+    }
+
+    // Fail fast on any unrecognized or malformed extra_args before any model
+    // budget is spent.
+    for tier in tiers {
+        parse_extra_args(&tier.name, &tier.extra_args)?;
     }
 
     Ok(())
@@ -755,15 +849,11 @@ async fn run_tier(
     if let Some(budget) = tier.per_task_budget_usd {
         cfg.root.agent.per_task_budget_usd = Some(budget);
     }
-    if !tier.extra_args.is_empty() {
-        tracing::warn!(
-            tier = %tier.name,
-            extra_args = ?tier.extra_args,
-            "cascade: extra_args are not yet applied to tier runs"
-        );
-    }
 
-    let tier_args = crate::run::swebench::SwebenchArgs {
+    // extra_args were already validated in validate_tiers; parse returns Ok here.
+    let extra_overrides = parse_extra_args(&tier.name, &tier.extra_args)?;
+
+    let mut tier_args = crate::run::swebench::SwebenchArgs {
         dataset_source: ctx.dataset_source,
         dataset_cache_dir: ctx.dataset_cache_dir,
         output_dir: tier_sweep_dir,
@@ -820,6 +910,8 @@ async fn run_tier(
         notify_webhook_url: None,
         notify_webhook_headers: vec![],
     };
+
+    apply_extra_arg_overrides(&extra_overrides, &mut tier_args);
 
     crate::run::swebench::run(tier_args).await
 }

--- a/tests/bench_cascade.rs
+++ b/tests/bench_cascade.rs
@@ -716,3 +716,237 @@ async fn cascade_artifacts_have_correct_kind_field() {
         "cascade-summary"
     );
 }
+
+// ── Unit: validate_tiers extra_args validation ────────────────────────────────
+
+/// AC: unrecognized extra_arg fails fast with a usage error naming the tier and arg.
+#[test]
+fn validate_tiers_rejects_unknown_extra_arg() {
+    let tiers = vec![TierDef {
+        name: "haiku".into(),
+        model: "m1".into(),
+        extra_args: vec!["--unknown-flag".into()],
+        ..TierDef::default()
+    }];
+    let err = validate_tiers(&tiers).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("haiku"),
+        "error should name the offending tier: {err}"
+    );
+    assert!(
+        msg.contains("--unknown-flag"),
+        "error should name the offending arg: {err}"
+    );
+}
+
+/// AC: malformed value for a known extra_arg fails fast naming the tier and arg.
+#[test]
+fn validate_tiers_rejects_malformed_extra_arg_value() {
+    let tiers = vec![TierDef {
+        name: "sonnet".into(),
+        model: "m1".into(),
+        extra_args: vec!["--max-rpm".into(), "not-a-number".into()],
+        ..TierDef::default()
+    }];
+    let err = validate_tiers(&tiers).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("sonnet"),
+        "error should name the offending tier: {err}"
+    );
+    assert!(
+        msg.contains("--max-rpm"),
+        "error should name the offending arg: {err}"
+    );
+}
+
+/// AC: missing value for a valued extra_arg fails fast naming the tier and arg.
+#[test]
+fn validate_tiers_rejects_missing_extra_arg_value() {
+    let tiers = vec![TierDef {
+        name: "opus".into(),
+        model: "m1".into(),
+        extra_args: vec!["--max-rpm".into()],
+        ..TierDef::default()
+    }];
+    let err = validate_tiers(&tiers).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("opus"),
+        "error should name the offending tier: {err}"
+    );
+    assert!(
+        msg.contains("--max-rpm"),
+        "error should name the offending arg: {err}"
+    );
+}
+
+/// AC: known extra_arg `--skip-patch-validation` is accepted.
+#[test]
+fn validate_tiers_accepts_skip_patch_validation() {
+    let tiers = vec![TierDef {
+        name: "haiku".into(),
+        model: "m1".into(),
+        extra_args: vec!["--skip-patch-validation".into()],
+        ..TierDef::default()
+    }];
+    assert!(validate_tiers(&tiers).is_ok());
+}
+
+/// AC: known extra_arg `--max-rpm` with a valid value is accepted.
+#[test]
+fn validate_tiers_accepts_max_rpm_with_valid_value() {
+    let tiers = vec![TierDef {
+        name: "haiku".into(),
+        model: "m1".into(),
+        extra_args: vec!["--max-rpm".into(), "1000".into()],
+        ..TierDef::default()
+    }];
+    assert!(validate_tiers(&tiers).is_ok());
+}
+
+/// AC: known extra_arg `--max-input-tpm` with a valid value is accepted.
+#[test]
+fn validate_tiers_accepts_max_input_tpm_with_valid_value() {
+    let tiers = vec![TierDef {
+        name: "haiku".into(),
+        model: "m1".into(),
+        extra_args: vec!["--max-input-tpm".into(), "500000".into()],
+        ..TierDef::default()
+    }];
+    assert!(validate_tiers(&tiers).is_ok());
+}
+
+// ── Integration: extra_args applied and isolated ──────────────────────────────
+
+/// AC: per-tier extra_args are applied to that tier's sweep.
+/// Observable via `rate_limit_events` in the tier's results.json when --max-rpm is set.
+#[tokio::test]
+async fn cascade_extra_args_max_rpm_applied_to_tier() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dataset = minimal_dataset(tmp.path(), &["inst-1"]);
+    let output = tmp.path().join("out");
+
+    let path = tmp.path().join("cascade.toml");
+    std::fs::write(
+        &path,
+        "[[tier]]\nname = \"haiku\"\nmodel = \"deterministic\"\nstep_limit = 1\n\
+         extra_args = [\"--max-rpm\", \"1000\"]\n",
+    )
+    .unwrap();
+
+    let args = default_cascade_args(path, dataset, output.clone());
+    cascade_run(args).await.unwrap();
+
+    let results_path = output.join("tier-haiku").join("results.json");
+    assert!(results_path.exists(), "tier-haiku/results.json must exist");
+    let results: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&results_path).unwrap()).unwrap();
+
+    assert!(
+        results.get("rate_limit_events").is_some(),
+        "rate_limit_events must be present when --max-rpm is applied via extra_args; \
+         keys present: {:?}",
+        results.as_object().map(|o| o.keys().collect::<Vec<_>>())
+    );
+}
+
+/// AC: extra_args apply per-tier in isolation — tier A's args do not leak into tier B.
+#[tokio::test]
+async fn cascade_extra_args_isolation_between_tiers() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dataset = minimal_dataset(tmp.path(), &["inst-1"]);
+    let output = tmp.path().join("out");
+
+    let path = tmp.path().join("cascade.toml");
+    std::fs::write(
+        &path,
+        "[[tier]]\nname = \"haiku\"\nmodel = \"deterministic\"\nstep_limit = 1\n\
+         extra_args = [\"--max-rpm\", \"1000\"]\n\n\
+         [[tier]]\nname = \"sonnet\"\nmodel = \"deterministic\"\nstep_limit = 1\n",
+    )
+    .unwrap();
+
+    let args = default_cascade_args(path, dataset, output.clone());
+    cascade_run(args).await.unwrap();
+
+    let haiku_results: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(output.join("tier-haiku").join("results.json")).unwrap(),
+    )
+    .unwrap();
+    assert!(
+        haiku_results.get("rate_limit_events").is_some(),
+        "tier-haiku should have rate_limit_events (--max-rpm set via extra_args)"
+    );
+
+    let sonnet_results: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(output.join("tier-sonnet").join("results.json")).unwrap(),
+    )
+    .unwrap();
+    assert!(
+        sonnet_results.get("rate_limit_events").is_none(),
+        "tier-sonnet must NOT have rate_limit_events (no extra_args; isolation check)"
+    );
+}
+
+/// AC: unrecognized extra_args fail fast before any model budget is spent —
+/// no tier directories are created when validation fails.
+#[tokio::test]
+async fn cascade_unknown_extra_arg_fails_fast_before_any_tier_runs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dataset = minimal_dataset(tmp.path(), &["inst-1"]);
+    let output = tmp.path().join("out");
+
+    let path = tmp.path().join("cascade.toml");
+    std::fs::write(
+        &path,
+        "[[tier]]\nname = \"cheap\"\nmodel = \"deterministic\"\nstep_limit = 1\n\n\
+         [[tier]]\nname = \"expensive\"\nmodel = \"deterministic\"\nstep_limit = 1\n\
+         extra_args = [\"--unknown-flag\"]\n",
+    )
+    .unwrap();
+
+    let args = default_cascade_args(path, dataset, output.clone());
+    let err = cascade_run(args).await.unwrap_err();
+    let msg = err.to_string();
+
+    assert!(
+        msg.contains("expensive"),
+        "error must name the offending tier: {err}"
+    );
+    assert!(
+        msg.contains("--unknown-flag"),
+        "error must name the offending arg: {err}"
+    );
+
+    assert!(
+        !output.join("tier-cheap").join("results.json").exists(),
+        "tier-cheap must not have run (validation failed before any tier started)"
+    );
+}
+
+/// AC: a tier with empty/absent extra_args behaves exactly as today (golden path regression).
+#[tokio::test]
+async fn cascade_empty_extra_args_golden_path_unchanged() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dataset = minimal_dataset(tmp.path(), &["inst-1"]);
+    let config = write_cascade_toml(tmp.path(), &[("haiku", "deterministic")]);
+    let output = tmp.path().join("out");
+
+    let args = default_cascade_args(config, dataset, output.clone());
+    let summary = cascade_run(args).await.unwrap();
+
+    assert!(output.join("tier-haiku").join("results.json").exists());
+
+    let results: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(output.join("tier-haiku").join("results.json")).unwrap(),
+    )
+    .unwrap();
+    assert!(
+        results.get("rate_limit_events").is_none(),
+        "empty extra_args must not set rate_limit_events (golden path)"
+    );
+
+    assert_eq!(summary.tiers.len(), 1);
+}


### PR DESCRIPTION
## Summary

This PR adds support for per-tier `extra_args` in the cascade command, enabling fine-grained control over sweep parameters on a per-tier basis. The implementation includes fail-fast validation of extra arguments before any model budget is spent, and proper isolation of arguments between tiers.

## Key Changes

- **Extra args parsing and validation**: Added `parse_extra_args()` function that validates tier-specific arguments and fails fast with clear error messages naming the offending tier and argument. Recognized arguments include `--skip-patch-validation`, `--max-rpm <n>`, and `--max-input-tpm <n>`.

- **Validation integration**: Extended `validate_tiers()` to parse and validate all extra_args entries before cascade execution begins, preventing any model budget expenditure on invalid configurations.

- **Argument application**: Implemented `apply_extra_arg_overrides()` to apply parsed extra arguments to tier sweep configurations, with proper isolation between tiers (arguments from one tier do not leak to others).

- **Tier execution**: Modified `run_tier()` to parse and apply extra_args overrides to each tier's sweep arguments, replacing the previous warning about unimplemented extra_args.

- **Comprehensive test coverage**: Added 10 new tests covering:
  - Unit tests for validation (unknown args, malformed values, missing values, valid args)
  - Integration tests for argument application and isolation between tiers
  - Fail-fast behavior verification (no tier directories created on validation failure)
  - Golden path regression test (empty extra_args behaves as before)

- **Documentation**: Added `docs/spec-cascade.md` with complete cascade specification including CLI options, manifest format, extra_args reference, routing logic, output artifacts, budget enforcement, and resume behavior.

## Implementation Details

- Extra args are validated at cascade startup via `validate_tiers()`, ensuring configuration errors are caught before any tier runs.
- Each tier's arguments are parsed independently and applied only to that tier's sweep configuration.
- Error messages include both the tier name and the problematic argument for easy debugging.
- The implementation maintains backward compatibility: tiers without extra_args behave identically to before.

https://claude.ai/code/session_01DkkmqmsUL6kXUfJ99oD5sz