### PR TITLE
🌟 Nova: Asciicast Trajectory Exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+asciicast-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
 

--- a/docs/spec-export.md
+++ b/docs/spec-export.md
@@ -34,6 +34,7 @@ max bench inspect --list-formats
 | `csv` | stable | `csv-export` | spreadsheets, jq pipelines, tabular tools |
 | `html` | stable | `html-export` | self-contained browser view, shared notebooks |
 | `mermaid` | experimental | `mermaid-export` | Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live) |
+| `asciicast` | experimental | `asciicast-export` | Asciinema player (terminal session replay) |
 
 Feature-gated formats require rebuilding with the corresponding feature:
 

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -527,6 +527,7 @@ mod tests {
     // ── Network mode RED-phase tests ─────────────────────────────────────────
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
@@ -535,7 +536,7 @@ mod tests {
             "expected --network flag in args: {args:?}"
         );
         assert_eq!(
-            args.get(network_pos.unwrap_or(0) + 1).map(String::as_str),
+            args.get(network_pos.unwrap() + 1).map(String::as_str),
             Some("none")
         );
     }
@@ -550,10 +551,11 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap_or(0);
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap_or(0);
+        let network_pos = args.iter().position(|a| a == "--network").unwrap();
+        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -535,7 +535,7 @@ mod tests {
             "expected --network flag in args: {args:?}"
         );
         assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
+            args.get(network_pos.unwrap_or(0) + 1).map(String::as_str),
             Some("none")
         );
     }
@@ -552,8 +552,8 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let network_pos = args.iter().position(|a| a == "--network").unwrap_or(0);
+        let image_pos = args.iter().position(|a| a == "my-image").unwrap_or(0);
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -95,6 +95,14 @@ pub fn registry() -> Vec<ExportFormat> {
         render: MermaidExporter::export,
     });
 
+    #[cfg(feature = "asciicast-export")]
+    formats.push(ExportFormat {
+        name: "asciicast",
+        tier: StabilityTier::Experimental,
+        consumer: "Asciinema player (terminal session replay)",
+        render: AsciicastExporter::export,
+    });
+
     formats
 }
 
@@ -109,6 +117,7 @@ pub const FEATURE_GATED_FORMATS: &[(&str, &str)] = &[
     ("csv", "csv-export"),
     ("html", "html-export"),
     ("mermaid", "mermaid-export"),
+    ("asciicast", "asciicast-export"),
 ];
 
 /// Returns `true` if `name` is a trajectory export format known to this codebase,
@@ -162,6 +171,9 @@ pub struct CsvExporter;
 
 #[cfg(feature = "mermaid-export")]
 pub struct MermaidExporter;
+
+#[cfg(feature = "asciicast-export")]
+pub struct AsciicastExporter;
 
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
@@ -452,5 +464,65 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+}
+
+#[cfg(feature = "asciicast-export")]
+impl TrajectoryExporter for AsciicastExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut cast = String::new();
+
+        // Asciicast v2 header
+        let _ = writeln!(
+            cast,
+            r#"{{"version": 2, "width": 100, "height": 40, "timestamp": 0, "env": {{"TERM": "xterm-256color"}}}}"#
+        );
+
+        let mut current_time = 0.0;
+
+        for msg in &trajectory.messages {
+            let role = msg.role.as_str();
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+
+            let formatted = match role {
+                "system" => format!("\x1b[1;35m[System]\x1b[0m {content}\r\n"),
+                "user" => format!("\x1b[1;34m[User]\x1b[0m {content}\r\n"),
+                "assistant" => format!("\x1b[1;32m[Assistant]\x1b[0m {content}\r\n"),
+                "tool" => format!("\x1b[1;36m[Tool]\x1b[0m {content}\r\n"),
+                _ => format!("[{role}] {content}\r\n"),
+            };
+
+            let escaped_text = match serde_json::to_string(&formatted) {
+                Ok(s) => s,
+                Err(_) => format!("\"{}\"", formatted.replace('"', "\\\"")),
+            };
+
+            current_time += 1.0;
+            let _ = writeln!(cast, "[{current_time:.3}, \"o\", {escaped_text}]");
+        }
+
+        cast
+    }
+}
+
+#[cfg(test)]
+mod asciicast_tests {
+    use super::*;
+    use crate::model::Message;
+
+    #[cfg(feature = "asciicast-export")]
+    #[test]
+    fn test_asciicast_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+
+        t.record_message(&Message::user("Hello agent"));
+
+        let cast = AsciicastExporter::export(&t);
+
+        assert!(cast.starts_with(r#"{"version": 2"#));
+        assert!(cast.contains(r#"[User]"#));
+        assert!(cast.contains("Hello agent"));
     }
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -506,12 +506,11 @@ impl TrajectoryExporter for AsciicastExporter {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "asciicast-export"))]
 mod asciicast_tests {
     use super::*;
     use crate::model::Message;
 
-    #[cfg(feature = "asciicast-export")]
     #[test]
     fn test_asciicast_export_format() {
         let mut t = Trajectory::new();


### PR DESCRIPTION
💡 The Spark: I noticed we export trajectories to markdown, html, mermaid, and csv, but debugging or showcasing agent sessions is very text-heavy. What if we could export a terminal session as an interactive replay using Asciicast (Asciinema format)?
🚀 The Feature: Implemented `AsciicastExporter` to map the agent's interaction trajectory step-by-step into an Asciicast v2 JSON stream. Added an `asciicast-export` feature flag in `Cargo.toml`.
🔭 The Potential: This allows developers to easily replay an agent's terminal interactions locally or embed `.cast` files onto web platforms, generating awesome visualizations of the agent's workspace.
⚠️ Risk: Low. Isolated in `src/trajectory/export.rs` under a new feature flag `asciicast-export`. No existing core logic or exports are modified. All tests pass with explicit redaction handled by the new exporter.

---
*PR created automatically by Jules for task [7086421141201023951](https://jules.google.com/task/7086421141201023951) started by @madmax983*