### PR TITLE
🎨 Mosaic: UI Polish for bench inspect list-formats

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3896,9 +3896,15 @@ fn parse_breakdown_selection(
 fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
     if i.list_formats {
         use crate::trajectory::export::registry;
+        let mut table = comfy_table::Table::new();
+        table
+            .load_preset(comfy_table::presets::UTF8_FULL)
+            .apply_modifier(comfy_table::modifiers::UTF8_ROUND_CORNERS)
+            .set_header(vec!["Format", "Tier", "Consumer"]);
         for fmt in registry() {
-            println!("{:<12}{:<14}{}", fmt.name, fmt.tier.as_str(), fmt.consumer);
+            table.add_row(vec![fmt.name, fmt.tier.as_str(), fmt.consumer]);
         }
+        println!("{table}");
         return Ok(());
     }
 


### PR DESCRIPTION
🖌️ Before: The `bench inspect --list-formats` output was an unformatted block of text without a structured UI.
✨ After: The format list is now presented securely and beautifully via a `comfy-table` with the UTF-8 preset and rounded corners to conform to the ecosystem's table-styling conventions.
🖼️ Visuals: A well-spaced TUI table containing the `Format`, `Tier`, and `Consumer` columns.

---
*PR created automatically by Jules for task [8937207351132842835](https://jules.google.com/task/8937207351132842835) started by @madmax983*