### PR TITLE
👺 Havoc: Fix panic on malicious Retry-After headers in RateLimitGovernor

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,3 @@
+1. **Fix `rustfmt` failure**: Run `cargo fmt --all` to format the code properly. The `rustfmt` check failed due to a line length issue in `src/run/rate_limit.rs`: `let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();`.
+2. **Fix `clippy` failure**: Add `#![allow(clippy::unwrap_used)]` or `#[allow(clippy::unwrap_used)]` to the test in `src/run/rate_limit.rs`.
+3. Submit the changes again using `submit` tool to the `havoc-rate-limit-panic` branch.

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -527,6 +527,7 @@ mod tests {
     // ── Network mode RED-phase tests ─────────────────────────────────────────
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
@@ -550,6 +551,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network").unwrap();

--- a/src/run/rate_limit.rs
+++ b/src/run/rate_limit.rs
@@ -287,7 +287,9 @@ impl RateLimitGovernor {
         inner.events.throttled_calls += 1;
 
         if let Some(secs) = retry_after_secs {
-            let until = now + Duration::from_secs(secs);
+            let until = now
+                .checked_add(Duration::from_secs(secs))
+                .unwrap_or_else(|| now + Duration::from_secs(60 * 60 * 24 * 365));
             // Keep the furthest-future floor if multiple workers race.
             match inner.retry_after_until {
                 Some(existing) if existing >= until => {}
@@ -496,6 +498,14 @@ mod tests {
         fn test_civil_to_unix_no_panic(year in any::<i64>(), month in any::<i64>(), day in any::<i64>(), h in any::<u64>(), m in any::<u64>(), s in any::<u64>()) {
             let _ = civil_to_unix(year, month, day, h, m, s);
         }
+    }
+
+    #[test]
+    fn test_report_429_handles_large_retry_after_without_panic() {
+        let gov = RateLimitGovernor::new(Some(100), None, 1).unwrap();
+        // Using tokio's current thread runtime to await report_429 directly
+        let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
+        rt.block_on(gov.report_429(Some(u64::MAX)));
     }
 
     #[test]

--- a/src/run/rate_limit.rs
+++ b/src/run/rate_limit.rs
@@ -501,10 +501,13 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn test_report_429_handles_large_retry_after_without_panic() {
         let gov = RateLimitGovernor::new(Some(100), None, 1).unwrap();
         // Using tokio's current thread runtime to await report_429 directly
-        let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
         rt.block_on(gov.report_429(Some(u64::MAX)));
     }
 


### PR DESCRIPTION
🧨 **The Trigger:** A provider returning an anomalously large `Retry-After: 9999999999999999999` value causes `Duration::from_secs(secs)` to be added to `Instant::now()`, which exceeds `Instant::MAX` and panics the rate limit governor.

📉 **The Stack Trace:**
```
thread 'run::rate_limit::tests::test_report_429_handles_large_retry_after_without_panic' panicked at 'overflow when adding duration to instant'
```

🧪 **Reproduction:** Run the newly added `test_report_429_handles_large_retry_after_without_panic` or use `proptest`.

😈 **Comment:** You assumed time was infinite. You were wrong.

---
*PR created automatically by Jules for task [9172869744152325402](https://jules.google.com/task/9172869744152325402) started by @madmax983*