### PR TITLE
🗺️ Atlas: Enforce strict pub(crate) module boundaries

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -13,7 +13,7 @@ pub mod confirm;
 pub mod confirm_cli;
 pub mod confirm_tui;
 pub mod default;
-pub mod interactive;
+pub(crate) mod interactive;
 pub mod parse;
 
 pub use confirm::{ConfirmCallback, ConfirmContext, ConfirmDecision, ScriptedConfirmer};

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -527,6 +527,7 @@ mod tests {
     // ── Network mode RED-phase tests ─────────────────────────────────────────
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
@@ -550,6 +551,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network").unwrap();

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -13,10 +13,10 @@ use tokio::sync::watch;
 
 use crate::error::EnvError;
 
-pub mod chaos;
+pub(crate) mod chaos;
 #[cfg(feature = "docker")]
-pub mod docker;
-pub mod local;
+pub(crate) mod docker;
+pub(crate) mod local;
 
 /// Stderr sentinel written on a [`RunResult`] synthesized by
 /// [`chaos::ChaosEnvironment`]. The agent loop and `bench inspect` use it to

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -14,7 +14,7 @@ use std::collections::BTreeMap;
 use crate::error::ModelError;
 
 pub mod deterministic;
-pub mod fallback;
+pub(crate) mod fallback;
 pub mod litellm;
 
 pub use deterministic::DeterministicModel;

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -43,7 +43,7 @@ pub struct CheckResult {
     pub unmatched_pattern_indices: Vec<usize>,
 }
 
-pub mod surface {
+pub(crate) mod surface {
     pub const TRAJECTORY: &str = "trajectory";
     pub const MODEL_OBSERVATION: &str = "model_observation";
     pub const STREAM: &str = "stream";

--- a/src/trajectory/mod.rs
+++ b/src/trajectory/mod.rs
@@ -133,7 +133,7 @@ pub mod outcome {
 }
 
 /// Reasons an agent run might exit unexpectedly before submitting.
-pub mod exit_reason {
+pub(crate) mod exit_reason {
     /// The run was manually cancelled by the user.
     pub const CANCELLED: &str = "cancelled";
     /// The run exceeded the maximum allowed wallclock time.


### PR DESCRIPTION
🕸️ Tangle: Many internal modules in `src/` were overly visible (`pub mod`) despite not being part of the root `lib.rs` public API, causing a larger public surface than necessary and loosening structural boundaries. Additionally, tests within `src/env/docker.rs` were violating the strict `unwrap_used` lint rules.

📐 Blueprint: We replaced `pub mod` with `pub(crate) mod` for completely internal sub-modules (such as in `redaction.rs`, `env/mod.rs`, `model/mod.rs`, `trajectory/mod.rs`, and `agent/mod.rs`). To resolve the testing compilation failure without risking panics in production logic, we safely silenced the `clippy::unwrap_used` lint on the red-phase test functions inside `src/env/docker.rs`.

🧱 Stability: A reduced public API strictly matching `lib.rs` and the removal of lint warnings enforce better domain encapsulation, avoid leaking private implementations, and speed up downstream compilation and introspection.

🔬 Verification: `cargo check`, `cargo test --all-features --all-targets --lib`, and `cargo clippy --all-targets --all-features -- -D warnings` all executed perfectly on the tightened hierarchy. No missing exports or regressions were introduced.

---
*PR created automatically by Jules for task [17737519121001652380](https://jules.google.com/task/17737519121001652380) started by @madmax983*