### PR TITLE
⚒️ Forge: Extract common evaluator backend logic in selftest

### DIFF
--- a/src/run/evaluator_selftest.rs
+++ b/src/run/evaluator_selftest.rs
@@ -286,16 +286,18 @@ fn evaluate_gold_patch_none(instance: &SweBenchInstance) -> SelftestInstanceResu
 
 /// Route gold patches through the same `evaluate::run()` pipeline that real
 /// sweeps use, by creating a synthetic sweep directory.
-fn evaluate_via_sb_cli(
+#[allow(clippy::too_many_lines)]
+fn evaluate_via_backend(
     selected: &[SweBenchInstance],
     args: &SelftestArgs,
+    backend: EvaluateBackend,
+    scratch_dir_name: &str,
+    write_dataset: bool,
 ) -> Vec<SelftestInstanceResult> {
-    // Scratch dir for the synthetic sweep artifacts (results.json, all_preds.jsonl).
-    let scratch = args.output_dir.join("_eval_scratch");
+    let scratch = args.output_dir.join(scratch_dir_name);
     std::fs::create_dir_all(&scratch)
-        .unwrap_or_else(|e| panic!("cannot create eval scratch dir: {e}"));
+        .unwrap_or_else(|e| panic!("cannot create {scratch_dir_name} scratch dir: {e}"));
 
-    // Split into instances that have a gold patch and those that don't.
     let mut missing: Vec<SelftestInstanceResult> = Vec::new();
     let mut eval_pairs: Vec<(&SweBenchInstance, String)> = Vec::new();
 
@@ -324,10 +326,46 @@ fn evaluate_via_sb_cli(
     write_synthetic_results_json(&scratch, &eval_pairs);
     write_synthetic_predictions(&scratch, &eval_pairs);
 
+    if write_dataset {
+        for (inst, patch) in &eval_pairs {
+            let inst_dir = scratch.join(&inst.instance_id);
+            std::fs::create_dir_all(&inst_dir)
+                .unwrap_or_else(|e| panic!("cannot create instance dir for selftest: {e}"));
+            let patch_path = swebench::patch_path_for_run(&scratch, &inst.instance_id, 1);
+            std::fs::write(&patch_path, patch)
+                .unwrap_or_else(|e| panic!("failed to write selftest patch file: {e}"));
+        }
+
+        let dataset_path = scratch.join("selftest_dataset.jsonl");
+        let mut lines_jsonl = String::new();
+        for (inst, _) in &eval_pairs {
+            let row = serde_json::json!({
+                "instance_id": inst.instance_id,
+                "image": inst.image,
+                "FAIL_TO_PASS": inst.other.get("FAIL_TO_PASS").cloned().unwrap_or(serde_json::Value::Array(vec![])),
+                "PASS_TO_PASS": inst.other.get("PASS_TO_PASS").cloned().unwrap_or(serde_json::Value::Array(vec![])),
+                "test_patch": inst.other.get("test_patch").cloned().unwrap_or(serde_json::Value::Null),
+                "test_command": inst.other.get("test_command").cloned().unwrap_or(serde_json::Value::Null),
+                "image_name": inst.other.get("image_name").cloned().unwrap_or(serde_json::Value::Null),
+                "docker_image": inst.other.get("docker_image").cloned().unwrap_or(serde_json::Value::Null),
+            });
+            lines_jsonl.push_str(&serde_json::to_string(&row).unwrap_or_default());
+            lines_jsonl.push('\n');
+        }
+        std::fs::write(&dataset_path, lines_jsonl)
+            .unwrap_or_else(|e| panic!("failed to write selftest dataset: {e}"));
+    }
+
+    let dataset_path = if write_dataset {
+        Some(scratch.join("selftest_dataset.jsonl"))
+    } else {
+        Some(args.dataset_path.clone())
+    };
+
     let eval_args = EvaluateArgs {
         sweep_dir: scratch,
-        dataset_path: Some(args.dataset_path.clone()),
-        backend: EvaluateBackend::SbCli,
+        dataset_path,
+        backend,
         timeout_per_instance_secs: args.timeout_per_instance,
         parallel: args.parallel,
         sb_subset: args.sb_subset.clone(),
@@ -341,7 +379,7 @@ fn evaluate_via_sb_cli(
     let eval_result = crate::run::evaluate::run(&eval_args);
     let total_ms = start.elapsed().as_millis() as u64;
 
-    let mut sb_cli_results: Vec<SelftestInstanceResult> = match eval_result {
+    let mut results: Vec<SelftestInstanceResult> = match eval_result {
         Ok(eval) => {
             let n = eval.instances.len().max(1) as u64;
             let per_inst_ms = total_ms / n;
@@ -355,22 +393,32 @@ fn evaluate_via_sb_cli(
                 })
                 .collect()
         }
-        Err(e) => {
-            // Entire evaluator invocation failed — mark all submitted instances.
-            eval_pairs
-                .iter()
-                .map(|(inst, _)| SelftestInstanceResult {
-                    instance_id: inst.instance_id.clone(),
-                    resolved: false,
-                    evaluator_exit_reason: format!("{EXIT_REASON_EVALUATOR_FAILED}: {e}"),
-                    evaluator_duration_ms: total_ms,
-                })
-                .collect()
-        }
+        Err(e) => eval_pairs
+            .iter()
+            .map(|(inst, _)| SelftestInstanceResult {
+                instance_id: inst.instance_id.clone(),
+                resolved: false,
+                evaluator_exit_reason: format!("{EXIT_REASON_EVALUATOR_FAILED}: {e}"),
+                evaluator_duration_ms: total_ms,
+            })
+            .collect(),
     };
 
-    sb_cli_results.extend(missing);
-    sb_cli_results
+    results.extend(missing);
+    results
+}
+
+fn evaluate_via_sb_cli(
+    selected: &[SweBenchInstance],
+    args: &SelftestArgs,
+) -> Vec<SelftestInstanceResult> {
+    evaluate_via_backend(
+        selected,
+        args,
+        EvaluateBackend::SbCli,
+        "_eval_scratch",
+        false,
+    )
 }
 
 /// Write a minimal synthetic `results.json` that `evaluate::run()` / `load_sweep()`
@@ -445,118 +493,13 @@ fn evaluate_via_docker_tests(
     selected: &[SweBenchInstance],
     args: &SelftestArgs,
 ) -> Vec<SelftestInstanceResult> {
-    let scratch = args.output_dir.join("_docker_tests_scratch");
-    std::fs::create_dir_all(&scratch)
-        .unwrap_or_else(|e| panic!("cannot create docker-tests scratch dir: {e}"));
-
-    let mut missing: Vec<SelftestInstanceResult> = Vec::new();
-    let mut eval_pairs: Vec<(&SweBenchInstance, String)> = Vec::new();
-
-    for inst in selected {
-        let patch = inst
-            .other
-            .get("patch")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("");
-        if patch.trim().is_empty() {
-            missing.push(SelftestInstanceResult {
-                instance_id: inst.instance_id.clone(),
-                resolved: false,
-                evaluator_exit_reason: EXIT_REASON_GOLD_PATCH_MISSING.to_owned(),
-                evaluator_duration_ms: 0,
-            });
-        } else {
-            eval_pairs.push((inst, patch.to_owned()));
-        }
-    }
-
-    if eval_pairs.is_empty() {
-        return missing;
-    }
-
-    write_synthetic_results_json(&scratch, &eval_pairs);
-    write_synthetic_predictions(&scratch, &eval_pairs);
-
-    // Write per-instance run-1.patch files so docker-tests can read them via
-    // swebench::existing_patch_path_for_run(), which expects <sweep>/<id>/run-1.patch.
-    for (inst, patch) in &eval_pairs {
-        let inst_dir = scratch.join(&inst.instance_id);
-        std::fs::create_dir_all(&inst_dir)
-            .unwrap_or_else(|e| panic!("cannot create instance dir for selftest: {e}"));
-        let patch_path = swebench::patch_path_for_run(&scratch, &inst.instance_id, 1);
-        std::fs::write(&patch_path, patch)
-            .unwrap_or_else(|e| panic!("failed to write selftest patch file: {e}"));
-    }
-
-    // Write a minimal dataset JSONL containing the instances so docker-tests can
-    // find their image field and test lists.
-    let dataset_path = scratch.join("selftest_dataset.jsonl");
-    {
-        let mut lines = String::new();
-        for (inst, _) in &eval_pairs {
-            let row = serde_json::json!({
-                "instance_id": inst.instance_id,
-                "image": inst.image,
-                "FAIL_TO_PASS": inst.other.get("FAIL_TO_PASS").cloned().unwrap_or(serde_json::Value::Array(vec![])),
-                "PASS_TO_PASS": inst.other.get("PASS_TO_PASS").cloned().unwrap_or(serde_json::Value::Array(vec![])),
-                // Preserve oracle-test, runner, and alternate image fields so
-                // docker-tests can resolve the image and apply oracle tests.
-                "test_patch": inst.other.get("test_patch").cloned().unwrap_or(serde_json::Value::Null),
-                "test_command": inst.other.get("test_command").cloned().unwrap_or(serde_json::Value::Null),
-                "image_name": inst.other.get("image_name").cloned().unwrap_or(serde_json::Value::Null),
-                "docker_image": inst.other.get("docker_image").cloned().unwrap_or(serde_json::Value::Null),
-            });
-            lines.push_str(&serde_json::to_string(&row).unwrap_or_default());
-            lines.push('\n');
-        }
-        std::fs::write(&dataset_path, lines)
-            .unwrap_or_else(|e| panic!("failed to write selftest dataset: {e}"));
-    }
-
-    let eval_args = EvaluateArgs {
-        sweep_dir: scratch,
-        dataset_path: Some(dataset_path),
-        backend: EvaluateBackend::DockerTests,
-        timeout_per_instance_secs: args.timeout_per_instance,
-        parallel: args.parallel,
-        sb_subset: args.sb_subset.clone(),
-        sb_split: args.sb_split.clone(),
-        run_id: None,
-        breakdown: BreakdownSelection::none(),
-        cost_attribution: false,
-    };
-
-    let start = std::time::Instant::now();
-    let eval_result = crate::run::evaluate::run(&eval_args);
-    let total_ms = start.elapsed().as_millis() as u64;
-
-    let mut results: Vec<SelftestInstanceResult> = match eval_result {
-        Ok(eval) => {
-            let n = eval.instances.len().max(1) as u64;
-            let per_inst_ms = total_ms / n;
-            eval.instances
-                .into_iter()
-                .map(|e| SelftestInstanceResult {
-                    instance_id: e.instance_id,
-                    resolved: e.resolved,
-                    evaluator_exit_reason: map_eval_exit_reason(&e.eval_exit_reason),
-                    evaluator_duration_ms: per_inst_ms,
-                })
-                .collect()
-        }
-        Err(e) => eval_pairs
-            .iter()
-            .map(|(inst, _)| SelftestInstanceResult {
-                instance_id: inst.instance_id.clone(),
-                resolved: false,
-                evaluator_exit_reason: format!("{EXIT_REASON_EVALUATOR_FAILED}: {e}"),
-                evaluator_duration_ms: total_ms,
-            })
-            .collect(),
-    };
-
-    results.extend(missing);
-    results
+    evaluate_via_backend(
+        selected,
+        args,
+        EvaluateBackend::DockerTests,
+        "_docker_tests_scratch",
+        true,
+    )
 }
 
 // ── Aggregate computations ────────────────────────────────────────────────────


### PR DESCRIPTION
* 🚬 Smell: `evaluate_via_sb_cli` and `evaluate_via_docker_tests` in `src/run/evaluator_selftest.rs` are near-identical "God Functions" duplicating ~100 lines of complex synthetic sweep creation logic.
* ✨ Solution: Extracted the shared logic into a single parameterized `evaluate_via_backend` helper, routing backend-specific configurations effectively.
* 🧼 Benefit: Eliminates boilerplate, reduces file size, adheres to DRY principles, and makes adding new backends trivial.
* 🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [9497239840661162740](https://jules.google.com/task/9497239840661162740) started by @madmax983*