### PR TITLE
⚡ Bolt: Pre-allocate vectors in eval_flake

### DIFF
--- a/src/run/eval_flake.rs
+++ b/src/run/eval_flake.rs
@@ -316,6 +316,7 @@ fn load_original_verdicts(sweep_dir: &Path) -> HashMap<String, Verdict> {
 ///
 /// `stub.verdicts[instance_id][replay_index]` gives the verdict for that replay.
 /// Used exclusively in integration tests.
+/// Optimization: Pre-allocate `results` to avoid reallocations when analyzing evaluated instances.
 pub fn run_with_stub(
     args: &EvalFlakeArgs,
     stub: &EvalFlakeStubConfig,
@@ -342,7 +343,7 @@ pub fn run_with_stub(
         })
         .collect();
 
-    let mut results: Vec<InstanceFlakeResult> = Vec::new();
+    let mut results: Vec<InstanceFlakeResult> = Vec::with_capacity(instance_ids.len());
     for id in &instance_ids {
         let stub_verdicts = stub.verdicts.get(id.as_str());
         let verdicts: Vec<Verdict> = (0..args.replays)


### PR DESCRIPTION
💡 What: Pre-allocated the `results` vector in `run_with_stub` using `Vec::with_capacity(instance_ids.len())`.
🎯 Why: To avoid unnecessary reallocations on the heap when collecting results from evaluated instances.
📊 Impact: Reduces heap allocations proportional to the number of instances evaluated.
🔬 Measurement: Run tests via `cargo test --lib run::eval_flake` to verify logic is preserved and no regressions occur.

---
*PR created automatically by Jules for task [6789857751372145665](https://jules.google.com/task/6789857751372145665) started by @madmax983*