### PR TITLE
Add container network isolation mode configuration (issue #523)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -6,6 +6,30 @@ use clap::{Args, Subcommand, ValueEnum};
 
 // ── Agent subcommands ─────────────────────────────────────────────────────────
 
+/// Container network isolation mode for `--network-mode` (issue #523).
+///
+/// `unrestricted` (default) preserves today's behavior — no `--network` flag
+/// is added to `docker run`. `none` passes `--network none` to `docker run`,
+/// disabling all container egress.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum NetworkModeArg {
+    /// Default bridge networking — no isolation, no change from current behavior.
+    Unrestricted,
+    /// Pass `--network none` to `docker run`; all outbound calls fail inside
+    /// the container.
+    None,
+}
+
+impl NetworkModeArg {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unrestricted => "unrestricted",
+            Self::None => "none",
+        }
+    }
+}
+
 /// Validated environment-type selector for `agent env preview`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum EnvTypeArg {
@@ -989,6 +1013,13 @@ pub struct MiniCmd {
     /// Docker image, if `--env docker`.
     #[arg(long)]
     pub docker_image: Option<String>,
+
+    /// Container network isolation mode (issue #523). Overrides
+    /// `environment.network_mode` in the config file.
+    /// `unrestricted` (default): today's behavior, no `--network` flag.
+    /// `none`: adds `--network none` to `docker run`, disabling all egress.
+    #[arg(long, value_enum)]
+    pub network_mode: Option<NetworkModeArg>,
 
     /// Output directory for trajectories.
     #[arg(long, default_value = "./runs")]
@@ -2697,6 +2728,13 @@ pub struct SwebenchCmd {
     /// Docker image, if `--env docker`.
     #[arg(long)]
     pub docker_image: Option<String>,
+
+    /// Container network isolation mode (issue #523). Overrides
+    /// `environment.network_mode` in the config file.
+    /// `unrestricted` (default): today's behavior, no `--network` flag.
+    /// `none`: adds `--network none` to `docker run`, disabling all egress.
+    #[arg(long, value_enum)]
+    pub network_mode: Option<NetworkModeArg>,
 
     /// Resume from a previous run: `complete` trajectories are skipped, `partial`
     /// (mid-run checkpoint) trajectories continue from their last completed turn

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5758,14 +5758,8 @@ fn parse_env_kind(kind: &str) -> Result<crate::config::EnvKind, Error> {
 }
 
 fn parse_network_mode(mode: &str) -> Result<crate::config::NetworkMode, Error> {
-    match mode {
-        "unrestricted" => Ok(crate::config::NetworkMode::Unrestricted),
-        "none" => Ok(crate::config::NetworkMode::None),
-        "" => Err(Error::Config(crate::error::ConfigError::Invalid(
-            "network_mode cannot be empty; use \"unrestricted\" or \"none\"".into(),
-        ))),
-        other => Ok(crate::config::NetworkMode::Custom(other.to_owned())),
-    }
+    mode.parse()
+        .map_err(|e| Error::Config(crate::error::ConfigError::Invalid(e)))
 }
 
 /// Print a non-fatal skills-preview informational section for `bench doctor`.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -976,6 +976,9 @@ async fn mini_cmd(m: args::MiniCmd) -> Result<(), Error> {
     if let Some(img) = m.docker_image.clone() {
         cfg.root.environment.docker_image = Some(img);
     }
+    if let Some(nm) = m.network_mode {
+        cfg.root.environment.network_mode = parse_network_mode(nm.as_str())?;
+    }
     if m.chaos_fail_every > 0 {
         cfg.root.environment.chaos_fail_every = m.chaos_fail_every;
     }
@@ -2462,6 +2465,9 @@ fn swebench_config_from_cmd(s: &args::SwebenchCmd) -> Result<Config, Error> {
     }
     if let Some(img) = s.docker_image.clone() {
         cfg.root.environment.docker_image = Some(img);
+    }
+    if let Some(nm) = s.network_mode {
+        cfg.root.environment.network_mode = parse_network_mode(nm.as_str())?;
     }
     if s.chaos_fail_every > 0 {
         cfg.root.environment.chaos_fail_every = s.chaos_fail_every;
@@ -5751,6 +5757,17 @@ fn parse_env_kind(kind: &str) -> Result<crate::config::EnvKind, Error> {
     }
 }
 
+fn parse_network_mode(mode: &str) -> Result<crate::config::NetworkMode, Error> {
+    match mode {
+        "unrestricted" => Ok(crate::config::NetworkMode::Unrestricted),
+        "none" => Ok(crate::config::NetworkMode::None),
+        "" => Err(Error::Config(crate::error::ConfigError::Invalid(
+            "network_mode cannot be empty; use \"unrestricted\" or \"none\"".into(),
+        ))),
+        other => Ok(crate::config::NetworkMode::Custom(other.to_owned())),
+    }
+}
+
 /// Print a non-fatal skills-preview informational section for `bench doctor`.
 /// POST a `doctor_probe` event to the webhook URL and return a short status
 /// string for the non-fatal doctor output line.  Best-effort; never aborts.
@@ -7443,6 +7460,7 @@ mod tests {
             workdir: None,
             env: None,
             docker_image: None,
+            network_mode: None,
             output: PathBuf::from("runs"),
             trajectory_name: None,
             stream: None,

--- a/src/config/defaults/default.toml
+++ b/src/config/defaults/default.toml
@@ -111,6 +111,12 @@ kind = "local"
 # Per-command timeout in seconds.
 timeout_secs = 60
 workdir = "/workspace"
+# Container network isolation mode (issue #523). Applies only to Docker
+# environments. "unrestricted" (default) preserves today's behavior — no
+# --network flag is passed to docker run. "none" adds --network none,
+# disabling all outbound calls from the container. A non-empty string is
+# accepted as a future allowlist value but is not yet enforced.
+# network_mode = "unrestricted"
 
 [sweep]
 # Adaptive rate-limit governor (issue #44). Both keys are opt-in: when unset,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,8 +12,8 @@ use crate::error::ConfigError;
 pub mod schema;
 
 pub use schema::{
-    AgentCfg, AgentKind, EnvCfg, EnvKind, McpServerCfg, ModelCfg, PromptCfg, RedactionCfg, RootCfg,
-    SkillCfg, SweepCfg, ToolCfg, ToolHookCfg, ToolHooksCfg,
+    AgentCfg, AgentKind, EnvCfg, EnvKind, McpServerCfg, ModelCfg, NetworkMode, PromptCfg,
+    RedactionCfg, RootCfg, SkillCfg, SweepCfg, ToolCfg, ToolHookCfg, ToolHooksCfg,
 };
 
 const DEFAULT_TOML: &str = include_str!("defaults/default.toml");

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1,7 +1,7 @@
 //! Serde-visible shape of `config/*.toml`. Mirrors mini-swe-agent's layout
 //! with stronger typing — enum variants for backends rather than free-text.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -17,6 +17,66 @@ pub enum EnvKind {
     #[default]
     Local,
     Docker,
+}
+
+/// Network isolation mode for Docker container runs (issue #523).
+///
+/// `Unrestricted` (the default) preserves today's behavior — no `--network`
+/// flag is passed to `docker run`. `None` adds `--network none` to disable
+/// all container egress. `Custom(s)` accepts an allowlist string for future
+/// proxy-enforcement; the string is recorded in the manifest and reported by
+/// `env preview`, but no additional isolation is applied in this slice.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum NetworkMode {
+    /// Default bridge networking — no `--network` flag, no isolation.
+    #[default]
+    Unrestricted,
+    /// Pass `--network none` to `docker run`; all external calls fail.
+    None,
+    /// Allowlist string accepted for forward-compat; not yet enforced.
+    Custom(String),
+}
+
+impl NetworkMode {
+    /// The string representation stored in config and emitted by `env preview`.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Unrestricted => "unrestricted",
+            Self::None => "none",
+            Self::Custom(s) => s.as_str(),
+        }
+    }
+
+    /// Returns the value to pass after `--network` in `docker run`, or `None`
+    /// when no `--network` flag should be added (unrestricted = today's default).
+    #[must_use]
+    pub fn docker_network_arg(&self) -> Option<&str> {
+        match self {
+            Self::None => Some("none"),
+            Self::Unrestricted | Self::Custom(_) => None,
+        }
+    }
+}
+
+impl Serialize for NetworkMode {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for NetworkMode {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        match raw.as_str() {
+            "" => Err(serde::de::Error::custom(
+                "network_mode cannot be empty; use \"unrestricted\", \"none\", or an allowlist string",
+            )),
+            "unrestricted" => Ok(Self::Unrestricted),
+            "none" => Ok(Self::None),
+            other => Ok(Self::Custom(other.to_owned())),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -212,6 +272,13 @@ pub struct EnvCfg {
     /// CLI flag; recorded in the run manifest for reproducibility.
     #[serde(default)]
     pub chaos_fail_every: u32,
+    /// Network isolation mode for the Docker container (issue #523).
+    /// `unrestricted` (default) preserves today's behavior — no `--network` flag.
+    /// `none` adds `--network none` to `docker run`, disabling all egress.
+    /// Any other non-empty string is accepted as a future allowlist value but
+    /// not yet enforced.
+    #[serde(default)]
+    pub network_mode: NetworkMode,
 }
 
 fn default_timeout_secs() -> u64 {
@@ -348,5 +415,47 @@ mod tests {
     fn parse_error_retries_defaults_to_three() {
         let cfg: AgentCfg = toml::from_str("").unwrap();
         assert_eq!(cfg.parse_error_retries, 3);
+    }
+
+    // ── NetworkMode RED-phase tests ──────────────────────────────────────────
+
+    #[test]
+    fn network_mode_default_is_unrestricted() {
+        let cfg = EnvCfg::default();
+        assert_eq!(cfg.network_mode, NetworkMode::Unrestricted);
+    }
+
+    #[test]
+    fn network_mode_none_parses_from_toml() {
+        let cfg: EnvCfg = toml::from_str(r#"network_mode = "none""#).unwrap();
+        assert_eq!(cfg.network_mode, NetworkMode::None);
+    }
+
+    #[test]
+    fn network_mode_unrestricted_parses_from_toml() {
+        let cfg: EnvCfg = toml::from_str(r#"network_mode = "unrestricted""#).unwrap();
+        assert_eq!(cfg.network_mode, NetworkMode::Unrestricted);
+    }
+
+    #[test]
+    fn network_mode_empty_string_fails_parse() {
+        let result: Result<EnvCfg, _> = toml::from_str(r#"network_mode = """#);
+        assert!(result.is_err(), "empty network_mode should fail to parse");
+    }
+
+    #[test]
+    fn network_mode_none_docker_network_arg_is_none_str() {
+        assert_eq!(NetworkMode::None.docker_network_arg(), Some("none"));
+    }
+
+    #[test]
+    fn network_mode_unrestricted_docker_network_arg_is_absent() {
+        assert_eq!(NetworkMode::Unrestricted.docker_network_arg(), None);
+    }
+
+    #[test]
+    fn network_mode_as_str_roundtrips() {
+        assert_eq!(NetworkMode::Unrestricted.as_str(), "unrestricted");
+        assert_eq!(NetworkMode::None.as_str(), "none");
     }
 }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -59,6 +59,22 @@ impl NetworkMode {
     }
 }
 
+impl std::str::FromStr for NetworkMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "" => Err(
+                "network_mode cannot be empty; use \"unrestricted\", \"none\", or an allowlist string"
+                    .to_owned(),
+            ),
+            "unrestricted" => Ok(Self::Unrestricted),
+            "none" => Ok(Self::None),
+            other => Ok(Self::Custom(other.to_owned())),
+        }
+    }
+}
+
 impl Serialize for NetworkMode {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         s.serialize_str(self.as_str())
@@ -68,14 +84,7 @@ impl Serialize for NetworkMode {
 impl<'de> Deserialize<'de> for NetworkMode {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         let raw = String::deserialize(d)?;
-        match raw.as_str() {
-            "" => Err(serde::de::Error::custom(
-                "network_mode cannot be empty; use \"unrestricted\", \"none\", or an allowlist string",
-            )),
-            "unrestricted" => Ok(Self::Unrestricted),
-            "none" => Ok(Self::None),
-            other => Ok(Self::Custom(other.to_owned())),
-        }
+        raw.parse().map_err(serde::de::Error::custom)
     }
 }
 

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -80,7 +80,7 @@ impl DockerEnvironment {
         let image = image.into();
         preflight().await?;
 
-        let wd_str = workdir.to_string_lossy().into_owned();
+        let wd_str = workdir.to_string_lossy();
         let run_args = build_run_args(&image, &wd_str, LABEL, network);
         let out = Command::new("docker")
             .args(&run_args)

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -41,17 +41,49 @@ pub struct DockerEnvironment {
     cleanup_on_drop: bool,
 }
 
+/// Build the argument list for `docker run … <image> sleep infinity`.
+///
+/// Extracted so unit tests can assert the exact arg shape without running
+/// Docker. `network` is the value to pass after `--network` (e.g. `"none"`),
+/// or `None` to omit the flag entirely (preserving today's default behavior).
+fn build_run_args(image: &str, workdir: &str, label: &str, network: Option<&str>) -> Vec<String> {
+    let mut args = vec![
+        "run".to_owned(),
+        "-d".to_owned(),
+        "--rm".to_owned(),
+        "--label".to_owned(),
+        label.to_owned(),
+        "-w".to_owned(),
+        workdir.to_owned(),
+    ];
+    if let Some(net) = network {
+        args.push("--network".to_owned());
+        args.push(net.to_owned());
+    }
+    args.push(image.to_owned());
+    args.push("sleep".to_owned());
+    args.push("infinity".to_owned());
+    args
+}
+
 impl DockerEnvironment {
     /// Start a new container and return the handle.
-    pub async fn start(image: impl Into<String>, workdir: PathBuf) -> Result<Self, EnvError> {
+    ///
+    /// `network` controls the `--network` flag passed to `docker run`:
+    /// `None` preserves today's default (bridge networking), `Some("none")`
+    /// disables all egress, and any other string is forwarded verbatim.
+    pub async fn start(
+        image: impl Into<String>,
+        workdir: PathBuf,
+        network: Option<&str>,
+    ) -> Result<Self, EnvError> {
         let image = image.into();
         preflight().await?;
 
         let wd_str = workdir.to_string_lossy().into_owned();
+        let run_args = build_run_args(&image, &wd_str, LABEL, network);
         let out = Command::new("docker")
-            .args(["run", "-d", "--rm", "--label", LABEL, "-w", &wd_str])
-            .arg(&image)
-            .args(["sleep", "infinity"])
+            .args(&run_args)
             .stdin(StdStdio::null())
             .output()
             .await
@@ -490,5 +522,41 @@ mod tests {
     #[test]
     fn cleanup_labels_cover_current_and_legacy_rename_labels() {
         assert_eq!(cleanup_labels(), [LABEL, "rust-swe-agent=1"]);
+    }
+
+    // ── Network mode RED-phase tests ─────────────────────────────────────────
+
+    #[test]
+    fn build_run_args_include_network_none_when_mode_is_none() {
+        let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
+        let network_pos = args.iter().position(|a| a == "--network");
+        assert!(
+            network_pos.is_some(),
+            "expected --network flag in args: {args:?}"
+        );
+        assert_eq!(
+            args.get(network_pos.unwrap() + 1).map(String::as_str),
+            Some("none")
+        );
+    }
+
+    #[test]
+    fn build_run_args_unchanged_for_unrestricted_mode() {
+        let args_unrestricted = build_run_args("my-image", "/workspace", LABEL, None);
+        assert!(
+            !args_unrestricted.contains(&"--network".to_owned()),
+            "unrestricted mode must not add --network flag: {args_unrestricted:?}"
+        );
+    }
+
+    #[test]
+    fn build_run_args_network_none_positioned_before_image() {
+        let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
+        let network_pos = args.iter().position(|a| a == "--network").unwrap();
+        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        assert!(
+            network_pos < image_pos,
+            "--network must appear before the image name"
+        );
     }
 }

--- a/src/run/config_resolve.rs
+++ b/src/run/config_resolve.rs
@@ -237,6 +237,10 @@ const SCALAR_FIELDS: &[FieldDef] = &[
         path: &["environment", "workdir"],
         key: "environment.workdir",
     },
+    FieldDef {
+        path: &["environment", "network_mode"],
+        key: "environment.network_mode",
+    },
 ];
 
 fn build_resolved_fields(

--- a/src/run/env_preview.rs
+++ b/src/run/env_preview.rs
@@ -182,6 +182,21 @@ pub fn run_env_preview(cfg: &Config, opts: &EnvPreviewOpts) -> EnvPreview {
         });
     }
 
+    // Custom network modes are recorded in the config and reported by env
+    // preview for forward-compat, but are not yet enforced — no `--network`
+    // flag is passed and the container still has unrestricted egress.
+    if opts.env_type == "docker" {
+        if let crate::config::NetworkMode::Custom(ref s) = cfg.root.environment.network_mode {
+            findings.push(PreviewFinding {
+                severity: "warning".into(),
+                message: format!(
+                    "network_mode \"{s}\" is recorded but not yet enforced; \
+                     container egress is unrestricted"
+                ),
+            });
+        }
+    }
+
     // For docker, the workdir is the container's cwd, not a host path.
     let host_paths = if opts.env_type == "local" {
         vec![workdir]

--- a/src/run/env_preview.rs
+++ b/src/run/env_preview.rs
@@ -205,12 +205,12 @@ pub fn run_env_preview(cfg: &Config, opts: &EnvPreviewOpts) -> EnvPreview {
     if opts.env_type == "local"
         && cfg.root.environment.network_mode != crate::config::NetworkMode::Unrestricted
     {
+        let safe_mode = redact(&redactor, cfg.root.environment.network_mode.as_str());
         findings.push(PreviewFinding {
             severity: "warning".into(),
             message: format!(
-                "network_mode \"{}\" has no effect on local environments; \
-                 host process egress cannot be sandboxed",
-                cfg.root.environment.network_mode.as_str()
+                "network_mode \"{safe_mode}\" has no effect on local environments; \
+                 host process egress cannot be sandboxed"
             ),
         });
     }

--- a/src/run/env_preview.rs
+++ b/src/run/env_preview.rs
@@ -187,10 +187,11 @@ pub fn run_env_preview(cfg: &Config, opts: &EnvPreviewOpts) -> EnvPreview {
     // flag is passed and the container still has unrestricted egress.
     if opts.env_type == "docker" {
         if let crate::config::NetworkMode::Custom(ref s) = cfg.root.environment.network_mode {
+            let safe = redact(&redactor, s);
             findings.push(PreviewFinding {
                 severity: "warning".into(),
                 message: format!(
-                    "network_mode \"{s}\" is recorded but not yet enforced; \
+                    "network_mode \"{safe}\" is recorded but not yet enforced; \
                      container egress is unrestricted"
                 ),
             });
@@ -206,10 +207,12 @@ pub fn run_env_preview(cfg: &Config, opts: &EnvPreviewOpts) -> EnvPreview {
 
     // Local env cannot sandbox network egress at all; Docker reports the
     // effective configured mode so operators can confirm isolation is active.
+    // Custom values pass through the redactor in case a proxy URL or similar
+    // secret-bearing string was used as the mode value.
     let network_egress = if opts.env_type == "local" {
         "cannot_sandbox".to_owned()
     } else {
-        cfg.root.environment.network_mode.as_str().to_owned()
+        redact(&redactor, cfg.root.environment.network_mode.as_str())
     };
 
     EnvPreview {

--- a/src/run/env_preview.rs
+++ b/src/run/env_preview.rs
@@ -198,6 +198,23 @@ pub fn run_env_preview(cfg: &Config, opts: &EnvPreviewOpts) -> EnvPreview {
         }
     }
 
+    // network_mode has no effect on local environments — the host process
+    // cannot sandbox its own egress regardless of the configured value.
+    // Warn when a non-default mode is explicitly set so operators know it
+    // will be silently ignored rather than providing the expected isolation.
+    if opts.env_type == "local"
+        && cfg.root.environment.network_mode != crate::config::NetworkMode::Unrestricted
+    {
+        findings.push(PreviewFinding {
+            severity: "warning".into(),
+            message: format!(
+                "network_mode \"{}\" has no effect on local environments; \
+                 host process egress cannot be sandboxed",
+                cfg.root.environment.network_mode.as_str()
+            ),
+        });
+    }
+
     // For docker, the workdir is the container's cwd, not a host path.
     let host_paths = if opts.env_type == "local" {
         vec![workdir]

--- a/src/run/env_preview.rs
+++ b/src/run/env_preview.rs
@@ -189,11 +189,19 @@ pub fn run_env_preview(cfg: &Config, opts: &EnvPreviewOpts) -> EnvPreview {
         vec![]
     };
 
+    // Local env cannot sandbox network egress at all; Docker reports the
+    // effective configured mode so operators can confirm isolation is active.
+    let network_egress = if opts.env_type == "local" {
+        "cannot_sandbox".to_owned()
+    } else {
+        cfg.root.environment.network_mode.as_str().to_owned()
+    };
+
     EnvPreview {
         schema_version: 1,
         env_type: opts.env_type.clone(),
         host_paths,
-        network_egress: "unrestricted".to_owned(),
+        network_egress,
         hooks,
         mcp_servers,
         env_vars,

--- a/src/run/fork.rs
+++ b/src/run/fork.rs
@@ -765,7 +765,8 @@ async fn build_docker_env(cfg: &Config) -> Result<Box<dyn Environment>, Error> {
         ))
     })?;
     let wd = PathBuf::from(cfg.root.environment.workdir.clone());
-    let env = DockerEnvironment::start(image, wd).await?;
+    let network = cfg.root.environment.network_mode.docker_network_arg();
+    let env = DockerEnvironment::start(image, wd, network).await?;
     Ok(Box::new(env))
 }
 

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -1877,7 +1877,8 @@ async fn build_docker_env(cfg: &Config) -> Result<Box<dyn Environment>, Error> {
         ))
     })?;
     let wd = PathBuf::from(cfg.root.environment.workdir.clone());
-    let env = DockerEnvironment::start(image, wd).await?;
+    let network = cfg.root.environment.network_mode.docker_network_arg();
+    let env = DockerEnvironment::start(image, wd, network).await?;
     Ok(Box::new(env))
 }
 

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -529,7 +529,8 @@ async fn build_docker_env(cfg: &Config) -> Result<Box<dyn Environment>, Error> {
         ))
     })?;
     let wd = PathBuf::from(cfg.root.environment.workdir.clone());
-    let env = DockerEnvironment::start(image, wd).await?;
+    let network = cfg.root.environment.network_mode.docker_network_arg();
+    let env = DockerEnvironment::start(image, wd, network).await?;
     Ok(Box::new(env))
 }
 

--- a/tests/env_preview.rs
+++ b/tests/env_preview.rs
@@ -1953,3 +1953,38 @@ network_mode = ""
         "empty network_mode must fail config parsing"
     );
 }
+
+#[test]
+fn docker_custom_network_mode_produces_unenforced_warning() {
+    // A custom (allowlist) network_mode is accepted by the config but not yet
+    // enforced — env preview must warn that egress is still unrestricted.
+    let cfg = Config::from_toml_str(
+        r#"
+[environment]
+kind = "docker"
+docker_image = "ubuntu:22.04"
+network_mode = "github.com"
+"#,
+    )
+    .unwrap();
+    let opts = EnvPreviewOpts {
+        env_type: "docker".into(),
+        task: "task".into(),
+        config_path: None,
+        show_values: false,
+    };
+    let preview = run_env_preview(&cfg, &opts);
+    assert_eq!(
+        preview.network_egress, "github.com",
+        "custom mode value must appear in network_egress"
+    );
+    let has_unenforced_warning = preview
+        .findings
+        .iter()
+        .any(|f| f.message.contains("not yet enforced") && f.message.contains("github.com"));
+    assert!(
+        has_unenforced_warning,
+        "custom network_mode must produce an unenforced-egress warning; findings: {:?}",
+        preview.findings
+    );
+}

--- a/tests/env_preview.rs
+++ b/tests/env_preview.rs
@@ -497,13 +497,37 @@ fn sensitive_var_detection_covers_password_and_credential() {
     assert!(!is_sensitive_var_name_test_helper("USER"));
 }
 
-// ── Network egress always shows unrestricted ──────────────────────────────────
+// ── Network egress for local env reports cannot_sandbox ──────────────────────
 
 #[test]
-fn preview_network_egress_is_unrestricted() {
+fn preview_network_egress_local_cannot_sandbox() {
+    // Local env cannot sandbox egress; preview must be honest about this.
     let cfg = Config::defaults().unwrap();
     let opts = EnvPreviewOpts {
         env_type: "local".into(),
+        task: "task".into(),
+        config_path: None,
+        show_values: false,
+    };
+    let preview = run_env_preview(&cfg, &opts);
+    assert_eq!(preview.network_egress, "cannot_sandbox");
+}
+
+// ── Docker env reports the effective configured egress mode ───────────────────
+
+#[test]
+fn preview_network_egress_docker_default_is_unrestricted() {
+    // Default docker config (network_mode unset) must report "unrestricted".
+    let cfg = Config::from_toml_str(
+        r#"
+[environment]
+kind = "docker"
+docker_image = "ubuntu:22.04"
+"#,
+    )
+    .unwrap();
+    let opts = EnvPreviewOpts {
+        env_type: "docker".into(),
         task: "task".into(),
         config_path: None,
         show_values: false,
@@ -1809,3 +1833,124 @@ args = []
 
 // ── is_sensitive_var_name_test_helper covers all branch values ────────────────
 // (already tested above in sensitive_var_detection_covers_password_and_credential)
+
+// ── Issue #523: container network isolation ───────────────────────────────────
+
+#[test]
+fn docker_network_mode_none_sets_network_egress_to_none() {
+    // When network_mode = "none", env preview must report "none", not "unrestricted".
+    let cfg = Config::from_toml_str(
+        r#"
+[environment]
+kind = "docker"
+docker_image = "ubuntu:22.04"
+network_mode = "none"
+"#,
+    )
+    .unwrap();
+    let opts = EnvPreviewOpts {
+        env_type: "docker".into(),
+        task: "task".into(),
+        config_path: None,
+        show_values: false,
+    };
+    let preview = run_env_preview(&cfg, &opts);
+    assert_eq!(
+        preview.network_egress, "none",
+        "docker env with network_mode=none must report network_egress=none; got: {}",
+        preview.network_egress
+    );
+}
+
+#[test]
+fn docker_network_mode_unrestricted_preserves_default_egress() {
+    // Default config (network_mode = unrestricted) must still report "unrestricted".
+    let cfg = Config::from_toml_str(
+        r#"
+[environment]
+kind = "docker"
+docker_image = "ubuntu:22.04"
+network_mode = "unrestricted"
+"#,
+    )
+    .unwrap();
+    let opts = EnvPreviewOpts {
+        env_type: "docker".into(),
+        task: "task".into(),
+        config_path: None,
+        show_values: false,
+    };
+    let preview = run_env_preview(&cfg, &opts);
+    assert_eq!(
+        preview.network_egress, "unrestricted",
+        "docker env with explicit unrestricted must report unrestricted; got: {}",
+        preview.network_egress
+    );
+}
+
+#[test]
+fn local_env_network_egress_reports_cannot_sandbox() {
+    // Local env cannot sandbox egress; must report "cannot_sandbox" to be honest.
+    let cfg = Config::defaults().unwrap();
+    let opts = EnvPreviewOpts {
+        env_type: "local".into(),
+        task: "task".into(),
+        config_path: None,
+        show_values: false,
+    };
+    let preview = run_env_preview(&cfg, &opts);
+    assert_eq!(
+        preview.network_egress, "cannot_sandbox",
+        "local env must report network_egress=cannot_sandbox; got: {}",
+        preview.network_egress
+    );
+}
+
+#[test]
+fn docker_network_mode_none_does_not_add_extra_findings() {
+    // network_mode=none is a known, safe config; it must not produce any additional
+    // warning findings beyond the standard docker checks.
+    let cfg = Config::from_toml_str(
+        r#"
+[environment]
+kind = "docker"
+docker_image = "ubuntu:22.04"
+network_mode = "none"
+"#,
+    )
+    .unwrap();
+    let opts = EnvPreviewOpts {
+        env_type: "docker".into(),
+        task: "task".into(),
+        config_path: None,
+        show_values: false,
+    };
+    let preview = run_env_preview(&cfg, &opts);
+    // With a valid docker image and network_mode=none, no findings should appear
+    // beyond the standard "compiled without docker" warning (present in non-docker builds).
+    let unexpected: Vec<_> = preview
+        .findings
+        .iter()
+        .filter(|f| !f.message.contains("compiled without the 'docker' feature"))
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "network_mode=none must not introduce extra findings; got: {:?}",
+        unexpected
+    );
+}
+
+#[test]
+fn invalid_network_mode_in_config_produces_error() {
+    // An empty network_mode value must fail to parse — clear validation error.
+    let result = Config::from_toml_str(
+        r#"
+[environment]
+network_mode = ""
+"#,
+    );
+    assert!(
+        result.is_err(),
+        "empty network_mode must fail config parsing"
+    );
+}

--- a/tests/env_preview.rs
+++ b/tests/env_preview.rs
@@ -1988,3 +1988,37 @@ network_mode = "github.com"
         preview.findings
     );
 }
+
+#[test]
+fn local_env_with_nondefault_network_mode_produces_warning() {
+    // network_mode has no effect on local environments; setting it to "none"
+    // should produce a warning so operators know the setting is ignored.
+    let cfg = Config::from_toml_str(
+        r#"
+[environment]
+kind = "local"
+network_mode = "none"
+"#,
+    )
+    .unwrap();
+    let opts = EnvPreviewOpts {
+        env_type: "local".into(),
+        task: "task".into(),
+        config_path: None,
+        show_values: false,
+    };
+    let preview = run_env_preview(&cfg, &opts);
+    assert_eq!(
+        preview.network_egress, "cannot_sandbox",
+        "local env must always report cannot_sandbox"
+    );
+    let has_warning = preview
+        .findings
+        .iter()
+        .any(|f| f.message.contains("has no effect on local environments"));
+    assert!(
+        has_warning,
+        "non-default network_mode on local env must produce a warning; findings: {:?}",
+        preview.findings
+    );
+}

--- a/tests/env_preview.rs
+++ b/tests/env_preview.rs
@@ -1935,8 +1935,7 @@ network_mode = "none"
         .collect();
     assert!(
         unexpected.is_empty(),
-        "network_mode=none must not introduce extra findings; got: {:?}",
-        unexpected
+        "network_mode=none must not introduce extra findings; got: {unexpected:?}",
     );
 }
 


### PR DESCRIPTION
## Summary
Implement configurable network isolation for Docker containers via a new `network_mode` configuration option. This allows operators to restrict container egress by setting `network_mode = "none"` to pass `--network none` to `docker run`, while preserving backward compatibility with the default unrestricted behavior.

## Key Changes

- **New `NetworkMode` enum** in `src/config/schema.rs`:
  - `Unrestricted` (default): preserves current behavior, no `--network` flag
  - `None`: adds `--network none` to disable all container egress
  - `Custom(String)`: accepts allowlist strings for future proxy enforcement
  - Implements custom serialization/deserialization with validation (rejects empty strings)

- **Configuration support**:
  - Added `network_mode: NetworkMode` field to `EnvCfg` struct
  - Updated `default.toml` with commented example and documentation
  - Exported `NetworkMode` from `src/config/mod.rs` for public use

- **CLI argument support**:
  - New `NetworkModeArg` enum in `src/cli/args.rs` with `Unrestricted` and `None` variants
  - Added `--network-mode` flag to `MiniCmd` and `SwebenchCmd` to override config file settings
  - Added `parse_network_mode()` helper function in `src/cli/mod.rs` to convert CLI args to config

- **Docker integration** in `src/env/docker.rs`:
  - Extracted `build_run_args()` function to construct `docker run` arguments with optional `--network` flag
  - Updated `DockerEnvironment::start()` to accept `network: Option<&str>` parameter
  - Modified `build_docker_env()` in `src/run/mini.rs` to pass network mode from config

- **Environment preview** in `src/run/env_preview.rs`:
  - Local environments now report `network_egress: "cannot_sandbox"` (honest about lack of isolation)
  - Docker environments report the effective configured mode (`unrestricted`, `none`, or custom value)

- **Comprehensive test coverage**:
  - Schema parsing tests for all `NetworkMode` variants and empty string rejection
  - Docker argument building tests verifying flag placement and presence/absence
  - Environment preview tests for both local and Docker environments
  - Integration tests for issue #523 scenarios (network isolation behavior)

## Implementation Details

- The `network_mode` field defaults to `Unrestricted`, ensuring zero breaking changes
- Empty `network_mode` values in TOML fail validation with a clear error message
- The `docker_network_arg()` method returns `Some("none")` only for `None` mode; other modes return `None` to omit the flag
- CLI flags override config file settings, allowing per-run customization
- Local environments cannot sandbox network egress and now honestly report this limitation

https://claude.ai/code/session_014H2pSLbjhkczbDb9VUFykb