### PR TITLE
Add `bench merge` command for offline shard aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,11 @@ a valid trajectory in hand:
 - [`bench grep`](docs/spec-grep.md): regex search across all trajectory messages
   in a sweep — filter by role, instance, or outcome; redaction-safe; zero-cost
   (reads only on-disk artifacts).
+- [`bench merge`](docs/spec-merge.md): combine K completed sharded sweep
+  directories into one canonical aggregate — arithmetically correct cost/token/
+  pass@k recomputation, collision policies (`error`/`first-wins`/`last-wins`),
+  `merged_from` provenance manifest, and full `bench audit`/`report`/`triage`
+  compatibility. Enables horizontal scaling without sacrificing reproducibility.
 - [`bench matrix`](docs/spec-matrix.md): multi-arm experiment runner — compare
   models or configs against the same instance set, shared budget enforcement,
   `matrix.json` state, ranked `matrix-summary.json`, and `--resume` support.

--- a/docs/spec-merge.md
+++ b/docs/spec-merge.md
@@ -1,0 +1,196 @@
+# `bench merge` — Shard Aggregation Spec
+
+## Purpose
+
+Horizontal scaling: run independent sharded sweeps across multiple workers or
+machines, then recombine them offline into one canonical aggregate that is a
+drop-in for `bench evaluate`, `bench audit`, `bench report`, and `bench triage`.
+
+This command is **offline and read-only** — it never launches workers, does not
+continue an interrupted sweep (`--resume` exists for that), and does not merge
+different models or configs (`bench matrix` covers cross-config comparison).
+
+## Invocation
+
+```
+bench merge \
+  --shard /path/to/shard-a \
+  --shard /path/to/shard-b \
+  [--shard /path/to/shard-c ...] \
+  --output /path/to/merged \
+  [--on-collision error|first-wins|last-wins] \
+  [--label A --label B [--label C ...]] \
+  [--force] \
+  [--format text|json]
+```
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--shard PATH` | *(required, repeatable)* | Path to a completed sweep directory. Minimum 2. |
+| `--output PATH` | *(required)* | Output directory (must be empty unless `--force`). |
+| `--on-collision POLICY` | `error` | How to handle duplicate instance IDs across shards (see below). |
+| `--label STRING` | *(repeatable, optional)* | Human-readable label for each shard in provenance/report. If provided, must match `--shard` count. |
+| `--force` | `false` | Allow writing into a non-empty output directory. |
+| `--format text\|json` | `text` | Output format for the summary report. |
+
+## Collision Policies
+
+When the same `instance_id` appears in more than one shard:
+
+| Policy | Behaviour |
+|--------|-----------|
+| `error` (default) | Collect **all** colliding IDs and exit non-zero, listing every duplicate and the shard pair that owns it. |
+| `first-wins` | Keep the instance from the first shard that claimed it; the later shard's copy is dropped and `duplicates` counter is incremented. |
+| `last-wins` | Keep the instance from the last shard that claimed it; earlier copies are dropped and `duplicates` counter is incremented. |
+
+## Provenance Requirements
+
+All shards must share identical values for:
+
+- `manifest.dataset.sha256` — ensures all shards ran against the same dataset
+- `manifest.model.name` — ensures all shards used the same model
+- `manifest.config` (SHA-256 of the resolved TOML string) — ensures identical agent configuration
+
+On divergence the command fails with a descriptive error naming the differing
+field and both values. Cross-config or cross-model experiments belong in
+`bench matrix`.
+
+## `merged_from` Manifest Field
+
+The merged `results.json` carries a new field on the provenance manifest:
+
+```json
+{
+  "manifest": {
+    "merged_from": [
+      {
+        "label": "shard-a",
+        "dir": "/path/to/shard-a",
+        "model": "gpt-4o",
+        "instance_count": 200
+      },
+      {
+        "label": "shard-b",
+        "dir": "/path/to/shard-b",
+        "model": "gpt-4o",
+        "instance_count": 200
+      }
+    ],
+    "source": "merge"
+  }
+}
+```
+
+All existing manifest fields (dataset, model, config, harness, runtime) are
+inherited from shard 0. `merged_from` is additive and `skip_serializing_if =
+None`, so tools that read `results.json` without understanding this field are
+unaffected.
+
+## Audit Compatibility
+
+`bench merge` copies every per-instance artifact directory from each shard into
+the output sweep directory, preserving the source shard's on-disk layout:
+
+- **Nested layout** `<instance_id>/run-N.traj.json` — entire per-instance
+  subdirectory is copied recursively.
+- **Legacy flat layout** `<instance_id>.traj.json` — individual files are
+  copied to the output root.
+
+This preserves the bijection that `bench audit` enforces: every `instance_id`
+in `results.json` must have a corresponding trajectory file on disk, and every
+trajectory file must be referenced by `results.json`.
+
+## Aggregate Recomputation
+
+All top-line metrics are recomputed from the union instance list — no numbers
+are summed from per-shard headers, which prevents double-counting:
+
+- `total_cost_usd`, token counts — summed over the union
+- `submitted`, `errored`, `with_patch`, `failures_by_category` — counted over the union
+- `pass_at_k`, resolved rate — derived from the union counts
+
+Only `retry_history` is carried from shard 0 (documented limitation; retries
+are per-sweep, not per-merge).
+
+## `evaluation.json` Handling
+
+If any shard contains an `evaluation.json`, the merged output will contain one
+that is the union of all shard evaluations. Both modern (`instances[].resolved`)
+and legacy (`resolved_ids` / `submitted_ids`) formats are normalized to the
+modern format on merge. Instances dropped by the collision policy are excluded.
+
+## JSON Summary Format (AC6)
+
+With `--format json`:
+
+```json
+{
+  "shards": [
+    { "label": "shard-a", "dir": "/path/to/shard-a", "instance_count": 200 },
+    { "label": "shard-b", "dir": "/path/to/shard-b", "instance_count": 200 }
+  ],
+  "total_instances": 400,
+  "duplicates": 0,
+  "collision_policy": "Error",
+  "output_dir": "/path/to/merged",
+  "total_cost_usd": 42.50,
+  "submitted": 400,
+  "errored": 12,
+  "resolved": 180,
+  "pass_at_k": 0.45
+}
+```
+
+## Error Conditions (AC7)
+
+| Condition | Exit code | Message |
+|-----------|-----------|---------|
+| Fewer than 2 `--shard` args | non-zero | "bench merge requires at least 2 shards" |
+| `--label` count ≠ `--shard` count | non-zero | "number of --label values must match --shard count" |
+| `results.json` missing or unreadable | non-zero | "merge: shard '…' results.json: …" |
+| `sweep_status` ≠ `completed` | non-zero | "merge: shard '…' sweep_status is '…'; only completed sweeps can be merged" |
+| Shard has no provenance manifest | non-zero | "merge: shard '…' has no provenance manifest" |
+| Dataset / model / config divergence | non-zero | "merge: shard '…' dataset_sha256 '…' differs from shard '…' '…'" |
+| Collision with `--on-collision error` | non-zero | "merge: N duplicate instance IDs found: …" |
+| Output dir non-empty without `--force` | non-zero | "merge: output directory '…' is not empty; use --force to overwrite" |
+
+## Worked 2-Shard Example
+
+```
+# Run two independent shards
+bench swebench --dataset swe-bench-lite.jsonl --filter-even --output shard-a
+bench swebench --dataset swe-bench-lite.jsonl --filter-odd  --output shard-b
+
+# Combine them
+bench merge \
+  --shard shard-a --label "even-instances" \
+  --shard shard-b --label "odd-instances" \
+  --output merged
+
+# All downstream commands work on the merged output
+bench audit  --sweep merged          # exit 0 — bijection intact
+bench report --sweep merged          # full markdown summary
+bench triage --sweep merged          # failure cluster table
+bench evaluate --sweep merged        # pass@k, cost-per-resolved
+```
+
+Sample text output:
+
+```
+bench merge
+  shard even-instances  /path/to/shard-a  200 instances
+  shard odd-instances   /path/to/shard-b  200 instances
+  ─────────────────────────────────────────────────────
+  total                                   400 instances
+  duplicates                              0
+  output                                  /path/to/merged
+
+merged results:
+  cost      $42.50
+  submitted 400
+  errored   12
+  resolved  180
+  pass@k    0.4500
+```

--- a/docs/spec-merge.md
+++ b/docs/spec-merge.md
@@ -97,6 +97,8 @@ the output sweep directory, preserving the source shard's on-disk layout:
   subdirectory is copied recursively.
 - **Legacy flat layout** `<instance_id>.traj.json` — individual files are
   copied to the output root.
+- **Bundled layout** `trajectories/<instance_id>.traj.json` and
+  `patches/<instance_id>.patch` — as produced by an extracted `bench bundle`.
 
 This preserves the bijection that `bench audit` enforces: every `instance_id`
 in `results.json` must have a corresponding trajectory file on disk, and every
@@ -108,18 +110,66 @@ All top-line metrics are recomputed from the union instance list — no numbers
 are summed from per-shard headers, which prevents double-counting:
 
 - `total_cost_usd`, token counts — summed over the union
-- `submitted`, `errored`, `with_patch`, `failures_by_category` — counted over the union
-- `pass_at_k`, resolved rate — derived from the union counts
+- `with_patch`, `failures_by_category` — counted over the union
+- `pass_at_k`, resolved rate — derived per-instance from the union
+
+The outcome **slot** counts (`submitted`, `errored`, `skipped`, `budget_halted`)
+are recounted from the copied run trajectories — exactly the way `bench audit`
+recomputes them — rather than from the collapsed per-task rows. For a pass@k /
+multi-run sweep one task spans several run slots (e.g. 2 runs both submitted →
+2 submitted slots), so a per-task count would disagree with the on-disk
+trajectories and fail audit. Counting per slot keeps the merged `results.json`
+reconciled with the trajectories for both single-run and multi-run sweeps.
 
 Only `retry_history` is carried from shard 0 (documented limitation; retries
 are per-sweep, not per-merge).
 
+## Predictions (`bench evaluate` compatibility)
+
+`bench evaluate` scores a sweep from `<sweep>/all_preds.jsonl`. Merge produces a
+complete prediction set for the union:
+
+- `all_preds.jsonl` — the aggregate file, restricted to union-owned rows. For
+  multi-run shards each row keeps its unique `<id>::run-k` id plus
+  `original_instance_id`, and the regenerated metadata marks
+  `swebench_evaluator_compatible: false` (duplicate ids are not sb-cli-safe).
+- `all_preds.run-k.jsonl` — one per run index, original SWE-bench ids, safe to
+  hand directly to sb-cli.
+- `all_preds.metadata.json` / `all_preds.run-k.metadata.json` — regenerated with
+  the merged row counts.
+
+Prediction rows are filtered by the same owning shard used for trajectories, so
+collision-dropped instances never appear twice.
+
+## Subset Metadata
+
+Both `results.json.filter_spec` and `manifest.dataset.filter_spec` are rebuilt
+to describe the merged union (the sorted union instance-id list), not shard 0's
+per-shard filter. This keeps `bench compare`'s "same subset?" check honest when
+shards used different `--instance-ids`/filters.
+
+## Output Isolation
+
+`--output` must not be equal to, contain, or be contained by any input shard.
+Because `--force` clears a non-empty output directory with `remove_dir_all`, an
+overlapping output path would delete shard artifacts before they are copied;
+merge rejects such paths up front with a clear error.
+
 ## `evaluation.json` Handling
 
-If any shard contains an `evaluation.json`, the merged output will contain one
-that is the union of all shard evaluations. Both modern (`instances[].resolved`)
-and legacy (`resolved_ids` / `submitted_ids`) formats are normalized to the
-modern format on merge. Instances dropped by the collision policy are excluded.
+Evaluation is merged **all-or-nothing**: the merged output gets an
+`evaluation.json` only when *every* shard carries one. A modern `evaluation.json`
+requires an entry for every on-disk trajectory, so a partial merge (some shards
+evaluated, some not) would turn the unevaluated shards' trajectories into
+`audit:orphan:evaluation` failures. When evaluation is present in only some
+shards, merge warns and omits the file so the merged sweep still audits cleanly
+as an unevaluated sweep — re-run `bench evaluate` on the merged output, or
+evaluate every shard first.
+
+When all shards are evaluated, both modern (`instances[].resolved`) and legacy
+(`resolved_ids` / `submitted_ids`) formats are normalized to the modern format
+(legacy rows gain the required `eval_exit_reason`). Instances dropped by the
+collision policy are excluded.
 
 ## JSON Summary Format (AC6)
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1391,6 +1391,56 @@ pub enum BenchCmd {
     ExportOtlp(ExportOtlpCmd),
     /// Classify per-instance flakiness from a rerun sweep (zero cost: reads only on-disk artifacts).
     Variance(BenchVarianceCmd),
+    /// Combine two or more completed sharded sweep directories into one canonical aggregate (offline; zero model cost).
+    Merge(MergeCmd),
+}
+
+/// `bench merge` — combine completed sharded sweep directories into one canonical aggregate.
+///
+/// Recombines K independent sharded sweeps into a single canonical sweep directory
+/// that is a drop-in for `bench evaluate`, `bench report`, `bench triage`, and `bench audit`.
+/// Runs entirely offline with no model or network calls.
+#[derive(Debug, Args)]
+pub struct MergeCmd {
+    /// A completed sweep directory to merge. Repeat for each shard (2+ required).
+    #[arg(long = "shard", required = true, action = clap::ArgAction::Append)]
+    pub shards: Vec<std::path::PathBuf>,
+
+    /// Destination directory for the merged canonical sweep. Created if absent; must be empty otherwise.
+    #[arg(long)]
+    pub output: std::path::PathBuf,
+
+    /// Collision policy when the same instance_id appears in more than one shard.
+    /// `error` (default): fail with a clear message listing all colliding IDs.
+    /// `first-wins`: keep the occurrence from the earliest --shard.
+    /// `last-wins`: keep the occurrence from the latest --shard.
+    #[arg(long = "on-collision", value_enum, default_value_t = MergeCollisionPolicy::Error)]
+    pub on_collision: MergeCollisionPolicy,
+
+    /// Optional human-readable shard labels, positionally aligned with --shard.
+    /// Defaults to the directory name of each shard.
+    #[arg(long = "label", action = clap::ArgAction::Append)]
+    pub labels: Vec<String>,
+
+    /// Overwrite the output directory if it is non-empty.
+    #[arg(long, default_value_t = false)]
+    pub force: bool,
+
+    /// Output format: `text` (default) or `json`.
+    /// The `json` format emits a machine-readable summary to stdout.
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
+/// Collision policy for `bench merge` when the same instance_id appears in multiple shards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum MergeCollisionPolicy {
+    /// Fail loudly if any instance_id appears in two or more shards (default).
+    Error,
+    /// Keep the occurrence from the earliest --shard; log duplicates in the report.
+    FirstWins,
+    /// Keep the occurrence from the latest --shard; log duplicates in the report.
+    LastWins,
 }
 
 /// `bench export-otlp` — re-export reconstructed sweep + instance spans from a

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1428,8 +1428,17 @@ pub struct MergeCmd {
 
     /// Output format: `text` (default) or `json`.
     /// The `json` format emits a machine-readable summary to stdout.
-    #[arg(long, default_value = "text")]
-    pub format: String,
+    #[arg(long, value_enum, default_value_t = MergeFormat::Text)]
+    pub format: MergeFormat,
+}
+
+/// Output format for `bench merge`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum MergeFormat {
+    /// Human-readable text summary (default).
+    Text,
+    /// Machine-readable JSON summary.
+    Json,
 }
 
 /// Collision policy for `bench merge` when the same instance_id appears in multiple shards.

--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -368,6 +368,12 @@ pub fn entries() -> &'static [CatalogEntry] {
             stage: "run",
         },
         CatalogEntry {
+            path: "bench merge",
+            summary: "Combine sharded sweep result directories into one aggregate",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
             path: "bench near-miss",
             summary: "Rank unresolved sweep instances by gold-patch proximity",
             cost_tier: "free",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -140,7 +140,7 @@ pub async fn run() -> Result<(), Error> {
             args::BenchCmd::Utilization(u) => bench_utilization(u),
             args::BenchCmd::ExportOtlp(c) => Box::pin(bench_export_otlp(c)).await,
             args::BenchCmd::Variance(v) => bench_variance(v),
-            args::BenchCmd::Merge(m) => bench_merge(m),
+            args::BenchCmd::Merge(m) => bench_merge(&m),
         },
         Command::Agent { cmd } => match *cmd {
             args::AgentCmd::SkillsPreview(s) => agent_skills_preview_cmd(&s),
@@ -6158,17 +6158,9 @@ fn bench_audit(a: args::AuditCmd) -> Result<(), Error> {
     crate::run::audit::run(&a)
 }
 
-fn bench_merge(m: args::MergeCmd) -> Result<(), Error> {
-    let is_json = match m.format.as_str() {
-        "text" => false,
-        "json" => true,
-        other => {
-            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text` or `json`)"
-            ))));
-        }
-    };
-    let report = crate::run::merge::run(&m)?;
+fn bench_merge(m: &args::MergeCmd) -> Result<(), Error> {
+    let is_json = matches!(m.format, args::MergeFormat::Json);
+    let report = crate::run::merge::run(m)?;
     if is_json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -140,6 +140,7 @@ pub async fn run() -> Result<(), Error> {
             args::BenchCmd::Utilization(u) => bench_utilization(u),
             args::BenchCmd::ExportOtlp(c) => Box::pin(bench_export_otlp(c)).await,
             args::BenchCmd::Variance(v) => bench_variance(v),
+            args::BenchCmd::Merge(m) => bench_merge(m),
         },
         Command::Agent { cmd } => match *cmd {
             args::AgentCmd::SkillsPreview(s) => agent_skills_preview_cmd(&s),
@@ -6155,6 +6156,25 @@ async fn bench_bisect(b: args::BisectCmd) -> Result<(), Error> {
 #[allow(clippy::needless_pass_by_value)]
 fn bench_audit(a: args::AuditCmd) -> Result<(), Error> {
     crate::run::audit::run(&a)
+}
+
+fn bench_merge(m: args::MergeCmd) -> Result<(), Error> {
+    let is_json = match m.format.as_str() {
+        "text" => false,
+        "json" => true,
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "unknown --format `{other}` (expected `text` or `json`)"
+            ))));
+        }
+    };
+    let report = crate::run::merge::run(&m)?;
+    if is_json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        report.render_text();
+    }
+    Ok(())
 }
 
 fn bench_failure_digest(f: args::FailureDigestCmd) -> Result<(), Error> {

--- a/src/run/audit.rs
+++ b/src/run/audit.rs
@@ -674,7 +674,7 @@ pub fn run(args: &AuditCmd) -> Result<(), Error> {
 }
 
 /// Recursively collect all trajectory files in the sweep directory.
-fn collect_trajectories_on_disk(dir: &Path) -> Result<Vec<PathBuf>, std::io::Error> {
+pub(crate) fn collect_trajectories_on_disk(dir: &Path) -> Result<Vec<PathBuf>, std::io::Error> {
     let mut files = Vec::new();
     if dir.is_dir() {
         for entry in fs::read_dir(dir)? {
@@ -698,7 +698,7 @@ fn collect_trajectories_on_disk(dir: &Path) -> Result<Vec<PathBuf>, std::io::Err
 /// 1. Root: <sweep_dir>/<instance_id>.traj.json
 /// 2. Nested: <sweep_dir>/<instance_id>/run-<run_index>.traj.json or trajectory.json
 /// 3. Bundled: <sweep_dir>/trajectories/<instance_id>.traj.json
-fn parse_trajectory_path(sweep_dir: &Path, path: &Path) -> Option<(String, u32)> {
+pub(crate) fn parse_trajectory_path(sweep_dir: &Path, path: &Path) -> Option<(String, u32)> {
     let rel = path.strip_prefix(sweep_dir).ok()?;
     let components: Vec<_> = rel
         .components()

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -3868,6 +3868,7 @@ mod tests {
             import_predictions_path: None,
             import_predictions_sha256: None,
             reproduced_from: None,
+            merged_from: None,
         };
         let mut candidate = baseline.clone();
         candidate.prompt_template.sha256 = "p2".into();
@@ -4330,6 +4331,7 @@ mod tests {
                 },
                 cli: crate::run::swebench::CliManifest { argv: Vec::new() },
                 reproduced_from: None,
+                merged_from: None,
                 chaos_fail_every: 0,
                 circuit_breaker: None,
                 source: None,
@@ -4528,6 +4530,7 @@ mod tests {
                 },
                 cli: crate::run::swebench::CliManifest { argv: Vec::new() },
                 reproduced_from: None,
+                merged_from: None,
                 chaos_fail_every: 0,
                 circuit_breaker: None,
                 source: None,
@@ -4652,6 +4655,7 @@ mod tests {
                     argv: vec!["max".into()],
                 },
                 reproduced_from: None,
+                merged_from: None,
                 chaos_fail_every: 0,
                 circuit_breaker: None,
                 source: None,

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -767,7 +767,9 @@ fn attach_patch_stats(
 }
 
 #[allow(clippy::cast_precision_loss, clippy::too_many_lines)]
-fn build_submission_class_rollup(instances: &[InstanceEvaluation]) -> (SubmissionClassRollup, f64) {
+pub(crate) fn build_submission_class_rollup(
+    instances: &[InstanceEvaluation],
+) -> (SubmissionClassRollup, f64) {
     let mut total_submitted = 0;
     let mut total_resolved = 0;
 

--- a/src/run/import.rs
+++ b/src/run/import.rs
@@ -472,6 +472,7 @@ pub fn run(args: &ImportArgs) -> Result<ImportSummary, Error> {
         import_predictions_path: Some(predictions_path_str),
         import_predictions_sha256: Some(predictions_sha256.clone()),
         reproduced_from: None,
+        merged_from: None,
     };
 
     // 8. Build SweepResults.

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -231,6 +231,17 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
             .count()
     });
 
+    // Keep the report's pass@k consistent with `resolved`: when the merged
+    // evaluation supplies an authoritative resolved count, derive pass@k from it
+    // rather than from `merged.pass_at_k` (the submission proxy over instance rows),
+    // so `bench merge --format json` doesn't mix evaluated and proxy rates.
+    #[allow(clippy::cast_precision_loss)]
+    let pass_at_k = if eval_resolved.is_some() && !union_instances.is_empty() {
+        resolved as f64 / union_instances.len() as f64
+    } else {
+        merged.pass_at_k
+    };
+
     Ok(MergeReport {
         shards: shard_summaries,
         total_instances: union_instances.len(),
@@ -241,7 +252,7 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
         submitted: merged.submitted,
         errored: merged.errored,
         resolved,
-        pass_at_k: merged.pass_at_k,
+        pass_at_k,
     })
 }
 
@@ -1166,17 +1177,25 @@ fn merge_predictions(
 
     // Owning shard for a prediction row: the aggregate file may carry unique
     // `<id>::run-k` IDs plus an `original_instance_id`; per-run files keep the
-    // original SWE-bench ID. Resolve both to the underlying instance id.
-    let owned_line = |shard_idx: usize, line: &str| -> bool {
-        let Ok(val) = serde_json::from_str::<Value>(line) else {
-            return false;
-        };
+    // original SWE-bench ID. Resolve both to the underlying instance id. A
+    // malformed/idless row is corruption — fail rather than silently dropping a
+    // submission that `bench evaluate` would then see as missing.
+    let owned_line = |shard_idx: usize, line: &str, label: &str| -> Result<bool, Error> {
+        let val: Value = serde_json::from_str(line).map_err(|e| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: shard '{label}' has a malformed prediction row: {e}"
+            )))
+        })?;
         let orig = val
             .get("original_instance_id")
             .and_then(Value::as_str)
-            .or_else(|| val.get("instance_id").and_then(Value::as_str))
-            .unwrap_or("");
-        owner_shard.get(orig).copied() == Some(shard_idx)
+            .or_else(|| val.get("instance_id").and_then(Value::as_str));
+        let Some(orig) = orig else {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: shard '{label}' has a prediction row without an instance_id"
+            ))));
+        };
+        Ok(owner_shard.get(orig).copied() == Some(shard_idx))
     };
 
     // Collect every run index that has a per-run prediction file in any shard.
@@ -1209,13 +1228,13 @@ fn merge_predictions(
     let mut aggregate = String::new();
     let mut aggregate_rows = 0usize;
     let mut aggregate_unique_ids = false;
-    for (shard_idx, (_, dir, _)) in loaded.iter().enumerate() {
+    for (shard_idx, (label, dir, _)) in loaded.iter().enumerate() {
         let path = predictions_path(dir);
         let Ok(text) = fs::read_to_string(&path) else {
             continue;
         };
         for line in text.lines().filter(|l| !l.trim().is_empty()) {
-            if owned_line(shard_idx, line) {
+            if owned_line(shard_idx, line, label)? {
                 if line.contains("original_instance_id") {
                     aggregate_unique_ids = true;
                 }
@@ -1262,7 +1281,7 @@ fn merge_predictions(
                 )))
             })?;
             for line in text.lines().filter(|l| !l.trim().is_empty()) {
-                if owned_line(shard_idx, line) {
+                if owned_line(shard_idx, line, label)? {
                     run_text.push_str(line);
                     run_text.push('\n');
                     run_rows += 1;

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -387,7 +387,15 @@ fn check_provenance_compatibility(loaded: &[(String, PathBuf, SweepResults)]) ->
 fn check_uniform_rerun_count(loaded: &[(String, PathBuf, SweepResults)]) -> Result<(), Error> {
     let mut reference: Option<(&str, u32)> = None;
     for (label, _, results) in loaded {
-        let Some(runs) = results.instances.iter().map(|r| r.runs).max() else {
+        // Normalize legacy rows (written before `runs` existed, serde-default 0) the
+        // same way the rest of the code does, so a 1-run legacy shard isn't rejected
+        // against a 1-run modern shard.
+        let Some(runs) = results
+            .instances
+            .iter()
+            .map(crate::run::swebench::effective_runs)
+            .max()
+        else {
             continue; // empty shard contributes no rerun signal
         };
         match reference {
@@ -648,6 +656,7 @@ fn merge_evaluation_json(
 
     let mut eval_entries: Vec<Value> = Vec::new();
     let mut merged_provenance: Option<(String, Value)> = None; // (shard label, provenance)
+    let mut shards_with_provenance = 0usize;
 
     for (shard_idx, (label, shard_dir, shard_results)) in loaded.iter().enumerate() {
         let owns = |id: &str| owner_shard.get(id).copied().unwrap_or(shard_idx) == shard_idx;
@@ -672,6 +681,7 @@ fn merge_evaluation_json(
         // backends / versions / dataset settings into one authoritative file would
         // hide the mismatch from downstream compare/report.
         if let Some(prov) = eval.get("provenance").filter(|p| !p.is_null()) {
+            shards_with_provenance += 1;
             match &merged_provenance {
                 None => merged_provenance = Some((label.clone(), prov.clone())),
                 Some((ref0, prov0)) => {
@@ -718,7 +728,10 @@ fn merge_evaluation_json(
                 continue;
             }
             if let Some(entry) = modern.get(id) {
-                eval_entries.push((*entry).clone());
+                // Normalize: a pre-`eval_exit_reason` modern entry would otherwise be
+                // copied verbatim and fail `InstanceEvaluation` deserialization
+                // downstream, even though synthesized rows below carry the field.
+                eval_entries.push(normalize_eval_entry(entry));
             } else {
                 // `eval_exit_reason` is required by `InstanceEvaluation`; downstream
                 // commands (report/triage/inspect) reject rows that omit it.
@@ -765,8 +778,13 @@ fn merge_evaluation_json(
         }
         merged_eval["test_only_resolved_rate"] = serde_json::json!(test_only_resolved_rate);
     }
-    if let Some((_, prov)) = merged_provenance {
-        merged_eval["provenance"] = prov;
+    // Only stamp the merged file with evaluator provenance when *every* evaluated
+    // shard recorded one — otherwise we'd label a legacy/unprovenanced shard's
+    // verdicts as if they shared the first shard's backend/dataset settings.
+    if shards_with_provenance == loaded.len() {
+        if let Some((_, prov)) = merged_provenance {
+            merged_eval["provenance"] = prov;
+        }
     }
 
     let eval_json = serde_json::to_string_pretty(&merged_eval).map_err(|e| {
@@ -781,6 +799,26 @@ fn merge_evaluation_json(
     })?;
 
     Ok(Some(resolved_count))
+}
+
+/// Ensure a copied modern evaluation entry carries the `eval_exit_reason` field
+/// that `InstanceEvaluation` requires (legacy artifacts predate it), deriving a
+/// value from `resolved` when absent.
+fn normalize_eval_entry(entry: &Value) -> Value {
+    let mut e = entry.clone();
+    if let Some(obj) = e.as_object_mut() {
+        if !obj.contains_key("eval_exit_reason") {
+            let resolved = obj
+                .get("resolved")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            obj.insert(
+                "eval_exit_reason".to_owned(),
+                Value::String(if resolved { "resolved" } else { "unresolved" }.to_owned()),
+            );
+        }
+    }
+    e
 }
 
 /// The scoring-relevant evaluator identity that must match across shards before

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -128,6 +128,10 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
         .flat_map(|(_, _, r)| r.retry_history.iter().cloned())
         .collect();
 
+    // Combine rate-limit telemetry across shards (recompute_aggregates only cloned
+    // shard 0's), or a throttled later worker would be invisible in the merged run.
+    merged.rate_limit_events = merge_rate_limit_events(&loaded);
+
     // `recompute_aggregates` counts outcomes per-instance, but a pass@k sweep has
     // one collapsed row per task while results.json records per-run *slots* (and
     // `bench audit` recomputes the same way from the copied trajectories). Recount
@@ -322,6 +326,35 @@ fn check_provenance_compatibility(loaded: &[(String, PathBuf, SweepResults)]) ->
                  bench merge requires identical config across shards \
                  (use bench matrix for cross-config comparison)"
             ))));
+        }
+
+        // Model endpoint identity lives outside config.resolved: two shards can
+        // share a model name + config yet hit a different backend/base_url.
+        if manifest.model.backend != manifest0.model.backend
+            || manifest.model.base_url != manifest0.model.base_url
+        {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: shard '{label}' model endpoint (backend '{}', base_url {:?}) differs from \
+                 shard '{label0}' (backend '{}', base_url {:?}); \
+                 bench merge requires an identical model endpoint across shards",
+                manifest.model.backend,
+                manifest.model.base_url,
+                manifest0.model.backend,
+                manifest0.model.base_url
+            ))));
+        }
+
+        // Reject shards produced by a different harness commit — the merged
+        // manifest carries only shard 0's git_sha, so mixing revisions would
+        // misrepresent provenance. Only enforced when both shards recorded a sha.
+        if let (Some(sha), Some(sha0)) = (&manifest.harness.git_sha, &manifest0.harness.git_sha) {
+            if sha != sha0 {
+                return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "merge: shard '{label}' harness git_sha '{sha}' differs from shard \
+                     '{label0}' '{sha0}'; bench merge requires shards built from the same \
+                     harness revision"
+                ))));
+            }
         }
     }
 
@@ -956,6 +989,34 @@ fn merge_predictions(
     }
 
     Ok(())
+}
+
+/// Combine per-shard rate-limit telemetry: sum throttled calls/seconds, take the
+/// peak concurrency, and keep the configured caps (identical across shards).
+fn merge_rate_limit_events(
+    loaded: &[(String, PathBuf, SweepResults)],
+) -> Option<crate::run::rate_limit::RateLimitEvents> {
+    let mut any = false;
+    let mut merged = crate::run::rate_limit::RateLimitEvents {
+        throttled_calls: 0,
+        total_throttled_seconds: 0.0,
+        peak_concurrent: 0,
+        configured_max_rpm: None,
+        configured_max_input_tpm: None,
+    };
+    for (_, _, results) in loaded {
+        if let Some(ev) = &results.rate_limit_events {
+            any = true;
+            merged.throttled_calls += ev.throttled_calls;
+            merged.total_throttled_seconds += ev.total_throttled_seconds;
+            merged.peak_concurrent = merged.peak_concurrent.max(ev.peak_concurrent);
+            merged.configured_max_rpm = merged.configured_max_rpm.or(ev.configured_max_rpm);
+            merged.configured_max_input_tpm = merged
+                .configured_max_input_tpm
+                .or(ev.configured_max_input_tpm);
+        }
+    }
+    any.then_some(merged)
 }
 
 fn config_hash(resolved_toml: &str) -> String {

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -468,12 +468,34 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
 }
 
 /// Merge evaluation.json from all shards. Normalizes legacy format to modern.
-/// Writes merged output if any shard had eval data.
+///
+/// A modern `evaluation.json` requires an entry for every on-disk trajectory, or
+/// `bench audit` reports `audit:orphan:evaluation`. We therefore only emit a
+/// merged file when *every* shard carries evaluation data; if evaluation is
+/// present in only some shards we omit it entirely (and warn) so the merged
+/// sweep still audits cleanly as an unevaluated sweep.
 fn merge_evaluation_json(
     loaded: &[(String, PathBuf, SweepResults)],
     owner_shard: &HashMap<String, usize>,
     output: &Path,
 ) -> Result<(), Error> {
+    let shards_with_eval = loaded
+        .iter()
+        .filter(|(_, dir, _)| dir.join("evaluation.json").exists())
+        .count();
+    if shards_with_eval == 0 {
+        return Ok(());
+    }
+    if shards_with_eval < loaded.len() {
+        eprintln!(
+            "merge: warning: evaluation.json present in {shards_with_eval}/{} shards; \
+             omitting merged evaluation.json so the output audits as unevaluated \
+             (re-run `bench evaluate` on the merged sweep, or evaluate every shard first)",
+            loaded.len()
+        );
+        return Ok(());
+    }
+
     let mut eval_entries: Vec<Value> = Vec::new();
 
     for (shard_idx, (label, shard_dir, _)) in loaded.iter().enumerate() {
@@ -531,9 +553,12 @@ fn merge_evaluation_json(
             for id in resolved_ids.union(&submitted_ids) {
                 if owner_shard.get(*id).copied().unwrap_or(shard_idx) == shard_idx {
                     let resolved = resolved_ids.contains(id);
+                    // `eval_exit_reason` is required by `InstanceEvaluation`; downstream
+                    // commands (report/triage/inspect) reject rows that omit it.
                     eval_entries.push(serde_json::json!({
                         "instance_id": id,
-                        "resolved": resolved
+                        "resolved": resolved,
+                        "eval_exit_reason": if resolved { "resolved" } else { "unresolved" }
                     }));
                 }
             }

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -135,12 +135,28 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
     // `recompute_aggregates` counts outcomes per-instance, but a pass@k sweep has
     // one collapsed row per task while results.json records per-run *slots* (and
     // `bench audit` recomputes the same way from the copied trajectories). Recount
-    // submitted/errored/skipped/budget_halted per slot so the merged sweep audits.
+    // the per-slot aggregates so the merged sweep audits and its report fields
+    // (with_patch / submitted_with_tests / failures_by_category) match a real sweep.
     let slots = recount_slot_outcomes(&args.output, &union_instances)?;
     merged.submitted = slots.submitted;
     merged.errored = slots.errored;
     merged.skipped = slots.skipped;
     merged.budget_halted = slots.budget_halted;
+    merged.submitted_with_tests = slots.submitted_with_tests;
+    merged.with_patch = slots.with_patch;
+    // patch_empty / patch_apply_invalid are derived from the failure histogram,
+    // exactly as a canonical sweep's finalization does.
+    merged.patch_empty = slots
+        .failures_by_category
+        .get(&crate::trajectory::FailureCategory::PatchEmpty)
+        .copied()
+        .unwrap_or(0);
+    merged.patch_apply_invalid = slots
+        .failures_by_category
+        .get(&crate::trajectory::FailureCategory::PatchApplyInvalid)
+        .copied()
+        .unwrap_or(0);
+    merged.failures_by_category = slots.failures_by_category;
 
     // Rebuild subset metadata so it describes the merged union rather than shard 0;
     // downstream `bench compare` keys "same subset?" off this filter spec.
@@ -748,11 +764,28 @@ struct SlotOutcomeCounts {
     errored: usize,
     skipped: usize,
     budget_halted: usize,
+    submitted_with_tests: usize,
+    with_patch: usize,
+    failures_by_category: BTreeMap<crate::trajectory::FailureCategory, usize>,
 }
 
-/// Recount per-run-slot outcomes from the copied trajectories, mirroring exactly
-/// what `bench audit` recomputes (see `audit::run`), so the merged results.json
-/// reconciles for pass@k/rerun sweeps where one task spans several run slots.
+/// Map a run-slot trajectory path to its sibling patch and report whether it is a
+/// non-empty patch (`<...>/run-k.traj.json` → `<...>/run-k.patch`, etc.).
+fn slot_has_nonempty_patch(traj_path: &Path) -> bool {
+    let Some(name) = traj_path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    let Some(stem) = name.strip_suffix(".traj.json") else {
+        return false; // e.g. legacy `trajectory.json` — no deterministic patch sibling
+    };
+    let patch_path = traj_path.with_file_name(format!("{stem}.patch"));
+    fs::read_to_string(&patch_path).is_ok_and(|s| !s.trim().is_empty())
+}
+
+/// Recount per-run-slot aggregates from the copied trajectories, mirroring exactly
+/// what `bench audit` recomputes and what a canonical sweep records, so the merged
+/// results.json reconciles for pass@k/rerun sweeps where one task spans several
+/// run slots (the collapsed per-task rows only carry run 1's representative).
 fn recount_slot_outcomes(
     output: &Path,
     union_instances: &[crate::run::swebench::InstanceResult],
@@ -808,8 +841,8 @@ fn recount_slot_outcomes(
             let Ok(val) = serde_json::from_str::<Value>(&content) else {
                 continue;
             };
-            let outcome = val
-                .get("info")
+            let info = val.get("info");
+            let outcome = info
                 .and_then(|i| i.get("outcome"))
                 .and_then(Value::as_str)
                 .unwrap_or("");
@@ -819,6 +852,27 @@ fn recount_slot_outcomes(
                 "skipped" if !is_skipped_resume => counts.skipped += 1,
                 "budget_halted" | "budget_halt" => counts.budget_halted += 1,
                 _ => {}
+            }
+
+            // Per-slot report fields (match a canonical sweep's finalization).
+            if outcome == "submitted" && !is_skipped_resume {
+                let tests_run = info
+                    .and_then(|i| i.get("tests_run_before_submit"))
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                if tests_run {
+                    counts.submitted_with_tests += 1;
+                }
+                if slot_has_nonempty_patch(path) {
+                    counts.with_patch += 1;
+                }
+            }
+            if let Some(cat) = info
+                .and_then(|i| i.get("failure_category"))
+                .cloned()
+                .and_then(|v| serde_json::from_value::<crate::trajectory::FailureCategory>(v).ok())
+            {
+                *counts.failures_by_category.entry(cat).or_insert(0) += 1;
             }
         }
     }

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -213,9 +213,11 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
     // Prefer the authoritative resolved count from the merged evaluation.json
     // when present; otherwise fall back to the pass@k/submission proxy.
     let resolved = eval_resolved.unwrap_or_else(|| {
+        // `resolved_count` handles legacy rows (pre-`runs`/`resolved_count`), where
+        // the raw field is 0; a raw `> 0` check would report all-legacy merges as 0.
         union_instances
             .iter()
-            .filter(|r| r.resolved_count > 0)
+            .filter(|r| crate::run::swebench::resolved_count(r) > 0)
             .count()
     });
 
@@ -684,35 +686,43 @@ fn merge_evaluation_json(
             }
         }
 
-        // Parse modern format: instances[].{instance_id, resolved}
-        if let Some(instances) = eval.get("instances").and_then(Value::as_array) {
-            for inst in instances {
-                let id = inst
-                    .get("instance_id")
-                    .and_then(Value::as_str)
-                    .unwrap_or("");
-                if !id.is_empty() && owns(id) {
-                    eval_entries.push(inst.clone());
-                }
+        // Index whatever verdicts the shard's evaluation.json carries, in either
+        // the modern (`instances[]`) or legacy (`resolved_ids`) shape.
+        let modern: HashMap<&str, &Value> = eval
+            .get("instances")
+            .and_then(Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(|e| {
+                        e.get("instance_id")
+                            .and_then(Value::as_str)
+                            .map(|id| (id, e))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let resolved_ids: HashSet<&str> = eval
+            .get("resolved_ids")
+            .and_then(Value::as_array)
+            .map(|a| a.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
+
+        // Emit exactly one entry for every owned instance (each has a copied
+        // trajectory), reusing the shard's rich modern entry when present and
+        // synthesizing an unresolved one otherwise. This guarantees exact coverage
+        // and never emits unknown/extra IDs, so a stale or partial shard eval still
+        // yields a merged modern evaluation.json that passes audit/budget-fit.
+        for inst in &shard_results.instances {
+            let id = inst.instance_id.as_str();
+            if !owns(id) {
+                continue;
             }
-        } else {
-            // Legacy sb-cli format: resolved_ids / submitted_ids arrays. These omit
-            // errored/no-patch instances, but the merged file is modern, so audit
-            // wants an entry for *every* owned trajectory. Synthesize an entry for
-            // each owned instance, marking those absent from resolved_ids unresolved.
-            let resolved_ids: HashSet<&str> = eval
-                .get("resolved_ids")
-                .and_then(Value::as_array)
-                .map(|a| a.iter().filter_map(Value::as_str).collect())
-                .unwrap_or_default();
-            for inst in &shard_results.instances {
-                let id = inst.instance_id.as_str();
-                if !owns(id) {
-                    continue;
-                }
-                let resolved = resolved_ids.contains(id);
+            if let Some(entry) = modern.get(id) {
+                eval_entries.push((*entry).clone());
+            } else {
                 // `eval_exit_reason` is required by `InstanceEvaluation`; downstream
                 // commands (report/triage/inspect) reject rows that omit it.
+                let resolved = resolved_ids.contains(id);
                 eval_entries.push(serde_json::json!({
                     "instance_id": id,
                     "resolved": resolved,
@@ -773,15 +783,50 @@ fn merge_evaluation_json(
     Ok(Some(resolved_count))
 }
 
-/// Evaluator identity fields that must match across shards before their verdicts
-/// can be merged into one authoritative `evaluation.json`.
-fn evaluator_identity(prov: &Value) -> (String, String, String) {
-    let field = |k: &str| prov.get(k).and_then(Value::as_str).unwrap_or("").to_owned();
-    (
-        field("backend"),
-        field("backend_version"),
-        field("dataset_sha256"),
-    )
+/// The scoring-relevant evaluator identity that must match across shards before
+/// their verdicts can be merged. We compare the whole provenance object with the
+/// per-shard *volatile* fields (run ids, file paths/hashes, timestamps, command
+/// shapes, per-slot source reports) recursively stripped, so scoring-relevant
+/// settings — dataset subset/split, Docker image names, timeouts, parallelism —
+/// are all included.
+fn evaluator_identity(prov: &Value) -> Value {
+    let mut v = prov.clone();
+    strip_volatile_provenance(&mut v);
+    v
+}
+
+fn strip_volatile_provenance(v: &mut Value) {
+    const VOLATILE: &[&str] = &[
+        "run_id",
+        "prediction_path",
+        "prediction_sha256",
+        "eval_started_at",
+        "eval_ended_at",
+        "report_source",
+        "report_paths",
+        "report_hashes",
+        "submit_command",
+        "report_command",
+        "report_path",
+        "report_sha256",
+        "source_reports",
+    ];
+    match v {
+        Value::Object(obj) => {
+            for k in VOLATILE {
+                obj.remove(*k);
+            }
+            for child in obj.values_mut() {
+                strip_volatile_provenance(child);
+            }
+        }
+        Value::Array(arr) => {
+            for child in arr.iter_mut() {
+                strip_volatile_provenance(child);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Best-effort absolute, symlink-resolved path. Falls back to a lexical absolute

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -5,7 +5,7 @@
 //! correct, provenance-preserving, and a drop-in for `bench evaluate`, `bench
 //! report`, `bench triage`, and `bench audit`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -99,18 +99,40 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
     let policy = args.on_collision;
     let (union_instances, duplicates, owner_shard) = build_union_instances(&loaded, policy)?;
 
+    // Refuse to write into (or delete, under --force) a directory that overlaps an
+    // input shard — that would destroy the very artifacts we are about to copy.
+    validate_output_isolation(&args.output, &args.shards)?;
+
     // Prepare output directory
     prepare_output_dir(&args.output, args.force)?;
 
     // Copy artifacts for each instance from its owning shard
     copy_artifacts(&loaded, &union_instances, &owner_shard, &args.output)?;
 
-    // Merge evaluation.json if any shard has one
+    // Merge prediction files (all_preds*.jsonl + metadata) for `bench evaluate`.
+    merge_predictions(&loaded, &owner_shard, &args.output)?;
+
+    // Merge evaluation.json if every shard has one
     merge_evaluation_json(&loaded, &owner_shard, &args.output)?;
 
     // Recompute aggregates over the union
     let base = &loaded[0].2;
     let mut merged = crate::run::swebench::recompute_aggregates(base, union_instances.clone());
+
+    // `recompute_aggregates` counts outcomes per-instance, but a pass@k sweep has
+    // one collapsed row per task while results.json records per-run *slots* (and
+    // `bench audit` recomputes the same way from the copied trajectories). Recount
+    // submitted/errored/skipped/budget_halted per slot so the merged sweep audits.
+    let slots = recount_slot_outcomes(&args.output, &union_instances)?;
+    merged.submitted = slots.submitted;
+    merged.errored = slots.errored;
+    merged.skipped = slots.skipped;
+    merged.budget_halted = slots.budget_halted;
+
+    // Rebuild subset metadata so it describes the merged union rather than shard 0;
+    // downstream `bench compare` keys "same subset?" off this filter spec.
+    let union_filter_spec = merged_filter_spec(base, &union_instances);
+    merged.filter_spec = union_filter_spec.clone();
 
     // Build merged manifest (clone shard0's, add merged_from)
     let merged_from: Vec<MergeShardProvenance> = loaded
@@ -135,6 +157,7 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
         manifest.dataset.instance_count = union_instances.len();
         manifest.dataset.selected_row_count = union_instances.len();
         manifest.dataset.post_filter_row_count = union_instances.len();
+        manifest.dataset.filter_spec = Some(union_filter_spec);
     }
 
     // Update sweep_status to completed
@@ -417,14 +440,37 @@ fn copy_artifacts(
     Ok(())
 }
 
-/// Copy all artifact files for a single instance from `src_sweep` to `dst_sweep`.
-/// Supports both the nested layout (`<id>/run-N.traj.json`) and legacy flat layout
-/// (`<id>.traj.json`). Copies the entire per-instance subdirectory if it exists.
+/// Copy all artifact files for a single instance from `src_sweep` to `dst_sweep`,
+/// preserving the source shard's on-disk layout so the copied paths still satisfy
+/// `bench audit`. Recognizes the same three layouts audit does:
+///   * nested      `<id>/run-N.traj.json`   (whole per-instance dir)
+///   * legacy flat `<id>.traj.json` / `<id>.patch`
+///   * bundled     `trajectories/<id>.traj.json` / `patches/<id>.patch`
 fn copy_instance_artifacts(
     src_sweep: &Path,
     dst_sweep: &Path,
     instance_id: &str,
 ) -> Result<(), Error> {
+    let copy_file = |src: PathBuf, dst: PathBuf| -> Result<(), Error> {
+        if src.exists() {
+            if let Some(parent) = dst.parent() {
+                fs::create_dir_all(parent).map_err(|e| {
+                    Error::Config(crate::error::ConfigError::Invalid(format!(
+                        "merge: failed to create '{}': {e}",
+                        parent.display()
+                    )))
+                })?;
+            }
+            fs::copy(&src, &dst).map_err(|e| {
+                Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "merge: failed to copy '{}': {e}",
+                    src.display()
+                )))
+            })?;
+        }
+        Ok(())
+    };
+
     let inst_dir = src_sweep.join(instance_id);
     if inst_dir.is_dir() {
         // Nested layout: copy the whole per-instance directory
@@ -435,19 +481,28 @@ fn copy_instance_artifacts(
             )))
         })?;
     } else {
-        // Legacy flat layout: copy <id>.traj.json and <id>.patch if they exist
+        // Legacy flat layout: <id>.traj.json / <id>.patch at the sweep root.
         for ext in [".traj.json", ".patch"] {
-            let src = src_sweep.join(format!("{instance_id}{ext}"));
-            if src.exists() {
-                let dst = dst_sweep.join(format!("{instance_id}{ext}"));
-                fs::copy(&src, &dst).map_err(|e| {
-                    Error::Config(crate::error::ConfigError::Invalid(format!(
-                        "merge: failed to copy '{}': {e}",
-                        src.display()
-                    )))
-                })?;
-            }
+            let name = format!("{instance_id}{ext}");
+            copy_file(src_sweep.join(&name), dst_sweep.join(&name))?;
         }
+        // Bundled layout: trajectories/<id>.traj.json and patches/<id>.patch.
+        copy_file(
+            src_sweep
+                .join("trajectories")
+                .join(format!("{instance_id}.traj.json")),
+            dst_sweep
+                .join("trajectories")
+                .join(format!("{instance_id}.traj.json")),
+        )?;
+        copy_file(
+            src_sweep
+                .join("patches")
+                .join(format!("{instance_id}.patch")),
+            dst_sweep
+                .join("patches")
+                .join(format!("{instance_id}.patch")),
+        )?;
     }
     Ok(())
 }
@@ -585,6 +640,252 @@ fn merge_evaluation_json(
             "merge: failed to write evaluation.json: {e}"
         )))
     })?;
+
+    Ok(())
+}
+
+/// Best-effort absolute, symlink-resolved path. Falls back to a lexical absolute
+/// path when the target does not exist yet (e.g. the not-yet-created output dir).
+fn abs_path(p: &Path) -> PathBuf {
+    p.canonicalize()
+        .or_else(|_| std::path::absolute(p))
+        .unwrap_or_else(|_| p.to_path_buf())
+}
+
+/// Reject an `--output` that is equal to, contains, or is contained by any input
+/// shard. Under `--force` the output dir is `remove_dir_all`'d, so an overlapping
+/// path would delete the shard artifacts before they are copied.
+fn validate_output_isolation(output: &Path, shards: &[PathBuf]) -> Result<(), Error> {
+    let out_abs = abs_path(output);
+    for shard in shards {
+        let shard_abs = abs_path(shard);
+        if out_abs == shard_abs
+            || out_abs.starts_with(&shard_abs)
+            || shard_abs.starts_with(&out_abs)
+        {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: output directory '{}' overlaps input shard '{}'; \
+                 choose an --output path that is outside every shard",
+                output.display(),
+                shard.display()
+            ))));
+        }
+    }
+    Ok(())
+}
+
+/// Rebuild the subset filter spec so it describes the merged union (sorted
+/// instance IDs) rather than inheriting shard 0's per-shard filter.
+fn merged_filter_spec(
+    base: &SweepResults,
+    union_instances: &[crate::run::swebench::InstanceResult],
+) -> crate::run::swebench::FilterSpec {
+    let mut ids: Vec<String> = union_instances
+        .iter()
+        .map(|r| r.instance_id.clone())
+        .collect();
+    ids.sort();
+    crate::run::swebench::FilterSpec {
+        // The full dataset size is identical across shards (provenance-checked).
+        original_count: base.filter_spec.original_count,
+        selected_count: ids.len(),
+        instance_ids: Some(ids),
+        limit: None,
+        sample: None,
+        seed: None,
+        stratify_by: None,
+        stratify_mode: None,
+    }
+}
+
+#[derive(Default)]
+struct SlotOutcomeCounts {
+    submitted: usize,
+    errored: usize,
+    skipped: usize,
+    budget_halted: usize,
+}
+
+/// Recount per-run-slot outcomes from the copied trajectories, mirroring exactly
+/// what `bench audit` recomputes (see `audit::run`), so the merged results.json
+/// reconciles for pass@k/rerun sweeps where one task spans several run slots.
+fn recount_slot_outcomes(
+    output: &Path,
+    union_instances: &[crate::run::swebench::InstanceResult],
+) -> Result<SlotOutcomeCounts, Error> {
+    let exit_reasons: HashMap<&str, &str> = union_instances
+        .iter()
+        .map(|r| (r.instance_id.as_str(), r.exit_reason.as_str()))
+        .collect();
+
+    // Map each instance to its run-slot trajectory files, reusing audit's
+    // discovery + path parsing so merge and audit agree on what counts.
+    let trajectories = crate::run::audit::collect_trajectories_on_disk(output).map_err(|e| {
+        Error::Config(crate::error::ConfigError::Invalid(format!(
+            "merge: failed to scan merged trajectories: {e}"
+        )))
+    })?;
+    let mut instances_runs: HashMap<String, BTreeMap<u32, PathBuf>> = HashMap::new();
+    for path in &trajectories {
+        if let Some((inst_id, run_index)) = crate::run::audit::parse_trajectory_path(output, path) {
+            instances_runs
+                .entry(inst_id)
+                .or_default()
+                .entry(run_index)
+                .or_insert_with(|| path.clone());
+        }
+    }
+
+    let mut counts = SlotOutcomeCounts::default();
+    for (inst_id, runs) in &instances_runs {
+        let is_skipped_resume =
+            exit_reasons.get(inst_id.as_str()).copied() == Some("skipped_resume");
+        if is_skipped_resume {
+            counts.skipped += 1;
+        }
+        for path in runs.values() {
+            let Ok(content) = fs::read_to_string(path) else {
+                continue;
+            };
+            let Ok(val) = serde_json::from_str::<Value>(&content) else {
+                continue;
+            };
+            let outcome = val
+                .get("info")
+                .and_then(|i| i.get("outcome"))
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            match outcome {
+                "submitted" if !is_skipped_resume => counts.submitted += 1,
+                "errored" | "error" => counts.errored += 1,
+                "skipped" if !is_skipped_resume => counts.skipped += 1,
+                "budget_halted" | "budget_halt" => counts.budget_halted += 1,
+                _ => {}
+            }
+        }
+    }
+    Ok(counts)
+}
+
+/// Merge prediction files so the merged sweep can be scored by `bench evaluate`,
+/// which reads `<sweep>/all_preds.jsonl`. Keeps only rows owned by the merged
+/// union, preserves per-run `all_preds.run-k.jsonl` files, and rewrites metadata.
+fn merge_predictions(
+    loaded: &[(String, PathBuf, SweepResults)],
+    owner_shard: &HashMap<String, usize>,
+    output: &Path,
+) -> Result<(), Error> {
+    use crate::run::swebench::{
+        PredictionsMetadata, predictions_metadata_path, predictions_metadata_path_for_run,
+        predictions_path, predictions_path_for_run, write_predictions_metadata,
+    };
+
+    // Only merge predictions if the shards actually wrote them.
+    if !loaded
+        .iter()
+        .any(|(_, dir, _)| predictions_path(dir).exists())
+    {
+        return Ok(());
+    }
+
+    // Owning shard for a prediction row: the aggregate file may carry unique
+    // `<id>::run-k` IDs plus an `original_instance_id`; per-run files keep the
+    // original SWE-bench ID. Resolve both to the underlying instance id.
+    let owned_line = |shard_idx: usize, line: &str| -> bool {
+        let Ok(val) = serde_json::from_str::<Value>(line) else {
+            return false;
+        };
+        let orig = val
+            .get("original_instance_id")
+            .and_then(Value::as_str)
+            .or_else(|| val.get("instance_id").and_then(Value::as_str))
+            .unwrap_or("");
+        owner_shard.get(orig).copied() == Some(shard_idx)
+    };
+
+    // Collect the set of run indices present across shards (uniform by config).
+    let mut run_indices: Vec<u32> = Vec::new();
+    for (_, dir, _) in loaded {
+        let mut k = 1u32;
+        while predictions_path_for_run(dir, k).exists() {
+            if !run_indices.contains(&k) {
+                run_indices.push(k);
+            }
+            k += 1;
+        }
+    }
+    run_indices.sort_unstable();
+
+    // Merge the aggregate all_preds.jsonl.
+    let mut aggregate = String::new();
+    let mut aggregate_rows = 0usize;
+    let mut aggregate_unique_ids = false;
+    for (shard_idx, (_, dir, _)) in loaded.iter().enumerate() {
+        let path = predictions_path(dir);
+        let Ok(text) = fs::read_to_string(&path) else {
+            continue;
+        };
+        for line in text.lines().filter(|l| !l.trim().is_empty()) {
+            if owned_line(shard_idx, line) {
+                if line.contains("original_instance_id") {
+                    aggregate_unique_ids = true;
+                }
+                aggregate.push_str(line);
+                aggregate.push('\n');
+                aggregate_rows += 1;
+            }
+        }
+    }
+    fs::write(predictions_path(output), aggregate).map_err(|e| {
+        Error::Config(crate::error::ConfigError::Invalid(format!(
+            "merge: failed to write all_preds.jsonl: {e}"
+        )))
+    })?;
+    write_predictions_metadata(
+        &predictions_metadata_path(output),
+        &PredictionsMetadata {
+            predictions_file: "all_preds.jsonl".to_owned(),
+            aggregate: true,
+            run_index: None,
+            row_count: aggregate_rows,
+            // The aggregate is sb-cli-safe only when it carries no duplicate
+            // (per-run) instance IDs — i.e. a single-run merge.
+            swebench_evaluator_compatible: !aggregate_unique_ids,
+        },
+    )?;
+
+    // Merge each per-run all_preds.run-k.jsonl.
+    for &k in &run_indices {
+        let mut run_text = String::new();
+        let mut run_rows = 0usize;
+        for (shard_idx, (_, dir, _)) in loaded.iter().enumerate() {
+            let Ok(text) = fs::read_to_string(predictions_path_for_run(dir, k)) else {
+                continue;
+            };
+            for line in text.lines().filter(|l| !l.trim().is_empty()) {
+                if owned_line(shard_idx, line) {
+                    run_text.push_str(line);
+                    run_text.push('\n');
+                    run_rows += 1;
+                }
+            }
+        }
+        fs::write(predictions_path_for_run(output, k), run_text).map_err(|e| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: failed to write all_preds.run-{k}.jsonl: {e}"
+            )))
+        })?;
+        write_predictions_metadata(
+            &predictions_metadata_path_for_run(output, k),
+            &PredictionsMetadata {
+                predictions_file: format!("all_preds.run-{k}.jsonl"),
+                aggregate: false,
+                run_index: Some(k),
+                row_count: run_rows,
+                swebench_evaluator_compatible: true,
+            },
+        )?;
+    }
 
     Ok(())
 }

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -1,0 +1,554 @@
+//! Offline merge of independent sharded sweep result directories.
+//!
+//! `bench merge --shard <dir> --shard <dir> ... --output <dir>` recombines K
+//! completed sweep directories into one canonical aggregate — arithmetically
+//! correct, provenance-preserving, and a drop-in for `bench evaluate`, `bench
+//! report`, `bench triage`, and `bench audit`.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::cli::args::{MergeCmd, MergeCollisionPolicy};
+use crate::error::Error;
+use crate::run::swebench::{
+    MergeShardProvenance, SweepResults, SWEEP_STATUS_COMPLETED, write_sweep_results_atomic,
+};
+
+// ── public types ──────────────────────────────────────────────────────────────
+
+/// Summary of a `bench merge` run, emitted via `--format text|json`.
+#[derive(Debug, Serialize)]
+pub struct MergeReport {
+    /// Per-shard summary: label, dir, instance count.
+    pub shards: Vec<MergeShardSummary>,
+    /// Total instances in the merged output (after collision resolution).
+    pub total_instances: usize,
+    /// Number of instance IDs that appeared in more than one shard.
+    pub duplicates: usize,
+    /// The collision policy that was applied.
+    pub collision_policy: String,
+    /// Path to the output directory.
+    pub output_dir: String,
+    // Combined top-line metrics:
+    pub total_cost_usd: f64,
+    pub submitted: usize,
+    pub errored: usize,
+    pub resolved: usize,
+    pub pass_at_k: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MergeShardSummary {
+    pub label: String,
+    pub dir: String,
+    pub instance_count: usize,
+}
+
+// ── entry point ───────────────────────────────────────────────────────────────
+
+pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
+    // Require ≥2 shards
+    if args.shards.len() < 2 {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(
+            "bench merge requires at least 2 --shard arguments (merging one shard is just a copy)"
+                .to_owned(),
+        )));
+    }
+
+    // Validate label count if provided
+    if !args.labels.is_empty() && args.labels.len() != args.shards.len() {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "number of --label values ({}) must match number of --shard values ({})",
+            args.labels.len(),
+            args.shards.len(),
+        ))));
+    }
+
+    // Build shard labels
+    let labels: Vec<String> = args
+        .shards
+        .iter()
+        .enumerate()
+        .map(|(i, path)| {
+            args.labels.get(i).cloned().unwrap_or_else(|| {
+                path.file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("shard")
+                    .to_owned()
+            })
+        })
+        .collect();
+
+    // Load and validate each shard
+    let mut loaded: Vec<(String, PathBuf, SweepResults)> = Vec::with_capacity(args.shards.len());
+    for (label, dir) in labels.iter().zip(args.shards.iter()) {
+        let results = load_shard(label, dir)?;
+        loaded.push((label.clone(), dir.clone(), results));
+    }
+
+    // Check provenance compatibility
+    check_provenance_compatibility(&loaded)?;
+
+    // Detect collisions and build union instance list
+    let policy = args.on_collision;
+    let (union_instances, duplicates, owner_shard) =
+        build_union_instances(&loaded, policy)?;
+
+    // Prepare output directory
+    prepare_output_dir(&args.output, args.force)?;
+
+    // Copy artifacts for each instance from its owning shard
+    copy_artifacts(&loaded, &union_instances, &owner_shard, &args.output)?;
+
+    // Merge evaluation.json if any shard has one
+    merge_evaluation_json(&loaded, &owner_shard, &args.output)?;
+
+    // Recompute aggregates over the union
+    let base = &loaded[0].2;
+    let mut merged = crate::run::swebench::recompute_aggregates(base, union_instances.clone());
+
+    // Build merged manifest (clone shard0's, add merged_from)
+    let merged_from: Vec<MergeShardProvenance> = loaded
+        .iter()
+        .map(|(label, dir, results)| {
+            let manifest = results.manifest.as_ref();
+            MergeShardProvenance {
+                label: label.clone(),
+                dir: dir.to_string_lossy().to_string(),
+                model: manifest.map(|m| m.model.name.clone()),
+                config_sha256: manifest.map(|m| config_hash(&m.config.resolved)),
+                dataset_sha256: manifest.map(|m| m.dataset.sha256.clone()),
+                git_sha: manifest.and_then(|m| m.harness.git_sha.clone()),
+                instance_count: results.instances.len(),
+            }
+        })
+        .collect();
+
+    if let Some(ref mut manifest) = merged.manifest {
+        manifest.merged_from = Some(merged_from);
+        manifest.source = Some("merge".to_owned());
+        manifest.dataset.instance_count = union_instances.len();
+        manifest.dataset.selected_row_count = union_instances.len();
+        manifest.dataset.post_filter_row_count = union_instances.len();
+    }
+
+    // Update sweep_status to completed
+    merged.sweep_status = SWEEP_STATUS_COMPLETED.into();
+
+    // Write results.json
+    let results_path = args.output.join("results.json");
+    write_sweep_results_atomic(&results_path, &merged)?;
+
+    // Build report
+    let shard_summaries: Vec<MergeShardSummary> = loaded
+        .iter()
+        .map(|(label, dir, results)| MergeShardSummary {
+            label: label.clone(),
+            dir: dir.to_string_lossy().to_string(),
+            instance_count: results.instances.len(),
+        })
+        .collect();
+
+    let resolved = union_instances
+        .iter()
+        .filter(|r| r.resolved_count > 0)
+        .count();
+
+    Ok(MergeReport {
+        shards: shard_summaries,
+        total_instances: union_instances.len(),
+        duplicates,
+        collision_policy: policy_label(policy),
+        output_dir: args.output.to_string_lossy().to_string(),
+        total_cost_usd: merged.estimated_cost_usd,
+        submitted: merged.submitted,
+        errored: merged.errored,
+        resolved,
+        pass_at_k: merged.pass_at_k,
+    })
+}
+
+// ── rendering ─────────────────────────────────────────────────────────────────
+
+impl MergeReport {
+    pub fn render_text(&self) {
+        println!("Shards merged: {}", self.shards.len());
+        for s in &self.shards {
+            println!("  {:20}  {:6} instances  {}", s.label, s.instance_count, s.dir);
+        }
+        println!();
+        println!(
+            "Total instances: {} ({} duplicates resolved via {})",
+            self.total_instances, self.duplicates, self.collision_policy
+        );
+        println!("Output: {}", self.output_dir);
+        println!();
+        println!("Top-line metrics:");
+        println!("  total_cost_usd : {:.6}", self.total_cost_usd);
+        println!("  submitted      : {}", self.submitted);
+        println!("  errored        : {}", self.errored);
+        println!("  resolved       : {}", self.resolved);
+        println!("  pass_at_k      : {:.4}", self.pass_at_k);
+    }
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn load_shard(label: &str, dir: &Path) -> Result<SweepResults, Error> {
+    let results_path = dir.join("results.json");
+    if !results_path.exists() {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "merge: shard '{label}' is missing results.json (path: {})",
+            results_path.display()
+        ))));
+    }
+
+    let text = fs::read_to_string(&results_path).map_err(|e| {
+        Error::Config(crate::error::ConfigError::Invalid(format!(
+            "merge: failed to read shard '{label}' results.json: {e}"
+        )))
+    })?;
+
+    let results: SweepResults = serde_json::from_str(&text).map_err(|e| {
+        Error::Config(crate::error::ConfigError::Invalid(format!(
+            "merge: failed to parse shard '{label}' results.json: {e}"
+        )))
+    })?;
+
+    if results.sweep_status != SWEEP_STATUS_COMPLETED {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "merge: shard '{label}' is not completed (sweep_status={}); \
+             only completed sweeps can be merged",
+            results.sweep_status
+        ))));
+    }
+
+    if results.manifest.is_none() {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+            "merge: shard '{label}' has no manifest in results.json; \
+             manifest is required for provenance-preserving merge"
+        ))));
+    }
+
+    Ok(results)
+}
+
+fn check_provenance_compatibility(loaded: &[(String, PathBuf, SweepResults)]) -> Result<(), Error> {
+    let (label0, _, ref0) = &loaded[0];
+    let manifest0 = ref0.manifest.as_ref().ok_or_else(|| {
+        Error::Config(crate::error::ConfigError::Invalid(format!(
+            "merge: shard '{label0}' has no manifest (should have been caught in load_shard)"
+        )))
+    })?;
+    let dataset_sha0 = &manifest0.dataset.sha256;
+    let model0 = &manifest0.model.name;
+
+    for (label, _, results) in loaded.iter().skip(1) {
+        let manifest = results.manifest.as_ref().ok_or_else(|| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: shard '{label}' has no manifest (should have been caught in load_shard)"
+            )))
+        })?;
+
+        if &manifest.dataset.sha256 != dataset_sha0 {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: shard '{label}' dataset_sha256 '{}' differs from shard '{label0}' '{}'; \
+                 bench merge requires identical dataset across shards \
+                 (use bench matrix for cross-dataset comparison)",
+                manifest.dataset.sha256, dataset_sha0
+            ))));
+        }
+
+        if &manifest.model.name != model0 {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: shard '{label}' model '{}' differs from shard '{label0}' '{}'; \
+                 bench merge requires identical model across shards \
+                 (use bench matrix for cross-model comparison)",
+                manifest.model.name, model0
+            ))));
+        }
+    }
+
+    Ok(())
+}
+
+type UnionResult = Result<(Vec<crate::run::swebench::InstanceResult>, usize, HashMap<String, usize>), Error>;
+
+/// Build the union instance list, detecting/resolving collisions.
+/// Returns (union_instances, duplicates_count, owner_shard_index per instance_id).
+fn build_union_instances(
+    loaded: &[(String, PathBuf, SweepResults)],
+    policy: MergeCollisionPolicy,
+) -> UnionResult {
+    let mut seen: HashMap<String, usize> = HashMap::new(); // id → shard index
+    let mut collisions: Vec<(String, usize, usize)> = Vec::new(); // (id, first_shard, second_shard)
+    let mut duplicates = 0;
+
+    // First pass: detect all collisions
+    for (shard_idx, (_, _, results)) in loaded.iter().enumerate() {
+        for inst in &results.instances {
+            match seen.get(&inst.instance_id) {
+                None => {
+                    seen.insert(inst.instance_id.clone(), shard_idx);
+                }
+                Some(&first_shard) => {
+                    collisions.push((inst.instance_id.clone(), first_shard, shard_idx));
+                }
+            }
+        }
+    }
+
+    if !collisions.is_empty() {
+        match policy {
+            MergeCollisionPolicy::Error => {
+                let ids: Vec<String> = collisions
+                    .iter()
+                    .map(|(id, first, second)| {
+                        format!(
+                            "  '{}' in shards '{}' and '{}'",
+                            id, loaded[*first].0, loaded[*second].0
+                        )
+                    })
+                    .collect();
+                return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "merge: {} instance ID collision(s) detected (use --on-collision \
+                     first-wins or last-wins to override):\n{}",
+                    collisions.len(),
+                    ids.join("\n")
+                ))));
+            }
+            MergeCollisionPolicy::FirstWins => {
+                // owner already set to first occurrence; just count
+                duplicates = collisions.len();
+            }
+            MergeCollisionPolicy::LastWins => {
+                // Override owner to last occurrence
+                for (id, _, last_shard) in &collisions {
+                    seen.insert(id.clone(), *last_shard);
+                }
+                duplicates = collisions.len();
+            }
+        }
+    }
+
+    // Build ordered union (shard order, then instance order within shard)
+    let mut included: HashSet<String> = HashSet::new();
+    let mut union: Vec<crate::run::swebench::InstanceResult> = Vec::new();
+
+    for (shard_idx, (_, _, results)) in loaded.iter().enumerate() {
+        for inst in &results.instances {
+            let owner = seen.get(&inst.instance_id).copied().unwrap_or(shard_idx);
+            if owner == shard_idx && !included.contains(&inst.instance_id) {
+                included.insert(inst.instance_id.clone());
+                union.push(inst.clone());
+            }
+        }
+    }
+
+    Ok((union, duplicates, seen))
+}
+
+fn prepare_output_dir(output: &Path, force: bool) -> Result<(), Error> {
+    if output.exists() {
+        let is_empty = output
+            .read_dir()
+            .map(|mut d| d.next().is_none())
+            .unwrap_or(false);
+        if !is_empty && !force {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: output directory '{}' already exists and is non-empty; \
+                 use --force to overwrite",
+                output.display()
+            ))));
+        }
+    } else {
+        fs::create_dir_all(output).map_err(|e| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: failed to create output directory '{}': {e}",
+                output.display()
+            )))
+        })?;
+    }
+    Ok(())
+}
+
+/// Copy trajectory and patch artifacts for each included instance from its owning shard.
+fn copy_artifacts(
+    loaded: &[(String, PathBuf, SweepResults)],
+    union_instances: &[crate::run::swebench::InstanceResult],
+    owner_shard: &HashMap<String, usize>,
+    output: &Path,
+) -> Result<(), Error> {
+    for inst in union_instances {
+        let shard_idx = owner_shard
+            .get(&inst.instance_id)
+            .copied()
+            .unwrap_or(0);
+        let shard_dir = &loaded[shard_idx].1;
+        copy_instance_artifacts(shard_dir, output, &inst.instance_id)?;
+    }
+    Ok(())
+}
+
+/// Copy all artifact files for a single instance from `src_sweep` to `dst_sweep`.
+/// Supports both the nested layout (`<id>/run-N.traj.json`) and legacy flat layout
+/// (`<id>.traj.json`). Copies the entire per-instance subdirectory if it exists.
+fn copy_instance_artifacts(src_sweep: &Path, dst_sweep: &Path, instance_id: &str) -> Result<(), Error> {
+    let inst_dir = src_sweep.join(instance_id);
+    if inst_dir.is_dir() {
+        // Nested layout: copy the whole per-instance directory
+        let dst_inst_dir = dst_sweep.join(instance_id);
+        copy_dir_recursive(&inst_dir, &dst_inst_dir).map_err(|e| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: failed to copy instance artifacts for '{instance_id}': {e}"
+            )))
+        })?;
+    } else {
+        // Legacy flat layout: copy <id>.traj.json and <id>.patch if they exist
+        for ext in [".traj.json", ".patch"] {
+            let src = src_sweep.join(format!("{instance_id}{ext}"));
+            if src.exists() {
+                let dst = dst_sweep.join(format!("{instance_id}{ext}"));
+                fs::copy(&src, &dst).map_err(|e| {
+                    Error::Config(crate::error::ConfigError::Invalid(format!(
+                        "merge: failed to copy '{}': {e}",
+                        src.display()
+                    )))
+                })?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let target = dst.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_recursive(&entry.path(), &target)?;
+        } else {
+            fs::copy(entry.path(), target)?;
+        }
+    }
+    Ok(())
+}
+
+/// Merge evaluation.json from all shards. Normalizes legacy format to modern.
+/// Writes merged output if any shard had eval data.
+fn merge_evaluation_json(
+    loaded: &[(String, PathBuf, SweepResults)],
+    owner_shard: &HashMap<String, usize>,
+    output: &Path,
+) -> Result<(), Error> {
+    let mut eval_entries: Vec<Value> = Vec::new();
+
+    for (shard_idx, (label, shard_dir, _)) in loaded.iter().enumerate() {
+        let eval_path = shard_dir.join("evaluation.json");
+        if !eval_path.exists() {
+            continue;
+        }
+
+        let text = fs::read_to_string(&eval_path).map_err(|e| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: failed to read shard '{label}' evaluation.json: {e}"
+            )))
+        })?;
+
+        let eval: Value = serde_json::from_str(&text).map_err(|e| {
+            Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: failed to parse shard '{label}' evaluation.json: {e}"
+            )))
+        })?;
+
+        // Parse modern format: instances[].{instance_id, resolved}
+        if let Some(instances) = eval.get("instances").and_then(Value::as_array) {
+            for inst in instances {
+                let id = inst
+                    .get("instance_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if id.is_empty() {
+                    continue;
+                }
+                // Only include if this shard owns the instance
+                if owner_shard.get(id).copied().unwrap_or(shard_idx) == shard_idx {
+                    eval_entries.push(inst.clone());
+                }
+            }
+        } else {
+            // Legacy format: resolved_ids / submitted_ids arrays
+            let mut resolved_ids: HashSet<&str> = HashSet::new();
+            let mut submitted_ids: HashSet<&str> = HashSet::new();
+
+            if let Some(ids) = eval.get("resolved_ids").and_then(Value::as_array) {
+                for v in ids {
+                    if let Some(id) = v.as_str() {
+                        resolved_ids.insert(id);
+                    }
+                }
+            }
+            if let Some(ids) = eval.get("submitted_ids").and_then(Value::as_array) {
+                for v in ids {
+                    if let Some(id) = v.as_str() {
+                        submitted_ids.insert(id);
+                    }
+                }
+            }
+            for id in resolved_ids.union(&submitted_ids) {
+                if owner_shard.get(*id).copied().unwrap_or(shard_idx) == shard_idx {
+                    let resolved = resolved_ids.contains(id);
+                    eval_entries.push(serde_json::json!({
+                        "instance_id": id,
+                        "resolved": resolved
+                    }));
+                }
+            }
+        }
+    }
+
+    if eval_entries.is_empty() {
+        return Ok(());
+    }
+
+    let merged_eval = serde_json::json!({
+        "artifact_kind": "evaluation_results",
+        "schema_version": {"major": 1, "minor": 3},
+        "instances": eval_entries
+    });
+
+    let eval_json = serde_json::to_string_pretty(&merged_eval).map_err(|e| {
+        Error::Config(crate::error::ConfigError::Invalid(format!(
+            "merge: failed to serialize evaluation.json: {e}"
+        )))
+    })?;
+    fs::write(output.join("evaluation.json"), eval_json).map_err(|e| {
+        Error::Config(crate::error::ConfigError::Invalid(format!(
+            "merge: failed to write evaluation.json: {e}"
+        )))
+    })?;
+
+    Ok(())
+}
+
+fn config_hash(resolved_toml: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(resolved_toml.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn policy_label(policy: MergeCollisionPolicy) -> String {
+    match policy {
+        MergeCollisionPolicy::Error => "error".to_owned(),
+        MergeCollisionPolicy::FirstWins => "first-wins".to_owned(),
+        MergeCollisionPolicy::LastWins => "last-wins".to_owned(),
+    }
+}

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -863,6 +863,10 @@ fn strip_volatile_provenance(v: &mut Value) {
         "report_path",
         "report_sha256",
         "source_reports",
+        // `image_names` is the set of Docker images used by *this shard's* instances;
+        // disjoint shards of the same dataset legitimately differ, so it is not a
+        // scoring-identity field (timeout/parallel/backend/dataset still are).
+        "image_names",
     ];
     match v {
         Value::Object(obj) => {
@@ -882,12 +886,34 @@ fn strip_volatile_provenance(v: &mut Value) {
     }
 }
 
-/// Best-effort absolute, symlink-resolved path. Falls back to a lexical absolute
-/// path when the target does not exist yet (e.g. the not-yet-created output dir).
+/// Best-effort absolute, symlink-resolved path. When the target does not exist
+/// yet (e.g. the not-yet-created output dir), canonicalize the nearest existing
+/// ancestor — so symlinks in the parent chain are resolved — and re-append the
+/// non-existent tail. A purely lexical `absolute()` would miss a parent symlink
+/// that points into a shard, letting an overlapping output slip past isolation.
 fn abs_path(p: &Path) -> PathBuf {
-    p.canonicalize()
-        .or_else(|_| std::path::absolute(p))
-        .unwrap_or_else(|_| p.to_path_buf())
+    if let Ok(canon) = p.canonicalize() {
+        return canon;
+    }
+    let mut ancestor = p;
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    loop {
+        if let Ok(base) = ancestor.canonicalize() {
+            let mut result = base;
+            for comp in tail.iter().rev() {
+                result.push(comp);
+            }
+            return result;
+        }
+        match (ancestor.file_name(), ancestor.parent()) {
+            (Some(name), Some(parent)) => {
+                tail.push(name.to_os_string());
+                ancestor = parent;
+            }
+            _ => break,
+        }
+    }
+    std::path::absolute(p).unwrap_or_else(|_| p.to_path_buf())
 }
 
 /// Reject an `--output` that is equal to, contains, or is contained by any input
@@ -1208,10 +1234,20 @@ fn merge_predictions(
     for &k in &run_indices {
         let mut run_text = String::new();
         let mut run_rows = 0usize;
-        for (shard_idx, (_, dir, _)) in loaded.iter().enumerate() {
-            let Ok(text) = fs::read_to_string(predictions_path_for_run(dir, k)) else {
+        for (shard_idx, (label, dir, _)) in loaded.iter().enumerate() {
+            let path = predictions_path_for_run(dir, k);
+            // A missing per-run file is legitimate: rerun sweeps only write a slot
+            // file when that slot produced a submission. But a file that exists yet
+            // cannot be read is corruption — fail rather than silently drop its rows
+            // (bench evaluate reads per-run files when max_runs > 1).
+            if !path.exists() {
                 continue;
-            };
+            }
+            let text = fs::read_to_string(&path).map_err(|e| {
+                Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "merge: shard '{label}' all_preds.run-{k}.jsonl is unreadable: {e}"
+                )))
+            })?;
             for line in text.lines().filter(|l| !l.trim().is_empty()) {
                 if owned_line(shard_idx, line) {
                     run_text.push_str(line);

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -138,6 +138,11 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
     // rather than presenting one shard's cap over all shards' cost.
     merged.cost_limit_usd = None;
 
+    // recompute_aggregates hardcodes the cost source to RateCardEstimate; preserve
+    // the shards' real provenance (provider-reported / free-tier) when they agree,
+    // and report a mix as Unknown rather than mislabeling it as an estimate.
+    merged.actual_cost_source = merged_cost_source(&loaded, merged.actual_cost_usd.is_some());
+
     // `recompute_aggregates` counts outcomes per-instance, but a pass@k sweep has
     // one collapsed row per task while results.json records per-run *slots* (and
     // `bench audit` recomputes the same way from the copied trajectories). Recount
@@ -736,7 +741,7 @@ fn merge_evaluation_json(
                 // Normalize: a pre-`eval_exit_reason` modern entry would otherwise be
                 // copied verbatim and fail `InstanceEvaluation` deserialization
                 // downstream, even though synthesized rows below carry the field.
-                eval_entries.push(normalize_eval_entry(entry));
+                eval_entries.push(normalize_eval_entry(entry, inst.non_empty_patch));
             } else {
                 // `eval_exit_reason` is required by `InstanceEvaluation`; downstream
                 // commands (report/triage/inspect) reject rows that omit it. A row
@@ -817,9 +822,10 @@ fn merge_evaluation_json(
 }
 
 /// Ensure a copied modern evaluation entry carries the `eval_exit_reason` field
-/// that `InstanceEvaluation` requires (legacy artifacts predate it), deriving a
-/// value from `resolved` when absent.
-fn normalize_eval_entry(entry: &Value) -> Value {
+/// that `InstanceEvaluation` requires (legacy artifacts predate it). A row with
+/// no submitted patch was never scored, so classify it `skipped_no_patch` rather
+/// than `unresolved` — the same patch-aware logic used for synthesized rows.
+fn normalize_eval_entry(entry: &Value, has_patch: bool) -> Value {
     let mut e = entry.clone();
     if let Some(obj) = e.as_object_mut() {
         if !obj.contains_key("eval_exit_reason") {
@@ -827,9 +833,16 @@ fn normalize_eval_entry(entry: &Value) -> Value {
                 .get("resolved")
                 .and_then(Value::as_bool)
                 .unwrap_or(false);
+            let reason = if resolved {
+                "resolved"
+            } else if has_patch {
+                "unresolved"
+            } else {
+                "skipped_no_patch"
+            };
             obj.insert(
                 "eval_exit_reason".to_owned(),
-                Value::String(if resolved { "resolved" } else { "unresolved" }.to_owned()),
+                Value::String(reason.to_owned()),
             );
         }
     }
@@ -1324,6 +1337,31 @@ fn merge_rate_limit_events(
         configured_max_rpm: agreed_rpm,
         configured_max_input_tpm: agreed_input_tpm,
     })
+}
+
+/// Combine per-shard actual-cost provenance. When every shard that recorded a
+/// source agrees, keep it; a mix is reported as `Unknown` so a merged
+/// provider-reported + free-tier sweep is not mislabeled. Falls back to
+/// `RateCardEstimate` (recompute_aggregates' default) only when no shard recorded
+/// a source. Returns `None` when the merged sweep has no actual cost at all.
+fn merged_cost_source(
+    loaded: &[(String, PathBuf, SweepResults)],
+    has_actual_cost: bool,
+) -> Option<crate::cost::CostSource> {
+    if !has_actual_cost {
+        return None;
+    }
+    let mut found: Option<crate::cost::CostSource> = None;
+    for (_, _, results) in loaded {
+        if let Some(src) = results.actual_cost_source {
+            match found {
+                None => found = Some(src),
+                Some(f) if f != src => return Some(crate::cost::CostSource::Unknown),
+                _ => {}
+            }
+        }
+    }
+    found.or(Some(crate::cost::CostSource::RateCardEstimate))
 }
 
 fn config_hash(resolved_toml: &str) -> String {

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -133,6 +133,11 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
     // shard 0's), or a throttled later worker would be invisible in the merged run.
     merged.rate_limit_events = merge_rate_limit_events(&loaded);
 
+    // A merged multi-shard sweep ran under no single global cost cap — shard 0's
+    // `--sweep-cost-limit-usd` does not bound the union's ~K× spend, so clear it
+    // rather than presenting one shard's cap over all shards' cost.
+    merged.cost_limit_usd = None;
+
     // `recompute_aggregates` counts outcomes per-instance, but a pass@k sweep has
     // one collapsed row per task while results.json records per-run *slots* (and
     // `bench audit` recomputes the same way from the copied trajectories). Recount
@@ -734,12 +739,22 @@ fn merge_evaluation_json(
                 eval_entries.push(normalize_eval_entry(entry));
             } else {
                 // `eval_exit_reason` is required by `InstanceEvaluation`; downstream
-                // commands (report/triage/inspect) reject rows that omit it.
+                // commands (report/triage/inspect) reject rows that omit it. A row
+                // with no submitted patch was never scored, so label it
+                // `skipped_no_patch` (evaluator-unavailable) rather than `unresolved`
+                // (a real failed verdict), matching canonical `bench evaluate`.
                 let resolved = resolved_ids.contains(id);
+                let eval_exit_reason = if resolved {
+                    "resolved"
+                } else if inst.non_empty_patch {
+                    "unresolved"
+                } else {
+                    "skipped_no_patch"
+                };
                 eval_entries.push(serde_json::json!({
                     "instance_id": id,
                     "resolved": resolved,
-                    "eval_exit_reason": if resolved { "resolved" } else { "unresolved" }
+                    "eval_exit_reason": eval_exit_reason
                 }));
             }
         }
@@ -1089,6 +1104,27 @@ fn merge_predictions(
         return Ok(());
     }
 
+    // If any shard has predictions, every shard must — otherwise we would silently
+    // drop a shard's submissions while still keeping its rows/patches, and
+    // `bench evaluate` would treat those submissions as missing. Fail loudly with
+    // the incomplete shard instead of writing a partial predictions artifact.
+    for (label, dir, _) in loaded {
+        let path = predictions_path(dir);
+        if !path.exists() {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: shard '{label}' is missing all_preds.jsonl while other shards have \
+                 predictions; cannot produce a complete merged predictions set \
+                 (re-run the shard's sweep or evaluate the merged sweep instead)"
+            ))));
+        }
+        if fs::read_to_string(&path).is_err() {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: shard '{label}' all_preds.jsonl is unreadable; cannot produce a \
+                 complete merged predictions set"
+            ))));
+        }
+    }
+
     // Owning shard for a prediction row: the aggregate file may carry unique
     // `<id>::run-k` IDs plus an `original_instance_id`; per-run files keep the
     // original SWE-bench ID. Resolve both to the underlying instance id.
@@ -1205,31 +1241,53 @@ fn merge_predictions(
 }
 
 /// Combine per-shard rate-limit telemetry: sum throttled calls/seconds, take the
-/// peak concurrency, and keep the configured caps (identical across shards).
+/// peak concurrency. The configured caps are kept only when every shard that
+/// recorded telemetry used the same value; a mix is reported as `None` rather
+/// than presenting one shard's cap as if it applied to all.
 fn merge_rate_limit_events(
     loaded: &[(String, PathBuf, SweepResults)],
 ) -> Option<crate::run::rate_limit::RateLimitEvents> {
     let mut any = false;
-    let mut merged = crate::run::rate_limit::RateLimitEvents {
-        throttled_calls: 0,
-        total_throttled_seconds: 0.0,
-        peak_concurrent: 0,
-        configured_max_rpm: None,
-        configured_max_input_tpm: None,
-    };
+    let mut throttled_calls = 0u64;
+    let mut total_throttled_seconds = 0.0;
+    let mut peak_concurrent = 0u32;
+    let mut rpm_caps: HashSet<u32> = HashSet::new();
+    let mut tpm_caps: HashSet<u64> = HashSet::new();
     for (_, _, results) in loaded {
         if let Some(ev) = &results.rate_limit_events {
             any = true;
-            merged.throttled_calls += ev.throttled_calls;
-            merged.total_throttled_seconds += ev.total_throttled_seconds;
-            merged.peak_concurrent = merged.peak_concurrent.max(ev.peak_concurrent);
-            merged.configured_max_rpm = merged.configured_max_rpm.or(ev.configured_max_rpm);
-            merged.configured_max_input_tpm = merged
-                .configured_max_input_tpm
-                .or(ev.configured_max_input_tpm);
+            throttled_calls += ev.throttled_calls;
+            total_throttled_seconds += ev.total_throttled_seconds;
+            peak_concurrent = peak_concurrent.max(ev.peak_concurrent);
+            if let Some(rpm) = ev.configured_max_rpm {
+                rpm_caps.insert(rpm);
+            }
+            if let Some(tpm) = ev.configured_max_input_tpm {
+                tpm_caps.insert(tpm);
+            }
         }
     }
-    any.then_some(merged)
+    if !any {
+        return None;
+    }
+    // Only a single agreed value survives; mixed (or absent) caps become None.
+    let agreed_rpm = if rpm_caps.len() == 1 {
+        rpm_caps.iter().next().copied()
+    } else {
+        None
+    };
+    let agreed_input_tpm = if tpm_caps.len() == 1 {
+        tpm_caps.iter().next().copied()
+    } else {
+        None
+    };
+    Some(crate::run::rate_limit::RateLimitEvents {
+        throttled_calls,
+        total_throttled_seconds,
+        peak_concurrent,
+        configured_max_rpm: agreed_rpm,
+        configured_max_input_tpm: agreed_input_tpm,
+    })
 }
 
 fn config_hash(resolved_toml: &str) -> String {

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -52,6 +52,7 @@ pub struct MergeShardSummary {
 
 // ── entry point ───────────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_lines)]
 pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
     // Require ≥2 shards
     if args.shards.len() < 2 {
@@ -112,12 +113,20 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
     // Merge prediction files (all_preds*.jsonl + metadata) for `bench evaluate`.
     merge_predictions(&loaded, &owner_shard, &args.output)?;
 
-    // Merge evaluation.json if every shard has one
-    merge_evaluation_json(&loaded, &owner_shard, &args.output)?;
+    // Merge evaluation.json if every shard has one; returns the authoritative
+    // resolved count when a merged evaluation file was actually written.
+    let eval_resolved = merge_evaluation_json(&loaded, &owner_shard, &args.output)?;
 
     // Recompute aggregates over the union
     let base = &loaded[0].2;
     let mut merged = crate::run::swebench::recompute_aggregates(base, union_instances.clone());
+
+    // Carry every shard's retry_history, not just shard 0's — downstream freshness
+    // checks (e.g. bench budget-fit) use it to reject stale post-retry artifacts.
+    merged.retry_history = loaded
+        .iter()
+        .flat_map(|(_, _, r)| r.retry_history.iter().cloned())
+        .collect();
 
     // `recompute_aggregates` counts outcomes per-instance, but a pass@k sweep has
     // one collapsed row per task while results.json records per-run *slots* (and
@@ -154,7 +163,10 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
     if let Some(ref mut manifest) = merged.manifest {
         manifest.merged_from = Some(merged_from);
         manifest.source = Some("merge".to_owned());
-        manifest.dataset.instance_count = union_instances.len();
+        // Keep `instance_count` (the source dataset cardinality) from the
+        // shard manifest — overwriting it with the union size would make a
+        // 400-of-2294 subset look like a 400-row dataset to evaluation provenance.
+        // Only the subset/post-filter counts describe the merged selection.
         manifest.dataset.selected_row_count = union_instances.len();
         manifest.dataset.post_filter_row_count = union_instances.len();
         manifest.dataset.filter_spec = Some(union_filter_spec);
@@ -177,10 +189,14 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
         })
         .collect();
 
-    let resolved = union_instances
-        .iter()
-        .filter(|r| r.resolved_count > 0)
-        .count();
+    // Prefer the authoritative resolved count from the merged evaluation.json
+    // when present; otherwise fall back to the pass@k/submission proxy.
+    let resolved = eval_resolved.unwrap_or_else(|| {
+        union_instances
+            .iter()
+            .filter(|r| r.resolved_count > 0)
+            .count()
+    });
 
     Ok(MergeReport {
         shards: shard_summaries,
@@ -533,13 +549,13 @@ fn merge_evaluation_json(
     loaded: &[(String, PathBuf, SweepResults)],
     owner_shard: &HashMap<String, usize>,
     output: &Path,
-) -> Result<(), Error> {
+) -> Result<Option<usize>, Error> {
     let shards_with_eval = loaded
         .iter()
         .filter(|(_, dir, _)| dir.join("evaluation.json").exists())
         .count();
     if shards_with_eval == 0 {
-        return Ok(());
+        return Ok(None);
     }
     if shards_with_eval < loaded.len() {
         eprintln!(
@@ -548,12 +564,13 @@ fn merge_evaluation_json(
              (re-run `bench evaluate` on the merged sweep, or evaluate every shard first)",
             loaded.len()
         );
-        return Ok(());
+        return Ok(None);
     }
 
     let mut eval_entries: Vec<Value> = Vec::new();
 
-    for (shard_idx, (label, shard_dir, _)) in loaded.iter().enumerate() {
+    for (shard_idx, (label, shard_dir, shard_results)) in loaded.iter().enumerate() {
+        let owns = |id: &str| owner_shard.get(id).copied().unwrap_or(shard_idx) == shard_idx;
         let eval_path = shard_dir.join("evaluation.json");
         if !eval_path.exists() {
             continue;
@@ -578,51 +595,45 @@ fn merge_evaluation_json(
                     .get("instance_id")
                     .and_then(Value::as_str)
                     .unwrap_or("");
-                if id.is_empty() {
-                    continue;
-                }
-                // Only include if this shard owns the instance
-                if owner_shard.get(id).copied().unwrap_or(shard_idx) == shard_idx {
+                if !id.is_empty() && owns(id) {
                     eval_entries.push(inst.clone());
                 }
             }
         } else {
-            // Legacy format: resolved_ids / submitted_ids arrays
-            let mut resolved_ids: HashSet<&str> = HashSet::new();
-            let mut submitted_ids: HashSet<&str> = HashSet::new();
-
-            if let Some(ids) = eval.get("resolved_ids").and_then(Value::as_array) {
-                for v in ids {
-                    if let Some(id) = v.as_str() {
-                        resolved_ids.insert(id);
-                    }
+            // Legacy sb-cli format: resolved_ids / submitted_ids arrays. These omit
+            // errored/no-patch instances, but the merged file is modern, so audit
+            // wants an entry for *every* owned trajectory. Synthesize an entry for
+            // each owned instance, marking those absent from resolved_ids unresolved.
+            let resolved_ids: HashSet<&str> = eval
+                .get("resolved_ids")
+                .and_then(Value::as_array)
+                .map(|a| a.iter().filter_map(Value::as_str).collect())
+                .unwrap_or_default();
+            for inst in &shard_results.instances {
+                let id = inst.instance_id.as_str();
+                if !owns(id) {
+                    continue;
                 }
-            }
-            if let Some(ids) = eval.get("submitted_ids").and_then(Value::as_array) {
-                for v in ids {
-                    if let Some(id) = v.as_str() {
-                        submitted_ids.insert(id);
-                    }
-                }
-            }
-            for id in resolved_ids.union(&submitted_ids) {
-                if owner_shard.get(*id).copied().unwrap_or(shard_idx) == shard_idx {
-                    let resolved = resolved_ids.contains(id);
-                    // `eval_exit_reason` is required by `InstanceEvaluation`; downstream
-                    // commands (report/triage/inspect) reject rows that omit it.
-                    eval_entries.push(serde_json::json!({
-                        "instance_id": id,
-                        "resolved": resolved,
-                        "eval_exit_reason": if resolved { "resolved" } else { "unresolved" }
-                    }));
-                }
+                let resolved = resolved_ids.contains(id);
+                // `eval_exit_reason` is required by `InstanceEvaluation`; downstream
+                // commands (report/triage/inspect) reject rows that omit it.
+                eval_entries.push(serde_json::json!({
+                    "instance_id": id,
+                    "resolved": resolved,
+                    "eval_exit_reason": if resolved { "resolved" } else { "unresolved" }
+                }));
             }
         }
     }
 
     if eval_entries.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
+
+    let resolved_count = eval_entries
+        .iter()
+        .filter(|e| e.get("resolved").and_then(Value::as_bool) == Some(true))
+        .count();
 
     let merged_eval = serde_json::json!({
         "artifact_kind": "evaluation_results",
@@ -641,7 +652,7 @@ fn merge_evaluation_json(
         )))
     })?;
 
-    Ok(())
+    Ok(Some(resolved_count))
 }
 
 /// Best-effort absolute, symlink-resolved path. Falls back to a lexical absolute
@@ -719,7 +730,9 @@ fn recount_slot_outcomes(
         .collect();
 
     // Map each instance to its run-slot trajectory files, reusing audit's
-    // discovery + path parsing so merge and audit agree on what counts.
+    // discovery + path parsing so merge and audit agree on what counts. The
+    // de-duplication rule matches audit exactly: prefer the deeper (nested) path,
+    // and at equal depth prefer `run-N.traj.json` over a sibling `trajectory.json`.
     let trajectories = crate::run::audit::collect_trajectories_on_disk(output).map_err(|e| {
         Error::Config(crate::error::ConfigError::Invalid(format!(
             "merge: failed to scan merged trajectories: {e}"
@@ -728,11 +741,23 @@ fn recount_slot_outcomes(
     let mut instances_runs: HashMap<String, BTreeMap<u32, PathBuf>> = HashMap::new();
     for path in &trajectories {
         if let Some((inst_id, run_index)) = crate::run::audit::parse_trajectory_path(output, path) {
-            instances_runs
-                .entry(inst_id)
-                .or_default()
-                .entry(run_index)
-                .or_insert_with(|| path.clone());
+            let slot = instances_runs.entry(inst_id).or_default();
+            match slot.get(&run_index) {
+                None => {
+                    slot.insert(run_index, path.clone());
+                }
+                Some(existing) => {
+                    let current_depth = path.components().count();
+                    let existing_depth = existing.components().count();
+                    let prefer = current_depth > existing_depth
+                        || (current_depth == existing_depth
+                            && file_name_contains(path, "run-1")
+                            && file_name_contains(existing, "trajectory.json"));
+                    if prefer {
+                        slot.insert(run_index, path.clone());
+                    }
+                }
+            }
         }
     }
 
@@ -764,12 +789,42 @@ fn recount_slot_outcomes(
             }
         }
     }
+
+    // Budget-halted / skipped tasks that never started have no trajectory files;
+    // audit counts them from results.json, so we must too or the merged
+    // `budget_halted`/`skipped` would drop to zero and fail audit.
+    for inst in union_instances {
+        if instances_runs.contains_key(&inst.instance_id) {
+            continue;
+        }
+        let exit_reason = inst.exit_reason.as_str();
+        let outcome = inst.outcome.as_deref().unwrap_or("");
+        if exit_reason == "budget_halt"
+            || exit_reason == "budget_halted"
+            || outcome == "budget_halted"
+        {
+            counts.budget_halted += 1;
+        } else if exit_reason == "skipped"
+            || exit_reason == "skipped_resume"
+            || outcome == "skipped"
+        {
+            counts.skipped += 1;
+        }
+    }
+
     Ok(counts)
+}
+
+fn file_name_contains(path: &Path, needle: &str) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.contains(needle))
 }
 
 /// Merge prediction files so the merged sweep can be scored by `bench evaluate`,
 /// which reads `<sweep>/all_preds.jsonl`. Keeps only rows owned by the merged
 /// union, preserves per-run `all_preds.run-k.jsonl` files, and rewrites metadata.
+#[allow(clippy::too_many_lines)]
 fn merge_predictions(
     loaded: &[(String, PathBuf, SweepResults)],
     owner_shard: &HashMap<String, usize>,
@@ -803,15 +858,28 @@ fn merge_predictions(
         owner_shard.get(orig).copied() == Some(shard_idx)
     };
 
-    // Collect the set of run indices present across shards (uniform by config).
+    // Collect every run index that has a per-run prediction file in any shard.
+    // Rerun sweeps write `all_preds.run-k.jsonl` only for run slots that produced
+    // a submission, so indices can be sparse (e.g. run 1 empty, run 2 present) —
+    // a contiguous `while exists(k)` scan would stop at the first gap and drop
+    // later runs, so scan the directory listing instead.
     let mut run_indices: Vec<u32> = Vec::new();
     for (_, dir, _) in loaded {
-        let mut k = 1u32;
-        while predictions_path_for_run(dir, k).exists() {
-            if !run_indices.contains(&k) {
-                run_indices.push(k);
+        let Ok(entries) = fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if let Some(k) = entry
+                .file_name()
+                .to_str()
+                .and_then(|n| n.strip_prefix("all_preds.run-"))
+                .and_then(|n| n.strip_suffix(".jsonl"))
+                .and_then(|n| n.parse::<u32>().ok())
+            {
+                if !run_indices.contains(&k) {
+                    run_indices.push(k);
+                }
             }
-            k += 1;
         }
     }
     run_indices.sort_unstable();

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -95,6 +95,7 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
 
     // Check provenance compatibility
     check_provenance_compatibility(&loaded)?;
+    check_uniform_rerun_count(&loaded)?;
 
     // Detect collisions and build union instance list
     let policy = args.on_collision;
@@ -377,6 +378,31 @@ fn check_provenance_compatibility(loaded: &[(String, PathBuf, SweepResults)]) ->
     Ok(())
 }
 
+/// Reject shards sampled with different `--rerun` (pass@k) counts. `runs` is a
+/// per-row sweep-shaping value, not part of `config.resolved`, so a `--rerun 1`
+/// shard and a `--rerun 3` shard would otherwise pass the config check and yield
+/// a single pass@k summary over tasks sampled with different k.
+fn check_uniform_rerun_count(loaded: &[(String, PathBuf, SweepResults)]) -> Result<(), Error> {
+    let mut reference: Option<(&str, u32)> = None;
+    for (label, _, results) in loaded {
+        let Some(runs) = results.instances.iter().map(|r| r.runs).max() else {
+            continue; // empty shard contributes no rerun signal
+        };
+        match reference {
+            None => reference = Some((label, runs)),
+            Some((ref_label, ref_runs)) if runs != ref_runs => {
+                return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "merge: shard '{label}' rerun count ({runs}) differs from shard \
+                     '{ref_label}' ({ref_runs}); bench merge requires the same --rerun \
+                     (pass@k) count across shards"
+                ))));
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
 type UnionResult = Result<
     (
         Vec<crate::run::swebench::InstanceResult>,
@@ -545,30 +571,31 @@ fn copy_instance_artifacts(
                 "merge: failed to copy instance artifacts for '{instance_id}': {e}"
             )))
         })?;
-    } else {
-        // Legacy flat layout: <id>.traj.json / <id>.patch at the sweep root.
-        for ext in [".traj.json", ".patch"] {
-            let name = format!("{instance_id}{ext}");
-            copy_file(src_sweep.join(&name), dst_sweep.join(&name))?;
-        }
-        // Bundled layout: trajectories/<id>.traj.json and patches/<id>.patch.
-        copy_file(
-            src_sweep
-                .join("trajectories")
-                .join(format!("{instance_id}.traj.json")),
-            dst_sweep
-                .join("trajectories")
-                .join(format!("{instance_id}.traj.json")),
-        )?;
-        copy_file(
-            src_sweep
-                .join("patches")
-                .join(format!("{instance_id}.patch")),
-            dst_sweep
-                .join("patches")
-                .join(format!("{instance_id}.patch")),
-        )?;
     }
+    // Always also copy the flat and bundled artifacts: a shard can store the
+    // trajectory under a nested `<id>/` dir while keeping the submitted patch at
+    // the root (`<id>.patch`) or under `patches/<id>.patch`. copy_file no-ops on
+    // missing sources, so this is safe regardless of the source layout.
+    for ext in [".traj.json", ".patch"] {
+        let name = format!("{instance_id}{ext}");
+        copy_file(src_sweep.join(&name), dst_sweep.join(&name))?;
+    }
+    copy_file(
+        src_sweep
+            .join("trajectories")
+            .join(format!("{instance_id}.traj.json")),
+        dst_sweep
+            .join("trajectories")
+            .join(format!("{instance_id}.traj.json")),
+    )?;
+    copy_file(
+        src_sweep
+            .join("patches")
+            .join(format!("{instance_id}.patch")),
+        dst_sweep
+            .join("patches")
+            .join(format!("{instance_id}.patch")),
+    )?;
     Ok(())
 }
 
@@ -594,6 +621,7 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
 /// merged file when *every* shard carries evaluation data; if evaluation is
 /// present in only some shards we omit it entirely (and warn) so the merged
 /// sweep still audits cleanly as an unevaluated sweep.
+#[allow(clippy::too_many_lines)]
 fn merge_evaluation_json(
     loaded: &[(String, PathBuf, SweepResults)],
     owner_shard: &HashMap<String, usize>,
@@ -617,6 +645,7 @@ fn merge_evaluation_json(
     }
 
     let mut eval_entries: Vec<Value> = Vec::new();
+    let mut merged_provenance: Option<(String, Value)> = None; // (shard label, provenance)
 
     for (shard_idx, (label, shard_dir, shard_results)) in loaded.iter().enumerate() {
         let owns = |id: &str| owner_shard.get(id).copied().unwrap_or(shard_idx) == shard_idx;
@@ -636,6 +665,24 @@ fn merge_evaluation_json(
                 "merge: failed to parse shard '{label}' evaluation.json: {e}"
             )))
         })?;
+
+        // Evaluator provenance must agree: merging verdicts produced by different
+        // backends / versions / dataset settings into one authoritative file would
+        // hide the mismatch from downstream compare/report.
+        if let Some(prov) = eval.get("provenance").filter(|p| !p.is_null()) {
+            match &merged_provenance {
+                None => merged_provenance = Some((label.clone(), prov.clone())),
+                Some((ref0, prov0)) => {
+                    if evaluator_identity(prov) != evaluator_identity(prov0) {
+                        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                            "merge: shard '{label}' evaluator provenance (backend/version/dataset) \
+                             differs from shard '{ref0}'; bench merge requires shards evaluated \
+                             with the same evaluator"
+                        ))));
+                    }
+                }
+            }
+        }
 
         // Parse modern format: instances[].{instance_id, resolved}
         if let Some(instances) = eval.get("instances").and_then(Value::as_array) {
@@ -684,11 +731,33 @@ fn merge_evaluation_json(
         .filter(|e| e.get("resolved").and_then(Value::as_bool) == Some(true))
         .count();
 
-    let merged_eval = serde_json::json!({
+    let mut merged_eval = serde_json::json!({
         "artifact_kind": "evaluation_results",
         "schema_version": {"major": 1, "minor": 3},
-        "instances": eval_entries
+        "instances": eval_entries,
     });
+
+    // Recompute the top-level summary fields `bench report` (submission_class_rollup)
+    // and `bench compare` (test_only_resolved_rate) read, over the merged union.
+    let insts: Vec<crate::run::evaluate::InstanceEvaluation> = merged_eval["instances"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|e| serde_json::from_value(e.clone()).ok())
+                .collect()
+        })
+        .unwrap_or_default();
+    if insts.len() == merged_eval["instances"].as_array().map_or(0, Vec::len) {
+        let (rollup, test_only_resolved_rate) =
+            crate::run::evaluate::build_submission_class_rollup(&insts);
+        if let Ok(v) = serde_json::to_value(rollup) {
+            merged_eval["submission_class_rollup"] = v;
+        }
+        merged_eval["test_only_resolved_rate"] = serde_json::json!(test_only_resolved_rate);
+    }
+    if let Some((_, prov)) = merged_provenance {
+        merged_eval["provenance"] = prov;
+    }
 
     let eval_json = serde_json::to_string_pretty(&merged_eval).map_err(|e| {
         Error::Config(crate::error::ConfigError::Invalid(format!(
@@ -702,6 +771,17 @@ fn merge_evaluation_json(
     })?;
 
     Ok(Some(resolved_count))
+}
+
+/// Evaluator identity fields that must match across shards before their verdicts
+/// can be merged into one authoritative `evaluation.json`.
+fn evaluator_identity(prov: &Value) -> (String, String, String) {
+    let field = |k: &str| prov.get(k).and_then(Value::as_str).unwrap_or("").to_owned();
+    (
+        field("backend"),
+        field("backend_version"),
+        field("dataset_sha256"),
+    )
 }
 
 /// Best-effort absolute, symlink-resolved path. Falls back to a lexical absolute
@@ -769,16 +849,12 @@ struct SlotOutcomeCounts {
     failures_by_category: BTreeMap<crate::trajectory::FailureCategory, usize>,
 }
 
-/// Map a run-slot trajectory path to its sibling patch and report whether it is a
-/// non-empty patch (`<...>/run-k.traj.json` → `<...>/run-k.patch`, etc.).
-fn slot_has_nonempty_patch(traj_path: &Path) -> bool {
-    let Some(name) = traj_path.file_name().and_then(|n| n.to_str()) else {
-        return false;
-    };
-    let Some(stem) = name.strip_suffix(".traj.json") else {
-        return false; // e.g. legacy `trajectory.json` — no deterministic patch sibling
-    };
-    let patch_path = traj_path.with_file_name(format!("{stem}.patch"));
+/// Report whether the run slot has a non-empty patch, using the canonical patch
+/// resolver so every layout (nested `run-k.patch`, legacy `<id>.patch`, bundled
+/// `patches/<id>.patch`) is found exactly as the sweep/evaluator would.
+fn slot_has_nonempty_patch(sweep_dir: &Path, instance_id: &str, run_index: u32) -> bool {
+    let patch_path =
+        crate::run::swebench::existing_patch_path_for_run(sweep_dir, instance_id, run_index);
     fs::read_to_string(&patch_path).is_ok_and(|s| !s.trim().is_empty())
 }
 
@@ -834,7 +910,7 @@ fn recount_slot_outcomes(
         if is_skipped_resume {
             counts.skipped += 1;
         }
-        for path in runs.values() {
+        for (run_index, path) in runs {
             let Ok(content) = fs::read_to_string(path) else {
                 continue;
             };
@@ -863,7 +939,7 @@ fn recount_slot_outcomes(
                 if tests_run {
                     counts.submitted_with_tests += 1;
                 }
-                if slot_has_nonempty_patch(path) {
+                if slot_has_nonempty_patch(output, inst_id, *run_index) {
                     counts.with_patch += 1;
                 }
             }

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -17,7 +17,7 @@ use sha2::{Digest, Sha256};
 use crate::cli::args::{MergeCmd, MergeCollisionPolicy};
 use crate::error::Error;
 use crate::run::swebench::{
-    MergeShardProvenance, SweepResults, SWEEP_STATUS_COMPLETED, write_sweep_results_atomic,
+    MergeShardProvenance, SWEEP_STATUS_COMPLETED, SweepResults, write_sweep_results_atomic,
 };
 
 // ── public types ──────────────────────────────────────────────────────────────
@@ -97,8 +97,7 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
 
     // Detect collisions and build union instance list
     let policy = args.on_collision;
-    let (union_instances, duplicates, owner_shard) =
-        build_union_instances(&loaded, policy)?;
+    let (union_instances, duplicates, owner_shard) = build_union_instances(&loaded, policy)?;
 
     // Prepare output directory
     prepare_output_dir(&args.output, args.force)?;
@@ -180,7 +179,10 @@ impl MergeReport {
     pub fn render_text(&self) {
         println!("Shards merged: {}", self.shards.len());
         for s in &self.shards {
-            println!("  {:20}  {:6} instances  {}", s.label, s.instance_count, s.dir);
+            println!(
+                "  {:20}  {:6} instances  {}",
+                s.label, s.instance_count, s.dir
+            );
         }
         println!();
         println!(
@@ -248,6 +250,7 @@ fn check_provenance_compatibility(loaded: &[(String, PathBuf, SweepResults)]) ->
     })?;
     let dataset_sha0 = &manifest0.dataset.sha256;
     let model0 = &manifest0.model.name;
+    let config0 = config_hash(&manifest0.config.resolved);
 
     for (label, _, results) in loaded.iter().skip(1) {
         let manifest = results.manifest.as_ref().ok_or_else(|| {
@@ -273,12 +276,27 @@ fn check_provenance_compatibility(loaded: &[(String, PathBuf, SweepResults)]) ->
                 manifest.model.name, model0
             ))));
         }
+
+        if config_hash(&manifest.config.resolved) != config0 {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "merge: shard '{label}' resolved config differs from shard '{label0}'; \
+                 bench merge requires identical config across shards \
+                 (use bench matrix for cross-config comparison)"
+            ))));
+        }
     }
 
     Ok(())
 }
 
-type UnionResult = Result<(Vec<crate::run::swebench::InstanceResult>, usize, HashMap<String, usize>), Error>;
+type UnionResult = Result<
+    (
+        Vec<crate::run::swebench::InstanceResult>,
+        usize,
+        HashMap<String, usize>,
+    ),
+    Error,
+>;
 
 /// Build the union instance list, detecting/resolving collisions.
 /// Returns (union_instances, duplicates_count, owner_shard_index per instance_id).
@@ -356,25 +374,31 @@ fn build_union_instances(
 
 fn prepare_output_dir(output: &Path, force: bool) -> Result<(), Error> {
     if output.exists() {
-        let is_empty = output
-            .read_dir()
-            .map(|mut d| d.next().is_none())
-            .unwrap_or(false);
-        if !is_empty && !force {
-            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "merge: output directory '{}' already exists and is non-empty; \
-                 use --force to overwrite",
-                output.display()
-            ))));
+        let is_empty = output.read_dir().is_ok_and(|mut d| d.next().is_none());
+        if !is_empty {
+            if !force {
+                return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "merge: output directory '{}' already exists and is non-empty; \
+                     use --force to overwrite",
+                    output.display()
+                ))));
+            }
+            // --force: clear stale artifacts so the merged results.json↔trajectory
+            // bijection that `bench audit` enforces stays intact.
+            fs::remove_dir_all(output).map_err(|e| {
+                Error::Config(crate::error::ConfigError::Invalid(format!(
+                    "merge: failed to clear output directory '{}': {e}",
+                    output.display()
+                )))
+            })?;
         }
-    } else {
-        fs::create_dir_all(output).map_err(|e| {
-            Error::Config(crate::error::ConfigError::Invalid(format!(
-                "merge: failed to create output directory '{}': {e}",
-                output.display()
-            )))
-        })?;
     }
+    fs::create_dir_all(output).map_err(|e| {
+        Error::Config(crate::error::ConfigError::Invalid(format!(
+            "merge: failed to create output directory '{}': {e}",
+            output.display()
+        )))
+    })?;
     Ok(())
 }
 
@@ -386,10 +410,7 @@ fn copy_artifacts(
     output: &Path,
 ) -> Result<(), Error> {
     for inst in union_instances {
-        let shard_idx = owner_shard
-            .get(&inst.instance_id)
-            .copied()
-            .unwrap_or(0);
+        let shard_idx = owner_shard.get(&inst.instance_id).copied().unwrap_or(0);
         let shard_dir = &loaded[shard_idx].1;
         copy_instance_artifacts(shard_dir, output, &inst.instance_id)?;
     }
@@ -399,7 +420,11 @@ fn copy_artifacts(
 /// Copy all artifact files for a single instance from `src_sweep` to `dst_sweep`.
 /// Supports both the nested layout (`<id>/run-N.traj.json`) and legacy flat layout
 /// (`<id>.traj.json`). Copies the entire per-instance subdirectory if it exists.
-fn copy_instance_artifacts(src_sweep: &Path, dst_sweep: &Path, instance_id: &str) -> Result<(), Error> {
+fn copy_instance_artifacts(
+    src_sweep: &Path,
+    dst_sweep: &Path,
+    instance_id: &str,
+) -> Result<(), Error> {
     let inst_dir = src_sweep.join(instance_id);
     if inst_dir.is_dir() {
         // Nested layout: copy the whole per-instance directory

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -48,6 +48,7 @@ pub mod inspect;
 pub mod instance_history;
 pub mod ladder;
 pub mod matrix;
+pub mod merge;
 pub mod mini;
 pub mod mini_result;
 pub mod near_miss;

--- a/src/run/retry.rs
+++ b/src/run/retry.rs
@@ -4,7 +4,7 @@
 //! the selected failed instances and merges their outcomes back into the same
 //! `results.json` with full provenance in `retry_history`.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -191,156 +191,7 @@ pub fn merge_retry_results<S: std::hash::BuildHasher>(
 
     // Recompute all aggregates from the merged instance list so reports and
     // comparisons don't see stale counters from the pre-retry sweep.
-    let total = merged_instances.len();
-    let submitted = merged_instances
-        .iter()
-        .filter(|r| r.outcome.as_deref() == Some("submitted") && r.exit_reason != "skipped_resume")
-        .count();
-    let submitted_with_tests = merged_instances
-        .iter()
-        .filter(|r| {
-            r.outcome.as_deref() == Some("submitted")
-                && r.exit_reason != "skipped_resume"
-                && r.tests_run_before_submit
-        })
-        .count();
-    let skipped = merged_instances
-        .iter()
-        .filter(|r| r.exit_reason == "skipped_resume")
-        .count();
-    let errored = merged_instances
-        .iter()
-        .filter(|r| r.outcome.as_deref() == Some("error"))
-        .count();
-    let budget_halted = merged_instances
-        .iter()
-        .filter(|r| r.exit_reason.starts_with("budget_halt"))
-        .count();
-    let with_patch = merged_instances
-        .iter()
-        .filter(|r| r.non_empty_patch && r.outcome.as_deref() == Some("submitted"))
-        .count();
-    let patch_empty = merged_instances.iter().filter(|r| r.patch_empty()).count();
-    let patch_apply_invalid = merged_instances
-        .iter()
-        .filter(|r| r.failure_category == Some(FailureCategory::PatchApplyInvalid))
-        .count();
-    let github_pr_failures = merged_instances
-        .iter()
-        .filter(|r| r.github_pr_error.is_some())
-        .count();
-    let failures_by_category: BTreeMap<FailureCategory, usize> = {
-        let mut map = BTreeMap::new();
-        for r in &merged_instances {
-            if let Some(cat) = r.failure_category {
-                *map.entry(cat).or_insert(0) += 1;
-            }
-        }
-        map
-    };
-    // Count rows with any resolved run (pass@k semantics: resolved_count > 0 means
-    // at least one of the k runs submitted successfully, regardless of value).
-    let resolved_any = merged_instances
-        .iter()
-        .filter(|r| r.resolved_count > 0)
-        .count();
-    #[allow(clippy::cast_precision_loss)]
-    let pass_at_k = if merged_instances.is_empty() {
-        0.0
-    } else {
-        resolved_any as f64 / merged_instances.len() as f64
-    };
-    let total_prompt_tokens: u64 = merged_instances
-        .iter()
-        .filter_map(|r| r.prompt_tokens)
-        .sum();
-    let total_cache_read_tokens: u64 = merged_instances
-        .iter()
-        .filter_map(|r| r.cache_read_tokens)
-        .sum();
-    let total_cache_creation_tokens: u64 = merged_instances
-        .iter()
-        .filter_map(|r| r.cache_creation_tokens)
-        .sum();
-    let total_completion_tokens: u64 = merged_instances
-        .iter()
-        .filter_map(|r| r.completion_tokens)
-        .sum();
-    let estimated_cost_usd: f64 = merged_instances.iter().filter_map(|r| r.cost_usd).sum();
-    // actual_cost_usd is the sum of per-instance cost_usd when all rows have it.
-    let actual_cost_usd: Option<f64> = if merged_instances.iter().all(|r| r.cost_usd.is_some()) {
-        Some(estimated_cost_usd)
-    } else {
-        None
-    };
-    let baseline_cost_usd = crate::run::swebench::estimate_cost_usd(
-        total_prompt_tokens,
-        total_cache_read_tokens,
-        total_cache_creation_tokens,
-        total_completion_tokens,
-        crate::run::swebench::BASELINE_COST_MODEL,
-    );
-    #[allow(clippy::cast_precision_loss)]
-    let cache_hit_rate =
-        if total_prompt_tokens + total_cache_read_tokens + total_cache_creation_tokens > 0 {
-            (total_cache_read_tokens + total_cache_creation_tokens) as f64
-                / (total_prompt_tokens + total_cache_read_tokens + total_cache_creation_tokens)
-                    as f64
-        } else {
-            0.0
-        };
-    let retried_instances = merged_instances
-        .iter()
-        .filter(|r| !r.retry_reasons.is_empty())
-        .count();
-    let retries: u64 = merged_instances
-        .iter()
-        .map(|r| r.retry_reasons.len() as u64)
-        .sum();
-    let total_fallbacks: u64 = merged_instances
-        .iter()
-        .filter_map(|r| r.fallback_count)
-        .map(u64::from)
-        .sum();
-    let model_mix: BTreeMap<String, usize> = {
-        let mut map = BTreeMap::new();
-        for r in &merged_instances {
-            if let Some(m) = &r.final_model {
-                *map.entry(m.clone()).or_insert(0) += 1;
-            }
-        }
-        map
-    };
-
-    let mut result = original.clone();
-    result.total = total;
-    result.submitted = submitted;
-    result.submitted_with_tests = submitted_with_tests;
-    result.skipped = skipped;
-    result.errored = errored;
-    result.budget_halted = budget_halted;
-    result.with_patch = with_patch;
-    result.patch_empty = patch_empty;
-    result.patch_apply_invalid = patch_apply_invalid;
-    result.github_pr_failures = github_pr_failures;
-    result.failures_by_category = failures_by_category;
-    result.pass_at_k = pass_at_k;
-    result.total_prompt_tokens = total_prompt_tokens;
-    result.total_cache_read_tokens = total_cache_read_tokens;
-    result.total_cache_creation_tokens = total_cache_creation_tokens;
-    result.total_completion_tokens = total_completion_tokens;
-    result.estimated_cost_usd = estimated_cost_usd;
-    result.actual_cost_usd = actual_cost_usd;
-    result.actual_cost_source =
-        actual_cost_usd.map(|_| crate::run::swebench::CostSource::RateCardEstimate);
-    result.baseline_cost_usd = Some(baseline_cost_usd);
-    result.baseline_cost_model = Some(crate::run::swebench::BASELINE_COST_MODEL.to_owned());
-    result.cache_hit_rate = cache_hit_rate;
-    result.retried_instances = retried_instances;
-    result.retries = retries;
-    result.total_fallbacks = total_fallbacks;
-    result.model_mix = model_mix;
-    result.instances = merged_instances;
+    let mut result = crate::run::swebench::recompute_aggregates(original, merged_instances);
     result.retry_history.push(entry);
     result
 }
@@ -651,14 +502,3 @@ pub fn build_history_entry(
     }
 }
 
-// ─── trait helpers used in merge ──────────────────────────────────────────────
-
-trait InstanceResultExt {
-    fn patch_empty(&self) -> bool;
-}
-
-impl InstanceResultExt for InstanceResult {
-    fn patch_empty(&self) -> bool {
-        self.patch_present && !self.non_empty_patch
-    }
-}

--- a/src/run/retry.rs
+++ b/src/run/retry.rs
@@ -501,4 +501,3 @@ pub fn build_history_entry(
         post_resolved_count: post_resolved as usize,
     }
 }
-

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -692,6 +692,33 @@ pub struct ProvenanceManifest {
     /// Points back at the source sweep's manifest for full provenance chain.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reproduced_from: Option<ManifestReproducedFrom>,
+    /// Present only when this sweep was produced by `bench merge`. Records each
+    /// source shard's provenance so the aggregate is fully auditable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merged_from: Option<Vec<MergeShardProvenance>>,
+}
+
+/// Per-shard provenance record written into a merged sweep's manifest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MergeShardProvenance {
+    /// Human-readable label (defaults to the shard directory name).
+    pub label: String,
+    /// Canonical path of the shard directory at merge time.
+    pub dir: String,
+    /// Model name from the shard's manifest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// SHA-256 hash of the config's resolved TOML.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_sha256: Option<String>,
+    /// Dataset content hash from the shard's manifest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset_sha256: Option<String>,
+    /// Harness git SHA from the shard's manifest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_sha: Option<String>,
+    /// Number of instances in this shard.
+    pub instance_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -941,6 +968,158 @@ impl Default for SweepResults {
             span_export_dropped: 0,
         }
     }
+}
+
+/// Recompute all sweep-wide aggregate counters from an instance list.
+///
+/// Returns `base` cloned with every derived aggregate field overwritten from
+/// `instances`. Provenance, manifest, sweep_status, retry_history, and other
+/// run-metadata fields are taken unchanged from `base`. Used by `bench retry`
+/// and `bench merge` to get arithmetically correct aggregates after modifying
+/// the instance list.
+#[must_use]
+#[allow(clippy::too_many_lines)]
+pub(crate) fn recompute_aggregates(base: &SweepResults, instances: Vec<InstanceResult>) -> SweepResults {
+    use crate::trajectory::FailureCategory;
+
+    let total = instances.len();
+    let submitted = instances
+        .iter()
+        .filter(|r| r.outcome.as_deref() == Some("submitted") && r.exit_reason != "skipped_resume")
+        .count();
+    let submitted_with_tests = instances
+        .iter()
+        .filter(|r| {
+            r.outcome.as_deref() == Some("submitted")
+                && r.exit_reason != "skipped_resume"
+                && r.tests_run_before_submit
+        })
+        .count();
+    let skipped = instances
+        .iter()
+        .filter(|r| r.exit_reason == "skipped_resume")
+        .count();
+    let errored = instances
+        .iter()
+        .filter(|r| r.outcome.as_deref() == Some("error"))
+        .count();
+    let budget_halted = instances
+        .iter()
+        .filter(|r| r.exit_reason.starts_with("budget_halt"))
+        .count();
+    let with_patch = instances
+        .iter()
+        .filter(|r| r.non_empty_patch && r.outcome.as_deref() == Some("submitted"))
+        .count();
+    let patch_empty = instances
+        .iter()
+        .filter(|r| r.patch_present && !r.non_empty_patch)
+        .count();
+    let patch_apply_invalid = instances
+        .iter()
+        .filter(|r| r.failure_category == Some(FailureCategory::PatchApplyInvalid))
+        .count();
+    let github_pr_failures = instances
+        .iter()
+        .filter(|r| r.github_pr_error.is_some())
+        .count();
+    let failures_by_category: BTreeMap<FailureCategory, usize> = {
+        let mut map = BTreeMap::new();
+        for r in &instances {
+            if let Some(cat) = r.failure_category {
+                *map.entry(cat).or_insert(0) += 1;
+            }
+        }
+        map
+    };
+    let resolved_any = instances
+        .iter()
+        .filter(|r| r.resolved_count > 0)
+        .count();
+    #[allow(clippy::cast_precision_loss)]
+    let pass_at_k = if instances.is_empty() {
+        0.0
+    } else {
+        resolved_any as f64 / instances.len() as f64
+    };
+    let total_prompt_tokens: u64 = instances.iter().filter_map(|r| r.prompt_tokens).sum();
+    let total_cache_read_tokens: u64 = instances.iter().filter_map(|r| r.cache_read_tokens).sum();
+    let total_cache_creation_tokens: u64 = instances.iter().filter_map(|r| r.cache_creation_tokens).sum();
+    let total_completion_tokens: u64 = instances.iter().filter_map(|r| r.completion_tokens).sum();
+    let estimated_cost_usd: f64 = instances.iter().filter_map(|r| r.cost_usd).sum();
+    let actual_cost_usd: Option<f64> = if instances.iter().all(|r| r.cost_usd.is_some()) {
+        Some(estimated_cost_usd)
+    } else {
+        None
+    };
+    let baseline_cost_usd = estimate_cost_usd(
+        total_prompt_tokens,
+        total_cache_read_tokens,
+        total_cache_creation_tokens,
+        total_completion_tokens,
+        BASELINE_COST_MODEL,
+    );
+    #[allow(clippy::cast_precision_loss)]
+    let cache_hit_rate =
+        if total_prompt_tokens + total_cache_read_tokens + total_cache_creation_tokens > 0 {
+            (total_cache_read_tokens + total_cache_creation_tokens) as f64
+                / (total_prompt_tokens + total_cache_read_tokens + total_cache_creation_tokens) as f64
+        } else {
+            0.0
+        };
+    let retried_instances = instances
+        .iter()
+        .filter(|r| !r.retry_reasons.is_empty())
+        .count();
+    let retries: u64 = instances
+        .iter()
+        .map(|r| r.retry_reasons.len() as u64)
+        .sum();
+    let total_fallbacks: u64 = instances
+        .iter()
+        .filter_map(|r| r.fallback_count)
+        .map(u64::from)
+        .sum();
+    let model_mix: BTreeMap<String, usize> = {
+        let mut map = BTreeMap::new();
+        for r in &instances {
+            if let Some(m) = &r.final_model {
+                *map.entry(m.clone()).or_insert(0) += 1;
+            }
+        }
+        map
+    };
+
+    let mut result = base.clone();
+    result.total = total;
+    result.submitted = submitted;
+    result.submitted_with_tests = submitted_with_tests;
+    result.skipped = skipped;
+    result.errored = errored;
+    result.budget_halted = budget_halted;
+    result.with_patch = with_patch;
+    result.patch_empty = patch_empty;
+    result.patch_apply_invalid = patch_apply_invalid;
+    result.github_pr_failures = github_pr_failures;
+    result.failures_by_category = failures_by_category;
+    result.pass_at_k = pass_at_k;
+    result.total_prompt_tokens = total_prompt_tokens;
+    result.total_cache_read_tokens = total_cache_read_tokens;
+    result.total_cache_creation_tokens = total_cache_creation_tokens;
+    result.total_completion_tokens = total_completion_tokens;
+    result.estimated_cost_usd = estimated_cost_usd;
+    result.actual_cost_usd = actual_cost_usd;
+    result.actual_cost_source =
+        actual_cost_usd.map(|_| crate::cost::CostSource::RateCardEstimate);
+    result.baseline_cost_usd = Some(baseline_cost_usd);
+    result.baseline_cost_model = Some(BASELINE_COST_MODEL.to_owned());
+    result.cache_hit_rate = cache_hit_rate;
+    result.retried_instances = retried_instances;
+    result.retries = retries;
+    result.total_fallbacks = total_fallbacks;
+    result.model_mix = model_mix;
+    result.instances = instances;
+    result
 }
 
 impl SweepResults {
@@ -3499,6 +3678,7 @@ fn build_manifest(
                 manifest_hash: hash.clone(),
                 sweep_dir: dir.clone(),
             }),
+        merged_from: None,
     }
 }
 

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -4490,16 +4490,19 @@ fn write_predictions_file(
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct PredictionsMetadata {
-    predictions_file: String,
-    aggregate: bool,
+pub(crate) struct PredictionsMetadata {
+    pub(crate) predictions_file: String,
+    pub(crate) aggregate: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    run_index: Option<u32>,
-    row_count: usize,
-    swebench_evaluator_compatible: bool,
+    pub(crate) run_index: Option<u32>,
+    pub(crate) row_count: usize,
+    pub(crate) swebench_evaluator_compatible: bool,
 }
 
-fn write_predictions_metadata(path: &Path, metadata: &PredictionsMetadata) -> Result<(), Error> {
+pub(crate) fn write_predictions_metadata(
+    path: &Path,
+    metadata: &PredictionsMetadata,
+) -> Result<(), Error> {
     let file = std::fs::File::create(path)?;
     crate::artifact::to_writer_pretty(file, ArtifactKind::SwebenchPredictionsMetadata, metadata)?;
     Ok(())

--- a/src/run/swebench.rs
+++ b/src/run/swebench.rs
@@ -979,7 +979,10 @@ impl Default for SweepResults {
 /// the instance list.
 #[must_use]
 #[allow(clippy::too_many_lines)]
-pub(crate) fn recompute_aggregates(base: &SweepResults, instances: Vec<InstanceResult>) -> SweepResults {
+pub(crate) fn recompute_aggregates(
+    base: &SweepResults,
+    instances: Vec<InstanceResult>,
+) -> SweepResults {
     use crate::trajectory::FailureCategory;
 
     let total = instances.len();
@@ -1032,10 +1035,7 @@ pub(crate) fn recompute_aggregates(base: &SweepResults, instances: Vec<InstanceR
         }
         map
     };
-    let resolved_any = instances
-        .iter()
-        .filter(|r| r.resolved_count > 0)
-        .count();
+    let resolved_any = instances.iter().filter(|r| r.resolved_count > 0).count();
     #[allow(clippy::cast_precision_loss)]
     let pass_at_k = if instances.is_empty() {
         0.0
@@ -1044,7 +1044,10 @@ pub(crate) fn recompute_aggregates(base: &SweepResults, instances: Vec<InstanceR
     };
     let total_prompt_tokens: u64 = instances.iter().filter_map(|r| r.prompt_tokens).sum();
     let total_cache_read_tokens: u64 = instances.iter().filter_map(|r| r.cache_read_tokens).sum();
-    let total_cache_creation_tokens: u64 = instances.iter().filter_map(|r| r.cache_creation_tokens).sum();
+    let total_cache_creation_tokens: u64 = instances
+        .iter()
+        .filter_map(|r| r.cache_creation_tokens)
+        .sum();
     let total_completion_tokens: u64 = instances.iter().filter_map(|r| r.completion_tokens).sum();
     let estimated_cost_usd: f64 = instances.iter().filter_map(|r| r.cost_usd).sum();
     let actual_cost_usd: Option<f64> = if instances.iter().all(|r| r.cost_usd.is_some()) {
@@ -1063,7 +1066,8 @@ pub(crate) fn recompute_aggregates(base: &SweepResults, instances: Vec<InstanceR
     let cache_hit_rate =
         if total_prompt_tokens + total_cache_read_tokens + total_cache_creation_tokens > 0 {
             (total_cache_read_tokens + total_cache_creation_tokens) as f64
-                / (total_prompt_tokens + total_cache_read_tokens + total_cache_creation_tokens) as f64
+                / (total_prompt_tokens + total_cache_read_tokens + total_cache_creation_tokens)
+                    as f64
         } else {
             0.0
         };
@@ -1071,10 +1075,7 @@ pub(crate) fn recompute_aggregates(base: &SweepResults, instances: Vec<InstanceR
         .iter()
         .filter(|r| !r.retry_reasons.is_empty())
         .count();
-    let retries: u64 = instances
-        .iter()
-        .map(|r| r.retry_reasons.len() as u64)
-        .sum();
+    let retries: u64 = instances.iter().map(|r| r.retry_reasons.len() as u64).sum();
     let total_fallbacks: u64 = instances
         .iter()
         .filter_map(|r| r.fallback_count)
@@ -1109,8 +1110,7 @@ pub(crate) fn recompute_aggregates(base: &SweepResults, instances: Vec<InstanceR
     result.total_completion_tokens = total_completion_tokens;
     result.estimated_cost_usd = estimated_cost_usd;
     result.actual_cost_usd = actual_cost_usd;
-    result.actual_cost_source =
-        actual_cost_usd.map(|_| crate::cost::CostSource::RateCardEstimate);
+    result.actual_cost_source = actual_cost_usd.map(|_| crate::cost::CostSource::RateCardEstimate);
     result.baseline_cost_usd = Some(baseline_cost_usd);
     result.baseline_cost_model = Some(BASELINE_COST_MODEL.to_owned());
     result.cache_hit_rate = cache_hit_rate;

--- a/tests/bench_budget_fit.rs
+++ b/tests/bench_budget_fit.rs
@@ -193,6 +193,7 @@ fn make_manifest(step_limit: Option<u32>, task_timeout_secs: Option<u64>) -> Pro
         import_predictions_path: None,
         import_predictions_sha256: None,
         reproduced_from: None,
+        merged_from: None,
     }
 }
 
@@ -914,6 +915,7 @@ fn mixed_cost_caps_in_resolved_config_are_rejected() {
         import_predictions_path: None,
         import_predictions_sha256: None,
         reproduced_from: None,
+        merged_from: None,
     };
     write_results(dir.path(), instances, manifest);
 
@@ -1003,6 +1005,7 @@ fn per_task_budget_usd_read_from_resolved_config_toml() {
         import_predictions_path: None,
         import_predictions_sha256: None,
         reproduced_from: None,
+        merged_from: None,
     };
     write_results(dir.path(), instances, manifest);
 
@@ -1186,6 +1189,7 @@ fn step_limit_read_from_resolved_config_toml() {
         import_predictions_path: None,
         import_predictions_sha256: None,
         reproduced_from: None,
+        merged_from: None,
     };
     write_results(dir.path(), instances, manifest);
 
@@ -1764,6 +1768,7 @@ fn cli_per_task_budget_with_config_cost_limit_is_rejected() {
         import_predictions_path: None,
         import_predictions_sha256: None,
         reproduced_from: None,
+        merged_from: None,
     };
     write_results(dir.path(), instances, manifest);
 
@@ -2119,6 +2124,7 @@ fn config_sourced_per_task_budget_silent_reset_is_rejected() {
         import_predictions_path: None,
         import_predictions_sha256: None,
         reproduced_from: None,
+        merged_from: None,
     };
     write_results(dir.path(), instances, manifest);
 
@@ -2314,6 +2320,7 @@ fn original_config_overlay_with_retry_is_rejected() {
         import_predictions_path: None,
         import_predictions_sha256: None,
         reproduced_from: None,
+        merged_from: None,
     };
     write_results(dir.path(), instances, manifest);
 
@@ -2417,6 +2424,7 @@ fn original_docker_environment_with_retry_is_rejected() {
         import_predictions_path: None,
         import_predictions_sha256: None,
         reproduced_from: None,
+        merged_from: None,
     };
     write_results(dir.path(), instances, manifest);
 
@@ -2723,6 +2731,7 @@ fn mixed_cost_caps_accepted_with_non_cost_axis() {
         import_predictions_path: None,
         import_predictions_sha256: None,
         reproduced_from: None,
+        merged_from: None,
     };
     write_results(dir.path(), instances, manifest);
 

--- a/tests/bench_calibrate.rs
+++ b/tests/bench_calibrate.rs
@@ -991,6 +991,7 @@ fn manifest_for(case: ManifestCase, total: usize, wall_clock_secs: f64) -> Prove
         import_predictions_path: None,
         import_predictions_sha256: None,
         reproduced_from: None,
+        merged_from: None,
     }
 }
 

--- a/tests/bench_compare.rs
+++ b/tests/bench_compare.rs
@@ -226,6 +226,7 @@ fn write_results_with_filter_spec_and_model(
             import_predictions_path: None,
             import_predictions_sha256: None,
             reproduced_from: None,
+            merged_from: None,
         }),
         cost_limit_usd: None,
         instances,

--- a/tests/bench_dataset_stats.rs
+++ b/tests/bench_dataset_stats.rs
@@ -364,6 +364,7 @@ fn test_historical_resolved_rates_legacy_and_hash_handling() {
         import_predictions_path: None,
         import_predictions_sha256: None,
         reproduced_from: None,
+        merged_from: None,
     };
 
     // 2. Write a modern results.json that has a manifest matching our expected hash

--- a/tests/bench_forecast.rs
+++ b/tests/bench_forecast.rs
@@ -231,6 +231,7 @@ fn fixture_results_with_model(model_name: Option<&str>) -> SweepResults {
             import_predictions_path: None,
             import_predictions_sha256: None,
             reproduced_from: None,
+            merged_from: None,
         }),
         cost_limit_usd: None,
         instances,

--- a/tests/bench_import.rs
+++ b/tests/bench_import.rs
@@ -192,6 +192,7 @@ fn write_native_sweep(dir: &Path, instances: Vec<InstanceResult>) {
             import_predictions_path: None,
             import_predictions_sha256: None,
             reproduced_from: None,
+            merged_from: None,
         }),
         cost_limit_usd: None,
         instances,

--- a/tests/bench_instance_history.rs
+++ b/tests/bench_instance_history.rs
@@ -172,6 +172,7 @@ fn write_sweep(dir: &Path, instances: Vec<InstanceResult>, finished_at: &str) {
             import_predictions_path: None,
             import_predictions_sha256: None,
             reproduced_from: None,
+            merged_from: None,
         }),
         cost_limit_usd: None,
         instances,

--- a/tests/bench_merge.rs
+++ b/tests/bench_merge.rs
@@ -727,10 +727,66 @@ fn provenance_divergence_dataset_sha_exits_nonzero() {
 // ── evaluation.json handling ──────────────────────────────────────────────────
 
 #[test]
-fn eval_present_in_one_shard_is_merged() {
+fn eval_in_all_shards_is_merged_and_audits() {
     let work = tempfile::tempdir().unwrap();
 
-    // shard_a has evaluation.json, shard_b does not
+    // Both shards carry evaluation.json → the merged sweep is fully evaluated.
+    let shard_a = ShardFixture::create_with_eval(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+        &[("inst-001", true)],
+    );
+    let shard_b = ShardFixture::create_with_eval(
+        work.path(),
+        "shard_b",
+        &[InstanceSpec::submitted("inst-002", 0.12)],
+        &[("inst-002", false)],
+    );
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "merge failed: {:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // A merged evaluation.json with an entry for every union instance.
+    let eval: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(output.join("evaluation.json")).unwrap()).unwrap();
+    let eval_instances = eval["instances"].as_array().unwrap();
+    assert_eq!(eval_instances.len(), 2, "both shards' eval entries present");
+
+    // The fully-evaluated merged sweep must still audit cleanly.
+    let audit_out = Command::new(binary_path())
+        .args(["bench", "audit", "--sweep"])
+        .arg(&output)
+        .output()
+        .unwrap();
+    assert!(
+        audit_out.status.success(),
+        "audit failed on merged evaluated sweep!\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&audit_out.stdout),
+        String::from_utf8_lossy(&audit_out.stderr)
+    );
+}
+
+#[test]
+fn eval_in_some_shards_is_omitted_and_audits() {
+    let work = tempfile::tempdir().unwrap();
+
+    // Only shard_a is evaluated. A partial modern evaluation.json would make
+    // shard_b's trajectories orphans under `bench audit`, so merge must omit it.
     let shard_a = ShardFixture::create_with_eval(
         work.path(),
         "shard_a",
@@ -751,25 +807,30 @@ fn eval_present_in_one_shard_is_merged() {
         .arg(&output)
         .output()
         .unwrap();
-
     assert!(
         out.status.success(),
         "merge failed: {:?}",
         String::from_utf8_lossy(&out.stderr)
     );
 
-    // evaluation.json should exist in output
+    // evaluation.json is omitted because not every shard was evaluated.
     assert!(
-        output.join("evaluation.json").exists(),
-        "merged evaluation.json should exist when any shard had eval data"
+        !output.join("evaluation.json").exists(),
+        "merged evaluation.json must be omitted when only some shards were evaluated"
     );
 
-    let eval: serde_json::Value =
-        serde_json::from_str(&fs::read_to_string(output.join("evaluation.json")).unwrap()).unwrap();
-    let eval_instances = eval["instances"].as_array().unwrap();
-    assert_eq!(eval_instances.len(), 1, "only inst-001 had eval data");
-    assert_eq!(eval_instances[0]["instance_id"], "inst-001");
-    assert_eq!(eval_instances[0]["resolved"], true);
+    // The (unevaluated) merged sweep still audits cleanly.
+    let audit_out = Command::new(binary_path())
+        .args(["bench", "audit", "--sweep"])
+        .arg(&output)
+        .output()
+        .unwrap();
+    assert!(
+        audit_out.status.success(),
+        "audit failed on merged unevaluated sweep!\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&audit_out.stdout),
+        String::from_utf8_lossy(&audit_out.stderr)
+    );
 }
 
 // ── AC7: error cases exit non-zero ────────────────────────────────────────────

--- a/tests/bench_merge.rs
+++ b/tests/bench_merge.rs
@@ -1,0 +1,827 @@
+//! `bench merge` — combine sharded sweep result directories into one canonical aggregate.
+
+#![allow(clippy::unwrap_used)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+mod support;
+use support::binary_path;
+
+// ── fixture helpers ───────────────────────────────────────────────────────────
+
+/// A minimal completed sweep fixture for testing.
+struct ShardFixture {
+    dir: PathBuf,
+}
+
+impl ShardFixture {
+    fn create(root: &Path, label: &str, instances: &[InstanceSpec]) -> Self {
+        let dir = root.join(label);
+        fs::create_dir_all(&dir).unwrap();
+
+        let mut inst_results = Vec::new();
+        let mut total_cost = 0.0_f64;
+        let mut total_input = 0_u64;
+        let mut total_completion = 0_u64;
+
+        for spec in instances {
+            total_cost += spec.cost;
+            total_input += spec.input_tokens;
+            total_completion += spec.completion_tokens;
+
+            let submitted = spec.outcome == "submitted";
+            let pass_at_1 = submitted;
+
+            inst_results.push(serde_json::json!({
+                "instance_id": spec.id,
+                "exit_reason": spec.outcome,
+                "outcome": spec.outcome,
+                "cost_usd": spec.cost,
+                "total_input_tokens": spec.input_tokens,
+                "total_completion_tokens": spec.completion_tokens,
+                "duration_secs": 1.0,
+                "patch_present": submitted,
+                "non_empty_patch": submitted,
+                "attempts": 1,
+                "runs": 1,
+                "resolved_count": if submitted { 1 } else { 0 },
+                "pass_at_1": pass_at_1,
+                "tests_run_before_submit": false,
+                "steps": 2
+            }));
+
+            // Write a trajectory file (nested layout: <id>/run-1.traj.json)
+            let inst_dir = dir.join(&spec.id);
+            fs::create_dir_all(&inst_dir).unwrap();
+            let traj = serde_json::json!({
+                "trajectory_format": "mini-swe-agent-1.1",
+                "artifact_kind": "trajectory",
+                "schema_version": {"major": 1, "minor": 3},
+                "info": {
+                    "task": spec.id,
+                    "model_name": "deterministic",
+                    "outcome": spec.outcome,
+                    "exit_reason": spec.outcome,
+                    "total_cost_usd": spec.cost,
+                    "token_usage": {
+                        "prompt_tokens": spec.input_tokens,
+                        "completion_tokens": spec.completion_tokens
+                    },
+                    "redaction": {"enabled": false, "redacted": false},
+                    "steps": 2,
+                    "test_invocations": [],
+                    "tests_run_before_submit": false
+                },
+                "messages": []
+            });
+            fs::write(
+                inst_dir.join("run-1.traj.json"),
+                serde_json::to_string_pretty(&traj).unwrap(),
+            )
+            .unwrap();
+
+            // Write a patch for submitted instances
+            if submitted {
+                fs::write(inst_dir.join("run-1.patch"), format!("--- a/{id}\n+++ b/{id}\n@@ -0,0 +1 @@\n+fix\n", id = spec.id)).unwrap();
+            }
+        }
+
+        let submitted_count = instances.iter().filter(|i| i.outcome == "submitted").count();
+        let errored_count = instances.iter().filter(|i| i.outcome == "error").count();
+        #[allow(clippy::cast_precision_loss)]
+        let pass_at_k = if instances.is_empty() {
+            0.0
+        } else {
+            submitted_count as f64 / instances.len() as f64
+        };
+
+        let results = serde_json::json!({
+            "artifact_kind": "sweep_results",
+            "schema_version": {"major": 1, "minor": 11},
+            "total": instances.len(),
+            "sweep_status": "completed",
+            "completed": instances.len(),
+            "in_flight_at_cancel": 0,
+            "not_started": 0,
+            "submitted": submitted_count,
+            "submitted_with_tests": 0,
+            "skipped": 0,
+            "errored": errored_count,
+            "failures_by_category": {},
+            "budget_halted": 0,
+            "with_patch": submitted_count,
+            "patch_empty": 0,
+            "patch_apply_invalid": 0,
+            "github_pr_failures": 0,
+            "total_input_tokens": total_input,
+            "total_cache_read_tokens": 0,
+            "total_cache_creation_tokens": 0,
+            "total_completion_tokens": total_completion,
+            "total_cost_usd": total_cost,
+            "cache_hit_rate": 0.0,
+            "retries": 0,
+            "retried_instances": 0,
+            "pass_at_k": pass_at_k,
+            "filter_spec": {
+                "original_count": instances.len(),
+                "selected_count": instances.len()
+            },
+            "manifest": {
+                "harness": {
+                    "name": "maxwells-daemon",
+                    "version": "fixture",
+                    "git_sha": "fixture-sha-abc123",
+                    "git_dirty": false,
+                    "git_resolution": "ok"
+                },
+                "dataset": {
+                    "path": "dataset.jsonl",
+                    "sha256": "fixture-dataset-hash-abc",
+                    "instance_count": instances.len(),
+                    "source_kind": "local",
+                    "selected_row_count": instances.len(),
+                    "post_filter_row_count": instances.len()
+                },
+                "prompt_template": {
+                    "source": "inline",
+                    "sha256": "fixture-template-hash"
+                },
+                "config": {
+                    "resolved": "[model]\nname = \"deterministic\"\n",
+                    "overlay_paths": []
+                },
+                "model": {
+                    "name": "deterministic",
+                    "backend": "deterministic"
+                },
+                "runtime": {
+                    "started_at_utc": "2026-05-01T00:00:00Z",
+                    "finished_at_utc": "2026-05-01T00:00:01Z",
+                    "host_os": "fixture",
+                    "resume_mode": false
+                },
+                "cli": {
+                    "argv": ["max", "bench", "swebench"]
+                }
+            },
+            "instances": inst_results
+        });
+
+        fs::write(
+            dir.join("results.json"),
+            serde_json::to_string_pretty(&results).unwrap(),
+        )
+        .unwrap();
+
+        Self { dir }
+    }
+
+    fn create_with_eval(root: &Path, label: &str, instances: &[InstanceSpec], eval_instances: &[(&str, bool)]) -> Self {
+        let fixture = Self::create(root, label, instances);
+        let eval_data = serde_json::json!({
+            "artifact_kind": "evaluation_results",
+            "schema_version": {"major": 1, "minor": 3},
+            "instances": eval_instances.iter().map(|(id, resolved)| serde_json::json!({
+                "instance_id": id,
+                "resolved": resolved,
+                "runs": 1,
+                "tests_passed": [],
+                "tests_failed": [],
+                "eval_exit_reason": if *resolved { "resolved" } else { "unresolved" }
+            })).collect::<Vec<_>>()
+        });
+        fs::write(
+            fixture.dir.join("evaluation.json"),
+            serde_json::to_string_pretty(&eval_data).unwrap(),
+        )
+        .unwrap();
+        fixture
+    }
+}
+
+struct InstanceSpec {
+    id: &'static str,
+    outcome: &'static str,
+    cost: f64,
+    input_tokens: u64,
+    completion_tokens: u64,
+}
+
+impl InstanceSpec {
+    fn submitted(id: &'static str, cost: f64) -> Self {
+        Self { id, outcome: "submitted", cost, input_tokens: 100, completion_tokens: 20 }
+    }
+    fn errored(id: &'static str) -> Self {
+        Self { id, outcome: "error", cost: 0.05, input_tokens: 50, completion_tokens: 10 }
+    }
+}
+
+// ── help / basic invocation ───────────────────────────────────────────────────
+
+#[test]
+fn help_lists_merge_subcommand() {
+    let out = Command::new(binary_path())
+        .args(["bench", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("merge"), "expected 'merge' in bench --help:\n{stdout}");
+}
+
+#[test]
+fn merge_help_lists_expected_flags() {
+    let out = Command::new(binary_path())
+        .args(["bench", "merge", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in ["--shard", "--output", "--on-collision", "--format"] {
+        assert!(stdout.contains(flag), "expected '{flag}' in bench merge --help:\n{stdout}");
+    }
+}
+
+// ── happy path ────────────────────────────────────────────────────────────────
+
+#[test]
+fn two_shard_merge_produces_correct_aggregates() {
+    let work = tempfile::tempdir().unwrap();
+
+    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
+        InstanceSpec::submitted("django__django-001", 0.10),
+        InstanceSpec::errored("django__django-002"),
+    ]);
+    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
+        InstanceSpec::submitted("django__django-003", 0.20),
+        InstanceSpec::errored("django__django-004"),
+    ]);
+
+    let output = work.path().join("merged");
+
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard").arg(&shard_a.dir)
+        .arg("--shard").arg(&shard_b.dir)
+        .arg("--output").arg(&output)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "bench merge failed!\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    assert!(output.join("results.json").exists(), "results.json missing");
+
+    let merged: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(output.join("results.json")).unwrap()).unwrap();
+
+    // AC2: arithmetically correct counts
+    assert_eq!(merged["total"], 4, "total should be 4");
+    assert_eq!(merged["submitted"], 2, "submitted should be 2");
+    assert_eq!(merged["errored"], 2, "errored should be 2");
+    assert_eq!(merged["sweep_status"], "completed");
+
+    // AC2: total cost = sum of per-shard costs (0.10 + 0.05 + 0.20 + 0.05 = 0.40)
+    let cost = merged["total_cost_usd"].as_f64().unwrap();
+    assert!(
+        (cost - 0.40).abs() < 0.001,
+        "expected total_cost_usd ≈ 0.40 got {cost}"
+    );
+
+    // AC2: pass_at_k recomputed over union = 2/4 = 0.5
+    let pak = merged["pass_at_k"].as_f64().unwrap();
+    assert!(
+        (pak - 0.5).abs() < 0.001,
+        "expected pass_at_k ≈ 0.5 got {pak}"
+    );
+
+    // AC2: total tokens correct
+    assert_eq!(merged["total_input_tokens"], 100 + 50 + 100 + 50);
+}
+
+#[test]
+fn two_shard_merge_then_audit_passes() {
+    let work = tempfile::tempdir().unwrap();
+
+    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
+        InstanceSpec::submitted("inst-001", 0.10),
+        InstanceSpec::errored("inst-002"),
+    ]);
+    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
+        InstanceSpec::submitted("inst-003", 0.15),
+    ]);
+
+    let output = work.path().join("merged");
+
+    // Merge
+    let merge_out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard").arg(&shard_a.dir)
+        .arg("--shard").arg(&shard_b.dir)
+        .arg("--output").arg(&output)
+        .output()
+        .unwrap();
+    let merge_stdout = String::from_utf8_lossy(&merge_out.stdout);
+    let merge_stderr = String::from_utf8_lossy(&merge_out.stderr);
+    assert!(
+        merge_out.status.success(),
+        "bench merge failed!\nstdout:\n{merge_stdout}\nstderr:\n{merge_stderr}"
+    );
+
+    // AC4/AC5: bench audit must pass on merged output
+    let audit_out = Command::new(binary_path())
+        .args(["bench", "audit", "--sweep"])
+        .arg(&output)
+        .output()
+        .unwrap();
+
+    let audit_stdout = String::from_utf8_lossy(&audit_out.stdout);
+    let audit_stderr = String::from_utf8_lossy(&audit_out.stderr);
+    assert!(
+        audit_out.status.success(),
+        "bench audit failed on merged sweep!\nstdout:\n{audit_stdout}\nstderr:\n{audit_stderr}"
+    );
+    assert!(
+        audit_stdout.contains("pass") || output.join("audit.json").exists(),
+        "audit should produce audit.json:\n{audit_stdout}"
+    );
+
+    // Verify audit.json says pass
+    if output.join("audit.json").exists() {
+        let audit_json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(output.join("audit.json")).unwrap()).unwrap();
+        assert_eq!(audit_json["overall_pass_fail"], "pass", "audit should pass:\n{audit_json}");
+    }
+}
+
+#[test]
+fn merged_dir_works_with_report_and_triage() {
+    let work = tempfile::tempdir().unwrap();
+
+    // Create shards with evaluation.json so bench triage can run
+    let shard_a = ShardFixture::create_with_eval(
+        work.path(), "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+        &[("inst-001", true)],
+    );
+    let shard_b = ShardFixture::create_with_eval(
+        work.path(), "shard_b",
+        &[InstanceSpec::errored("inst-002")],
+        &[("inst-002", false)],
+    );
+
+    let output = work.path().join("merged");
+    let report_output = work.path().join("report.md");
+
+    // Merge
+    let merge_out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard").arg(&shard_a.dir)
+        .arg("--shard").arg(&shard_b.dir)
+        .arg("--output").arg(&output)
+        .output()
+        .unwrap();
+    assert!(merge_out.status.success(), "merge failed: {:?}", String::from_utf8_lossy(&merge_out.stderr));
+
+    // AC5: bench report works on merged dir
+    let report_out = Command::new(binary_path())
+        .args(["bench", "report", "--sweep"])
+        .arg(&output)
+        .arg("--output")
+        .arg(&report_output)
+        .output()
+        .unwrap();
+    let report_stderr = String::from_utf8_lossy(&report_out.stderr);
+    assert!(
+        report_out.status.success(),
+        "bench report failed on merged sweep!\nstderr:\n{report_stderr}"
+    );
+
+    // AC5: bench triage works on merged dir
+    let triage_out = Command::new(binary_path())
+        .args(["bench", "triage", "--sweep"])
+        .arg(&output)
+        .output()
+        .unwrap();
+    let triage_stderr = String::from_utf8_lossy(&triage_out.stderr);
+    assert!(
+        triage_out.status.success(),
+        "bench triage failed on merged sweep!\nstderr:\n{triage_stderr}"
+    );
+}
+
+// ── AC3: collision detection ──────────────────────────────────────────────────
+
+#[test]
+fn collision_default_error_exits_nonzero() {
+    let work = tempfile::tempdir().unwrap();
+
+    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
+        InstanceSpec::submitted("shared-inst-001", 0.10),
+        InstanceSpec::submitted("unique-a-001", 0.05),
+    ]);
+    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
+        InstanceSpec::submitted("shared-inst-001", 0.10), // collision!
+        InstanceSpec::submitted("unique-b-001", 0.05),
+    ]);
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard").arg(&shard_a.dir)
+        .arg("--shard").arg(&shard_b.dir)
+        .arg("--output").arg(&output)
+        .output()
+        .unwrap();
+
+    assert!(
+        !out.status.success(),
+        "bench merge should fail on ID collision (default --on-collision error)"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("shared-inst-001"),
+        "error output should name the colliding id:\n{combined}"
+    );
+}
+
+#[test]
+fn collision_first_wins_exits_zero_and_reports_duplicate() {
+    let work = tempfile::tempdir().unwrap();
+
+    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
+        InstanceSpec::submitted("shared-001", 0.10),
+        InstanceSpec::submitted("unique-a", 0.05),
+    ]);
+    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
+        InstanceSpec::submitted("shared-001", 0.20), // collision
+        InstanceSpec::submitted("unique-b", 0.05),
+    ]);
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge",
+               "--on-collision", "first-wins",
+               "--format", "json"])
+        .arg("--shard").arg(&shard_a.dir)
+        .arg("--shard").arg(&shard_b.dir)
+        .arg("--output").arg(&output)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "bench merge --on-collision first-wins should exit 0!\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let report: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(report["duplicates"], 1, "should report 1 duplicate:\n{report}");
+    // first-wins: shared-001 from shard_a (cost 0.10) wins
+    // total = 3 distinct instances: shared-001 (0.10), unique-a (0.05), unique-b (0.05)
+    assert_eq!(report["total_instances"], 3);
+}
+
+// ── AC6: --format json summary ────────────────────────────────────────────────
+
+#[test]
+fn json_format_summary_contains_required_keys() {
+    let work = tempfile::tempdir().unwrap();
+
+    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
+        InstanceSpec::submitted("inst-001", 0.10),
+    ]);
+    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
+        InstanceSpec::errored("inst-002"),
+    ]);
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge", "--format", "json"])
+        .arg("--shard").arg(&shard_a.dir)
+        .arg("--shard").arg(&shard_b.dir)
+        .arg("--output").arg(&output)
+        .output()
+        .unwrap();
+
+    assert!(out.status.success(), "stderr: {:?}", String::from_utf8_lossy(&out.stderr));
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let report: serde_json::Value = serde_json::from_str(&stdout)
+        .expect("--format json should produce valid JSON on stdout");
+
+    // AC6: shards merged, instances per shard, total instances, duplicates, top-line metrics
+    assert!(report.get("shards").is_some(), "missing 'shards' key:\n{report}");
+    assert!(report.get("total_instances").is_some(), "missing 'total_instances':\n{report}");
+    assert!(report.get("duplicates").is_some(), "missing 'duplicates':\n{report}");
+    assert!(report.get("total_cost_usd").is_some(), "missing 'total_cost_usd':\n{report}");
+    assert!(report.get("submitted").is_some(), "missing 'submitted':\n{report}");
+    assert!(report.get("errored").is_some(), "missing 'errored':\n{report}");
+    assert!(report.get("pass_at_k").is_some(), "missing 'pass_at_k':\n{report}");
+
+    // Per-shard counts in the shards array
+    let shards = report["shards"].as_array().unwrap();
+    assert_eq!(shards.len(), 2, "should have 2 shard entries:\n{report}");
+    assert!(shards[0].get("instance_count").is_some(), "shard missing 'instance_count':\n{report}");
+    assert!(shards[1].get("instance_count").is_some(), "shard missing 'instance_count':\n{report}");
+
+    assert_eq!(report["total_instances"], 2);
+    assert_eq!(report["duplicates"], 0);
+    assert_eq!(report["submitted"], 1);
+    assert_eq!(report["errored"], 1);
+}
+
+// ── provenance divergence ─────────────────────────────────────────────────────
+
+#[test]
+fn provenance_divergence_dataset_sha_exits_nonzero() {
+    let work = tempfile::tempdir().unwrap();
+
+    // Create shard_a with one dataset hash
+    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
+        InstanceSpec::submitted("inst-001", 0.10),
+    ]);
+    // Mutate shard_b's dataset sha256
+    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
+        InstanceSpec::submitted("inst-002", 0.10),
+    ]);
+    let results_path = shard_b.dir.join("results.json");
+    let mut results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&results_path).unwrap()).unwrap();
+    results["manifest"]["dataset"]["sha256"] = serde_json::json!("different-hash-xyz");
+    fs::write(&results_path, serde_json::to_string_pretty(&results).unwrap()).unwrap();
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard").arg(&shard_a.dir)
+        .arg("--shard").arg(&shard_b.dir)
+        .arg("--output").arg(&output)
+        .output()
+        .unwrap();
+
+    assert!(
+        !out.status.success(),
+        "bench merge should fail when dataset_sha256 differs"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("dataset") || combined.contains("sha256") || combined.contains("provenance"),
+        "error should mention dataset/sha256 divergence:\n{combined}"
+    );
+}
+
+// ── evaluation.json handling ──────────────────────────────────────────────────
+
+#[test]
+fn eval_present_in_one_shard_is_merged() {
+    let work = tempfile::tempdir().unwrap();
+
+    // shard_a has evaluation.json, shard_b does not
+    let shard_a = ShardFixture::create_with_eval(
+        work.path(), "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+        &[("inst-001", true)],
+    );
+    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
+        InstanceSpec::errored("inst-002"),
+    ]);
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard").arg(&shard_a.dir)
+        .arg("--shard").arg(&shard_b.dir)
+        .arg("--output").arg(&output)
+        .output()
+        .unwrap();
+
+    assert!(out.status.success(), "merge failed: {:?}", String::from_utf8_lossy(&out.stderr));
+
+    // evaluation.json should exist in output
+    assert!(
+        output.join("evaluation.json").exists(),
+        "merged evaluation.json should exist when any shard had eval data"
+    );
+
+    let eval: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(output.join("evaluation.json")).unwrap()).unwrap();
+    let eval_instances = eval["instances"].as_array().unwrap();
+    assert_eq!(eval_instances.len(), 1, "only inst-001 had eval data");
+    assert_eq!(eval_instances[0]["instance_id"], "inst-001");
+    assert_eq!(eval_instances[0]["resolved"], true);
+}
+
+// ── AC7: error cases exit non-zero ────────────────────────────────────────────
+
+#[test]
+fn single_shard_exits_nonzero() {
+    let work = tempfile::tempdir().unwrap();
+    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
+        InstanceSpec::submitted("inst-001", 0.10),
+    ]);
+    let output = work.path().join("merged");
+
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard").arg(&shard_a.dir)
+        .arg("--output").arg(&output)
+        .output()
+        .unwrap();
+
+    // clap requires at least one --shard (required = true) but we need to error
+    // on exactly one shard (merge requires 2+)
+    // Note: clap won't prevent 1 shard; our validation must catch it
+    assert!(
+        !out.status.success(),
+        "bench merge with a single shard should fail"
+    );
+}
+
+#[test]
+fn missing_results_json_exits_nonzero() {
+    let work = tempfile::tempdir().unwrap();
+    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
+        InstanceSpec::submitted("inst-001", 0.10),
+    ]);
+    let shard_bad = work.path().join("shard_bad");
+    fs::create_dir_all(&shard_bad).unwrap();
+    // No results.json in shard_bad
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard").arg(&shard_a.dir)
+        .arg("--shard").arg(&shard_bad)
+        .arg("--output").arg(&output)
+        .output()
+        .unwrap();
+
+    assert!(
+        !out.status.success(),
+        "bench merge should fail when shard is missing results.json"
+    );
+}
+
+#[test]
+fn incomplete_sweep_status_exits_nonzero() {
+    let work = tempfile::tempdir().unwrap();
+    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
+        InstanceSpec::submitted("inst-001", 0.10),
+    ]);
+    // Mutate shard_a to have sweep_status = "running"
+    let results_path = shard_a.dir.join("results.json");
+    let mut results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&results_path).unwrap()).unwrap();
+    results["sweep_status"] = serde_json::json!("running");
+    fs::write(&results_path, serde_json::to_string_pretty(&results).unwrap()).unwrap();
+
+    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
+        InstanceSpec::submitted("inst-002", 0.10),
+    ]);
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard").arg(&shard_a.dir)
+        .arg("--shard").arg(&shard_b.dir)
+        .arg("--output").arg(&output)
+        .output()
+        .unwrap();
+
+    assert!(
+        !out.status.success(),
+        "bench merge should fail when a shard is not completed"
+    );
+}
+
+#[test]
+fn output_dir_not_empty_without_force_exits_nonzero() {
+    let work = tempfile::tempdir().unwrap();
+    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
+        InstanceSpec::submitted("inst-001", 0.10),
+    ]);
+    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
+        InstanceSpec::submitted("inst-002", 0.10),
+    ]);
+
+    let output = work.path().join("merged");
+    fs::create_dir_all(&output).unwrap();
+    fs::write(output.join("something.txt"), "existing content").unwrap();
+
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard").arg(&shard_a.dir)
+        .arg("--shard").arg(&shard_b.dir)
+        .arg("--output").arg(&output)
+        .output()
+        .unwrap();
+
+    assert!(
+        !out.status.success(),
+        "bench merge to non-empty output without --force should fail"
+    );
+}
+
+// ── AC4: provenance in merged manifest ────────────────────────────────────────
+
+#[test]
+fn merged_manifest_contains_shard_provenance() {
+    let work = tempfile::tempdir().unwrap();
+
+    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
+        InstanceSpec::submitted("inst-001", 0.10),
+    ]);
+    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
+        InstanceSpec::submitted("inst-002", 0.10),
+    ]);
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard").arg(&shard_a.dir)
+        .arg("--shard").arg(&shard_b.dir)
+        .arg("--output").arg(&output)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "merge failed: {:?}", String::from_utf8_lossy(&out.stderr));
+
+    let results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(output.join("results.json")).unwrap()).unwrap();
+
+    // AC4: provenance preserved; merged_from records per-shard info
+    let manifest = &results["manifest"];
+    assert!(
+        manifest.get("merged_from").is_some(),
+        "merged manifest should contain 'merged_from' field:\n{manifest}"
+    );
+    let merged_from = manifest["merged_from"].as_array().unwrap();
+    assert_eq!(merged_from.len(), 2, "should have 2 shard entries in merged_from");
+
+    // Each shard entry has label, dir, instance_count
+    for entry in merged_from {
+        assert!(entry.get("label").is_some(), "shard entry missing 'label':\n{entry}");
+        assert!(entry.get("dir").is_some(), "shard entry missing 'dir':\n{entry}");
+        assert!(entry.get("instance_count").is_some(), "shard entry missing 'instance_count':\n{entry}");
+    }
+
+    // source should be "merge"
+    assert_eq!(
+        manifest["source"], "merge",
+        "manifest source should be 'merge':\n{manifest}"
+    );
+}
+
+// ── three-shard merge ─────────────────────────────────────────────────────────
+
+#[test]
+fn three_shard_merge_aggregates_correctly() {
+    let work = tempfile::tempdir().unwrap();
+
+    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
+        InstanceSpec::submitted("inst-001", 0.10),
+        InstanceSpec::errored("inst-002"),
+    ]);
+    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
+        InstanceSpec::submitted("inst-003", 0.20),
+    ]);
+    let shard_c = ShardFixture::create(work.path(), "shard_c", &[
+        InstanceSpec::errored("inst-004"),
+        InstanceSpec::errored("inst-005"),
+    ]);
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge", "--format", "json"])
+        .arg("--shard").arg(&shard_a.dir)
+        .arg("--shard").arg(&shard_b.dir)
+        .arg("--shard").arg(&shard_c.dir)
+        .arg("--output").arg(&output)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "3-shard merge failed!\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+    let report: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(report["total_instances"], 5);
+    assert_eq!(report["shards"].as_array().unwrap().len(), 3);
+
+    let merged: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(output.join("results.json")).unwrap()).unwrap();
+    assert_eq!(merged["total"], 5);
+    assert_eq!(merged["submitted"], 2);
+    assert_eq!(merged["errored"], 3);
+}

--- a/tests/bench_merge.rs
+++ b/tests/bench_merge.rs
@@ -1026,6 +1026,48 @@ fn provenance_divergence_harness_sha_exits_nonzero() {
 }
 
 #[test]
+fn legacy_runs_zero_merges_with_modern_single_run() {
+    let work = tempfile::tempdir().unwrap();
+    // shard_a is a legacy single-run sweep whose rows predate the `runs` field
+    // (serde-default 0); shard_b is a modern single-run sweep (runs=1). Both are
+    // effectively single-run and must merge without a rerun-count mismatch.
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+    );
+    let path = shard_a.dir.join("results.json");
+    let mut results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    for inst in results["instances"].as_array_mut().unwrap() {
+        inst["runs"] = serde_json::json!(0);
+    }
+    fs::write(&path, serde_json::to_string_pretty(&results).unwrap()).unwrap();
+
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[InstanceSpec::submitted("inst-002", 0.10)],
+    );
+
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(work.path().join("merged"))
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "legacy runs=0 must merge with modern runs=1: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
 fn mixed_rerun_counts_exit_nonzero() {
     let work = tempfile::tempdir().unwrap();
     // shard_a is single-run (runs=1); shard_b is pass@k with runs=2.

--- a/tests/bench_merge.rs
+++ b/tests/bench_merge.rs
@@ -65,46 +65,50 @@ impl ShardFixture {
                 "steps": 2
             }));
 
-            // Write a trajectory file (nested layout: <id>/run-1.traj.json)
-            let inst_dir = dir.join(spec.id);
-            fs::create_dir_all(&inst_dir).unwrap();
-            let traj = serde_json::json!({
-                "trajectory_format": "mini-swe-agent-1.1",
-                "artifact_kind": "trajectory",
-                "schema_version": {"major": 1, "minor": 3},
-                "info": {
-                    "task": spec.id,
-                    "model_name": "deterministic",
-                    "outcome": spec.outcome,
-                    "exit_reason": spec.outcome,
-                    "total_cost_usd": spec.cost,
-                    "token_usage": {
-                        "prompt_tokens": spec.input_tokens,
-                        "completion_tokens": spec.completion_tokens
+            // Budget-halted tasks never ran: no trajectory/patch on disk (mirrors a
+            // real budget-capped sweep, where audit counts them from results.json).
+            if spec.outcome != "budget_halted" {
+                // Write a trajectory file (nested layout: <id>/run-1.traj.json)
+                let inst_dir = dir.join(spec.id);
+                fs::create_dir_all(&inst_dir).unwrap();
+                let traj = serde_json::json!({
+                    "trajectory_format": "mini-swe-agent-1.1",
+                    "artifact_kind": "trajectory",
+                    "schema_version": {"major": 1, "minor": 3},
+                    "info": {
+                        "task": spec.id,
+                        "model_name": "deterministic",
+                        "outcome": spec.outcome,
+                        "exit_reason": spec.outcome,
+                        "total_cost_usd": spec.cost,
+                        "token_usage": {
+                            "prompt_tokens": spec.input_tokens,
+                            "completion_tokens": spec.completion_tokens
+                        },
+                        "redaction": {"enabled": false, "redacted": false},
+                        "steps": 2,
+                        "test_invocations": [],
+                        "tests_run_before_submit": false
                     },
-                    "redaction": {"enabled": false, "redacted": false},
-                    "steps": 2,
-                    "test_invocations": [],
-                    "tests_run_before_submit": false
-                },
-                "messages": []
-            });
-            fs::write(
-                inst_dir.join("run-1.traj.json"),
-                serde_json::to_string_pretty(&traj).unwrap(),
-            )
-            .unwrap();
-
-            // Write a patch for submitted instances
-            if submitted {
+                    "messages": []
+                });
                 fs::write(
-                    inst_dir.join("run-1.patch"),
-                    format!(
-                        "--- a/{id}\n+++ b/{id}\n@@ -0,0 +1 @@\n+fix\n",
-                        id = spec.id
-                    ),
+                    inst_dir.join("run-1.traj.json"),
+                    serde_json::to_string_pretty(&traj).unwrap(),
                 )
                 .unwrap();
+
+                // Write a patch for submitted instances
+                if submitted {
+                    fs::write(
+                        inst_dir.join("run-1.patch"),
+                        format!(
+                            "--- a/{id}\n+++ b/{id}\n@@ -0,0 +1 @@\n+fix\n",
+                            id = spec.id
+                        ),
+                    )
+                    .unwrap();
+                }
             }
         }
 
@@ -117,6 +121,10 @@ impl ShardFixture {
             .filter(|i| i.outcome == "submitted")
             .count();
         let errored_count = instances.iter().filter(|i| i.outcome == "error").count();
+        let budget_halted_count = instances
+            .iter()
+            .filter(|i| i.outcome == "budget_halted")
+            .count();
         #[allow(clippy::cast_precision_loss)]
         let pass_at_k = if instances.is_empty() {
             0.0
@@ -137,7 +145,7 @@ impl ShardFixture {
             "skipped": 0,
             "errored": errored_count,
             "failures_by_category": {},
-            "budget_halted": 0,
+            "budget_halted": budget_halted_count,
             "with_patch": submitted_count,
             "patch_empty": 0,
             "patch_apply_invalid": 0,
@@ -186,6 +194,32 @@ impl ShardFixture {
                 "tests_failed": [],
                 "eval_exit_reason": if *resolved { "resolved" } else { "unresolved" }
             })).collect::<Vec<_>>()
+        });
+        fs::write(
+            fixture.dir.join("evaluation.json"),
+            serde_json::to_string_pretty(&eval_data).unwrap(),
+        )
+        .unwrap();
+        fixture
+    }
+
+    /// Like `create_with_eval` but writes a *legacy* sb-cli `evaluation.json`
+    /// (`resolved_ids`/`submitted_ids` arrays) rather than the modern format.
+    fn create_with_legacy_eval(
+        root: &Path,
+        label: &str,
+        instances: &[InstanceSpec],
+        resolved_ids: &[&str],
+    ) -> Self {
+        let fixture = Self::create(root, label, instances);
+        let submitted_ids: Vec<&str> = instances
+            .iter()
+            .filter(|i| i.outcome == "submitted")
+            .map(|i| i.id)
+            .collect();
+        let eval_data = serde_json::json!({
+            "resolved_ids": resolved_ids,
+            "submitted_ids": submitted_ids,
         });
         fs::write(
             fixture.dir.join("evaluation.json"),
@@ -410,6 +444,15 @@ impl InstanceSpec {
             cost: 0.05,
             input_tokens: 50,
             completion_tokens: 10,
+        }
+    }
+    fn budget_halted(id: &'static str) -> Self {
+        Self {
+            id,
+            outcome: "budget_halted",
+            cost: 0.0,
+            input_tokens: 0,
+            completion_tokens: 0,
         }
     }
 }
@@ -1454,5 +1497,167 @@ fn merged_filter_spec_lists_union_ids() {
         ids,
         vec!["inst-001", "inst-002"],
         "filter_spec must list the merged union, not just shard 0"
+    );
+}
+
+#[test]
+fn budget_halted_rows_preserved_and_audits() {
+    let work = tempfile::tempdir().unwrap();
+
+    // shard_a has a budget-halted task with no trajectory on disk.
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[
+            InstanceSpec::submitted("inst-001", 0.10),
+            InstanceSpec::budget_halted("inst-002"),
+        ],
+    );
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[InstanceSpec::submitted("inst-003", 0.10)],
+    );
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "merge failed");
+
+    // The budget-halted row (no trajectory) must survive the per-slot recount.
+    let merged: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(output.join("results.json")).unwrap()).unwrap();
+    assert_eq!(
+        merged["budget_halted"], 1,
+        "budget_halted must be preserved"
+    );
+
+    let audit = Command::new(binary_path())
+        .args(["bench", "audit", "--sweep"])
+        .arg(&output)
+        .output()
+        .unwrap();
+    assert!(
+        audit.status.success(),
+        "audit failed on merged budget-capped sweep!\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&audit.stdout),
+        String::from_utf8_lossy(&audit.stderr)
+    );
+}
+
+#[test]
+fn legacy_eval_emits_entry_for_every_owned_instance() {
+    let work = tempfile::tempdir().unwrap();
+
+    // Both shards carry a legacy sb-cli evaluation.json. shard_a has an errored
+    // instance that is absent from resolved_ids/submitted_ids.
+    let shard_a = ShardFixture::create_with_legacy_eval(
+        work.path(),
+        "shard_a",
+        &[
+            InstanceSpec::submitted("inst-001", 0.10),
+            InstanceSpec::errored("inst-002"),
+        ],
+        &["inst-001"],
+    );
+    let shard_b = ShardFixture::create_with_legacy_eval(
+        work.path(),
+        "shard_b",
+        &[InstanceSpec::submitted("inst-003", 0.10)],
+        &[],
+    );
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "merge failed");
+
+    // The merged modern evaluation.json must contain an entry for every owned
+    // instance — including the errored one absent from the legacy arrays — or
+    // bench audit reports audit:orphan:evaluation.
+    let eval: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(output.join("evaluation.json")).unwrap()).unwrap();
+    let ids: Vec<&str> = eval["instances"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["instance_id"].as_str().unwrap())
+        .collect();
+    assert!(ids.contains(&"inst-001"));
+    assert!(
+        ids.contains(&"inst-002"),
+        "errored instance must have an entry"
+    );
+    assert!(ids.contains(&"inst-003"));
+
+    let audit = Command::new(binary_path())
+        .args(["bench", "audit", "--sweep"])
+        .arg(&output)
+        .output()
+        .unwrap();
+    assert!(
+        audit.status.success(),
+        "audit failed on merged legacy-eval sweep!\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&audit.stdout),
+        String::from_utf8_lossy(&audit.stderr)
+    );
+}
+
+#[test]
+fn merged_manifest_keeps_source_dataset_count() {
+    let work = tempfile::tempdir().unwrap();
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+    );
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[InstanceSpec::submitted("inst-002", 0.10)],
+    );
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "merge failed");
+
+    // Each shard fixture records dataset.instance_count == 1 (its own selection).
+    // The merged manifest must keep that source cardinality, not overwrite it
+    // with the union size (2); only the subset counts describe the selection.
+    let merged: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(output.join("results.json")).unwrap()).unwrap();
+    let dataset = &merged["manifest"]["dataset"];
+    assert_eq!(
+        dataset["instance_count"], 1,
+        "source dataset count preserved"
+    );
+    assert_eq!(
+        dataset["selected_row_count"], 2,
+        "subset count is the union"
     );
 }

--- a/tests/bench_merge.rs
+++ b/tests/bench_merge.rs
@@ -1025,6 +1025,38 @@ fn provenance_divergence_harness_sha_exits_nonzero() {
     );
 }
 
+#[test]
+fn mixed_rerun_counts_exit_nonzero() {
+    let work = tempfile::tempdir().unwrap();
+    // shard_a is single-run (runs=1); shard_b is pass@k with runs=2.
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+    );
+    let shard_b =
+        ShardFixture::create_multi_run(work.path(), "shard_b", &[("inst-002", "submitted")], 2);
+
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(work.path().join("merged"))
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "merge must reject shards with different --rerun counts"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("rerun"),
+        "error should mention the rerun-count mismatch"
+    );
+}
+
 // ── evaluation.json handling ──────────────────────────────────────────────────
 
 #[test]

--- a/tests/bench_merge.rs
+++ b/tests/bench_merge.rs
@@ -1,6 +1,6 @@
 //! `bench merge` — combine sharded sweep result directories into one canonical aggregate.
 
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::unwrap_used, clippy::too_many_lines)]
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -46,14 +46,14 @@ impl ShardFixture {
                 "non_empty_patch": submitted,
                 "attempts": 1,
                 "runs": 1,
-                "resolved_count": if submitted { 1 } else { 0 },
+                "resolved_count": u8::from(submitted),
                 "pass_at_1": pass_at_1,
                 "tests_run_before_submit": false,
                 "steps": 2
             }));
 
             // Write a trajectory file (nested layout: <id>/run-1.traj.json)
-            let inst_dir = dir.join(&spec.id);
+            let inst_dir = dir.join(spec.id);
             fs::create_dir_all(&inst_dir).unwrap();
             let traj = serde_json::json!({
                 "trajectory_format": "mini-swe-agent-1.1",
@@ -84,11 +84,21 @@ impl ShardFixture {
 
             // Write a patch for submitted instances
             if submitted {
-                fs::write(inst_dir.join("run-1.patch"), format!("--- a/{id}\n+++ b/{id}\n@@ -0,0 +1 @@\n+fix\n", id = spec.id)).unwrap();
+                fs::write(
+                    inst_dir.join("run-1.patch"),
+                    format!(
+                        "--- a/{id}\n+++ b/{id}\n@@ -0,0 +1 @@\n+fix\n",
+                        id = spec.id
+                    ),
+                )
+                .unwrap();
             }
         }
 
-        let submitted_count = instances.iter().filter(|i| i.outcome == "submitted").count();
+        let submitted_count = instances
+            .iter()
+            .filter(|i| i.outcome == "submitted")
+            .count();
         let errored_count = instances.iter().filter(|i| i.outcome == "error").count();
         #[allow(clippy::cast_precision_loss)]
         let pass_at_k = if instances.is_empty() {
@@ -178,7 +188,12 @@ impl ShardFixture {
         Self { dir }
     }
 
-    fn create_with_eval(root: &Path, label: &str, instances: &[InstanceSpec], eval_instances: &[(&str, bool)]) -> Self {
+    fn create_with_eval(
+        root: &Path,
+        label: &str,
+        instances: &[InstanceSpec],
+        eval_instances: &[(&str, bool)],
+    ) -> Self {
         let fixture = Self::create(root, label, instances);
         let eval_data = serde_json::json!({
             "artifact_kind": "evaluation_results",
@@ -211,10 +226,22 @@ struct InstanceSpec {
 
 impl InstanceSpec {
     fn submitted(id: &'static str, cost: f64) -> Self {
-        Self { id, outcome: "submitted", cost, input_tokens: 100, completion_tokens: 20 }
+        Self {
+            id,
+            outcome: "submitted",
+            cost,
+            input_tokens: 100,
+            completion_tokens: 20,
+        }
     }
     fn errored(id: &'static str) -> Self {
-        Self { id, outcome: "error", cost: 0.05, input_tokens: 50, completion_tokens: 10 }
+        Self {
+            id,
+            outcome: "error",
+            cost: 0.05,
+            input_tokens: 50,
+            completion_tokens: 10,
+        }
     }
 }
 
@@ -228,7 +255,10 @@ fn help_lists_merge_subcommand() {
         .unwrap();
     assert!(out.status.success());
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("merge"), "expected 'merge' in bench --help:\n{stdout}");
+    assert!(
+        stdout.contains("merge"),
+        "expected 'merge' in bench --help:\n{stdout}"
+    );
 }
 
 #[test]
@@ -240,7 +270,10 @@ fn merge_help_lists_expected_flags() {
     assert!(out.status.success());
     let stdout = String::from_utf8_lossy(&out.stdout);
     for flag in ["--shard", "--output", "--on-collision", "--format"] {
-        assert!(stdout.contains(flag), "expected '{flag}' in bench merge --help:\n{stdout}");
+        assert!(
+            stdout.contains(flag),
+            "expected '{flag}' in bench merge --help:\n{stdout}"
+        );
     }
 }
 
@@ -250,22 +283,33 @@ fn merge_help_lists_expected_flags() {
 fn two_shard_merge_produces_correct_aggregates() {
     let work = tempfile::tempdir().unwrap();
 
-    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
-        InstanceSpec::submitted("django__django-001", 0.10),
-        InstanceSpec::errored("django__django-002"),
-    ]);
-    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
-        InstanceSpec::submitted("django__django-003", 0.20),
-        InstanceSpec::errored("django__django-004"),
-    ]);
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[
+            InstanceSpec::submitted("django__django-001", 0.10),
+            InstanceSpec::errored("django__django-002"),
+        ],
+    );
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[
+            InstanceSpec::submitted("django__django-003", 0.20),
+            InstanceSpec::errored("django__django-004"),
+        ],
+    );
 
     let output = work.path().join("merged");
 
     let out = Command::new(binary_path())
         .args(["bench", "merge"])
-        .arg("--shard").arg(&shard_a.dir)
-        .arg("--shard").arg(&shard_b.dir)
-        .arg("--output").arg(&output)
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
         .output()
         .unwrap();
 
@@ -309,22 +353,31 @@ fn two_shard_merge_produces_correct_aggregates() {
 fn two_shard_merge_then_audit_passes() {
     let work = tempfile::tempdir().unwrap();
 
-    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
-        InstanceSpec::submitted("inst-001", 0.10),
-        InstanceSpec::errored("inst-002"),
-    ]);
-    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
-        InstanceSpec::submitted("inst-003", 0.15),
-    ]);
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[
+            InstanceSpec::submitted("inst-001", 0.10),
+            InstanceSpec::errored("inst-002"),
+        ],
+    );
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[InstanceSpec::submitted("inst-003", 0.15)],
+    );
 
     let output = work.path().join("merged");
 
     // Merge
     let merge_out = Command::new(binary_path())
         .args(["bench", "merge"])
-        .arg("--shard").arg(&shard_a.dir)
-        .arg("--shard").arg(&shard_b.dir)
-        .arg("--output").arg(&output)
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
         .output()
         .unwrap();
     let merge_stdout = String::from_utf8_lossy(&merge_out.stdout);
@@ -356,7 +409,10 @@ fn two_shard_merge_then_audit_passes() {
     if output.join("audit.json").exists() {
         let audit_json: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(output.join("audit.json")).unwrap()).unwrap();
-        assert_eq!(audit_json["overall_pass_fail"], "pass", "audit should pass:\n{audit_json}");
+        assert_eq!(
+            audit_json["overall_pass_fail"], "pass",
+            "audit should pass:\n{audit_json}"
+        );
     }
 }
 
@@ -366,12 +422,14 @@ fn merged_dir_works_with_report_and_triage() {
 
     // Create shards with evaluation.json so bench triage can run
     let shard_a = ShardFixture::create_with_eval(
-        work.path(), "shard_a",
+        work.path(),
+        "shard_a",
         &[InstanceSpec::submitted("inst-001", 0.10)],
         &[("inst-001", true)],
     );
     let shard_b = ShardFixture::create_with_eval(
-        work.path(), "shard_b",
+        work.path(),
+        "shard_b",
         &[InstanceSpec::errored("inst-002")],
         &[("inst-002", false)],
     );
@@ -382,12 +440,19 @@ fn merged_dir_works_with_report_and_triage() {
     // Merge
     let merge_out = Command::new(binary_path())
         .args(["bench", "merge"])
-        .arg("--shard").arg(&shard_a.dir)
-        .arg("--shard").arg(&shard_b.dir)
-        .arg("--output").arg(&output)
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
         .output()
         .unwrap();
-    assert!(merge_out.status.success(), "merge failed: {:?}", String::from_utf8_lossy(&merge_out.stderr));
+    assert!(
+        merge_out.status.success(),
+        "merge failed: {:?}",
+        String::from_utf8_lossy(&merge_out.stderr)
+    );
 
     // AC5: bench report works on merged dir
     let report_out = Command::new(binary_path())
@@ -422,21 +487,32 @@ fn merged_dir_works_with_report_and_triage() {
 fn collision_default_error_exits_nonzero() {
     let work = tempfile::tempdir().unwrap();
 
-    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
-        InstanceSpec::submitted("shared-inst-001", 0.10),
-        InstanceSpec::submitted("unique-a-001", 0.05),
-    ]);
-    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
-        InstanceSpec::submitted("shared-inst-001", 0.10), // collision!
-        InstanceSpec::submitted("unique-b-001", 0.05),
-    ]);
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[
+            InstanceSpec::submitted("shared-inst-001", 0.10),
+            InstanceSpec::submitted("unique-a-001", 0.05),
+        ],
+    );
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[
+            InstanceSpec::submitted("shared-inst-001", 0.10), // collision!
+            InstanceSpec::submitted("unique-b-001", 0.05),
+        ],
+    );
 
     let output = work.path().join("merged");
     let out = Command::new(binary_path())
         .args(["bench", "merge"])
-        .arg("--shard").arg(&shard_a.dir)
-        .arg("--shard").arg(&shard_b.dir)
-        .arg("--output").arg(&output)
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
         .output()
         .unwrap();
 
@@ -457,23 +533,39 @@ fn collision_default_error_exits_nonzero() {
 fn collision_first_wins_exits_zero_and_reports_duplicate() {
     let work = tempfile::tempdir().unwrap();
 
-    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
-        InstanceSpec::submitted("shared-001", 0.10),
-        InstanceSpec::submitted("unique-a", 0.05),
-    ]);
-    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
-        InstanceSpec::submitted("shared-001", 0.20), // collision
-        InstanceSpec::submitted("unique-b", 0.05),
-    ]);
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[
+            InstanceSpec::submitted("shared-001", 0.10),
+            InstanceSpec::submitted("unique-a", 0.05),
+        ],
+    );
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[
+            InstanceSpec::submitted("shared-001", 0.20), // collision
+            InstanceSpec::submitted("unique-b", 0.05),
+        ],
+    );
 
     let output = work.path().join("merged");
     let out = Command::new(binary_path())
-        .args(["bench", "merge",
-               "--on-collision", "first-wins",
-               "--format", "json"])
-        .arg("--shard").arg(&shard_a.dir)
-        .arg("--shard").arg(&shard_b.dir)
-        .arg("--output").arg(&output)
+        .args([
+            "bench",
+            "merge",
+            "--on-collision",
+            "first-wins",
+            "--format",
+            "json",
+        ])
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
         .output()
         .unwrap();
 
@@ -485,7 +577,10 @@ fn collision_first_wins_exits_zero_and_reports_duplicate() {
     );
 
     let report: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    assert_eq!(report["duplicates"], 1, "should report 1 duplicate:\n{report}");
+    assert_eq!(
+        report["duplicates"], 1,
+        "should report 1 duplicate:\n{report}"
+    );
     // first-wins: shared-001 from shard_a (cost 0.10) wins
     // total = 3 distinct instances: shared-001 (0.10), unique-a (0.05), unique-b (0.05)
     assert_eq!(report["total_instances"], 3);
@@ -497,42 +592,76 @@ fn collision_first_wins_exits_zero_and_reports_duplicate() {
 fn json_format_summary_contains_required_keys() {
     let work = tempfile::tempdir().unwrap();
 
-    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
-        InstanceSpec::submitted("inst-001", 0.10),
-    ]);
-    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
-        InstanceSpec::errored("inst-002"),
-    ]);
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+    );
+    let shard_b =
+        ShardFixture::create(work.path(), "shard_b", &[InstanceSpec::errored("inst-002")]);
 
     let output = work.path().join("merged");
     let out = Command::new(binary_path())
         .args(["bench", "merge", "--format", "json"])
-        .arg("--shard").arg(&shard_a.dir)
-        .arg("--shard").arg(&shard_b.dir)
-        .arg("--output").arg(&output)
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
         .output()
         .unwrap();
 
-    assert!(out.status.success(), "stderr: {:?}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "stderr: {:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
 
     let stdout = String::from_utf8_lossy(&out.stdout);
-    let report: serde_json::Value = serde_json::from_str(&stdout)
-        .expect("--format json should produce valid JSON on stdout");
+    let report: serde_json::Value = serde_json::from_str(&stdout).unwrap();
 
     // AC6: shards merged, instances per shard, total instances, duplicates, top-line metrics
-    assert!(report.get("shards").is_some(), "missing 'shards' key:\n{report}");
-    assert!(report.get("total_instances").is_some(), "missing 'total_instances':\n{report}");
-    assert!(report.get("duplicates").is_some(), "missing 'duplicates':\n{report}");
-    assert!(report.get("total_cost_usd").is_some(), "missing 'total_cost_usd':\n{report}");
-    assert!(report.get("submitted").is_some(), "missing 'submitted':\n{report}");
-    assert!(report.get("errored").is_some(), "missing 'errored':\n{report}");
-    assert!(report.get("pass_at_k").is_some(), "missing 'pass_at_k':\n{report}");
+    assert!(
+        report.get("shards").is_some(),
+        "missing 'shards' key:\n{report}"
+    );
+    assert!(
+        report.get("total_instances").is_some(),
+        "missing 'total_instances':\n{report}"
+    );
+    assert!(
+        report.get("duplicates").is_some(),
+        "missing 'duplicates':\n{report}"
+    );
+    assert!(
+        report.get("total_cost_usd").is_some(),
+        "missing 'total_cost_usd':\n{report}"
+    );
+    assert!(
+        report.get("submitted").is_some(),
+        "missing 'submitted':\n{report}"
+    );
+    assert!(
+        report.get("errored").is_some(),
+        "missing 'errored':\n{report}"
+    );
+    assert!(
+        report.get("pass_at_k").is_some(),
+        "missing 'pass_at_k':\n{report}"
+    );
 
     // Per-shard counts in the shards array
     let shards = report["shards"].as_array().unwrap();
     assert_eq!(shards.len(), 2, "should have 2 shard entries:\n{report}");
-    assert!(shards[0].get("instance_count").is_some(), "shard missing 'instance_count':\n{report}");
-    assert!(shards[1].get("instance_count").is_some(), "shard missing 'instance_count':\n{report}");
+    assert!(
+        shards[0].get("instance_count").is_some(),
+        "shard missing 'instance_count':\n{report}"
+    );
+    assert!(
+        shards[1].get("instance_count").is_some(),
+        "shard missing 'instance_count':\n{report}"
+    );
 
     assert_eq!(report["total_instances"], 2);
     assert_eq!(report["duplicates"], 0);
@@ -547,25 +676,36 @@ fn provenance_divergence_dataset_sha_exits_nonzero() {
     let work = tempfile::tempdir().unwrap();
 
     // Create shard_a with one dataset hash
-    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
-        InstanceSpec::submitted("inst-001", 0.10),
-    ]);
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+    );
     // Mutate shard_b's dataset sha256
-    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
-        InstanceSpec::submitted("inst-002", 0.10),
-    ]);
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[InstanceSpec::submitted("inst-002", 0.10)],
+    );
     let results_path = shard_b.dir.join("results.json");
     let mut results: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&results_path).unwrap()).unwrap();
     results["manifest"]["dataset"]["sha256"] = serde_json::json!("different-hash-xyz");
-    fs::write(&results_path, serde_json::to_string_pretty(&results).unwrap()).unwrap();
+    fs::write(
+        &results_path,
+        serde_json::to_string_pretty(&results).unwrap(),
+    )
+    .unwrap();
 
     let output = work.path().join("merged");
     let out = Command::new(binary_path())
         .args(["bench", "merge"])
-        .arg("--shard").arg(&shard_a.dir)
-        .arg("--shard").arg(&shard_b.dir)
-        .arg("--output").arg(&output)
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
         .output()
         .unwrap();
 
@@ -577,7 +717,9 @@ fn provenance_divergence_dataset_sha_exits_nonzero() {
     let stdout = String::from_utf8_lossy(&out.stdout);
     let combined = format!("{stdout}{stderr}");
     assert!(
-        combined.contains("dataset") || combined.contains("sha256") || combined.contains("provenance"),
+        combined.contains("dataset")
+            || combined.contains("sha256")
+            || combined.contains("provenance"),
         "error should mention dataset/sha256 divergence:\n{combined}"
     );
 }
@@ -590,24 +732,31 @@ fn eval_present_in_one_shard_is_merged() {
 
     // shard_a has evaluation.json, shard_b does not
     let shard_a = ShardFixture::create_with_eval(
-        work.path(), "shard_a",
+        work.path(),
+        "shard_a",
         &[InstanceSpec::submitted("inst-001", 0.10)],
         &[("inst-001", true)],
     );
-    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
-        InstanceSpec::errored("inst-002"),
-    ]);
+    let shard_b =
+        ShardFixture::create(work.path(), "shard_b", &[InstanceSpec::errored("inst-002")]);
 
     let output = work.path().join("merged");
     let out = Command::new(binary_path())
         .args(["bench", "merge"])
-        .arg("--shard").arg(&shard_a.dir)
-        .arg("--shard").arg(&shard_b.dir)
-        .arg("--output").arg(&output)
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
         .output()
         .unwrap();
 
-    assert!(out.status.success(), "merge failed: {:?}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "merge failed: {:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
 
     // evaluation.json should exist in output
     assert!(
@@ -628,15 +777,19 @@ fn eval_present_in_one_shard_is_merged() {
 #[test]
 fn single_shard_exits_nonzero() {
     let work = tempfile::tempdir().unwrap();
-    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
-        InstanceSpec::submitted("inst-001", 0.10),
-    ]);
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+    );
     let output = work.path().join("merged");
 
     let out = Command::new(binary_path())
         .args(["bench", "merge"])
-        .arg("--shard").arg(&shard_a.dir)
-        .arg("--output").arg(&output)
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--output")
+        .arg(&output)
         .output()
         .unwrap();
 
@@ -652,9 +805,11 @@ fn single_shard_exits_nonzero() {
 #[test]
 fn missing_results_json_exits_nonzero() {
     let work = tempfile::tempdir().unwrap();
-    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
-        InstanceSpec::submitted("inst-001", 0.10),
-    ]);
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+    );
     let shard_bad = work.path().join("shard_bad");
     fs::create_dir_all(&shard_bad).unwrap();
     // No results.json in shard_bad
@@ -662,9 +817,12 @@ fn missing_results_json_exits_nonzero() {
     let output = work.path().join("merged");
     let out = Command::new(binary_path())
         .args(["bench", "merge"])
-        .arg("--shard").arg(&shard_a.dir)
-        .arg("--shard").arg(&shard_bad)
-        .arg("--output").arg(&output)
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_bad)
+        .arg("--output")
+        .arg(&output)
         .output()
         .unwrap();
 
@@ -677,26 +835,37 @@ fn missing_results_json_exits_nonzero() {
 #[test]
 fn incomplete_sweep_status_exits_nonzero() {
     let work = tempfile::tempdir().unwrap();
-    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
-        InstanceSpec::submitted("inst-001", 0.10),
-    ]);
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+    );
     // Mutate shard_a to have sweep_status = "running"
     let results_path = shard_a.dir.join("results.json");
     let mut results: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&results_path).unwrap()).unwrap();
     results["sweep_status"] = serde_json::json!("running");
-    fs::write(&results_path, serde_json::to_string_pretty(&results).unwrap()).unwrap();
+    fs::write(
+        &results_path,
+        serde_json::to_string_pretty(&results).unwrap(),
+    )
+    .unwrap();
 
-    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
-        InstanceSpec::submitted("inst-002", 0.10),
-    ]);
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[InstanceSpec::submitted("inst-002", 0.10)],
+    );
 
     let output = work.path().join("merged");
     let out = Command::new(binary_path())
         .args(["bench", "merge"])
-        .arg("--shard").arg(&shard_a.dir)
-        .arg("--shard").arg(&shard_b.dir)
-        .arg("--output").arg(&output)
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
         .output()
         .unwrap();
 
@@ -709,12 +878,16 @@ fn incomplete_sweep_status_exits_nonzero() {
 #[test]
 fn output_dir_not_empty_without_force_exits_nonzero() {
     let work = tempfile::tempdir().unwrap();
-    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
-        InstanceSpec::submitted("inst-001", 0.10),
-    ]);
-    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
-        InstanceSpec::submitted("inst-002", 0.10),
-    ]);
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+    );
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[InstanceSpec::submitted("inst-002", 0.10)],
+    );
 
     let output = work.path().join("merged");
     fs::create_dir_all(&output).unwrap();
@@ -722,9 +895,12 @@ fn output_dir_not_empty_without_force_exits_nonzero() {
 
     let out = Command::new(binary_path())
         .args(["bench", "merge"])
-        .arg("--shard").arg(&shard_a.dir)
-        .arg("--shard").arg(&shard_b.dir)
-        .arg("--output").arg(&output)
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
         .output()
         .unwrap();
 
@@ -740,22 +916,33 @@ fn output_dir_not_empty_without_force_exits_nonzero() {
 fn merged_manifest_contains_shard_provenance() {
     let work = tempfile::tempdir().unwrap();
 
-    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
-        InstanceSpec::submitted("inst-001", 0.10),
-    ]);
-    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
-        InstanceSpec::submitted("inst-002", 0.10),
-    ]);
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+    );
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[InstanceSpec::submitted("inst-002", 0.10)],
+    );
 
     let output = work.path().join("merged");
     let out = Command::new(binary_path())
         .args(["bench", "merge"])
-        .arg("--shard").arg(&shard_a.dir)
-        .arg("--shard").arg(&shard_b.dir)
-        .arg("--output").arg(&output)
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
         .output()
         .unwrap();
-    assert!(out.status.success(), "merge failed: {:?}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "merge failed: {:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
 
     let results: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(output.join("results.json")).unwrap()).unwrap();
@@ -767,13 +954,26 @@ fn merged_manifest_contains_shard_provenance() {
         "merged manifest should contain 'merged_from' field:\n{manifest}"
     );
     let merged_from = manifest["merged_from"].as_array().unwrap();
-    assert_eq!(merged_from.len(), 2, "should have 2 shard entries in merged_from");
+    assert_eq!(
+        merged_from.len(),
+        2,
+        "should have 2 shard entries in merged_from"
+    );
 
     // Each shard entry has label, dir, instance_count
     for entry in merged_from {
-        assert!(entry.get("label").is_some(), "shard entry missing 'label':\n{entry}");
-        assert!(entry.get("dir").is_some(), "shard entry missing 'dir':\n{entry}");
-        assert!(entry.get("instance_count").is_some(), "shard entry missing 'instance_count':\n{entry}");
+        assert!(
+            entry.get("label").is_some(),
+            "shard entry missing 'label':\n{entry}"
+        );
+        assert!(
+            entry.get("dir").is_some(),
+            "shard entry missing 'dir':\n{entry}"
+        );
+        assert!(
+            entry.get("instance_count").is_some(),
+            "shard entry missing 'instance_count':\n{entry}"
+        );
     }
 
     // source should be "merge"
@@ -789,31 +989,48 @@ fn merged_manifest_contains_shard_provenance() {
 fn three_shard_merge_aggregates_correctly() {
     let work = tempfile::tempdir().unwrap();
 
-    let shard_a = ShardFixture::create(work.path(), "shard_a", &[
-        InstanceSpec::submitted("inst-001", 0.10),
-        InstanceSpec::errored("inst-002"),
-    ]);
-    let shard_b = ShardFixture::create(work.path(), "shard_b", &[
-        InstanceSpec::submitted("inst-003", 0.20),
-    ]);
-    let shard_c = ShardFixture::create(work.path(), "shard_c", &[
-        InstanceSpec::errored("inst-004"),
-        InstanceSpec::errored("inst-005"),
-    ]);
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[
+            InstanceSpec::submitted("inst-001", 0.10),
+            InstanceSpec::errored("inst-002"),
+        ],
+    );
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[InstanceSpec::submitted("inst-003", 0.20)],
+    );
+    let shard_c = ShardFixture::create(
+        work.path(),
+        "shard_c",
+        &[
+            InstanceSpec::errored("inst-004"),
+            InstanceSpec::errored("inst-005"),
+        ],
+    );
 
     let output = work.path().join("merged");
     let out = Command::new(binary_path())
         .args(["bench", "merge", "--format", "json"])
-        .arg("--shard").arg(&shard_a.dir)
-        .arg("--shard").arg(&shard_b.dir)
-        .arg("--shard").arg(&shard_c.dir)
-        .arg("--output").arg(&output)
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--shard")
+        .arg(&shard_c.dir)
+        .arg("--output")
+        .arg(&output)
         .output()
         .unwrap();
 
     let stdout = String::from_utf8_lossy(&out.stdout);
     let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(out.status.success(), "3-shard merge failed!\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    assert!(
+        out.status.success(),
+        "3-shard merge failed!\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
 
     let report: serde_json::Value = serde_json::from_str(&stdout).unwrap();
     assert_eq!(report["total_instances"], 5);

--- a/tests/bench_merge.rs
+++ b/tests/bench_merge.rs
@@ -25,6 +25,7 @@ impl ShardFixture {
         let mut total_cost = 0.0_f64;
         let mut total_input = 0_u64;
         let mut total_completion = 0_u64;
+        let mut preds = String::new();
 
         for spec in instances {
             total_cost += spec.cost;
@@ -33,6 +34,18 @@ impl ShardFixture {
 
             let submitted = spec.outcome == "submitted";
             let pass_at_1 = submitted;
+
+            if submitted {
+                preds.push_str(
+                    &serde_json::to_string(&serde_json::json!({
+                        "instance_id": spec.id,
+                        "model_patch": format!("--- a/{id}\n+++ b/{id}\n", id = spec.id),
+                        "model_name_or_path": "deterministic",
+                    }))
+                    .unwrap(),
+                );
+                preds.push('\n');
+            }
 
             inst_results.push(serde_json::json!({
                 "instance_id": spec.id,
@@ -95,6 +108,10 @@ impl ShardFixture {
             }
         }
 
+        // Predictions: aggregate + single-run file (mirrors a real single-run sweep).
+        fs::write(dir.join("all_preds.jsonl"), &preds).unwrap();
+        fs::write(dir.join("all_preds.run-1.jsonl"), &preds).unwrap();
+
         let submitted_count = instances
             .iter()
             .filter(|i| i.outcome == "submitted")
@@ -138,44 +155,7 @@ impl ShardFixture {
                 "original_count": instances.len(),
                 "selected_count": instances.len()
             },
-            "manifest": {
-                "harness": {
-                    "name": "maxwells-daemon",
-                    "version": "fixture",
-                    "git_sha": "fixture-sha-abc123",
-                    "git_dirty": false,
-                    "git_resolution": "ok"
-                },
-                "dataset": {
-                    "path": "dataset.jsonl",
-                    "sha256": "fixture-dataset-hash-abc",
-                    "instance_count": instances.len(),
-                    "source_kind": "local",
-                    "selected_row_count": instances.len(),
-                    "post_filter_row_count": instances.len()
-                },
-                "prompt_template": {
-                    "source": "inline",
-                    "sha256": "fixture-template-hash"
-                },
-                "config": {
-                    "resolved": "[model]\nname = \"deterministic\"\n",
-                    "overlay_paths": []
-                },
-                "model": {
-                    "name": "deterministic",
-                    "backend": "deterministic"
-                },
-                "runtime": {
-                    "started_at_utc": "2026-05-01T00:00:00Z",
-                    "finished_at_utc": "2026-05-01T00:00:01Z",
-                    "host_os": "fixture",
-                    "resume_mode": false
-                },
-                "cli": {
-                    "argv": ["max", "bench", "swebench"]
-                }
-            },
+            "manifest": fixture_manifest(instances.len()),
             "instances": inst_results
         });
 
@@ -214,6 +194,195 @@ impl ShardFixture {
         .unwrap();
         fixture
     }
+
+    /// A completed pass@k shard: each instance runs `runs` times (run-1..run-N
+    /// trajectories). Cost/tokens are zero to keep audit reconciliation trivial;
+    /// the point is per-run-slot outcome counting. `instances` is `(id, outcome)`.
+    fn create_multi_run(
+        root: &Path,
+        label: &str,
+        instances: &[(&'static str, &'static str)],
+        runs: u32,
+    ) -> Self {
+        let dir = root.join(label);
+        fs::create_dir_all(&dir).unwrap();
+
+        let mut inst_results = Vec::new();
+        let mut aggregate_preds = String::new();
+        let mut per_run_preds: Vec<String> = vec![String::new(); runs as usize];
+        let mut slot_submitted = 0usize;
+        let mut slot_errored = 0usize;
+
+        for (id, outcome) in instances {
+            let submitted = *outcome == "submitted";
+            let inst_dir = dir.join(id);
+            fs::create_dir_all(&inst_dir).unwrap();
+            for k in 1..=runs {
+                let traj = serde_json::json!({
+                    "trajectory_format": "mini-swe-agent-1.1",
+                    "artifact_kind": "trajectory",
+                    "schema_version": {"major": 1, "minor": 3},
+                    "info": {
+                        "task": id,
+                        "model_name": "deterministic",
+                        "outcome": outcome,
+                        "exit_reason": outcome,
+                        "total_cost_usd": 0.0,
+                        "token_usage": {"prompt_tokens": 0, "completion_tokens": 0},
+                        "redaction": {"enabled": false, "redacted": false},
+                        "steps": 2,
+                        "test_invocations": [],
+                        "tests_run_before_submit": false
+                    },
+                    "messages": []
+                });
+                fs::write(
+                    inst_dir.join(format!("run-{k}.traj.json")),
+                    serde_json::to_string_pretty(&traj).unwrap(),
+                )
+                .unwrap();
+                if submitted {
+                    fs::write(inst_dir.join(format!("run-{k}.patch")), "patch\n").unwrap();
+                    per_run_preds[(k - 1) as usize].push_str(
+                        &serde_json::to_string(&serde_json::json!({
+                            "instance_id": id,
+                            "model_patch": "patch",
+                            "model_name_or_path": "deterministic",
+                            "run_index": k,
+                        }))
+                        .unwrap(),
+                    );
+                    per_run_preds[(k - 1) as usize].push('\n');
+                    aggregate_preds.push_str(
+                        &serde_json::to_string(&serde_json::json!({
+                            "instance_id": format!("{id}::run-{k}"),
+                            "original_instance_id": id,
+                            "run_index": k,
+                            "model_patch": "patch",
+                            "model_name_or_path": "deterministic",
+                        }))
+                        .unwrap(),
+                    );
+                    aggregate_preds.push('\n');
+                    slot_submitted += 1;
+                } else if *outcome == "error" {
+                    slot_errored += 1;
+                }
+            }
+
+            inst_results.push(serde_json::json!({
+                "instance_id": id,
+                "exit_reason": outcome,
+                "outcome": outcome,
+                "cost_usd": 0.0,
+                "total_input_tokens": 0,
+                "total_completion_tokens": 0,
+                "duration_secs": 1.0,
+                "patch_present": submitted,
+                "non_empty_patch": submitted,
+                "attempts": runs,
+                "runs": runs,
+                "resolved_count": 0,
+                "pass_at_1": false,
+                "tests_run_before_submit": false,
+                "steps": 2
+            }));
+        }
+
+        fs::write(dir.join("all_preds.jsonl"), &aggregate_preds).unwrap();
+        for k in 1..=runs {
+            fs::write(
+                dir.join(format!("all_preds.run-{k}.jsonl")),
+                &per_run_preds[(k - 1) as usize],
+            )
+            .unwrap();
+        }
+
+        let results = serde_json::json!({
+            "artifact_kind": "sweep_results",
+            "schema_version": {"major": 1, "minor": 11},
+            "total": instances.len(),
+            "sweep_status": "completed",
+            "completed": instances.len(),
+            "in_flight_at_cancel": 0,
+            "not_started": 0,
+            "submitted": slot_submitted,
+            "submitted_with_tests": 0,
+            "skipped": 0,
+            "errored": slot_errored,
+            "failures_by_category": {},
+            "budget_halted": 0,
+            "with_patch": instances.iter().filter(|(_, o)| *o == "submitted").count(),
+            "patch_empty": 0,
+            "patch_apply_invalid": 0,
+            "github_pr_failures": 0,
+            "total_input_tokens": 0,
+            "total_cache_read_tokens": 0,
+            "total_cache_creation_tokens": 0,
+            "total_completion_tokens": 0,
+            "total_cost_usd": 0.0,
+            "cache_hit_rate": 0.0,
+            "retries": 0,
+            "retried_instances": 0,
+            "pass_at_k": 0.0,
+            "filter_spec": {
+                "original_count": instances.len(),
+                "selected_count": instances.len()
+            },
+            "manifest": fixture_manifest(instances.len()),
+            "instances": inst_results
+        });
+        fs::write(
+            dir.join("results.json"),
+            serde_json::to_string_pretty(&results).unwrap(),
+        )
+        .unwrap();
+
+        Self { dir }
+    }
+}
+
+/// Shared provenance manifest used by every fixture shard so the cross-shard
+/// dataset/model/config compatibility checks pass.
+fn fixture_manifest(instance_count: usize) -> serde_json::Value {
+    serde_json::json!({
+        "harness": {
+            "name": "maxwells-daemon",
+            "version": "fixture",
+            "git_sha": "fixture-sha-abc123",
+            "git_dirty": false,
+            "git_resolution": "ok"
+        },
+        "dataset": {
+            "path": "dataset.jsonl",
+            "sha256": "fixture-dataset-hash-abc",
+            "instance_count": instance_count,
+            "source_kind": "local",
+            "selected_row_count": instance_count,
+            "post_filter_row_count": instance_count
+        },
+        "prompt_template": {
+            "source": "inline",
+            "sha256": "fixture-template-hash"
+        },
+        "config": {
+            "resolved": "[model]\nname = \"deterministic\"\n",
+            "overlay_paths": []
+        },
+        "model": {
+            "name": "deterministic",
+            "backend": "deterministic"
+        },
+        "runtime": {
+            "started_at_utc": "2026-05-01T00:00:00Z",
+            "finished_at_utc": "2026-05-01T00:00:01Z",
+            "host_os": "fixture",
+            "resume_mode": false
+        },
+        "cli": {
+            "argv": ["max", "bench", "swebench"]
+        }
+    })
 }
 
 struct InstanceSpec {
@@ -1102,4 +1271,188 @@ fn three_shard_merge_aggregates_correctly() {
     assert_eq!(merged["total"], 5);
     assert_eq!(merged["submitted"], 2);
     assert_eq!(merged["errored"], 3);
+}
+
+// ── pass@k / predictions / safety ─────────────────────────────────────────────
+
+#[test]
+fn pass_at_k_multi_run_merge_audits() {
+    let work = tempfile::tempdir().unwrap();
+
+    // Two disjoint pass@k shards, each instance run twice.
+    let shard_a = ShardFixture::create_multi_run(
+        work.path(),
+        "shard_a",
+        &[("inst-001", "submitted"), ("inst-002", "error")],
+        2,
+    );
+    let shard_b =
+        ShardFixture::create_multi_run(work.path(), "shard_b", &[("inst-003", "submitted")], 2);
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "multi-run merge failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Per-run-slot counts: 2 submitted instances × 2 runs = 4 submitted slots;
+    // 1 errored instance × 2 runs = 2 errored slots.
+    let merged: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(output.join("results.json")).unwrap()).unwrap();
+    assert_eq!(merged["submitted"], 4, "per-slot submitted count");
+    assert_eq!(merged["errored"], 2, "per-slot errored count");
+
+    // The merged pass@k sweep must reconcile under `bench audit`.
+    let audit = Command::new(binary_path())
+        .args(["bench", "audit", "--sweep"])
+        .arg(&output)
+        .output()
+        .unwrap();
+    assert!(
+        audit.status.success(),
+        "audit failed on merged pass@k sweep!\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&audit.stdout),
+        String::from_utf8_lossy(&audit.stderr)
+    );
+}
+
+#[test]
+fn merge_writes_all_preds_for_evaluate() {
+    let work = tempfile::tempdir().unwrap();
+
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+    );
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[
+            InstanceSpec::submitted("inst-002", 0.12),
+            InstanceSpec::errored("inst-003"),
+        ],
+    );
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "merge failed");
+
+    // `bench evaluate` reads <sweep>/all_preds.jsonl; it must exist with one row
+    // per submitted instance across both shards (the errored one is excluded).
+    let preds = fs::read_to_string(output.join("all_preds.jsonl")).unwrap();
+    let ids: Vec<String> = preds
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| {
+            serde_json::from_str::<serde_json::Value>(l).unwrap()["instance_id"]
+                .as_str()
+                .unwrap()
+                .to_string()
+        })
+        .collect();
+    assert_eq!(ids.len(), 2, "two submitted instances");
+    assert!(ids.contains(&"inst-001".to_string()));
+    assert!(ids.contains(&"inst-002".to_string()));
+    assert!(!ids.contains(&"inst-003".to_string()), "errored excluded");
+
+    // Metadata is rewritten for the merged aggregate.
+    assert!(output.join("all_preds.metadata.json").exists());
+}
+
+#[test]
+fn output_overlapping_shard_exits_nonzero() {
+    let work = tempfile::tempdir().unwrap();
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+    );
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[InstanceSpec::submitted("inst-002", 0.10)],
+    );
+
+    // --output IS shard_a; with --force this would delete the shard before copy.
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&shard_a.dir)
+        .arg("--force")
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "merge must reject an --output that overlaps an input shard"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("overlaps input shard"),
+        "stderr should explain the overlap: {stderr}"
+    );
+    // The shard's results.json must still be intact (not deleted).
+    assert!(shard_a.dir.join("results.json").exists());
+}
+
+#[test]
+fn merged_filter_spec_lists_union_ids() {
+    let work = tempfile::tempdir().unwrap();
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+    );
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[InstanceSpec::submitted("inst-002", 0.10)],
+    );
+
+    let output = work.path().join("merged");
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(&output)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "merge failed");
+
+    let merged: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(output.join("results.json")).unwrap()).unwrap();
+    let ids = merged["filter_spec"]["instance_ids"].as_array().unwrap();
+    let ids: Vec<&str> = ids.iter().map(|v| v.as_str().unwrap()).collect();
+    assert_eq!(
+        ids,
+        vec!["inst-001", "inst-002"],
+        "filter_spec must list the merged union, not just shard 0"
+    );
 }

--- a/tests/bench_merge.rs
+++ b/tests/bench_merge.rs
@@ -936,6 +936,95 @@ fn provenance_divergence_dataset_sha_exits_nonzero() {
     );
 }
 
+/// Patch a single dotted-path field inside a shard's results.json manifest.
+fn patch_manifest_field(shard_dir: &Path, pointer: &str, value: serde_json::Value) {
+    let path = shard_dir.join("results.json");
+    let mut results: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    *results.pointer_mut(pointer).unwrap() = value;
+    fs::write(&path, serde_json::to_string_pretty(&results).unwrap()).unwrap();
+}
+
+#[test]
+fn provenance_divergence_model_endpoint_exits_nonzero() {
+    let work = tempfile::tempdir().unwrap();
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+    );
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[InstanceSpec::submitted("inst-002", 0.10)],
+    );
+    // Same model name + config, but a different backend endpoint.
+    patch_manifest_field(
+        &shard_b.dir,
+        "/manifest/model/backend",
+        serde_json::json!("different-backend"),
+    );
+
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(work.path().join("merged"))
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "merge must reject differing model endpoints"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("endpoint"),
+        "error should mention the model endpoint"
+    );
+}
+
+#[test]
+fn provenance_divergence_harness_sha_exits_nonzero() {
+    let work = tempfile::tempdir().unwrap();
+    let shard_a = ShardFixture::create(
+        work.path(),
+        "shard_a",
+        &[InstanceSpec::submitted("inst-001", 0.10)],
+    );
+    let shard_b = ShardFixture::create(
+        work.path(),
+        "shard_b",
+        &[InstanceSpec::submitted("inst-002", 0.10)],
+    );
+    // A different harness commit produced shard_b.
+    patch_manifest_field(
+        &shard_b.dir,
+        "/manifest/harness/git_sha",
+        serde_json::json!("different-harness-sha-999"),
+    );
+
+    let out = Command::new(binary_path())
+        .args(["bench", "merge"])
+        .arg("--shard")
+        .arg(&shard_a.dir)
+        .arg("--shard")
+        .arg(&shard_b.dir)
+        .arg("--output")
+        .arg(work.path().join("merged"))
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "merge must reject differing harness revisions"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("harness"),
+        "error should mention the harness revision"
+    );
+}
+
 // ── evaluation.json handling ──────────────────────────────────────────────────
 
 #[test]

--- a/tests/bench_merge.rs
+++ b/tests/bench_merge.rs
@@ -1772,6 +1772,19 @@ fn legacy_eval_emits_entry_for_every_owned_instance() {
     );
     assert!(ids.contains(&"inst-003"));
 
+    // inst-002 errored with no patch → never scored → skipped_no_patch, not a
+    // real `unresolved` verdict.
+    let entry = eval["instances"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["instance_id"] == "inst-002")
+        .unwrap();
+    assert_eq!(
+        entry["eval_exit_reason"], "skipped_no_patch",
+        "no-patch legacy row should be skipped_no_patch"
+    );
+
     let audit = Command::new(binary_path())
         .args(["bench", "audit", "--sweep"])
         .arg(&output)

--- a/tests/bench_merge.rs
+++ b/tests/bench_merge.rs
@@ -1444,6 +1444,9 @@ fn pass_at_k_multi_run_merge_audits() {
         serde_json::from_str(&fs::read_to_string(output.join("results.json")).unwrap()).unwrap();
     assert_eq!(merged["submitted"], 4, "per-slot submitted count");
     assert_eq!(merged["errored"], 2, "per-slot errored count");
+    // with_patch is per slot too: 2 submitted instances × 2 runs, each with a
+    // patch → 4 (a per-task count would report only 2).
+    assert_eq!(merged["with_patch"], 4, "per-slot with_patch count");
 
     // The merged pass@k sweep must reconcile under `bench audit`.
     let audit = Command::new(binary_path())

--- a/tests/bench_report.rs
+++ b/tests/bench_report.rs
@@ -202,6 +202,7 @@ fn write_sweep(dir: &Path, instances: Vec<InstanceResult>) {
             import_predictions_path: None,
             import_predictions_sha256: None,
             reproduced_from: None,
+            merged_from: None,
         }),
         cost_limit_usd: None,
         instances,

--- a/tests/bench_reproduce.rs
+++ b/tests/bench_reproduce.rs
@@ -76,6 +76,7 @@ fn minimal_manifest(model_name: &str, git_sha: Option<&str>) -> ProvenanceManife
         import_predictions_path: None,
         import_predictions_sha256: None,
         reproduced_from: None,
+        merged_from: None,
     }
 }
 

--- a/tests/bench_retry.rs
+++ b/tests/bench_retry.rs
@@ -747,6 +747,7 @@ fn make_manifest_with_sha(sha: &str) -> ProvenanceManifest {
         import_predictions_path: None,
         import_predictions_sha256: None,
         reproduced_from: None,
+        merged_from: None,
     }
 }
 

--- a/tests/bench_utilization.rs
+++ b/tests/bench_utilization.rs
@@ -174,6 +174,7 @@ fn write_sweep(dir: &Path, spec: &SweepSpec) {
         import_predictions_path: None,
         import_predictions_sha256: None,
         reproduced_from: None,
+        merged_from: None,
     };
 
     let results = SweepResults {

--- a/tests/bench_variance.rs
+++ b/tests/bench_variance.rs
@@ -133,6 +133,7 @@ fn make_manifest() -> ProvenanceManifest {
         import_predictions_path: None,
         import_predictions_sha256: None,
         reproduced_from: None,
+        merged_from: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a new `bench merge` subcommand that combines multiple independent sharded sweep result directories into a single canonical aggregate. This enables horizontal scaling of sweeps across multiple workers or machines, with the merged output being a drop-in replacement for `bench evaluate`, `bench audit`, `bench report`, and `bench triage`.

## Key Changes

- **New `bench merge` command** (`src/run/merge.rs`): Implements offline aggregation of sharded sweeps with:
  - Collision detection and configurable resolution policies (`error`, `first-wins`, `last-wins`)
  - Provenance validation (ensures identical dataset, model, and config across shards)
  - Artifact copying (preserves both nested and flat trajectory layouts)
  - Aggregate recomputation (all metrics recalculated from union instance list)
  - `evaluation.json` merging (normalizes both modern and legacy formats)

- **CLI integration** (`src/cli/args.rs`, `src/cli/mod.rs`):
  - New `MergeCmd` struct with flags: `--shard` (repeatable, 2+ required), `--output`, `--on-collision`, `--label`, `--force`, `--format`
  - Wired into `BenchCmd` enum and main dispatch

- **Manifest extensions** (`src/run/swebench.rs`):
  - New `MergeShardProvenance` struct to record per-shard provenance (label, dir, model, config/dataset/git hashes, instance count)
  - Added `merged_from` field to `ProvenanceManifest` for full auditability
  - New `recompute_aggregates()` function (extracted from retry logic) to recalculate all sweep-wide counters from an instance list

- **Refactoring** (`src/run/retry.rs`):
  - Extracted aggregate recomputation logic into shared `recompute_aggregates()` function to avoid duplication between `bench retry` and `bench merge`

- **Comprehensive test suite** (`tests/bench_merge.rs`):
  - 827 lines of integration tests covering:
    - Help/invocation validation
    - Two-shard merge with correct arithmetic aggregates
    - Audit/report/triage compatibility
    - Collision detection and all three resolution policies
    - JSON format output with required fields
    - Provenance preservation and manifest validation
    - Evaluation.json merging (modern and legacy formats)
    - Edge cases (empty shards, single instance, large token counts)

- **Specification document** (`docs/spec-merge.md`):
  - Detailed specification of merge semantics, collision policies, provenance requirements, and audit compatibility

- **Documentation** (`README.md`):
  - Added `bench merge` to the command reference

## Notable Implementation Details

- **Arithmetic correctness**: All aggregates (cost, tokens, counts, pass_at_k) are recomputed from the union instance list, never summed from per-shard headers, preventing double-counting
- **Provenance preservation**: Merged output carries `merged_from` array recording each shard's label, path, model, config hash, dataset hash, git SHA, and instance count
- **Artifact layout agnostic**: Handles both nested (`<id>/run-N.traj.json`) and flat (`<id>.traj.json`) trajectory layouts
- **Evaluation normalization**: Merges evaluation.json from multiple shards, normalizing both modern (`instances[].resolved`) and legacy (`resolved_ids`/`submitted_ids`) formats
- **Collision policies**: Default `error` mode lists all collisions with shard pairs; `first-wins` and `last-wins` allow override with duplicate counting
- **Zero-cost operation**: Entirely offline; no model calls or network I/O

https://claude.ai/code/session_016McB6yvdsvdKBpEisqWV6g