### PR TITLE
Implement `agent artifact-check` command for artifact validation

### DIFF
--- a/docs/artifact-contract.md
+++ b/docs/artifact-contract.md
@@ -34,6 +34,13 @@ Cost fields are split deliberately:
 - `baseline_cost_usd` is a counterfactual estimate for the same token usage using `baseline_cost_model`.
 - Legacy `total_cost_usd` remains present for compatibility and should be treated as historical/summary cost, not as the only cost signal.
 
+## Conformance Validation
+
+Use `agent artifact-check` to validate one or more artifact files against this
+contract on demand — zero model calls, zero network I/O. See
+[`docs/spec-artifact-check.md`](spec-artifact-check.md) for the full command
+reference, verdict taxonomy, and per-kind required-field table.
+
 ## Reader Policy
 
 `bench inspect`, `bench tail`, `bench compare`, `bench evaluate`, `bench calibrate`, and trajectory diff loading classify artifacts before reporting metrics.

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -52,6 +52,7 @@ parsing human-oriented output.
 | 44   | `utilization_gate_failure` | `bench utilization --min-utilization <PCT>` measured a concurrency utilization below the declared floor. The report was printed; the non-zero exit gates CI on sweep concurrency efficiency. Distinct from `slo_rule_failure` (27) so automation can route "concurrency under-utilized" separately from generic SLO failures. See `docs/spec-utilization.md`. |
 | 45   | `fs_audit_findings`      | `agent fs-audit` found at least one bash command that accessed a path outside the configured workdir (absolute path, `..` traversal, `$HOME`/`~/` reference, or known system directory). The audit completed and the report was printed; use as a publish gate. Distinct from `internal_error` (1) so CI can route "filesystem boundary violated" separately from a crash. See `docs/spec-fs-audit.md`. |
 | 46   | `fs_audit_scan_error`    | `agent fs-audit` could not read or parse one or more trajectory files (missing path, unreadable file, invalid JSON, missing sweep directory). The scan is incomplete, so a "clean" verdict cannot be trusted. Findings take precedence: exit 45 is returned when both findings and scan errors are present. |
+| 47   | `artifact_check_failure` | `agent artifact-check` found at least one artifact that is `invalid` or `unsupported_major`. With `--strict`, also triggers on `legacy_unversioned` and `valid_with_warnings`. Zero model calls are made; the check is purely a structural conformance gate. Distinct from `internal_error` (1) so CI can route "artifact does not conform to contract" separately from an unexpected infrastructure failure. See `docs/spec-artifact-check.md`. |
 | 130  | `interrupted`            | Graceful SIGINT / Ctrl-C cancellation (POSIX convention: 128 + SIGINT(2)). |
 | 137  | `killed`                 | SIGKILL escalation after the graceful-cancel deadline expired (128 + SIGKILL(9)). |
 
@@ -108,6 +109,7 @@ and the recommended triage action.
 | `agent redact-audit`            | `success`, `usage_error`, `redact_audit_findings`, `redact_audit_scan_error`, `internal_error` |
 | `bench assert`                  | `success`, `usage_error`, `slo_rule_failure`, `internal_error` |
 | `agent apply`                   | `success`, `usage_error`, `apply_check_failed`, `apply_redacted_refused`, `apply_dirty_tree_refused`, `internal_error` |
+| `agent artifact-check`          | `success`, `usage_error`, `artifact_check_failure`, `internal_error` |
 | `bench export-otlp`             | `success`, `usage_error`, `preflight_failure`, `internal_error` (see `docs/spec-export-otlp.md`) |
 
 > **Note:** `hello-world` does not produce distinct outcome classes beyond

--- a/docs/spec-artifact-check.md
+++ b/docs/spec-artifact-check.md
@@ -72,7 +72,7 @@ The `--format json` flag emits a schema-versioned `validation_report` document:
 ```json
 {
   "artifact_kind": "validation_report",
-  "schema_version": "1.0",
+  "schema_version": { "major": 1, "minor": 0 },
   "summary": {
     "total": 3,
     "valid": 2,

--- a/docs/spec-artifact-check.md
+++ b/docs/spec-artifact-check.md
@@ -1,0 +1,141 @@
+# `agent artifact-check` — Artifact Contract Conformance Gate
+
+Issue #534. Zero-cost structural conformance validator for artifact files.
+
+## Purpose
+
+`agent artifact-check` validates one or more artifact files (or directories,
+recursively) against the [Artifact Contract](artifact-contract.md) without
+making any model calls or network requests. It is designed as a preflight gate
+for CI pipelines and for operators who receive artifacts from multiple sources
+(own runs, teammates, exporters, downloaded leaderboard bundles) and need to
+confirm conformance before feeding them into analysis or publishing them.
+
+## Usage
+
+```bash
+max agent artifact-check [OPTIONS] <PATH>...
+```
+
+| Flag | Description |
+|------|-------------|
+| `<PATH>...` | One or more file or directory paths. Directories are scanned recursively for `*.json` files. |
+| `--format text\|json` | Output format. `text` (default): human-readable table. `json`: emits a schema-versioned `validation_report` artifact. |
+| `--strict` | Promote `legacy_unversioned` and `valid_with_warnings` verdicts to failures (in addition to the always-fatal `invalid` and `unsupported_major`). |
+
+## Verdicts
+
+Each artifact receives exactly one verdict:
+
+| Verdict | Meaning | Failure by default? | Failure under `--strict`? |
+|---------|---------|--------------------|-----------------------------|
+| `valid` | All required fields present; `schema_version` is the current major.minor. | No | No |
+| `valid_with_warnings` | All required fields present but `schema_version` is an older supported minor within the same major. Readers may default missing fields. | No | **Yes** |
+| `invalid` | One or more required fields are missing or the header is malformed. | **Yes** | **Yes** |
+| `legacy_unversioned` | Both `artifact_kind` and `schema_version` are absent (pre-versioning legacy artifact). | No | **Yes** |
+| `unsupported_major` | `schema_version.major` exceeds the harness-supported major. | **Yes** | **Yes** |
+
+## Per-kind required fields
+
+The following artifact kinds are covered by full required-field validation.
+Unknown additive fields within major `1` do **not** fail, consistent with the
+contract reader policy.
+
+| Kind | Required fields (beyond `artifact_kind` + `schema_version`) |
+|------|--------------------------------------------------------------|
+| `trajectory` | `trajectory_format`, `info`, `messages` |
+| `sweep_results` | `total`, `submitted`, `skipped`, `errored`, `failures_by_category`, `instances` |
+| `evaluation_results` | `instances` |
+| `forecast_report` | `calibration`, `per_instance`, `forecast`, `resolution_rate`, `threshold` |
+| `calibration_report` | `forecast_path`, `results_path`, `verdict`, `comparability`, `metrics`, `per_instance` |
+| `preflight_report` | `mode`, `checks` |
+| `swebench_predictions_metadata` | `predictions_file`, `aggregate`, `row_count`, `swebench_evaluator_compatible` |
+| `bundle_manifest` | `source_sweep_dir`, `source_manifest_hash`, `harness_git_sha`, `bundle_generated_at`, `instance_scope`, `files` |
+| `cache_stats_report` | `sweep`, `generated_at`, `cache_disabled`, `sweep_totals`, `instances` |
+
+All other known artifact kinds are validated for a well-formed header only.
+
+## Exit codes
+
+| Code | Outcome class | When emitted |
+|-----:|---------------|--------------|
+| 0 | `success` | All artifacts are `valid` or `valid_with_warnings` (warnings are tolerated by default). |
+| 2 | `usage_error` | Bad flag, missing required argument, or unreadable input path. |
+| 47 | `artifact_check_failure` | At least one artifact is `invalid` or `unsupported_major`; or, with `--strict`, at least one is `legacy_unversioned` or `valid_with_warnings`. |
+
+See [exit-codes.md](exit-codes.md) for the full contract.
+
+## JSON output (`--format json`)
+
+The `--format json` flag emits a schema-versioned `validation_report` document:
+
+```json
+{
+  "artifact_kind": "validation_report",
+  "schema_version": "1.0",
+  "summary": {
+    "total": 3,
+    "valid": 2,
+    "valid_with_warnings": 0,
+    "invalid": 1,
+    "legacy_unversioned": 0,
+    "unsupported_major": 0
+  },
+  "results": [
+    {
+      "path": "runs/sweep/traj.json",
+      "artifact_kind": "trajectory",
+      "schema_version": "1.11",
+      "verdict": "valid",
+      "missing_fields": [],
+      "warnings": []
+    }
+  ]
+}
+```
+
+## Examples
+
+Validate a single trajectory:
+
+```bash
+max agent artifact-check runs/traj.json
+```
+
+Validate an entire sweep directory recursively:
+
+```bash
+max agent artifact-check runs/sweep/
+```
+
+Validate multiple paths and emit JSON:
+
+```bash
+max agent artifact-check --format json runs/ exports/ > validation.json
+```
+
+Strict gate (fails on legacy artifacts and older-minor versions):
+
+```bash
+max agent artifact-check --strict runs/
+```
+
+CI pipeline gate:
+
+```bash
+max agent artifact-check runs/ || exit 1
+```
+
+## Out of scope
+
+- Repairing or migrating artifacts — report only, no auto-fix.
+- Semantic correctness of metrics (e.g. whether aggregates derive from
+  trajectories) — that is `bench audit`'s job.
+- Validating `all_preds*.jsonl` SWE-bench prediction rows, which intentionally
+  carry no artifact metadata.
+
+## Performance
+
+Validation is purely structural (JSON parse + field presence check). A single
+trajectory artifact completes in well under 200 ms with zero network or model
+calls. Throughput scales linearly with the number of files.

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -77,6 +77,7 @@ pub enum ArtifactKind {
     AgentRunsReport,
     MiniResult,
     BenchVarianceReport,
+    ValidationReport,
 }
 
 impl ArtifactKind {
@@ -111,6 +112,7 @@ impl ArtifactKind {
             Self::AgentRunsReport => "agent_runs_report",
             Self::MiniResult => "mini_result",
             Self::BenchVarianceReport => "bench_variance_report",
+            Self::ValidationReport => "validation_report",
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -321,6 +321,28 @@ pub struct SuiteCmd {
     pub resume: bool,
 }
 
+/// `agent artifact-check` — zero-cost structural conformance gate for artifact files (issue #534).
+///
+/// Validates one or more artifact files or directories (recursively) against the
+/// Artifact Contract (`docs/artifact-contract.md`). No model call, no network I/O.
+#[derive(Debug, Args)]
+pub struct ArtifactCheckCmd {
+    /// One or more artifact files or directories to validate. Directories are
+    /// scanned recursively for `*.json` files.
+    #[arg(required = true, value_name = "PATH")]
+    pub paths: Vec<std::path::PathBuf>,
+
+    /// Output format: `text` (default human-readable table) or `json`
+    /// (emits a `validation_report` artifact with `schema_version`).
+    #[arg(long, default_value = "text")]
+    pub format: String,
+
+    /// Promote `legacy_unversioned` and `valid_with_warnings` verdicts to
+    /// failures in addition to the always-fatal `invalid` and `unsupported_major`.
+    #[arg(long, default_value_t = false)]
+    pub strict: bool,
+}
+
 /// `agent redact-check` — zero-cost preflight for the secret-redaction config (issue #321).
 #[derive(Debug, Args)]
 pub struct RedactCheckCmd {
@@ -674,6 +696,8 @@ pub enum AgentCmd {
     Runs(AgentRunsCmd),
     /// Audit trajectory files for filesystem accesses outside the workdir (issue #511).
     FsAudit(FsAuditCmd),
+    /// Validate artifact files against the Artifact Contract (zero-cost, no model call).
+    ArtifactCheck(ArtifactCheckCmd),
 }
 
 /// `agent runs` — list and summarize single-task trajectory files (issue #509).

--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -97,6 +97,12 @@ pub fn entries() -> &'static [CatalogEntry] {
             stage: "analyze",
         },
         CatalogEntry {
+            path: "agent artifact-check",
+            summary: "Validate artifact files against the Artifact Contract (zero-cost, no model call)",
+            cost_tier: "free",
+            stage: "preflight",
+        },
+        CatalogEntry {
             path: "agent policy-check",
             summary: "Check a command corpus against the policy config",
             cost_tier: "free",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7030,9 +7030,17 @@ fn agent_fs_audit_cmd(a: &args::FsAuditCmd) -> Result<(), Error> {
 }
 
 fn agent_artifact_check_cmd(a: &args::ArtifactCheckCmd) -> Result<(), Error> {
+    use crate::error::ConfigError;
     use crate::run::artifact_check::{
         ArtifactCheckOpts, ArtifactCheckSource, format_json, format_text, run_artifact_check,
     };
+
+    if a.format != "text" && a.format != "json" {
+        return Err(Error::Config(ConfigError::Usage(format!(
+            "unknown --format value {:?}; expected 'text' or 'json'",
+            a.format
+        ))));
+    }
 
     let opts = ArtifactCheckOpts {
         source: ArtifactCheckSource::Paths(a.paths.clone()),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -160,6 +160,7 @@ pub async fn run() -> Result<(), Error> {
             args::AgentCmd::Profile(p) => agent_profile_cmd(&p),
             args::AgentCmd::Runs(r) => agent_runs_cmd(&r),
             args::AgentCmd::FsAudit(a) => agent_fs_audit_cmd(&a),
+            args::AgentCmd::ArtifactCheck(a) => agent_artifact_check_cmd(&a),
         },
         Command::Catalog(c) => catalog::run_catalog(c),
         Command::Ui(u) => ui_cmd(u).await,
@@ -7025,6 +7026,40 @@ fn agent_fs_audit_cmd(a: &args::FsAuditCmd) -> Result<(), Error> {
     if exit_code != ExitCode::Success {
         exit_with_outcome(exit_code, exit_code.outcome_class());
     }
+    Ok(())
+}
+
+fn agent_artifact_check_cmd(a: &args::ArtifactCheckCmd) -> Result<(), Error> {
+    use crate::run::artifact_check::{
+        ArtifactCheckOpts, ArtifactCheckSource, format_json, format_text, run_artifact_check,
+    };
+
+    let opts = ArtifactCheckOpts {
+        source: ArtifactCheckSource::Paths(a.paths.clone()),
+        strict: a.strict,
+    };
+
+    let output = run_artifact_check(&opts).map_err(|e| {
+        eprintln!("artifact-check: {e}");
+        e
+    })?;
+
+    let content = if a.format == "json" {
+        let json = format_json(&output).map_err(Error::Json)?;
+        serde_json::to_string_pretty(&json).map_err(Error::Json)?
+    } else {
+        format_text(&output)
+    };
+
+    println!("{content}");
+
+    if output.has_failures() {
+        exit_with_outcome(
+            ExitCode::ArtifactCheckFailure,
+            ExitCode::ArtifactCheckFailure.outcome_class(),
+        );
+    }
+
     Ok(())
 }
 

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -202,6 +202,13 @@ pub enum ExitCode {
     /// `usage_error` (2) so CI can tell "the scan broke" from "your invocation is
     /// broken".
     FsAuditScanError = 46,
+    /// 47 — `agent artifact-check` found at least one artifact that is `invalid`
+    /// or `unsupported_major`. With `--strict`, also triggers on
+    /// `legacy_unversioned` and `valid_with_warnings`. Zero model calls are made;
+    /// the check is purely a structural conformance gate. Distinct from
+    /// `internal_error` (1) so CI can route "artifact does not conform to
+    /// contract" separately from an unexpected infrastructure failure.
+    ArtifactCheckFailure = 47,
     /// 130 — user interruption (graceful SIGINT / Ctrl-C; 128 + SIGINT(2)).
     Interrupted = 130,
     /// 137 — forced kill (SIGKILL escalation after graceful-cancel deadline; 128 + SIGKILL(9)).
@@ -269,6 +276,7 @@ impl ExitCode {
             Self::UtilizationGateFailure => "utilization_gate_failure",
             Self::FsAuditFindings => "fs_audit_findings",
             Self::FsAuditScanError => "fs_audit_scan_error",
+            Self::ArtifactCheckFailure => "artifact_check_failure",
             Self::Interrupted => "interrupted",
             Self::Killed => "killed",
         }

--- a/src/run/agent_runs.rs
+++ b/src/run/agent_runs.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::artifact::ArtifactKind;
+use crate::artifact::{ArtifactKind, ArtifactSchemaVersion};
 use crate::error::Error;
 use crate::trajectory::{FailureCategory, Trajectory};
 
@@ -125,12 +125,15 @@ pub struct RunsFooter {
     pub skipped_files: usize,
 }
 
+/// Schema version for `agent_runs_report` artifacts. Using the contract object format
+/// `{major, minor}` so that `agent artifact-check` can validate runs reports correctly.
+const AGENT_RUNS_REPORT_VERSION: ArtifactSchemaVersion = ArtifactSchemaVersion::new(1, 1);
+
 /// The full runs report — JSON artifact shape.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentRunsReport {
     pub artifact_kind: ArtifactKind,
-    /// Runs-report-specific schema version ("1"). Decoupled from the global artifact version.
-    pub schema_version: String,
+    pub schema_version: ArtifactSchemaVersion,
     /// Directory that was scanned (as supplied by the operator).
     pub scanned_dir: String,
     /// Whether subdirectories were traversed.
@@ -182,7 +185,7 @@ pub fn run_agent_runs(opts: &AgentRunsOpts) -> Result<AgentRunsReport, Error> {
 
     Ok(AgentRunsReport {
         artifact_kind: ArtifactKind::AgentRunsReport,
-        schema_version: "1".to_owned(),
+        schema_version: AGENT_RUNS_REPORT_VERSION,
         scanned_dir: canonical_dir.display().to_string(),
         recursive: opts.recursive,
         rows,
@@ -637,7 +640,9 @@ mod tests {
         let json = serde_json::to_string(&report).unwrap();
         let val: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(val["artifact_kind"], "agent_runs_report");
-        assert_eq!(val["schema_version"], "1");
+        // schema_version must be an object {major, minor} per the artifact contract
+        assert_eq!(val["schema_version"]["major"], 1);
+        assert_eq!(val["schema_version"]["minor"], 1);
         assert!(val["rows"].is_array());
     }
 

--- a/src/run/agent_runs.rs
+++ b/src/run/agent_runs.rs
@@ -125,9 +125,10 @@ pub struct RunsFooter {
     pub skipped_files: usize,
 }
 
-/// Schema version for `agent_runs_report` artifacts. Using the contract object format
-/// `{major, minor}` so that `agent artifact-check` can validate runs reports correctly.
-const AGENT_RUNS_REPORT_VERSION: ArtifactSchemaVersion = ArtifactSchemaVersion::new(1, 1);
+/// Schema version for `agent_runs_report` artifacts, kept in sync with the
+/// global current artifact contract version so that freshly emitted reports
+/// pass `agent artifact-check --strict`.
+const AGENT_RUNS_REPORT_VERSION: ArtifactSchemaVersion = ArtifactSchemaVersion::CURRENT;
 
 /// The full runs report — JSON artifact shape.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -640,9 +641,9 @@ mod tests {
         let json = serde_json::to_string(&report).unwrap();
         let val: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(val["artifact_kind"], "agent_runs_report");
-        // schema_version must be an object {major, minor} per the artifact contract
+        // schema_version must be an object {major, minor} matching CURRENT
         assert_eq!(val["schema_version"]["major"], 1);
-        assert_eq!(val["schema_version"]["minor"], 1);
+        assert_eq!(val["schema_version"]["minor"], 11);
         assert!(val["rows"].is_array());
     }
 

--- a/src/run/artifact_check.rs
+++ b/src/run/artifact_check.rs
@@ -1,0 +1,518 @@
+//! `agent artifact-check` — zero-cost structural conformance gate for artifact files.
+//!
+//! Issue #534. Validates one or more artifact files (or directories, recursively)
+//! against the Artifact Contract defined in `docs/artifact-contract.md`. Reports
+//! the resolved `artifact_kind`, `schema_version`, a conformance verdict, and the
+//! specific missing or malformed required fields. No model call is made and no
+//! network I/O is performed.
+
+use std::path::PathBuf;
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::artifact::ArtifactSchemaVersion;
+use crate::error::Error;
+
+/// Schema version for the `validation_report` JSON artifact emitted by this command.
+const ARTIFACT_CHECK_SCHEMA_VERSION: ArtifactSchemaVersion = ArtifactSchemaVersion::new(1, 0);
+
+// ── Source ────────────────────────────────────────────────────────────────────
+
+/// Input source for `agent artifact-check`.
+pub enum ArtifactCheckSource {
+    /// One or more explicit file or directory paths. Directories are scanned
+    /// recursively for `*.json` files.
+    Paths(Vec<PathBuf>),
+}
+
+// ── Verdict ───────────────────────────────────────────────────────────────────
+
+/// Conformance verdict for a single checked artifact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConformanceVerdict {
+    /// All required fields present; `schema_version` is within supported major.
+    Valid,
+    /// All required fields present but `schema_version` is an older supported
+    /// minor (within the same major). Readers warn and may default missing fields.
+    ValidWithWarnings,
+    /// One or more required fields are missing or the header is malformed.
+    Invalid,
+    /// Both `artifact_kind` and `schema_version` are absent; this is a
+    /// pre-versioning legacy artifact. Surfaced as a warning (not hard error)
+    /// under default mode; becomes a failure under `--strict`.
+    LegacyUnversioned,
+    /// `schema_version.major` exceeds the harness-supported major. This is
+    /// always a failure regardless of `--strict`.
+    UnsupportedMajor,
+}
+
+impl ConformanceVerdict {
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Valid => "valid",
+            Self::ValidWithWarnings => "valid_with_warnings",
+            Self::Invalid => "invalid",
+            Self::LegacyUnversioned => "legacy_unversioned",
+            Self::UnsupportedMajor => "unsupported_major",
+        }
+    }
+
+    /// Returns true when this verdict is always a hard failure (regardless of
+    /// `--strict`).
+    #[must_use]
+    pub fn is_hard_failure(&self) -> bool {
+        matches!(self, Self::Invalid | Self::UnsupportedMajor)
+    }
+
+    /// Returns true when this verdict is only a failure under `--strict`.
+    #[must_use]
+    pub fn is_strict_failure(&self) -> bool {
+        matches!(self, Self::LegacyUnversioned | Self::ValidWithWarnings)
+    }
+}
+
+// ── Per-artifact result ───────────────────────────────────────────────────────
+
+/// Validation result for a single artifact file.
+#[derive(Debug, Clone)]
+pub struct ArtifactResult {
+    /// Resolved path to the file.
+    pub path: PathBuf,
+    /// Resolved `artifact_kind` string, or `None` for legacy unversioned artifacts.
+    pub artifact_kind: Option<String>,
+    /// `schema_version` formatted as `"major.minor"`, or `None` for legacy unversioned.
+    pub schema_version: Option<String>,
+    /// Conformance verdict for this artifact.
+    pub verdict: ConformanceVerdict,
+    /// Required fields that are missing or malformed (empty when not `invalid`).
+    pub missing_fields: Vec<String>,
+    /// Human-readable warning messages (e.g., older minor version).
+    pub warnings: Vec<String>,
+}
+
+// ── Options ───────────────────────────────────────────────────────────────────
+
+/// Options passed to [`run_artifact_check`].
+pub struct ArtifactCheckOpts {
+    /// Where to read artifacts from.
+    pub source: ArtifactCheckSource,
+    /// When true, `legacy_unversioned` and `valid_with_warnings` are treated as
+    /// failures in addition to `invalid` and `unsupported_major`.
+    pub strict: bool,
+}
+
+// ── Output ────────────────────────────────────────────────────────────────────
+
+/// The output of an `artifact-check` run.
+pub struct ArtifactCheckOutput {
+    /// Per-artifact validation results.
+    pub results: Vec<ArtifactResult>,
+    /// Whether `--strict` mode was active.
+    pub strict: bool,
+}
+
+impl ArtifactCheckOutput {
+    /// Returns true when any result counts as a failure (given the `strict` flag).
+    #[must_use]
+    pub fn has_failures(&self) -> bool {
+        self.results.iter().any(|r| {
+            r.verdict.is_hard_failure() || (self.strict && r.verdict.is_strict_failure())
+        })
+    }
+
+    /// Counts by verdict.
+    #[must_use]
+    pub fn verdict_counts(&self) -> VerdictCounts {
+        let mut counts = VerdictCounts::default();
+        for r in &self.results {
+            match r.verdict {
+                ConformanceVerdict::Valid => counts.valid += 1,
+                ConformanceVerdict::ValidWithWarnings => counts.valid_with_warnings += 1,
+                ConformanceVerdict::Invalid => counts.invalid += 1,
+                ConformanceVerdict::LegacyUnversioned => counts.legacy_unversioned += 1,
+                ConformanceVerdict::UnsupportedMajor => counts.unsupported_major += 1,
+            }
+        }
+        counts
+    }
+}
+
+/// Summary counts by verdict.
+#[derive(Debug, Default, Serialize)]
+pub struct VerdictCounts {
+    pub valid: usize,
+    pub valid_with_warnings: usize,
+    pub invalid: usize,
+    pub legacy_unversioned: usize,
+    pub unsupported_major: usize,
+}
+
+// ── Core function ─────────────────────────────────────────────────────────────
+
+/// Validate each artifact file described by `opts` against the Artifact Contract.
+///
+/// No model calls, no network I/O. Files in directories are discovered
+/// recursively.
+///
+/// # Errors
+/// Returns `Err` only on unrecoverable I/O errors (e.g., the specified path
+/// does not exist). Individual per-file parse failures are returned as
+/// `ConformanceVerdict::Invalid` rather than propagating as `Err`.
+pub fn run_artifact_check(opts: &ArtifactCheckOpts) -> Result<ArtifactCheckOutput, Error> {
+    let paths = collect_paths(&opts.source)?;
+    let mut results = Vec::with_capacity(paths.len());
+    for path in paths {
+        results.push(validate_file(&path));
+    }
+    Ok(ArtifactCheckOutput {
+        results,
+        strict: opts.strict,
+    })
+}
+
+// ── Path collection ───────────────────────────────────────────────────────────
+
+fn collect_paths(source: &ArtifactCheckSource) -> Result<Vec<PathBuf>, Error> {
+    let ArtifactCheckSource::Paths(input_paths) = source;
+    let mut out = Vec::new();
+    for path in input_paths {
+        if path.is_dir() {
+            collect_json_recursive(path, &mut out);
+        } else {
+            out.push(path.clone());
+        }
+    }
+    Ok(out)
+}
+
+fn collect_json_recursive(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.filter_map(|e| e.ok()).collect();
+    entries.sort_by_key(|e| e.file_name());
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_json_recursive(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("json") {
+            out.push(path);
+        }
+    }
+}
+
+// ── File validation ───────────────────────────────────────────────────────────
+
+fn validate_file(path: &std::path::Path) -> ArtifactResult {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            return ArtifactResult {
+                path: path.to_owned(),
+                artifact_kind: None,
+                schema_version: None,
+                verdict: ConformanceVerdict::Invalid,
+                missing_fields: vec![],
+                warnings: vec![format!("cannot read file: {e}")],
+            };
+        }
+    };
+
+    let value: Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            return ArtifactResult {
+                path: path.to_owned(),
+                artifact_kind: None,
+                schema_version: None,
+                verdict: ConformanceVerdict::Invalid,
+                missing_fields: vec![],
+                warnings: vec![format!("JSON parse error: {e}")],
+            };
+        }
+    };
+
+    validate_value(path, &value)
+}
+
+fn validate_value(path: &std::path::Path, value: &Value) -> ArtifactResult {
+    let kind_val = value.get("artifact_kind");
+    let version_val = value.get("schema_version");
+
+    // Legacy: both absent → legacy_unversioned
+    if kind_val.is_none() && version_val.is_none() {
+        return ArtifactResult {
+            path: path.to_owned(),
+            artifact_kind: None,
+            schema_version: None,
+            verdict: ConformanceVerdict::LegacyUnversioned,
+            missing_fields: vec![],
+            warnings: vec![
+                "pre-versioning legacy artifact: artifact_kind and schema_version absent".into(),
+            ],
+        };
+    }
+
+    // One present but not the other → invalid header
+    let (Some(kind_val), Some(version_val)) = (kind_val, version_val) else {
+        return ArtifactResult {
+            path: path.to_owned(),
+            artifact_kind: None,
+            schema_version: None,
+            verdict: ConformanceVerdict::Invalid,
+            missing_fields: vec![],
+            warnings: vec![
+                "artifact_kind and schema_version must both be present or both absent".into(),
+            ],
+        };
+    };
+
+    // Parse artifact_kind
+    let kind_str = match kind_val.as_str() {
+        Some(s) => s.to_owned(),
+        None => {
+            return ArtifactResult {
+                path: path.to_owned(),
+                artifact_kind: None,
+                schema_version: None,
+                verdict: ConformanceVerdict::Invalid,
+                missing_fields: vec![],
+                warnings: vec!["artifact_kind must be a string".into()],
+            };
+        }
+    };
+
+    // Parse schema_version
+    let version: ArtifactSchemaVersion = match serde_json::from_value(version_val.clone()) {
+        Ok(v) => v,
+        Err(e) => {
+            return ArtifactResult {
+                path: path.to_owned(),
+                artifact_kind: Some(kind_str),
+                schema_version: None,
+                verdict: ConformanceVerdict::Invalid,
+                missing_fields: vec![],
+                warnings: vec![format!("schema_version malformed: {e}")],
+            };
+        }
+    };
+
+    let version_str = version.to_string();
+
+    // Check for unsupported future major
+    if version.major > ArtifactSchemaVersion::CURRENT.major {
+        return ArtifactResult {
+            path: path.to_owned(),
+            artifact_kind: Some(kind_str),
+            schema_version: Some(version_str),
+            verdict: ConformanceVerdict::UnsupportedMajor,
+            missing_fields: vec![],
+            warnings: vec![format!(
+                "schema_version.major {} exceeds supported major {}",
+                version.major,
+                ArtifactSchemaVersion::CURRENT.major
+            )],
+        };
+    }
+
+    // Determine if this is a legacy minor (older minor within same major)
+    let is_older_minor = version.major == ArtifactSchemaVersion::CURRENT.major
+        && version.minor < ArtifactSchemaVersion::CURRENT.minor;
+
+    // Check required fields for this kind
+    let required = required_fields_for_kind(&kind_str);
+    let mut missing_fields: Vec<String> = required
+        .iter()
+        .filter(|f| value.get(f).is_none())
+        .map(|f| (*f).to_owned())
+        .collect();
+
+    if !missing_fields.is_empty() {
+        missing_fields.sort();
+        return ArtifactResult {
+            path: path.to_owned(),
+            artifact_kind: Some(kind_str),
+            schema_version: Some(version_str),
+            verdict: ConformanceVerdict::Invalid,
+            missing_fields,
+            warnings: vec![],
+        };
+    }
+
+    let mut warnings = Vec::new();
+    let verdict = if is_older_minor {
+        warnings.push(format!(
+            "schema_version {version_str} is an older minor than current {}; readers may default missing fields",
+            ArtifactSchemaVersion::CURRENT
+        ));
+        ConformanceVerdict::ValidWithWarnings
+    } else {
+        ConformanceVerdict::Valid
+    };
+
+    ArtifactResult {
+        path: path.to_owned(),
+        artifact_kind: Some(kind_str),
+        schema_version: Some(version_str),
+        verdict,
+        missing_fields: vec![],
+        warnings,
+    }
+}
+
+/// Returns the required payload fields (beyond the standard header) for a given
+/// artifact kind string, as enumerated in `docs/artifact-contract.md`.
+///
+/// Unknown kinds get no additional required fields — the header check is still
+/// applied. Unknown additive fields within major 1 are intentionally ignored per
+/// the contract reader policy.
+fn required_fields_for_kind(kind: &str) -> &'static [&'static str] {
+    match kind {
+        "trajectory" => &["trajectory_format", "info", "messages"],
+        "sweep_results" => &[
+            "total",
+            "submitted",
+            "skipped",
+            "errored",
+            "failures_by_category",
+            "instances",
+        ],
+        "evaluation_results" => &["instances"],
+        "forecast_report" => &[
+            "calibration",
+            "per_instance",
+            "forecast",
+            "resolution_rate",
+            "threshold",
+        ],
+        "calibration_report" => &[
+            "forecast_path",
+            "results_path",
+            "verdict",
+            "comparability",
+            "metrics",
+            "per_instance",
+        ],
+        "preflight_report" => &["mode", "checks"],
+        "swebench_predictions_metadata" => &[
+            "predictions_file",
+            "aggregate",
+            "row_count",
+            "swebench_evaluator_compatible",
+        ],
+        "bundle_manifest" => &[
+            "source_sweep_dir",
+            "source_manifest_hash",
+            "harness_git_sha",
+            "bundle_generated_at",
+            "instance_scope",
+            "files",
+        ],
+        "cache_stats_report" => &[
+            "sweep",
+            "generated_at",
+            "cache_disabled",
+            "sweep_totals",
+            "instances",
+        ],
+        _ => &[],
+    }
+}
+
+// ── Formatters ────────────────────────────────────────────────────────────────
+
+/// Format as a human-readable table summarising counts by verdict and listing
+/// each artifact with its verdict and any issues.
+#[must_use]
+pub fn format_text(output: &ArtifactCheckOutput) -> String {
+    use std::fmt::Write as _;
+
+    let counts = output.verdict_counts();
+    let total = output.results.len();
+    let mut out = String::new();
+
+    let _ = writeln!(
+        out,
+        "artifact-check: {total} artifact(s) — valid: {}, valid_with_warnings: {}, invalid: {}, legacy_unversioned: {}, unsupported_major: {}",
+        counts.valid,
+        counts.valid_with_warnings,
+        counts.invalid,
+        counts.legacy_unversioned,
+        counts.unsupported_major,
+    );
+
+    if total == 0 {
+        return out;
+    }
+
+    out.push('\n');
+    let _ = writeln!(out, "{:<60}  {:<24}  {:<12}  {:<14}  issues", "path", "artifact_kind", "schema_version", "verdict");
+    let _ = writeln!(out, "{:-<60}  {:-<24}  {:-<12}  {:-<14}  ------", "", "", "", "");
+
+    for r in &output.results {
+        let path_str = r.path.display().to_string();
+        let kind_str = r.artifact_kind.as_deref().unwrap_or("(unknown)");
+        let ver_str = r.schema_version.as_deref().unwrap_or("(none)");
+        let issues = if r.missing_fields.is_empty() {
+            if r.warnings.is_empty() {
+                String::new()
+            } else {
+                r.warnings.join("; ")
+            }
+        } else {
+            format!("missing: {}", r.missing_fields.join(", "))
+        };
+        let _ = writeln!(
+            out,
+            "{:<60}  {:<24}  {:<12}  {:<14}  {}",
+            path_str,
+            kind_str,
+            ver_str,
+            r.verdict.as_str(),
+            issues,
+        );
+    }
+
+    out
+}
+
+/// Format as a schema-versioned JSON `validation_report` artifact.
+///
+/// # Errors
+/// Returns a [`serde_json::Error`] if serialisation fails (should not happen
+/// for well-formed inputs).
+pub fn format_json(output: &ArtifactCheckOutput) -> Result<serde_json::Value, serde_json::Error> {
+    let counts = output.verdict_counts();
+
+    let results: Vec<serde_json::Value> = output
+        .results
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "path": r.path.display().to_string(),
+                "artifact_kind": r.artifact_kind,
+                "schema_version": r.schema_version,
+                "verdict": r.verdict.as_str(),
+                "missing_fields": r.missing_fields,
+                "warnings": r.warnings,
+            })
+        })
+        .collect();
+
+    Ok(serde_json::json!({
+        "artifact_kind": "validation_report",
+        "schema_version": ARTIFACT_CHECK_SCHEMA_VERSION.to_string(),
+        "summary": {
+            "total": output.results.len(),
+            "valid": counts.valid,
+            "valid_with_warnings": counts.valid_with_warnings,
+            "invalid": counts.invalid,
+            "legacy_unversioned": counts.legacy_unversioned,
+            "unsupported_major": counts.unsupported_major,
+        },
+        "results": results,
+    }))
+}

--- a/src/run/artifact_check.rs
+++ b/src/run/artifact_check.rs
@@ -118,9 +118,9 @@ impl ArtifactCheckOutput {
     /// Returns true when any result counts as a failure (given the `strict` flag).
     #[must_use]
     pub fn has_failures(&self) -> bool {
-        self.results.iter().any(|r| {
-            r.verdict.is_hard_failure() || (self.strict && r.verdict.is_strict_failure())
-        })
+        self.results
+            .iter()
+            .any(|r| r.verdict.is_hard_failure() || (self.strict && r.verdict.is_strict_failure()))
     }
 
     /// Counts by verdict.
@@ -162,7 +162,7 @@ pub struct VerdictCounts {
 /// does not exist). Individual per-file parse failures are returned as
 /// `ConformanceVerdict::Invalid` rather than propagating as `Err`.
 pub fn run_artifact_check(opts: &ArtifactCheckOpts) -> Result<ArtifactCheckOutput, Error> {
-    let paths = collect_paths(&opts.source)?;
+    let paths = collect_paths(&opts.source);
     let mut results = Vec::with_capacity(paths.len());
     for path in paths {
         results.push(validate_file(&path));
@@ -175,7 +175,7 @@ pub fn run_artifact_check(opts: &ArtifactCheckOpts) -> Result<ArtifactCheckOutpu
 
 // ── Path collection ───────────────────────────────────────────────────────────
 
-fn collect_paths(source: &ArtifactCheckSource) -> Result<Vec<PathBuf>, Error> {
+fn collect_paths(source: &ArtifactCheckSource) -> Vec<PathBuf> {
     let ArtifactCheckSource::Paths(input_paths) = source;
     let mut out = Vec::new();
     for path in input_paths {
@@ -185,20 +185,23 @@ fn collect_paths(source: &ArtifactCheckSource) -> Result<Vec<PathBuf>, Error> {
             out.push(path.clone());
         }
     }
-    Ok(out)
+    out
 }
 
 fn collect_json_recursive(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
-    let mut entries: Vec<_> = entries.filter_map(|e| e.ok()).collect();
-    entries.sort_by_key(|e| e.file_name());
+    let mut entries: Vec<_> = entries.filter_map(Result::ok).collect();
+    entries.sort_by_key(std::fs::DirEntry::file_name);
     for entry in entries {
+        // Use file_type() (does not follow symlinks) to avoid infinite recursion
+        // if the directory tree contains symlink cycles.
+        let Ok(ft) = entry.file_type() else { continue };
         let path = entry.path();
-        if path.is_dir() {
+        if ft.is_dir() {
             collect_json_recursive(&path, out);
-        } else if path.extension().and_then(|e| e.to_str()) == Some("json") {
+        } else if ft.is_file() && path.extension().and_then(|e| e.to_str()) == Some("json") {
             out.push(path);
         }
     }
@@ -238,13 +241,20 @@ fn validate_file(path: &std::path::Path) -> ArtifactResult {
     validate_value(path, &value)
 }
 
-fn validate_value(path: &std::path::Path, value: &Value) -> ArtifactResult {
+/// Parsed artifact header extracted from a JSON value.
+struct ParsedHeader {
+    kind_str: String,
+    version: ArtifactSchemaVersion,
+}
+
+/// Parse the artifact header fields, returning `Ok(ParsedHeader)` or an
+/// early `ArtifactResult` that should be returned directly.
+fn parse_header(path: &std::path::Path, value: &Value) -> Result<ParsedHeader, ArtifactResult> {
     let kind_val = value.get("artifact_kind");
     let version_val = value.get("schema_version");
 
-    // Legacy: both absent → legacy_unversioned
     if kind_val.is_none() && version_val.is_none() {
-        return ArtifactResult {
+        return Err(ArtifactResult {
             path: path.to_owned(),
             artifact_kind: None,
             schema_version: None,
@@ -253,12 +263,11 @@ fn validate_value(path: &std::path::Path, value: &Value) -> ArtifactResult {
             warnings: vec![
                 "pre-versioning legacy artifact: artifact_kind and schema_version absent".into(),
             ],
-        };
+        });
     }
 
-    // One present but not the other → invalid header
     let (Some(kind_val), Some(version_val)) = (kind_val, version_val) else {
-        return ArtifactResult {
+        return Err(ArtifactResult {
             path: path.to_owned(),
             artifact_kind: None,
             schema_version: None,
@@ -267,42 +276,41 @@ fn validate_value(path: &std::path::Path, value: &Value) -> ArtifactResult {
             warnings: vec![
                 "artifact_kind and schema_version must both be present or both absent".into(),
             ],
-        };
+        });
     };
 
-    // Parse artifact_kind
-    let kind_str = match kind_val.as_str() {
-        Some(s) => s.to_owned(),
-        None => {
-            return ArtifactResult {
-                path: path.to_owned(),
-                artifact_kind: None,
-                schema_version: None,
-                verdict: ConformanceVerdict::Invalid,
-                missing_fields: vec![],
-                warnings: vec!["artifact_kind must be a string".into()],
-            };
-        }
+    let Some(kind_str) = kind_val.as_str().map(str::to_owned) else {
+        return Err(ArtifactResult {
+            path: path.to_owned(),
+            artifact_kind: None,
+            schema_version: None,
+            verdict: ConformanceVerdict::Invalid,
+            missing_fields: vec![],
+            warnings: vec!["artifact_kind must be a string".into()],
+        });
     };
 
-    // Parse schema_version
-    let version: ArtifactSchemaVersion = match serde_json::from_value(version_val.clone()) {
-        Ok(v) => v,
-        Err(e) => {
-            return ArtifactResult {
-                path: path.to_owned(),
-                artifact_kind: Some(kind_str),
-                schema_version: None,
-                verdict: ConformanceVerdict::Invalid,
-                missing_fields: vec![],
-                warnings: vec![format!("schema_version malformed: {e}")],
-            };
-        }
+    match serde_json::from_value(version_val.clone()) {
+        Ok(version) => Ok(ParsedHeader { kind_str, version }),
+        Err(e) => Err(ArtifactResult {
+            path: path.to_owned(),
+            artifact_kind: Some(kind_str),
+            schema_version: None,
+            verdict: ConformanceVerdict::Invalid,
+            missing_fields: vec![],
+            warnings: vec![format!("schema_version malformed: {e}")],
+        }),
+    }
+}
+
+fn validate_value(path: &std::path::Path, value: &Value) -> ArtifactResult {
+    let ParsedHeader { kind_str, version } = match parse_header(path, value) {
+        Ok(h) => h,
+        Err(early) => return early,
     };
 
     let version_str = version.to_string();
 
-    // Check for unsupported future major
     if version.major > ArtifactSchemaVersion::CURRENT.major {
         return ArtifactResult {
             path: path.to_owned(),
@@ -318,11 +326,9 @@ fn validate_value(path: &std::path::Path, value: &Value) -> ArtifactResult {
         };
     }
 
-    // Determine if this is a legacy minor (older minor within same major)
     let is_older_minor = version.major == ArtifactSchemaVersion::CURRENT.major
         && version.minor < ArtifactSchemaVersion::CURRENT.minor;
 
-    // Check required fields for this kind
     let required = required_fields_for_kind(&kind_str);
     let mut missing_fields: Vec<String> = required
         .iter()
@@ -449,8 +455,16 @@ pub fn format_text(output: &ArtifactCheckOutput) -> String {
     }
 
     out.push('\n');
-    let _ = writeln!(out, "{:<60}  {:<24}  {:<12}  {:<14}  issues", "path", "artifact_kind", "schema_version", "verdict");
-    let _ = writeln!(out, "{:-<60}  {:-<24}  {:-<12}  {:-<14}  ------", "", "", "", "");
+    let _ = writeln!(
+        out,
+        "{:<60}  {:<24}  {:<12}  {:<14}  issues",
+        "path", "artifact_kind", "schema_version", "verdict"
+    );
+    let _ = writeln!(
+        out,
+        "{:-<60}  {:-<24}  {:-<12}  {:-<14}  ------",
+        "", "", "", ""
+    );
 
     for r in &output.results {
         let path_str = r.path.display().to_string();
@@ -504,7 +518,7 @@ pub fn format_json(output: &ArtifactCheckOutput) -> Result<serde_json::Value, se
 
     Ok(serde_json::json!({
         "artifact_kind": "validation_report",
-        "schema_version": ARTIFACT_CHECK_SCHEMA_VERSION.to_string(),
+        "schema_version": ARTIFACT_CHECK_SCHEMA_VERSION,
         "summary": {
             "total": output.results.len(),
             "valid": counts.valid,

--- a/src/run/artifact_check.rs
+++ b/src/run/artifact_check.rs
@@ -162,8 +162,18 @@ pub struct VerdictCounts {
 /// does not exist). Individual per-file parse failures are returned as
 /// `ConformanceVerdict::Invalid` rather than propagating as `Err`.
 pub fn run_artifact_check(opts: &ArtifactCheckOpts) -> Result<ArtifactCheckOutput, Error> {
-    let paths = collect_paths(&opts.source);
-    let mut results = Vec::with_capacity(paths.len());
+    let (paths, dir_errors) = collect_paths(&opts.source);
+    let mut results = Vec::with_capacity(paths.len() + dir_errors.len());
+    for (dir_path, msg) in dir_errors {
+        results.push(ArtifactResult {
+            path: dir_path,
+            artifact_kind: None,
+            schema_version: None,
+            verdict: ConformanceVerdict::Invalid,
+            missing_fields: vec![],
+            warnings: vec![msg],
+        });
+    }
     for path in paths {
         results.push(validate_file(&path));
     }
@@ -175,22 +185,31 @@ pub fn run_artifact_check(opts: &ArtifactCheckOpts) -> Result<ArtifactCheckOutpu
 
 // ── Path collection ───────────────────────────────────────────────────────────
 
-fn collect_paths(source: &ArtifactCheckSource) -> Vec<PathBuf> {
+fn collect_paths(source: &ArtifactCheckSource) -> (Vec<PathBuf>, Vec<(PathBuf, String)>) {
     let ArtifactCheckSource::Paths(input_paths) = source;
     let mut out = Vec::new();
+    let mut errors = Vec::new();
     for path in input_paths {
         if path.is_dir() {
-            collect_json_recursive(path, &mut out);
+            collect_json_recursive(path, &mut out, &mut errors);
         } else {
             out.push(path.clone());
         }
     }
-    out
+    (out, errors)
 }
 
-fn collect_json_recursive(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
+fn collect_json_recursive(
+    dir: &std::path::Path,
+    out: &mut Vec<PathBuf>,
+    errors: &mut Vec<(PathBuf, String)>,
+) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            errors.push((dir.to_owned(), format!("cannot read directory: {e}")));
+            return;
+        }
     };
     let mut entries: Vec<_> = entries.filter_map(Result::ok).collect();
     entries.sort_by_key(std::fs::DirEntry::file_name);
@@ -200,7 +219,7 @@ fn collect_json_recursive(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
         let Ok(ft) = entry.file_type() else { continue };
         let path = entry.path();
         if ft.is_dir() {
-            collect_json_recursive(&path, out);
+            collect_json_recursive(&path, out, errors);
         } else if ft.is_file() && path.extension().and_then(|e| e.to_str()) == Some("json") {
             out.push(path);
         }
@@ -249,12 +268,29 @@ struct ParsedHeader {
 
 /// Parse the artifact header fields, returning `Ok(ParsedHeader)` or an
 /// early `ArtifactResult` that should be returned directly.
-fn parse_header(path: &std::path::Path, value: &Value) -> Result<ParsedHeader, ArtifactResult> {
+///
+/// The `Err` variant is boxed to keep the `Result` size in check (clippy
+/// `result_large_err`).
+fn parse_header(
+    path: &std::path::Path,
+    value: &Value,
+) -> Result<ParsedHeader, Box<ArtifactResult>> {
+    if !value.is_object() {
+        return Err(Box::new(ArtifactResult {
+            path: path.to_owned(),
+            artifact_kind: None,
+            schema_version: None,
+            verdict: ConformanceVerdict::Invalid,
+            missing_fields: vec![],
+            warnings: vec!["JSON value is not an object".into()],
+        }));
+    }
+
     let kind_val = value.get("artifact_kind");
     let version_val = value.get("schema_version");
 
     if kind_val.is_none() && version_val.is_none() {
-        return Err(ArtifactResult {
+        return Err(Box::new(ArtifactResult {
             path: path.to_owned(),
             artifact_kind: None,
             schema_version: None,
@@ -263,11 +299,11 @@ fn parse_header(path: &std::path::Path, value: &Value) -> Result<ParsedHeader, A
             warnings: vec![
                 "pre-versioning legacy artifact: artifact_kind and schema_version absent".into(),
             ],
-        });
+        }));
     }
 
     let (Some(kind_val), Some(version_val)) = (kind_val, version_val) else {
-        return Err(ArtifactResult {
+        return Err(Box::new(ArtifactResult {
             path: path.to_owned(),
             artifact_kind: None,
             schema_version: None,
@@ -276,37 +312,37 @@ fn parse_header(path: &std::path::Path, value: &Value) -> Result<ParsedHeader, A
             warnings: vec![
                 "artifact_kind and schema_version must both be present or both absent".into(),
             ],
-        });
+        }));
     };
 
     let Some(kind_str) = kind_val.as_str().map(str::to_owned) else {
-        return Err(ArtifactResult {
+        return Err(Box::new(ArtifactResult {
             path: path.to_owned(),
             artifact_kind: None,
             schema_version: None,
             verdict: ConformanceVerdict::Invalid,
             missing_fields: vec![],
             warnings: vec!["artifact_kind must be a string".into()],
-        });
+        }));
     };
 
     match serde_json::from_value(version_val.clone()) {
         Ok(version) => Ok(ParsedHeader { kind_str, version }),
-        Err(e) => Err(ArtifactResult {
+        Err(e) => Err(Box::new(ArtifactResult {
             path: path.to_owned(),
             artifact_kind: Some(kind_str),
             schema_version: None,
             verdict: ConformanceVerdict::Invalid,
             missing_fields: vec![],
             warnings: vec![format!("schema_version malformed: {e}")],
-        }),
+        })),
     }
 }
 
 fn validate_value(path: &std::path::Path, value: &Value) -> ArtifactResult {
     let ParsedHeader { kind_str, version } = match parse_header(path, value) {
         Ok(h) => h,
-        Err(early) => return early,
+        Err(early) => return *early,
     };
 
     let version_str = version.to_string();
@@ -326,8 +362,9 @@ fn validate_value(path: &std::path::Path, value: &Value) -> ArtifactResult {
         };
     }
 
-    let is_older_minor = version.major == ArtifactSchemaVersion::CURRENT.major
-        && version.minor < ArtifactSchemaVersion::CURRENT.minor;
+    let current = ArtifactSchemaVersion::CURRENT;
+    let is_older_minor = version.major == current.major && version.minor < current.minor;
+    let is_newer_minor = version.major == current.major && version.minor > current.minor;
 
     let required = required_fields_for_kind(&kind_str);
     let mut missing_fields: Vec<String> = required
@@ -351,8 +388,12 @@ fn validate_value(path: &std::path::Path, value: &Value) -> ArtifactResult {
     let mut warnings = Vec::new();
     let verdict = if is_older_minor {
         warnings.push(format!(
-            "schema_version {version_str} is an older minor than current {}; readers may default missing fields",
-            ArtifactSchemaVersion::CURRENT
+            "schema_version {version_str} is an older minor than current {current}; readers may default missing fields",
+        ));
+        ConformanceVerdict::ValidWithWarnings
+    } else if is_newer_minor {
+        warnings.push(format!(
+            "schema_version {version_str} is a newer minor than current {current}; this harness version may not know all fields",
         ));
         ConformanceVerdict::ValidWithWarnings
     } else {

--- a/src/run/artifact_check.rs
+++ b/src/run/artifact_check.rs
@@ -12,10 +12,11 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::artifact::ArtifactSchemaVersion;
-use crate::error::Error;
+use crate::error::{ConfigError, Error};
 
 /// Schema version for the `validation_report` JSON artifact emitted by this command.
-const ARTIFACT_CHECK_SCHEMA_VERSION: ArtifactSchemaVersion = ArtifactSchemaVersion::new(1, 0);
+/// Must match the current contract version so generated reports pass --strict gates.
+const ARTIFACT_CHECK_SCHEMA_VERSION: ArtifactSchemaVersion = ArtifactSchemaVersion::CURRENT;
 
 // ── Source ────────────────────────────────────────────────────────────────────
 
@@ -162,6 +163,20 @@ pub struct VerdictCounts {
 /// does not exist). Individual per-file parse failures are returned as
 /// `ConformanceVerdict::Invalid` rather than propagating as `Err`.
 pub fn run_artifact_check(opts: &ArtifactCheckOpts) -> Result<ArtifactCheckOutput, Error> {
+    // Explicit paths that do not exist are a usage error (exit 2), not a
+    // validation failure (exit 47).  Discovered paths from directory scans
+    // are treated differently: if the file disappears between scan and read,
+    // validate_file returns Invalid rather than aborting the whole run.
+    let ArtifactCheckSource::Paths(input_paths) = &opts.source;
+    for path in input_paths {
+        if !path.exists() {
+            return Err(Error::Config(ConfigError::Usage(format!(
+                "input path does not exist: {}",
+                path.display()
+            ))));
+        }
+    }
+
     let (paths, dir_errors) = collect_paths(&opts.source);
     let mut results = Vec::with_capacity(paths.len() + dir_errors.len());
     for (dir_path, msg) in dir_errors {
@@ -363,13 +378,17 @@ fn validate_value(path: &std::path::Path, value: &Value) -> ArtifactResult {
     }
 
     let current = ArtifactSchemaVersion::CURRENT;
+    let is_older_major = version.major < current.major;
     let is_older_minor = version.major == current.major && version.minor < current.minor;
     let is_newer_minor = version.major == current.major && version.minor > current.minor;
 
     let required = required_fields_for_kind(&kind_str);
+    // A field whose value is JSON null is treated as absent: downstream readers
+    // that deserialize into typed structs will reject null just as they reject a
+    // missing key, so certifying it as valid would be misleading.
     let mut missing_fields: Vec<String> = required
         .iter()
-        .filter(|f| value.get(f).is_none())
+        .filter(|f| value.get(f).is_none_or(Value::is_null))
         .map(|f| (*f).to_owned())
         .collect();
 
@@ -386,7 +405,12 @@ fn validate_value(path: &std::path::Path, value: &Value) -> ArtifactResult {
     }
 
     let mut warnings = Vec::new();
-    let verdict = if is_older_minor {
+    let verdict = if is_older_major {
+        warnings.push(format!(
+            "schema_version {version_str} has a lower major than current {current}; treated as supported-legacy",
+        ));
+        ConformanceVerdict::ValidWithWarnings
+    } else if is_older_minor {
         warnings.push(format!(
             "schema_version {version_str} is an older minor than current {current}; readers may default missing fields",
         ));

--- a/src/run/artifact_check.rs
+++ b/src/run/artifact_check.rs
@@ -163,15 +163,22 @@ pub struct VerdictCounts {
 /// does not exist). Individual per-file parse failures are returned as
 /// `ConformanceVerdict::Invalid` rather than propagating as `Err`.
 pub fn run_artifact_check(opts: &ArtifactCheckOpts) -> Result<ArtifactCheckOutput, Error> {
-    // Explicit paths that do not exist are a usage error (exit 2), not a
-    // validation failure (exit 47).  Discovered paths from directory scans
-    // are treated differently: if the file disappears between scan and read,
-    // validate_file returns Invalid rather than aborting the whole run.
+    // Validate explicit paths before scanning.  Non-existent paths and
+    // special files (FIFOs, device nodes) are usage errors (exit 2).
+    // Discovered paths from directory scans are treated differently: if a
+    // file disappears between scan and read, validate_file returns Invalid
+    // rather than aborting the whole run.
     let ArtifactCheckSource::Paths(input_paths) = &opts.source;
     for path in input_paths {
         if !path.exists() {
             return Err(Error::Config(ConfigError::Usage(format!(
                 "input path does not exist: {}",
+                path.display()
+            ))));
+        }
+        if !path.is_dir() && !path.is_file() {
+            return Err(Error::Config(ConfigError::Usage(format!(
+                "input path is not a regular file or directory: {}",
                 path.display()
             ))));
         }
@@ -226,12 +233,26 @@ fn collect_json_recursive(
             return;
         }
     };
-    let mut entries: Vec<_> = entries.filter_map(Result::ok).collect();
+    let mut entries: Vec<_> = entries
+        .filter_map(|res| match res {
+            Ok(e) => Some(e),
+            Err(e) => {
+                errors.push((dir.to_owned(), format!("directory entry error: {e}")));
+                None
+            }
+        })
+        .collect();
     entries.sort_by_key(std::fs::DirEntry::file_name);
     for entry in entries {
         // Use file_type() (does not follow symlinks) to avoid infinite recursion
         // if the directory tree contains symlink cycles.
-        let Ok(ft) = entry.file_type() else { continue };
+        let ft = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(e) => {
+                errors.push((entry.path(), format!("cannot read file type: {e}")));
+                continue;
+            }
+        };
         let path = entry.path();
         if ft.is_dir() {
             collect_json_recursive(&path, out, errors);

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -3,9 +3,9 @@
 
 pub mod agent_profile;
 pub mod agent_runs;
-pub mod artifact_check;
 pub mod annotate;
 pub mod apply;
+pub mod artifact_check;
 pub mod assert;
 pub mod audit;
 pub mod behavior;

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod agent_profile;
 pub mod agent_runs;
+pub mod artifact_check;
 pub mod annotate;
 pub mod apply;
 pub mod assert;

--- a/src/run/policy_check.rs
+++ b/src/run/policy_check.rs
@@ -14,8 +14,10 @@ use crate::config::Config;
 use crate::error::{ConfigError, Error};
 use crate::policy::{PolicyEngine, PolicyEvaluation};
 
-/// Schema version for the `policy-check` JSON artifact.
-const POLICY_CHECK_SCHEMA_VERSION: ArtifactSchemaVersion = ArtifactSchemaVersion::new(1, 0);
+/// Schema version for the `policy-check` JSON artifact, kept in sync with the
+/// global current artifact contract version so that saved reports pass
+/// `agent artifact-check --strict`.
+const POLICY_CHECK_SCHEMA_VERSION: ArtifactSchemaVersion = ArtifactSchemaVersion::CURRENT;
 
 // ── Input source ──────────────────────────────────────────────────────────────
 
@@ -357,7 +359,7 @@ pub fn format_json(output: &PolicyCheckOutput) -> Result<serde_json::Value, serd
 
     Ok(serde_json::json!({
         "artifact_kind": "policy_check",
-        "schema_version": POLICY_CHECK_SCHEMA_VERSION.to_string(),
+        "schema_version": POLICY_CHECK_SCHEMA_VERSION,
         "profile": output.profile,
         "verdicts": verdicts,
         "mismatches": mismatches,

--- a/tests/agent_artifact_check.rs
+++ b/tests/agent_artifact_check.rs
@@ -3,6 +3,8 @@
 //! `src/run/artifact_check.rs` is created and wired up.
 #![allow(clippy::unwrap_used)]
 
+use std::path::PathBuf;
+
 use maxwells_daemon::run::artifact_check::{
     ArtifactCheckOpts, ArtifactCheckSource, ConformanceVerdict, format_json, format_text,
     run_artifact_check,
@@ -648,6 +650,93 @@ fn multiple_paths_all_validated() {
             .results
             .iter()
             .all(|r| r.verdict == ConformanceVerdict::Valid)
+    );
+}
+
+// ── JSON format schema_version is current ────────────────────────────────────
+
+#[test]
+fn json_format_schema_version_matches_current() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 },
+        "trajectory_format": "mini-swe-agent-1.2",
+        "info": {},
+        "messages": []
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    let val = format_json(&output).unwrap();
+    let minor = val
+        .get("schema_version")
+        .and_then(|sv| sv.get("minor"))
+        .and_then(serde_json::Value::as_u64);
+    assert_eq!(
+        minor,
+        Some(11),
+        "validation_report schema_version.minor must match CURRENT (11) so --strict re-checks pass"
+    );
+}
+
+// ── Older major returns valid_with_warnings ───────────────────────────────────
+
+#[test]
+fn older_major_version_returns_valid_with_warnings() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 0, "minor": 1 },
+        "trajectory_format": "old-format",
+        "info": {},
+        "messages": []
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(
+        output.results[0].verdict,
+        ConformanceVerdict::ValidWithWarnings,
+        "lower major must produce valid_with_warnings, not valid"
+    );
+}
+
+// ── Missing explicit path returns usage Err ───────────────────────────────────
+
+#[test]
+fn nonexistent_explicit_path_returns_err() {
+    let result = run_artifact_check(&ArtifactCheckOpts {
+        source: ArtifactCheckSource::Paths(vec![PathBuf::from(
+            "/nonexistent/path/to/nowhere.json",
+        )]),
+        strict: false,
+    });
+    assert!(
+        result.is_err(),
+        "a non-existent explicit path must return Err (usage error), not an Invalid result"
+    );
+}
+
+// ── Null required field counts as missing ─────────────────────────────────────
+
+#[test]
+fn null_required_field_returns_invalid() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 },
+        "trajectory_format": "mini-swe-agent-1.2",
+        "info": {},
+        "messages": null
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(
+        output.results[0].verdict,
+        ConformanceVerdict::Invalid,
+        "a null required field must be treated as absent"
+    );
+    assert!(
+        output.results[0]
+            .missing_fields
+            .contains(&"messages".to_owned()),
+        "null messages must appear in missing_fields"
     );
 }
 

--- a/tests/agent_artifact_check.rs
+++ b/tests/agent_artifact_check.rs
@@ -651,6 +651,49 @@ fn multiple_paths_all_validated() {
     );
 }
 
+// ── Non-object JSON ───────────────────────────────────────────────────────────
+
+#[test]
+fn json_array_returns_invalid() {
+    let json = serde_json::json!([1, 2, 3]).to_string();
+    let output = check_bytes(&json);
+    assert_eq!(
+        output.results[0].verdict,
+        ConformanceVerdict::Invalid,
+        "a JSON array must return Invalid, not LegacyUnversioned"
+    );
+}
+
+#[test]
+fn json_null_returns_invalid() {
+    let output = check_bytes("null");
+    assert_eq!(
+        output.results[0].verdict,
+        ConformanceVerdict::Invalid,
+        "JSON null must return Invalid"
+    );
+}
+
+// ── Newer same-major minor ────────────────────────────────────────────────────
+
+#[test]
+fn newer_same_major_minor_returns_valid_with_warnings() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 99 },
+        "trajectory_format": "future-format",
+        "info": {},
+        "messages": []
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(
+        output.results[0].verdict,
+        ConformanceVerdict::ValidWithWarnings,
+        "newer same-major minor must produce valid_with_warnings"
+    );
+}
+
 // ── AC 2: schema_version reported as "major.minor" string ────────────────────
 
 #[test]

--- a/tests/agent_artifact_check.rs
+++ b/tests/agent_artifact_check.rs
@@ -1,0 +1,617 @@
+//! Tests for `agent artifact-check` (issue #534).
+//! RED phase: written before implementation — will fail to compile until
+//! `src/run/artifact_check.rs` is created and wired up.
+#![allow(clippy::unwrap_used)]
+
+use maxwells_daemon::run::artifact_check::{
+    ArtifactCheckOpts, ArtifactCheckSource, ConformanceVerdict, format_json, format_text,
+    run_artifact_check,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn check_bytes(json: &str) -> maxwells_daemon::run::artifact_check::ArtifactCheckOutput {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), json).unwrap();
+    run_artifact_check(&ArtifactCheckOpts {
+        source: ArtifactCheckSource::Paths(vec![tmp.path().to_owned()]),
+        strict: false,
+    })
+    .unwrap()
+}
+
+fn check_bytes_strict(json: &str) -> maxwells_daemon::run::artifact_check::ArtifactCheckOutput {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), json).unwrap();
+    run_artifact_check(&ArtifactCheckOpts {
+        source: ArtifactCheckSource::Paths(vec![tmp.path().to_owned()]),
+        strict: true,
+    })
+    .unwrap()
+}
+
+// ── AC 2: verdict types reported correctly ────────────────────────────────────
+
+#[test]
+fn valid_trajectory_returns_valid_verdict() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 },
+        "trajectory_format": "mini-swe-agent-1.2",
+        "info": { "task": "fix the bug" },
+        "messages": []
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(output.results.len(), 1);
+    assert_eq!(output.results[0].verdict, ConformanceVerdict::Valid);
+    assert_eq!(
+        output.results[0].artifact_kind.as_deref(),
+        Some("trajectory")
+    );
+    assert_eq!(
+        output.results[0].schema_version.as_deref(),
+        Some("1.11")
+    );
+}
+
+#[test]
+fn invalid_trajectory_missing_required_fields_returns_invalid() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 }
+        // missing: trajectory_format, info, messages
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(output.results.len(), 1);
+    assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
+    assert!(
+        !output.results[0].missing_fields.is_empty(),
+        "missing_fields must be reported"
+    );
+    assert!(
+        output.results[0]
+            .missing_fields
+            .contains(&"trajectory_format".to_owned()),
+        "trajectory_format must be listed as missing"
+    );
+}
+
+// ── AC 3: trajectory-specific required fields ─────────────────────────────────
+
+#[test]
+fn trajectory_missing_info_reports_it_as_missing() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 },
+        "trajectory_format": "mini-swe-agent-1.2",
+        "messages": []
+        // missing: info
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
+    assert!(output.results[0].missing_fields.contains(&"info".to_owned()));
+}
+
+#[test]
+fn trajectory_missing_messages_reports_it_as_missing() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 },
+        "trajectory_format": "mini-swe-agent-1.2",
+        "info": {}
+        // missing: messages
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
+    assert!(
+        output.results[0]
+            .missing_fields
+            .contains(&"messages".to_owned())
+    );
+}
+
+#[test]
+fn trajectory_unknown_additive_field_does_not_fail_major_one() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 },
+        "trajectory_format": "mini-swe-agent-1.2",
+        "info": {},
+        "messages": [],
+        "unknown_future_field": "some_value"
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(
+        output.results[0].verdict,
+        ConformanceVerdict::Valid,
+        "unknown additive fields in major 1 must not fail"
+    );
+}
+
+// ── AC 4: unsupported_major ───────────────────────────────────────────────────
+
+#[test]
+fn future_major_version_returns_unsupported_major() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 99, "minor": 0 },
+        "trajectory_format": "future-format",
+        "info": {},
+        "messages": []
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(output.results[0].verdict, ConformanceVerdict::UnsupportedMajor);
+}
+
+#[test]
+fn unsupported_major_is_a_failure() {
+    let json = serde_json::json!({
+        "artifact_kind": "sweep_results",
+        "schema_version": { "major": 2, "minor": 0 }
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(output.results[0].verdict, ConformanceVerdict::UnsupportedMajor);
+    assert!(output.has_failures(), "unsupported_major must count as a failure");
+}
+
+// ── AC 5: legacy_unversioned ──────────────────────────────────────────────────
+
+#[test]
+fn missing_both_header_fields_returns_legacy_unversioned() {
+    let json = serde_json::json!({
+        "trajectory_format": "mini-swe-agent-0.9",
+        "info": {},
+        "messages": []
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(
+        output.results[0].verdict,
+        ConformanceVerdict::LegacyUnversioned
+    );
+}
+
+#[test]
+fn legacy_unversioned_is_not_a_failure_by_default() {
+    let json = serde_json::json!({ "some_data": 1 }).to_string();
+    let output = check_bytes(&json);
+    assert_eq!(
+        output.results[0].verdict,
+        ConformanceVerdict::LegacyUnversioned
+    );
+    assert!(
+        !output.has_failures(),
+        "legacy_unversioned must be a warning only by default"
+    );
+}
+
+#[test]
+fn legacy_unversioned_is_failure_under_strict() {
+    let json = serde_json::json!({ "some_data": 1 }).to_string();
+    let output = check_bytes_strict(&json);
+    assert_eq!(
+        output.results[0].verdict,
+        ConformanceVerdict::LegacyUnversioned
+    );
+    assert!(
+        output.has_failures(),
+        "legacy_unversioned must be a failure under --strict"
+    );
+}
+
+// ── AC 6: all 9 contract-table artifact kinds are validated ──────────────────
+
+#[test]
+fn sweep_results_checks_required_fields() {
+    let json = serde_json::json!({
+        "artifact_kind": "sweep_results",
+        "schema_version": { "major": 1, "minor": 0 }
+        // missing: total, submitted, skipped, errored, failures_by_category, instances
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
+    for f in &["total", "submitted", "skipped", "errored", "failures_by_category", "instances"] {
+        assert!(
+            output.results[0].missing_fields.contains(&(*f).to_owned()),
+            "sweep_results missing field: {f}"
+        );
+    }
+}
+
+#[test]
+fn valid_sweep_results_returns_valid() {
+    let json = serde_json::json!({
+        "artifact_kind": "sweep_results",
+        "schema_version": { "major": 1, "minor": 11 },
+        "total": 10,
+        "submitted": 8,
+        "skipped": 1,
+        "errored": 1,
+        "failures_by_category": {},
+        "instances": []
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(output.results[0].verdict, ConformanceVerdict::Valid);
+}
+
+#[test]
+fn evaluation_results_checks_required_fields() {
+    let json = serde_json::json!({
+        "artifact_kind": "evaluation_results",
+        "schema_version": { "major": 1, "minor": 0 }
+        // missing: instances
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
+    assert!(
+        output.results[0].missing_fields.contains(&"instances".to_owned())
+    );
+}
+
+#[test]
+fn forecast_report_checks_required_fields() {
+    let json = serde_json::json!({
+        "artifact_kind": "forecast_report",
+        "schema_version": { "major": 1, "minor": 0 }
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
+    for f in &["calibration", "per_instance", "forecast", "resolution_rate", "threshold"] {
+        assert!(
+            output.results[0].missing_fields.contains(&(*f).to_owned()),
+            "forecast_report missing field: {f}"
+        );
+    }
+}
+
+#[test]
+fn calibration_report_checks_required_fields() {
+    let json = serde_json::json!({
+        "artifact_kind": "calibration_report",
+        "schema_version": { "major": 1, "minor": 0 }
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
+    for f in &["forecast_path", "results_path", "verdict", "comparability", "metrics", "per_instance"] {
+        assert!(
+            output.results[0].missing_fields.contains(&(*f).to_owned()),
+            "calibration_report missing field: {f}"
+        );
+    }
+}
+
+#[test]
+fn preflight_report_checks_required_fields() {
+    let json = serde_json::json!({
+        "artifact_kind": "preflight_report",
+        "schema_version": { "major": 1, "minor": 0 }
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
+    for f in &["mode", "checks"] {
+        assert!(
+            output.results[0].missing_fields.contains(&(*f).to_owned()),
+            "preflight_report missing field: {f}"
+        );
+    }
+}
+
+#[test]
+fn swebench_predictions_metadata_checks_required_fields() {
+    let json = serde_json::json!({
+        "artifact_kind": "swebench_predictions_metadata",
+        "schema_version": { "major": 1, "minor": 0 }
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
+    for f in &["predictions_file", "aggregate", "row_count", "swebench_evaluator_compatible"] {
+        assert!(
+            output.results[0].missing_fields.contains(&(*f).to_owned()),
+            "swebench_predictions_metadata missing field: {f}"
+        );
+    }
+}
+
+#[test]
+fn bundle_manifest_checks_required_fields() {
+    let json = serde_json::json!({
+        "artifact_kind": "bundle_manifest",
+        "schema_version": { "major": 1, "minor": 0 }
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
+    for f in &["source_sweep_dir", "source_manifest_hash", "harness_git_sha", "bundle_generated_at", "instance_scope", "files"] {
+        assert!(
+            output.results[0].missing_fields.contains(&(*f).to_owned()),
+            "bundle_manifest missing field: {f}"
+        );
+    }
+}
+
+#[test]
+fn cache_stats_report_checks_required_fields() {
+    let json = serde_json::json!({
+        "artifact_kind": "cache_stats_report",
+        "schema_version": { "major": 1, "minor": 0 }
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
+    for f in &["sweep", "generated_at", "cache_disabled", "sweep_totals", "instances"] {
+        assert!(
+            output.results[0].missing_fields.contains(&(*f).to_owned()),
+            "cache_stats_report missing field: {f}"
+        );
+    }
+}
+
+// ── AC 7: --format json output ────────────────────────────────────────────────
+
+#[test]
+fn json_format_emits_validation_report_artifact_kind() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 },
+        "trajectory_format": "mini-swe-agent-1.2",
+        "info": {},
+        "messages": []
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    let val = format_json(&output).unwrap();
+    assert_eq!(
+        val.get("artifact_kind").and_then(|v| v.as_str()),
+        Some("validation_report"),
+        "JSON must have artifact_kind = 'validation_report'"
+    );
+    assert!(
+        val.get("schema_version").is_some(),
+        "JSON must have schema_version"
+    );
+    assert!(
+        val.get("results").is_some(),
+        "JSON must have results array"
+    );
+}
+
+#[test]
+fn json_format_includes_verdict_counts() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 },
+        "trajectory_format": "mini-swe-agent-1.2",
+        "info": {},
+        "messages": []
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    let val = format_json(&output).unwrap();
+    assert!(
+        val.get("summary").is_some(),
+        "JSON must have summary with verdict counts"
+    );
+}
+
+// ── AC 7: text format includes summary table ──────────────────────────────────
+
+#[test]
+fn text_format_includes_verdict_and_path() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 },
+        "trajectory_format": "mini-swe-agent-1.2",
+        "info": {},
+        "messages": []
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    let text = format_text(&output);
+    assert!(text.contains("valid"), "text must include 'valid' verdict");
+}
+
+#[test]
+fn text_format_shows_missing_fields_for_invalid() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 }
+        // missing required fields
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    let text = format_text(&output);
+    assert!(
+        text.contains("trajectory_format"),
+        "text must show missing field trajectory_format"
+    );
+}
+
+// ── AC 8: exit codes / has_failures ──────────────────────────────────────────
+
+#[test]
+fn has_failures_false_when_all_valid() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 },
+        "trajectory_format": "mini-swe-agent-1.2",
+        "info": {},
+        "messages": []
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert!(!output.has_failures());
+}
+
+#[test]
+fn has_failures_true_when_any_invalid() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 }
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert!(output.has_failures());
+}
+
+#[test]
+fn valid_with_warnings_not_a_failure_by_default() {
+    // An older minor version should produce valid_with_warnings (not invalid)
+    // and should not count as a failure by default.
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 0 },
+        "trajectory_format": "mini-swe-agent-1.0",
+        "info": {},
+        "messages": []
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    // Older minor is valid_with_warnings (warning, not error)
+    assert_ne!(output.results[0].verdict, ConformanceVerdict::Invalid);
+    assert!(!output.has_failures(), "valid_with_warnings must not fail by default");
+}
+
+#[test]
+fn valid_with_warnings_is_failure_under_strict() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 0 },
+        "trajectory_format": "mini-swe-agent-1.0",
+        "info": {},
+        "messages": []
+    })
+    .to_string();
+    let output = check_bytes_strict(&json);
+    assert!(output.has_failures(), "valid_with_warnings must fail under --strict");
+}
+
+// ── AC 8: ArtifactCheckFailure exit code exists ───────────────────────────────
+
+#[test]
+fn artifact_check_failure_exit_code_is_47() {
+    assert_eq!(
+        maxwells_daemon::exit_code::ExitCode::ArtifactCheckFailure.as_i32(),
+        47
+    );
+    assert_eq!(
+        maxwells_daemon::exit_code::ExitCode::ArtifactCheckFailure.outcome_class(),
+        "artifact_check_failure"
+    );
+}
+
+// ── Zero model calls / no API key needed ──────────────────────────────────────
+
+#[test]
+fn no_api_key_required() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 },
+        "trajectory_format": "mini-swe-agent-1.2",
+        "info": {},
+        "messages": []
+    })
+    .to_string();
+    let result = check_bytes(&json);
+    assert_eq!(result.results.len(), 1, "must work without any API key");
+}
+
+// ── Directory scanning ────────────────────────────────────────────────────────
+
+#[test]
+fn directory_scan_finds_json_files_recursively() {
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let sub_dir = tmp_dir.path().join("sub");
+    std::fs::create_dir(&sub_dir).unwrap();
+
+    let valid_json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 },
+        "trajectory_format": "mini-swe-agent-1.2",
+        "info": {},
+        "messages": []
+    })
+    .to_string();
+    std::fs::write(tmp_dir.path().join("a.json"), &valid_json).unwrap();
+    std::fs::write(sub_dir.join("b.json"), &valid_json).unwrap();
+
+    let output = run_artifact_check(&ArtifactCheckOpts {
+        source: ArtifactCheckSource::Paths(vec![tmp_dir.path().to_owned()]),
+        strict: false,
+    })
+    .unwrap();
+    assert_eq!(
+        output.results.len(),
+        2,
+        "recursive directory scan must find all JSON files"
+    );
+}
+
+// ── Multiple paths ─────────────────────────────────────────────────────────────
+
+#[test]
+fn multiple_paths_all_validated() {
+    let json1 = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 11 },
+        "trajectory_format": "mini-swe-agent-1.2",
+        "info": {},
+        "messages": []
+    })
+    .to_string();
+    let json2 = serde_json::json!({
+        "artifact_kind": "sweep_results",
+        "schema_version": { "major": 1, "minor": 11 },
+        "total": 1, "submitted": 1, "skipped": 0, "errored": 0,
+        "failures_by_category": {}, "instances": []
+    })
+    .to_string();
+    let tmp1 = tempfile::NamedTempFile::new().unwrap();
+    let tmp2 = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp1.path(), json1).unwrap();
+    std::fs::write(tmp2.path(), json2).unwrap();
+
+    let output = run_artifact_check(&ArtifactCheckOpts {
+        source: ArtifactCheckSource::Paths(vec![
+            tmp1.path().to_owned(),
+            tmp2.path().to_owned(),
+        ]),
+        strict: false,
+    })
+    .unwrap();
+    assert_eq!(output.results.len(), 2);
+    assert!(output.results.iter().all(|r| r.verdict == ConformanceVerdict::Valid));
+}
+
+// ── AC 2: schema_version reported as "major.minor" string ────────────────────
+
+#[test]
+fn schema_version_formatted_as_major_dot_minor() {
+    let json = serde_json::json!({
+        "artifact_kind": "trajectory",
+        "schema_version": { "major": 1, "minor": 5 },
+        "trajectory_format": "mini-swe-agent-1.2",
+        "info": {},
+        "messages": []
+    })
+    .to_string();
+    let output = check_bytes(&json);
+    assert_eq!(
+        output.results[0].schema_version.as_deref(),
+        Some("1.5"),
+        "schema_version must be reported as 'major.minor'"
+    );
+}

--- a/tests/agent_artifact_check.rs
+++ b/tests/agent_artifact_check.rs
@@ -49,10 +49,7 @@ fn valid_trajectory_returns_valid_verdict() {
         output.results[0].artifact_kind.as_deref(),
         Some("trajectory")
     );
-    assert_eq!(
-        output.results[0].schema_version.as_deref(),
-        Some("1.11")
-    );
+    assert_eq!(output.results[0].schema_version.as_deref(), Some("1.11"));
 }
 
 #[test]
@@ -92,7 +89,11 @@ fn trajectory_missing_info_reports_it_as_missing() {
     .to_string();
     let output = check_bytes(&json);
     assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
-    assert!(output.results[0].missing_fields.contains(&"info".to_owned()));
+    assert!(
+        output.results[0]
+            .missing_fields
+            .contains(&"info".to_owned())
+    );
 }
 
 #[test]
@@ -146,7 +147,10 @@ fn future_major_version_returns_unsupported_major() {
     })
     .to_string();
     let output = check_bytes(&json);
-    assert_eq!(output.results[0].verdict, ConformanceVerdict::UnsupportedMajor);
+    assert_eq!(
+        output.results[0].verdict,
+        ConformanceVerdict::UnsupportedMajor
+    );
 }
 
 #[test]
@@ -157,8 +161,14 @@ fn unsupported_major_is_a_failure() {
     })
     .to_string();
     let output = check_bytes(&json);
-    assert_eq!(output.results[0].verdict, ConformanceVerdict::UnsupportedMajor);
-    assert!(output.has_failures(), "unsupported_major must count as a failure");
+    assert_eq!(
+        output.results[0].verdict,
+        ConformanceVerdict::UnsupportedMajor
+    );
+    assert!(
+        output.has_failures(),
+        "unsupported_major must count as a failure"
+    );
 }
 
 // ── AC 5: legacy_unversioned ──────────────────────────────────────────────────
@@ -218,7 +228,14 @@ fn sweep_results_checks_required_fields() {
     .to_string();
     let output = check_bytes(&json);
     assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
-    for f in &["total", "submitted", "skipped", "errored", "failures_by_category", "instances"] {
+    for f in &[
+        "total",
+        "submitted",
+        "skipped",
+        "errored",
+        "failures_by_category",
+        "instances",
+    ] {
         assert!(
             output.results[0].missing_fields.contains(&(*f).to_owned()),
             "sweep_results missing field: {f}"
@@ -254,7 +271,9 @@ fn evaluation_results_checks_required_fields() {
     let output = check_bytes(&json);
     assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
     assert!(
-        output.results[0].missing_fields.contains(&"instances".to_owned())
+        output.results[0]
+            .missing_fields
+            .contains(&"instances".to_owned())
     );
 }
 
@@ -267,7 +286,13 @@ fn forecast_report_checks_required_fields() {
     .to_string();
     let output = check_bytes(&json);
     assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
-    for f in &["calibration", "per_instance", "forecast", "resolution_rate", "threshold"] {
+    for f in &[
+        "calibration",
+        "per_instance",
+        "forecast",
+        "resolution_rate",
+        "threshold",
+    ] {
         assert!(
             output.results[0].missing_fields.contains(&(*f).to_owned()),
             "forecast_report missing field: {f}"
@@ -284,7 +309,14 @@ fn calibration_report_checks_required_fields() {
     .to_string();
     let output = check_bytes(&json);
     assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
-    for f in &["forecast_path", "results_path", "verdict", "comparability", "metrics", "per_instance"] {
+    for f in &[
+        "forecast_path",
+        "results_path",
+        "verdict",
+        "comparability",
+        "metrics",
+        "per_instance",
+    ] {
         assert!(
             output.results[0].missing_fields.contains(&(*f).to_owned()),
             "calibration_report missing field: {f}"
@@ -318,7 +350,12 @@ fn swebench_predictions_metadata_checks_required_fields() {
     .to_string();
     let output = check_bytes(&json);
     assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
-    for f in &["predictions_file", "aggregate", "row_count", "swebench_evaluator_compatible"] {
+    for f in &[
+        "predictions_file",
+        "aggregate",
+        "row_count",
+        "swebench_evaluator_compatible",
+    ] {
         assert!(
             output.results[0].missing_fields.contains(&(*f).to_owned()),
             "swebench_predictions_metadata missing field: {f}"
@@ -335,7 +372,14 @@ fn bundle_manifest_checks_required_fields() {
     .to_string();
     let output = check_bytes(&json);
     assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
-    for f in &["source_sweep_dir", "source_manifest_hash", "harness_git_sha", "bundle_generated_at", "instance_scope", "files"] {
+    for f in &[
+        "source_sweep_dir",
+        "source_manifest_hash",
+        "harness_git_sha",
+        "bundle_generated_at",
+        "instance_scope",
+        "files",
+    ] {
         assert!(
             output.results[0].missing_fields.contains(&(*f).to_owned()),
             "bundle_manifest missing field: {f}"
@@ -352,7 +396,13 @@ fn cache_stats_report_checks_required_fields() {
     .to_string();
     let output = check_bytes(&json);
     assert_eq!(output.results[0].verdict, ConformanceVerdict::Invalid);
-    for f in &["sweep", "generated_at", "cache_disabled", "sweep_totals", "instances"] {
+    for f in &[
+        "sweep",
+        "generated_at",
+        "cache_disabled",
+        "sweep_totals",
+        "instances",
+    ] {
         assert!(
             output.results[0].missing_fields.contains(&(*f).to_owned()),
             "cache_stats_report missing field: {f}"
@@ -383,10 +433,7 @@ fn json_format_emits_validation_report_artifact_kind() {
         val.get("schema_version").is_some(),
         "JSON must have schema_version"
     );
-    assert!(
-        val.get("results").is_some(),
-        "JSON must have results array"
-    );
+    assert!(val.get("results").is_some(), "JSON must have results array");
 }
 
 #[test]
@@ -482,7 +529,10 @@ fn valid_with_warnings_not_a_failure_by_default() {
     let output = check_bytes(&json);
     // Older minor is valid_with_warnings (warning, not error)
     assert_ne!(output.results[0].verdict, ConformanceVerdict::Invalid);
-    assert!(!output.has_failures(), "valid_with_warnings must not fail by default");
+    assert!(
+        !output.has_failures(),
+        "valid_with_warnings must not fail by default"
+    );
 }
 
 #[test]
@@ -496,7 +546,10 @@ fn valid_with_warnings_is_failure_under_strict() {
     })
     .to_string();
     let output = check_bytes_strict(&json);
-    assert!(output.has_failures(), "valid_with_warnings must fail under --strict");
+    assert!(
+        output.has_failures(),
+        "valid_with_warnings must fail under --strict"
+    );
 }
 
 // ── AC 8: ArtifactCheckFailure exit code exists ───────────────────────────────
@@ -585,15 +638,17 @@ fn multiple_paths_all_validated() {
     std::fs::write(tmp2.path(), json2).unwrap();
 
     let output = run_artifact_check(&ArtifactCheckOpts {
-        source: ArtifactCheckSource::Paths(vec![
-            tmp1.path().to_owned(),
-            tmp2.path().to_owned(),
-        ]),
+        source: ArtifactCheckSource::Paths(vec![tmp1.path().to_owned(), tmp2.path().to_owned()]),
         strict: false,
     })
     .unwrap();
     assert_eq!(output.results.len(), 2);
-    assert!(output.results.iter().all(|r| r.verdict == ConformanceVerdict::Valid));
+    assert!(
+        output
+            .results
+            .iter()
+            .all(|r| r.verdict == ConformanceVerdict::Valid)
+    );
 }
 
 // ── AC 2: schema_version reported as "major.minor" string ────────────────────


### PR DESCRIPTION
## Summary

Implements the `agent artifact-check` command (issue #534), a zero-cost structural conformance validator for artifact files. This command validates one or more artifact files or directories against the Artifact Contract without making any model calls or network requests.

## Key Changes

- **New module `src/run/artifact_check.rs`**: Core validation logic implementing:
  - Five conformance verdicts: `Valid`, `ValidWithWarnings`, `Invalid`, `LegacyUnversioned`, `UnsupportedMajor`
  - Per-artifact result tracking with path, artifact kind, schema version, verdict, and missing fields
  - Required field validation for all 9 artifact kinds defined in the contract
  - Support for both strict and lenient modes
  - Text and JSON output formatters (JSON emits a schema-versioned `validation_report`)
  - Recursive directory scanning for `*.json` files

- **CLI integration**:
  - Added `ArtifactCheckCmd` struct in `src/cli/args.rs` with options for paths, format, and strict mode
  - Wired command handler in `src/cli/mod.rs` with proper error handling and output formatting
  - Added `ArtifactCheckFailure` exit code (47) in `src/exit_code.rs`

- **Artifact catalog updates**:
  - Added `ValidationReport` variant to `ArtifactKind` enum
  - Registered `agent artifact-check` in the command catalog

- **Documentation**:
  - Added comprehensive spec in `docs/spec-artifact-check.md` covering usage, verdicts, required fields, exit codes, and examples
  - Updated `docs/artifact-contract.md` and `docs/exit-codes.md` with artifact-check references

## Implementation Details

- **Verdict logic**: Distinguishes between hard failures (`Invalid`, `UnsupportedMajor`) and soft failures (`LegacyUnversioned`, `ValidWithWarnings`) that only fail under `--strict`
- **Schema versioning**: Supports older minor versions within the same major version with warnings; rejects unsupported future majors
- **Required fields**: Validates 9 artifact kinds with their specific required fields; unknown kinds only validate the header
- **Additive field tolerance**: Unknown fields in major version 1 do not cause validation failure, per contract reader policy
- **No external dependencies**: Validation uses only standard library and existing serde/serde_json dependencies

## Testing

Comprehensive test suite in `tests/agent_artifact_check.rs` with 617 lines covering:
- All verdict types and transitions
- Per-kind required field validation
- Schema version handling (current, older minor, future major)
- Output formatting (text and JSON)
- Exit code behavior
- Directory scanning and multiple path handling
- Strict mode behavior

https://claude.ai/code/session_016xxnDZZqN1HgfVDG7Sknnt