### PR TITLE
⚡ Bolt: Replace intermediate .collect::<Vec<_>>() allocation in skills.rs

### DIFF
--- a/src/skills.rs
+++ b/src/skills.rs
@@ -540,6 +540,8 @@ fn searchable_tokens(name: &str, description: &str) -> BTreeSet<String> {
         .collect()
 }
 
+/// Normalizes search text by converting to lowercase and replacing non-alphanumeric characters with spaces.
+/// Performance optimization: Avoids an intermediate Vec allocation by directly joining the iterator components into a pre-allocated String.
 fn normalize_search_text(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     for ch in text.chars() {
@@ -549,7 +551,16 @@ fn normalize_search_text(text: &str) -> String {
             out.push(' ');
         }
     }
-    out.split_whitespace().collect::<Vec<_>>().join(" ")
+    let mut parts = out.split_whitespace();
+    let mut final_out = String::with_capacity(out.len());
+    if let Some(first) = parts.next() {
+        final_out.push_str(first);
+        for part in parts {
+            final_out.push(' ');
+            final_out.push_str(part);
+        }
+    }
+    final_out
 }
 
 fn is_stopword(token: &str) -> bool {


### PR DESCRIPTION
💡 What: Removed an intermediate `Vec` allocation in `src/skills.rs` (`normalize_search_text`) that was created via `.collect::<Vec<_>>().join(" ")`. Replaced it with a pre-allocated `String` and manual iterator consumption.
🎯 Why: Collecting strings into a `Vec` purely to `.join(" ")` them immediately after forces an unnecessary heap allocation for the array, which is inefficient.
📊 Impact: Reduces heap allocations. By pre-allocating the string to the maximum possible required capacity (`out.len()`), we ensure `O(N)` scaling with fewer underlying allocations per string processed.
🔬 Measurement: Run `cargo test --lib skills` and `cargo bench` to verify behavior remains correct and allocations drop.

---
*PR created automatically by Jules for task [5593890172518082543](https://jules.google.com/task/5593890172518082543) started by @madmax983*