### PR TITLE
Add `bench events` command for querying structured per-run event logs

### DIFF
--- a/docs/spec-event-log.md
+++ b/docs/spec-event-log.md
@@ -6,7 +6,7 @@
 Each line is one JSON object with:
 - `schema`: fixed string `event-log-v1`
 - `ts`: RFC3339 timestamp when the line is emitted
-- `event_type`: snake_case stream event type (`run_started`, `assistant_message`, `bash_start`, `bash_result`, `observation`, `format_error`, `run_ended`)
+- `event_type`: snake_case stream event type (`run_started`, `assistant_message`, `bash_start`, `bash_result`, `observation`, `format_error`, `run_ended`, `auto_approve_rule_created`)
 - `instance_id`: per-instance id (`mini` for standalone mini runs unless overridden by caller; SWE-bench uses dataset `instance_id`)
 - event-specific fields copied from the event payload
 
@@ -35,3 +35,9 @@ tail -f runs/events.jsonl | jq -c '.event_type'
 # per-instance progress in sweeps
 bench swebench --dataset-path data.jsonl --output runs/sweep --event-log runs/sweep.events.jsonl
 ```
+
+## Post-hoc querying
+
+For filtering and aggregating a completed event log by type, instance, and time
+window after a run/sweep finishes, see `bench events` (`docs/spec-events.md`).
+`tail`/`watch` are the live counterparts; `bench events` is read-only and offline.

--- a/docs/spec-events.md
+++ b/docs/spec-events.md
@@ -57,15 +57,19 @@ already redacted at write time, but the writer injects the `instance_id`
 records the run's **raw** instance id. To keep a secret-shaped id (a SWE-bench
 `instance_id` that matches a configured `secret_literals` / `custom_patterns`)
 from leaking into rows and summaries, `bench events` re-applies the run's
-configured redaction policy:
+redaction policy:
 
-- A completed **sweep** records its resolved `[redaction]` policy in
-  `manifest.json` / `results.json`; this is recovered automatically (unioned with
-  the default rules) when you pass the sweep directory or its
-  `{dir}.events.jsonl` sibling — no `--config` needed.
-- A standalone **`bench mini`** run records its literals *already redacted* in the
-  trajectory, so they cannot be auto-recovered; pass `--config <the run's config>`
-  to mask a configured-secret instance id for a bare event-log file.
+- **`--config <PATH>` is the reliable lever.** A run records its configured
+  `secret_literals` *already redacted* — sweeps redact the resolved config in
+  `manifest.json` / `results.json` (`build_manifest`), and a standalone
+  `bench mini` run redacts them in its trajectory — so a literal value cannot be
+  recovered from artifacts. Pass `--config` with the run's config to mask a
+  literal-shaped instance id (for both sweeps and mini).
+- **Best-effort auto-recovery (no `--config` needed).** When you pass a sweep
+  directory or its `{dir}.events.jsonl` sibling, the recorded `[redaction]` policy
+  is unioned with the defaults, recovering the `enabled` flag and any
+  `custom_patterns` (whose regex *source* is stored plaintext). This is a bonus,
+  not a substitute for `--config` when the secret is a configured literal.
 
 ### Valid `--type` values
 

--- a/docs/spec-events.md
+++ b/docs/spec-events.md
@@ -44,10 +44,28 @@ event log. Lines that are not valid JSON, or that lack an `event_type`, or whose
 | `--until <RFC3339>` | no | Keep events with `ts <=` this instant (inclusive). |
 | `--summary` | no | Print per-type (and per-instance, over a sweep) counts only. |
 | `--format <FMT>` | no | `table` (default), `json`, or `jsonl`. |
+| `--config <PATH>` | no | Config whose `[redaction]` rules are applied when rendering (see Redaction). |
 
 Events are emitted sorted by `(ts, instance_id, event_type)` for stable output.
-Event content is passed through the default redactor (the `inspect` surface)
-before printing, so secrets captured in event payloads are masked.
+
+### Redaction
+
+Event content is passed through a redactor (the `inspect` surface) before
+printing, so secrets captured in event payloads are masked. Payload fields are
+already redacted at write time, but the writer injects the `instance_id`
+*after* the runtime redactor (see `src/stream/event_log.rs`), so an event log
+records the run's **raw** instance id. To keep a secret-shaped id (a SWE-bench
+`instance_id` that matches a configured `secret_literals` / `custom_patterns`)
+from leaking into rows and summaries, `bench events` re-applies the run's
+configured redaction policy:
+
+- A completed **sweep** records its resolved `[redaction]` policy in
+  `manifest.json` / `results.json`; this is recovered automatically (unioned with
+  the default rules) when you pass the sweep directory or its
+  `{dir}.events.jsonl` sibling — no `--config` needed.
+- A standalone **`bench mini`** run records its literals *already redacted* in the
+  trajectory, so they cannot be auto-recovered; pass `--config <the run's config>`
+  to mask a configured-secret instance id for a bare event-log file.
 
 ### Valid `--type` values
 

--- a/docs/spec-events.md
+++ b/docs/spec-events.md
@@ -66,10 +66,15 @@ redaction policy:
   recovered from artifacts. Pass `--config` with the run's config to mask a
   literal-shaped instance id (for both sweeps and mini).
 - **Best-effort auto-recovery (no `--config` needed).** When you pass a sweep
-  directory or its `{dir}.events.jsonl` sibling, the recorded `[redaction]` policy
-  is unioned with the defaults, recovering the `enabled` flag and any
-  `custom_patterns` (whose regex *source* is stored plaintext). This is a bonus,
-  not a substitute for `--config` when the secret is a configured literal.
+  directory, its `{dir}.events.jsonl` sibling, or a parent holding several sweeps,
+  each governing `manifest.json` / `results.json` `[redaction]` policy is unioned
+  with the defaults, recovering the `enabled` flag and any `custom_patterns`
+  (whose regex *source* is stored plaintext). This is a bonus, not a substitute
+  for `--config` when the secret is a configured literal.
+
+When `--config` is given, its `enabled` flag is authoritative — auto-recovery
+adds rules but never re-enables redaction over an explicit `enabled = false`
+(e.g. to inspect raw instance ids). Without `--config`, redaction defaults on.
 
 ### Valid `--type` values
 

--- a/docs/spec-events.md
+++ b/docs/spec-events.md
@@ -21,8 +21,11 @@ bench events <PATH> [--type T]... [--instance ID]... \
 
 `<PATH>` may be:
 - an event-log `.jsonl` file, or
-- a single-run or sweep directory, which is walked **recursively** for `*.jsonl`
-  files.
+- a single-run or sweep directory, which is walked **recursively** for regular
+  `*.jsonl` files. The sibling log `<dir>.events.jsonl` is also picked up, since
+  the documented sweep pattern writes the log next to the output directory
+  (`--output runs/sweep --event-log runs/sweep.events.jsonl`) rather than inside
+  it. Symlinks, FIFOs, and other non-regular entries are skipped.
 
 Because every event line self-describes its `instance_id`, discovery does not
 depend on a file-naming convention: any `.jsonl` file whose lines carry a string

--- a/docs/spec-events.md
+++ b/docs/spec-events.md
@@ -1,0 +1,137 @@
+# `bench events` — query the structured per-run event log
+
+`bench events` filters and aggregates the structured, per-run event log that
+Maxwell's Daemon writes when `--event-log <PATH>` is passed to `bench mini` /
+`bench swebench` (writer: `src/stream/event_log.rs`, line format:
+`docs/spec-event-log.md`). It is the **post-hoc, offline** counterpart to the
+live `tail` / `watch` views: it reads only completed, on-disk logs, **never calls
+a model provider**, and **never mutates run artifacts**.
+
+For free-text search over trajectory *prose* use `bench grep`; this command
+filters *structured* events. For live streaming use `bench tail` / `bench watch`.
+For remote/OTLP export see `docs/spec-otlp-traces.md`.
+
+## Synopsis
+
+```bash
+bench events <PATH> [--type T]... [--instance ID]... \
+    [--since RFC3339] [--until RFC3339] [--summary] \
+    [--format table|json|jsonl]
+```
+
+`<PATH>` may be:
+- an event-log `.jsonl` file, or
+- a single-run or sweep directory, which is walked **recursively** for `*.jsonl`
+  files.
+
+Because every event line self-describes its `instance_id`, discovery does not
+depend on a file-naming convention: any `.jsonl` file whose lines carry a string
+`event_type` (and, when present, an `event-log-v*` `schema`) is treated as an
+event log. Lines that are not valid JSON, or that lack an `event_type`, or whose
+`schema` is not an event-log schema, are skipped and counted in `lines_skipped`
+(mirroring the writer's best-effort, never-fail philosophy).
+
+## Filters
+
+| Flag | Repeatable | Meaning |
+|------|:---------:|---------|
+| `--type <TYPE>` | yes | Keep only the named event type(s). Multiple values union. |
+| `--instance <ID>` | yes | Keep only the named instance id(s). Multiple values union. |
+| `--since <RFC3339>` | no | Keep events with `ts >=` this instant (inclusive). |
+| `--until <RFC3339>` | no | Keep events with `ts <=` this instant (inclusive). |
+| `--summary` | no | Print per-type (and per-instance, over a sweep) counts only. |
+| `--format <FMT>` | no | `table` (default), `json`, or `jsonl`. |
+
+Events are emitted sorted by `(ts, instance_id, event_type)` for stable output.
+Event content is passed through the default redactor (the `inspect` surface)
+before printing, so secrets captured in event payloads are masked.
+
+### Valid `--type` values
+
+All event types emitted by the writer are selectable; an unknown value is a
+usage error (exit 2) whose message lists the valid set:
+
+`run_started`, `assistant_message`, `bash_start`, `bash_result`, `observation`,
+`format_error`, `run_ended`, `auto_approve_rule_created`.
+
+This set is kept identical to `StreamEvent::event_name` (`src/stream/mod.rs`) and
+to the documented types in `docs/spec-event-log.md`.
+
+## Output
+
+### `--format table` (default)
+
+Tab-separated `ts<TAB>instance_id<TAB>event_type`, one row per matched event.
+With `--summary` (or when there are no rows), the count view is printed instead.
+
+### `--summary`
+
+```
+<N> event(s) across <M> instance(s)
+by type:
+  <event_type>: <count>
+  ...
+by instance:            # only when more than one instance is present
+  <instance_id>: <total>
+    <event_type>: <count>
+    ...
+```
+
+### `--format json`
+
+A single schema-versioned object (`schema: "events-query-v1"`):
+
+```json
+{
+  "schema": "events-query-v1",
+  "path": "runs/sweep",
+  "events": [
+    { "instance_id": "instance-a", "ts": "2026-01-01T00:00:03Z",
+      "event_type": "format_error", "schema": "event-log-v1", "step": 2, "...": "..." }
+  ],
+  "summary": {
+    "by_type": { "format_error": 1, "run_ended": 2 },
+    "by_instance": { "instance-a": { "format_error": 1, "run_ended": 1 } },
+    "instances": 2,
+    "total": 8
+  },
+  "files_scanned": 2,
+  "lines_skipped": 2
+}
+```
+
+In `--summary` mode `events` is empty (counts live in `summary`). Each event
+object flattens the original event-log line, so the raw `event-log-v1` fields are
+preserved losslessly (after redaction).
+
+### `--format jsonl`
+
+One matched event per line (the flattened, redacted event object). Empty in
+`--summary` mode. Suitable for piping to `jq`.
+
+## Exit codes
+
+Per `docs/exit-codes.md`:
+
+| Code | Class | When |
+|-----:|-------|------|
+| 0 | `success` | Query completed (including zero matches). |
+| 1 | `internal_error` | The path is missing or an event-log file is unreadable. |
+| 2 | `usage_error` | Unknown `--type`, unknown `--format`, or an invalid `--since`/`--until` timestamp. |
+
+The command is strictly read-only and never writes to or modifies the event log
+or any other run artifact.
+
+## Examples
+
+```bash
+# every tool/format error for one failed instance
+bench events runs/sweep --type format_error --instance django__django-12345
+
+# which instances emitted a given event type, as counts
+bench events runs/sweep --type bash_result --summary
+
+# events in a time window, machine-readable, piped to jq
+bench events runs/sweep --since 2026-01-01T00:00:00Z --until 2026-01-01T01:00:00Z \
+    --format jsonl | jq -c '{ts, instance_id, event_type}'
+```

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1357,6 +1357,8 @@ pub enum BenchCmd {
     CommandStats(CommandStatsCmd),
     /// Search every trajectory in a sweep for a regex pattern (zero-cost: reads only on-disk artifacts).
     Grep(GrepCmd),
+    /// Query the structured per-run event log by type, instance, and time window (zero-cost: reads only on-disk artifacts).
+    Events(EventsCmd),
     /// Pareto frontier across multiple sweep runs: ASCII chart + JSON dataset.
     Frontier(FrontierCmd),
     /// Replay a saved sweep from its manifest and report reproducibility.
@@ -3434,6 +3436,49 @@ pub struct GrepCmd {
     /// Output format: `text` (default, tab-separated `instance_id\tturn_index\trole\tsnippet`)
     /// or `json` (one JSON object per match, newline-delimited).
     #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
+/// `bench events` — query the structured per-run event log after a run/sweep.
+///
+/// Read-only and zero-cost: reads only the on-disk JSONL event log(s) defined by
+/// `docs/spec-event-log.md`, never calls a model provider, and never mutates run
+/// artifacts. Filters structured events by type/instance/time; for free-text
+/// search over trajectory prose use `bench grep`, and for live views use
+/// `bench tail` / `bench watch`.
+///
+/// Exit codes: 0 = success; 1 = missing/unreadable event log; 2 = usage error
+/// (unknown `--type`, bad `--format`, invalid `--since`/`--until`).
+#[derive(Debug, Args)]
+pub struct EventsCmd {
+    /// A single-run directory, a sweep directory, or an event-log `.jsonl` file.
+    pub path: PathBuf,
+
+    /// Keep only these event types (repeatable; default: all).
+    /// Example: `--type format_error --type run_ended`
+    #[arg(long = "type", value_name = "TYPE")]
+    pub types: Vec<String>,
+
+    /// Keep only these instance ids (repeatable; default: all).
+    #[arg(long = "instance", value_name = "INSTANCE_ID")]
+    pub instances: Vec<String>,
+
+    /// Inclusive RFC3339 lower bound on event timestamp.
+    #[arg(long, value_name = "RFC3339")]
+    pub since: Option<String>,
+
+    /// Inclusive RFC3339 upper bound on event timestamp.
+    #[arg(long, value_name = "RFC3339")]
+    pub until: Option<String>,
+
+    /// Print per-event-type counts (and per-instance counts over a sweep) instead
+    /// of individual event rows.
+    #[arg(long, default_value_t = false)]
+    pub summary: bool,
+
+    /// Output format: `table` (default, human), `json` (single schema-versioned
+    /// object), or `jsonl` (one event per line, machine-readable).
+    #[arg(long, default_value = "table")]
     pub format: String,
 }
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -3480,6 +3480,16 @@ pub struct EventsCmd {
     /// object), or `jsonl` (one event per line, machine-readable).
     #[arg(long, default_value = "table")]
     pub format: String,
+
+    /// Optional config file. The event log's payload fields are redacted at write
+    /// time, but the writer injects `instance_id` afterward with the run's raw
+    /// value, so a configured `[redaction].secret_literals`/`custom_patterns` is
+    /// re-applied here to mask a secret-shaped id. A sweep's recorded policy is
+    /// recovered automatically from its `manifest.json`/`results.json`; pass
+    /// `--config` to add rules (e.g. for a standalone `bench mini` run, whose
+    /// literals are recorded already-redacted and cannot be auto-recovered).
+    #[arg(long)]
+    pub config: Option<PathBuf>,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -3484,10 +3484,11 @@ pub struct EventsCmd {
     /// Optional config file. The event log's payload fields are redacted at write
     /// time, but the writer injects `instance_id` afterward with the run's raw
     /// value, so a configured `[redaction].secret_literals`/`custom_patterns` is
-    /// re-applied here to mask a secret-shaped id. A sweep's recorded policy is
-    /// recovered automatically from its `manifest.json`/`results.json`; pass
-    /// `--config` to add rules (e.g. for a standalone `bench mini` run, whose
-    /// literals are recorded already-redacted and cannot be auto-recovered).
+    /// re-applied here to mask a secret-shaped id. Configured `secret_literals`
+    /// are recorded *already-redacted* (sweep manifests and mini trajectories
+    /// alike), so `--config` is the reliable way to mask a literal-shaped id; a
+    /// sweep's recorded `custom_patterns`/`enabled` are recovered best-effort from
+    /// its `manifest.json`/`results.json` without `--config`.
     #[arg(long)]
     pub config: Option<PathBuf>,
 }

--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -302,6 +302,12 @@ pub fn entries() -> &'static [CatalogEntry] {
             stage: "preflight",
         },
         CatalogEntry {
+            path: "bench events",
+            summary: "Query the structured per-run event log by type, instance, and time window",
+            cost_tier: "free",
+            stage: "inspect",
+        },
+        CatalogEntry {
             path: "bench export-ci",
             summary: "Export a completed sweep as JUnit XML and/or GitHub Actions annotations",
             cost_tier: "free",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5155,6 +5155,20 @@ fn bench_events(e: args::EventsCmd) -> Result<(), Error> {
     // Only json/jsonl serialize the raw payload; table prints just the typed
     // columns, so we skip retaining payloads there to keep memory bounded.
     let include_payloads = matches!(format, EventsOutputFormat::Json | EventsOutputFormat::Jsonl);
+    // Build the redaction policy applied to event-only fields the writer injects
+    // after the runtime `RedactingSink` — notably the raw `instance_id`. Base it
+    // on `--config` (or defaults), then union the run/sweep's recorded resolved
+    // policy so a sweep run with configured literals masks a secret-shaped id
+    // without the operator re-supplying `--config`.
+    let mut redaction = match &e.config {
+        Some(p) => Config::load(p)?,
+        None => Config::defaults()?,
+    }
+    .root
+    .redaction;
+    for dir in events_recorded_config_dirs(&e.path) {
+        crate::run::redact_audit::merge_recorded_sweep_redaction(&dir, &mut redaction);
+    }
     let report = events::run(&events::EventsArgs {
         path: e.path,
         types: e.types,
@@ -5163,6 +5177,7 @@ fn bench_events(e: args::EventsCmd) -> Result<(), Error> {
         until: e.until,
         summary: e.summary,
         include_payloads,
+        redaction,
     })?;
     match format {
         EventsOutputFormat::Table => {
@@ -5183,6 +5198,39 @@ fn bench_events(e: args::EventsCmd) -> Result<(), Error> {
         }
     }
     Ok(())
+}
+
+/// Directories whose recorded resolved redaction policy (in `manifest.json` /
+/// `results.json`) applies to the event log at `path`, for
+/// [`merge_recorded_sweep_redaction`](crate::run::redact_audit::merge_recorded_sweep_redaction).
+///
+/// A sweep records its policy at the sweep-dir root, while the event log is
+/// conventionally either inside that dir (`runs/sweep/…`) or its
+/// `{dir}.events.jsonl` sibling (the documented `--output runs/sweep --event-log
+/// runs/sweep.events.jsonl` layout). So probe the path itself when it is a
+/// directory, and for a `*.events.jsonl` file the dir formed by stripping that
+/// suffix plus the file's parent. Non-existent or manifest-less dirs are harmless:
+/// the merge is best-effort and leaves the config unchanged.
+fn events_recorded_config_dirs(path: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut dirs = Vec::new();
+    if path.is_dir() {
+        dirs.push(path.to_path_buf());
+        return dirs;
+    }
+    if let (Some(parent), Some(stem)) = (
+        path.parent(),
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .and_then(|n| n.strip_suffix(".events.jsonl")),
+    ) {
+        dirs.push(parent.join(stem));
+    }
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            dirs.push(parent.to_path_buf());
+        }
+    }
+    dirs
 }
 
 fn bench_triage(t: args::TriageCmd) -> Result<(), Error> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5167,8 +5167,29 @@ fn bench_events(e: args::EventsCmd) -> Result<(), Error> {
     }
     .root
     .redaction;
-    for dir in events_recorded_config_dirs(&e.path) {
-        crate::run::redact_audit::merge_recorded_sweep_redaction(&dir, &mut redaction);
+    // An explicit `--config` is authoritative for the `enabled` flag. The recorded
+    // sweep policy may add literals/patterns and would otherwise force redaction
+    // back on (that force-enable is intended for `redact-audit`), but here it must
+    // not silently override an operator who set `enabled = false` to inspect raw
+    // ids; capture the requested state and restore it after the merge.
+    let config_enabled = redaction.enabled;
+    // Recover the recorded policy from every governing sweep dir: the path itself
+    // plus the governing dir of each discovered event log. Deriving from the
+    // discovered files (not just `path`) means a parent dir holding several sweeps
+    // — each with its own `manifest.json` in a sibling subdir — still has each
+    // child policy applied. Discovery errors are non-fatal here (`run` reports
+    // them); the merge is best-effort and a manifest-less dir is a no-op.
+    let mut config_dirs = events_recorded_config_dirs(&e.path);
+    for file in events::discover_event_files(&e.path).unwrap_or_default() {
+        config_dirs.extend(events_recorded_config_dirs(&file));
+    }
+    config_dirs.sort();
+    config_dirs.dedup();
+    for dir in &config_dirs {
+        crate::run::redact_audit::merge_recorded_sweep_redaction(dir, &mut redaction);
+    }
+    if e.config.is_some() {
+        redaction.enabled = config_enabled;
     }
     let report = events::run(&events::EventsArgs {
         path: e.path,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -100,6 +100,7 @@ pub async fn run() -> Result<(), Error> {
             args::BenchCmd::TriageDiff(t) => bench_triage_diff(t),
             args::BenchCmd::CommandStats(c) => bench_command_stats(c),
             args::BenchCmd::Grep(g) => bench_grep(g),
+            args::BenchCmd::Events(e) => bench_events(e),
             args::BenchCmd::Frontier(f) => bench_frontier(f),
             args::BenchCmd::Reproduce(r) => Box::pin(bench_reproduce(r)).await,
             args::BenchCmd::Bundle(b) => bench_bundle(b),
@@ -5139,6 +5140,47 @@ fn bench_grep(g: args::GrepCmd) -> Result<(), Error> {
     Ok(())
 }
 
+fn bench_events(e: args::EventsCmd) -> Result<(), Error> {
+    use crate::run::events;
+    let format = match e.format.as_str() {
+        "table" => EventsOutputFormat::Table,
+        "json" => EventsOutputFormat::Json,
+        "jsonl" => EventsOutputFormat::Jsonl,
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "unknown --format `{other}` (expected `table`, `json`, or `jsonl`)"
+            ))));
+        }
+    };
+    let report = events::run(&events::EventsArgs {
+        path: e.path,
+        types: e.types,
+        instances: e.instances,
+        since: e.since,
+        until: e.until,
+        summary: e.summary,
+    })?;
+    match format {
+        EventsOutputFormat::Table => {
+            if e.summary {
+                print!("{}", events::render_summary_table(&report));
+            } else {
+                print!("{}", events::render_table(&report));
+            }
+        }
+        EventsOutputFormat::Json => {
+            println!("{}", events::render_json(&report)?);
+        }
+        EventsOutputFormat::Jsonl => {
+            let lines = events::render_jsonl(&report)?;
+            if !lines.is_empty() {
+                println!("{lines}");
+            }
+        }
+    }
+    Ok(())
+}
+
 fn bench_triage(t: args::TriageCmd) -> Result<(), Error> {
     let format = match t.format.as_str() {
         "text" => TriageFormat::Text,
@@ -5767,6 +5809,13 @@ enum CommandStatsFormat {
 enum GrepOutputFormat {
     Text,
     Json,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EventsOutputFormat {
+    Table,
+    Json,
+    Jsonl,
 }
 
 async fn bench_tail(t: args::TailCmd) -> Result<(), Error> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5152,6 +5152,9 @@ fn bench_events(e: args::EventsCmd) -> Result<(), Error> {
             ))));
         }
     };
+    // Only json/jsonl serialize the raw payload; table prints just the typed
+    // columns, so we skip retaining payloads there to keep memory bounded.
+    let include_payloads = matches!(format, EventsOutputFormat::Json | EventsOutputFormat::Jsonl);
     let report = events::run(&events::EventsArgs {
         path: e.path,
         types: e.types,
@@ -5159,6 +5162,7 @@ fn bench_events(e: args::EventsCmd) -> Result<(), Error> {
         since: e.since,
         until: e.until,
         summary: e.summary,
+        include_payloads,
     })?;
     match format {
         EventsOutputFormat::Table => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5157,9 +5157,10 @@ fn bench_events(e: args::EventsCmd) -> Result<(), Error> {
     let include_payloads = matches!(format, EventsOutputFormat::Json | EventsOutputFormat::Jsonl);
     // Build the redaction policy applied to event-only fields the writer injects
     // after the runtime `RedactingSink` — notably the raw `instance_id`. Base it
-    // on `--config` (or defaults), then union the run/sweep's recorded resolved
-    // policy so a sweep run with configured literals masks a secret-shaped id
-    // without the operator re-supplying `--config`.
+    // on `--config` (or defaults), then union the run/sweep's recorded policy
+    // best-effort. Recorded `secret_literals` are stored already-redacted, so
+    // `--config` is the reliable lever for a literal-shaped id; the merge still
+    // recovers a sweep's `custom_patterns`/`enabled` for the no-`--config` case.
     let mut redaction = match &e.config {
         Some(p) => Config::load(p)?,
         None => Config::defaults()?,

--- a/src/run/events.rs
+++ b/src/run/events.rs
@@ -21,6 +21,7 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 use serde_json::Value;
 
+use crate::config::RedactionCfg;
 use crate::error::{ConfigError, Error};
 use crate::redaction::{Redactor, surface};
 
@@ -59,6 +60,16 @@ pub struct EventsArgs {
     /// `ts`/`instance_id`/`event_type`, so the CLI sets this `false` there to
     /// avoid allocating large assistant content / bash output for every event.
     pub include_payloads: bool,
+    /// Redaction policy applied when rendering/aggregating events. The on-disk
+    /// log's payload fields were already redacted at write time, but
+    /// event-only fields the writer injects *after* the runtime `RedactingSink`
+    /// — notably `instance_id` (see `crate::stream::event_log::EventLogSink`) —
+    /// carry the run's raw values, so a configured `secret_literals` /
+    /// `custom_patterns` must be applied here to keep a secret-shaped id from
+    /// leaking into rows and summaries. The CLI seeds this from `--config`
+    /// unioned with the run/sweep's recorded resolved policy; `default()`
+    /// reproduces the prior default/env-only behavior.
+    pub redaction: RedactionCfg,
 }
 
 /// One matched event. Serializes as the full original line object (`raw`, after
@@ -147,7 +158,7 @@ pub fn run(args: &EventsArgs) -> Result<EventsReport, Error> {
         Some(args.instances.iter().map(String::as_str).collect())
     };
 
-    let redactor = Redactor::default_enabled();
+    let redactor = Redactor::from_config_lossy(&args.redaction);
     let mut events: Vec<EventRow> = Vec::new();
     // In `--summary` mode we never retain raw events (a shared event log can be
     // multi-GB); aggregate counts during the scan instead so memory stays bounded

--- a/src/run/events.rs
+++ b/src/run/events.rs
@@ -161,14 +161,28 @@ pub fn run(args: &EventsArgs) -> Result<EventsReport, Error> {
     for file in &files {
         // Stream line-by-line: a completed sweep can share one `--event-log`,
         // so the file may be very large — never load it whole into memory.
-        let reader = std::io::BufReader::new(std::fs::File::open(file)?);
+        let mut reader = std::io::BufReader::new(std::fs::File::open(file)?);
         files_scanned += 1;
-        for line in reader.lines() {
-            let line = line?;
+        let mut buf: Vec<u8> = Vec::new();
+        loop {
+            buf.clear();
+            // Read one raw line as bytes: a non-UTF-8 byte sequence must not
+            // abort the whole query (the writer is best-effort and a shared log
+            // can contain arbitrary captured output), so decode leniently and
+            // skip undecodable lines, counting them as skipped.
+            let n = reader.read_until(b'\n', &mut buf)?;
+            if n == 0 {
+                break;
+            }
+            let Ok(line) = std::str::from_utf8(&buf) else {
+                lines_skipped += 1;
+                continue;
+            };
+            let line = line.trim_end_matches(['\n', '\r']);
             if line.trim().is_empty() {
                 continue;
             }
-            let Ok(mut value) = serde_json::from_str::<Value>(&line) else {
+            let Ok(mut value) = serde_json::from_str::<Value>(line) else {
                 lines_skipped += 1;
                 continue;
             };
@@ -182,8 +196,16 @@ pub fn run(args: &EventsArgs) -> Result<EventsReport, Error> {
                 lines_skipped += 1;
                 continue;
             };
-            if let Some(schema) = value.get("schema").and_then(Value::as_str) {
-                if !schema.starts_with("event-log-v") {
+            // When a `schema` key is present it must be an event-log schema
+            // *string*; a present-but-non-string schema (e.g. `{}`) — or a
+            // string naming a different schema — means the line is not one of
+            // our events, so skip it rather than letting `as_str()` returning
+            // `None` silently wave it through. Absent `schema` stays permissive.
+            if let Some(schema) = value.get("schema") {
+                let is_event_log = schema
+                    .as_str()
+                    .is_some_and(|s| s.starts_with("event-log-v"));
+                if !is_event_log {
                     lines_skipped += 1;
                     continue;
                 }
@@ -339,12 +361,26 @@ fn discover_event_files(path: &Path) -> Result<Vec<PathBuf>, Error> {
     }
     let mut out = Vec::new();
     collect_jsonl(path, &mut out)?;
-    // Probe the conventional sibling log `{dir}.events.jsonl`.
-    let mut sibling = path.as_os_str().to_owned();
-    sibling.push(".events.jsonl");
-    let sibling = PathBuf::from(sibling);
-    if sibling.is_file() {
-        out.push(sibling);
+    // Probe the conventional sibling log `{dir}.events.jsonl`. Build it from the
+    // dir's own file name (not the raw path string) so a trailing separator —
+    // `runs/sweep/`, as shell tab-completion commonly produces — yields
+    // `runs/sweep.events.jsonl` rather than `runs/sweep/.events.jsonl`.
+    if let Some(name) = path.file_name() {
+        let mut sibling_name = name.to_owned();
+        sibling_name.push(".events.jsonl");
+        let sibling = path
+            .parent()
+            .unwrap_or_else(|| Path::new(""))
+            .join(sibling_name);
+        // `symlink_metadata` does not follow symlinks, so a symlinked sibling
+        // (which could escape the artifact tree or point at a blocking FIFO) is
+        // not picked up — consistent with the symlink-safe `collect_jsonl` walk.
+        if std::fs::symlink_metadata(&sibling)
+            .map(|m| m.file_type().is_file())
+            .unwrap_or(false)
+        {
+            out.push(sibling);
+        }
     }
     out.sort();
     out.dedup();

--- a/src/run/events.rs
+++ b/src/run/events.rs
@@ -144,6 +144,12 @@ pub fn run(args: &EventsArgs) -> Result<EventsReport, Error> {
 
     let redactor = Redactor::default_enabled();
     let mut events: Vec<EventRow> = Vec::new();
+    // In `--summary` mode we never retain raw events (a shared event log can be
+    // multi-GB); aggregate counts during the scan instead so memory stays bounded
+    // by the distinct (instance, type) cardinality.
+    let mut by_type: BTreeMap<String, usize> = BTreeMap::new();
+    let mut by_instance: BTreeMap<String, BTreeMap<String, usize>> = BTreeMap::new();
+    let mut matched: usize = 0;
     let mut files_scanned = 0usize;
     let mut lines_skipped = 0usize;
 
@@ -230,30 +236,50 @@ pub fn run(args: &EventsArgs) -> Result<EventsReport, Error> {
                 .and_then(Value::as_str)
                 .unwrap_or("")
                 .to_owned();
-            events.push(EventRow {
-                instance_id,
-                ts,
-                event_type,
-                parsed_ts,
-                raw: value,
-            });
+            matched += 1;
+            if args.summary {
+                // Count and drop the value — `--summary` only needs the
+                // (redacted) instance id and the event type, not the payload.
+                *by_type.entry(event_type.clone()).or_insert(0) += 1;
+                *by_instance
+                    .entry(instance_id)
+                    .or_default()
+                    .entry(event_type)
+                    .or_insert(0) += 1;
+            } else {
+                events.push(EventRow {
+                    instance_id,
+                    ts,
+                    event_type,
+                    parsed_ts,
+                    raw: value,
+                });
+            }
         }
     }
 
-    events.sort_by(|a, b| {
-        a.parsed_ts
-            .cmp(&b.parsed_ts)
-            .then_with(|| a.ts.cmp(&b.ts))
-            .then_with(|| a.instance_id.cmp(&b.instance_id))
-            .then_with(|| a.event_type.cmp(&b.event_type))
-    });
-
-    let summary = build_summary(&events);
+    let summary = if args.summary {
+        EventsSummary {
+            instances: by_instance.len(),
+            total: matched,
+            by_type,
+            by_instance,
+        }
+    } else {
+        events.sort_by(|a, b| {
+            a.parsed_ts
+                .cmp(&b.parsed_ts)
+                .then_with(|| a.ts.cmp(&b.ts))
+                .then_with(|| a.instance_id.cmp(&b.instance_id))
+                .then_with(|| a.event_type.cmp(&b.event_type))
+        });
+        build_summary(&events)
+    };
 
     Ok(EventsReport {
         schema: QUERY_SCHEMA.to_owned(),
         path: args.path.display().to_string(),
-        events: if args.summary { Vec::new() } else { events },
+        events,
         summary,
         files_scanned,
         lines_skipped,

--- a/src/run/events.rs
+++ b/src/run/events.rs
@@ -1,0 +1,421 @@
+//! `bench events`: query the structured per-run event log after a run/sweep.
+//!
+//! Reads the append-only JSONL event log(s) written by [`crate::stream::event_log`]
+//! (format: `docs/spec-event-log.md`) and filters/aggregates them by event type,
+//! instance id, and time window. This is the post-hoc counterpart to the live
+//! `tail`/`watch` views: it operates only on completed, on-disk logs, never calls
+//! a model provider, and never mutates run artifacts.
+//!
+//! Each event line self-describes its `instance_id`, so discovery does not depend
+//! on a rigid file-naming convention — any `.jsonl` file whose lines carry a
+//! string `event_type` (and, when present, an `event-log-v*` `schema`) is treated
+//! as an event log. Non-event/garbage lines are skipped, mirroring the writer's
+//! best-effort philosophy.
+
+use std::collections::{BTreeMap, HashSet};
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::error::{ConfigError, Error};
+use crate::redaction::{Redactor, surface};
+
+/// Output schema identifier for the machine-readable (`--format json`) report.
+pub const QUERY_SCHEMA: &str = "events-query-v1";
+
+/// Every event type that the writer can emit, in the canonical order from
+/// `StreamEvent::event_name`. Kept in sync by a guard test in `tests/bench_events.rs`.
+pub const ALL_EVENT_TYPES: &[&str] = &[
+    "run_started",
+    "assistant_message",
+    "bash_start",
+    "bash_result",
+    "observation",
+    "format_error",
+    "run_ended",
+    "auto_approve_rule_created",
+];
+
+#[derive(Debug, Clone)]
+pub struct EventsArgs {
+    /// A single-run directory, a sweep directory, or an event-log `.jsonl` file.
+    pub path: PathBuf,
+    /// Event types to keep (`--type`, repeatable). Empty = all types.
+    pub types: Vec<String>,
+    /// Instance ids to keep (`--instance`, repeatable). Empty = all instances.
+    pub instances: Vec<String>,
+    /// Inclusive RFC3339 lower bound on `ts` (`--since`).
+    pub since: Option<String>,
+    /// Inclusive RFC3339 upper bound on `ts` (`--until`).
+    pub until: Option<String>,
+    /// Emit per-type/per-instance counts instead of individual rows.
+    pub summary: bool,
+}
+
+/// One matched event. Serializes as the full original line object (`raw`, after
+/// redaction) so machine-readable output is lossless and free of duplicate keys;
+/// the typed `instance_id`/`ts`/`event_type` are decoded copies kept only for
+/// in-process filtering, sorting, and aggregation.
+#[derive(Debug, Clone, Serialize)]
+pub struct EventRow {
+    #[serde(skip)]
+    pub instance_id: String,
+    #[serde(skip)]
+    pub ts: String,
+    #[serde(skip)]
+    pub event_type: String,
+    #[serde(flatten)]
+    pub raw: Value,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct EventsSummary {
+    /// event_type -> count.
+    pub by_type: BTreeMap<String, usize>,
+    /// instance_id -> (event_type -> count).
+    pub by_instance: BTreeMap<String, BTreeMap<String, usize>>,
+    /// Number of distinct instances represented in the matched events.
+    pub instances: usize,
+    /// Total number of matched events.
+    pub total: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EventsReport {
+    pub schema: String,
+    pub path: String,
+    /// Matched events (empty in `--summary` mode).
+    pub events: Vec<EventRow>,
+    pub summary: EventsSummary,
+    pub files_scanned: usize,
+    pub lines_skipped: usize,
+}
+
+/// Validate `--type` values against [`ALL_EVENT_TYPES`].
+///
+/// Returns a [`ConfigError::Invalid`] (→ usage error, exit 2) naming the unknown
+/// value and listing the valid types.
+pub fn validate_types(types: &[String]) -> Result<(), Error> {
+    for ty in types {
+        if !ALL_EVENT_TYPES.contains(&ty.as_str()) {
+            return Err(Error::Config(ConfigError::Invalid(format!(
+                "events: unknown --type `{ty}`; valid types: {}",
+                ALL_EVENT_TYPES.join(", ")
+            ))));
+        }
+    }
+    Ok(())
+}
+
+/// Query the event log(s) under `args.path`.
+#[allow(clippy::too_many_lines)]
+pub fn run(args: &EventsArgs) -> Result<EventsReport, Error> {
+    validate_types(&args.types)?;
+    let since = parse_bound(args.since.as_deref(), "--since")?;
+    let until = parse_bound(args.until.as_deref(), "--until")?;
+
+    if !args.path.exists() {
+        return Err(Error::Trajectory(format!(
+            "events: path does not exist: {}",
+            args.path.display()
+        )));
+    }
+
+    let files = discover_event_files(&args.path)?;
+
+    let type_set: Option<HashSet<&str>> = if args.types.is_empty() {
+        None
+    } else {
+        Some(args.types.iter().map(String::as_str).collect())
+    };
+    let instance_set: Option<HashSet<&str>> = if args.instances.is_empty() {
+        None
+    } else {
+        Some(args.instances.iter().map(String::as_str).collect())
+    };
+
+    let redactor = Redactor::default_enabled();
+    let mut events: Vec<EventRow> = Vec::new();
+    let mut files_scanned = 0usize;
+    let mut lines_skipped = 0usize;
+
+    for file in &files {
+        let text = std::fs::read_to_string(file)?;
+        files_scanned += 1;
+        for line in text.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let Ok(mut value) = serde_json::from_str::<Value>(line) else {
+                lines_skipped += 1;
+                continue;
+            };
+            // A line is an event iff it carries a string event_type and, when a
+            // schema is present, it is an event-log schema.
+            let Some(event_type) = value
+                .get("event_type")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+            else {
+                lines_skipped += 1;
+                continue;
+            };
+            if let Some(schema) = value.get("schema").and_then(Value::as_str) {
+                if !schema.starts_with("event-log-v") {
+                    lines_skipped += 1;
+                    continue;
+                }
+            }
+
+            let instance_id = value
+                .get("instance_id")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_owned();
+            let ts = value
+                .get("ts")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_owned();
+
+            if let Some(ref keep) = type_set {
+                if !keep.contains(event_type.as_str()) {
+                    continue;
+                }
+            }
+            if let Some(ref keep) = instance_set {
+                if !keep.contains(instance_id.as_str()) {
+                    continue;
+                }
+            }
+            if since.is_some() || until.is_some() {
+                let Some(parsed) = parse_ts(&ts) else {
+                    // Cannot place the event in the window — exclude it.
+                    continue;
+                };
+                if let Some(lower) = since {
+                    if parsed < lower {
+                        continue;
+                    }
+                }
+                if let Some(upper) = until {
+                    if parsed > upper {
+                        continue;
+                    }
+                }
+            }
+
+            redactor.redact_json_value(&mut value, surface::INSPECT);
+            events.push(EventRow {
+                instance_id,
+                ts,
+                event_type,
+                raw: value,
+            });
+        }
+    }
+
+    events.sort_by(|a, b| {
+        a.ts.cmp(&b.ts)
+            .then_with(|| a.instance_id.cmp(&b.instance_id))
+            .then_with(|| a.event_type.cmp(&b.event_type))
+    });
+
+    let summary = build_summary(&events);
+
+    Ok(EventsReport {
+        schema: QUERY_SCHEMA.to_owned(),
+        path: args.path.display().to_string(),
+        events: if args.summary { Vec::new() } else { events },
+        summary,
+        files_scanned,
+        lines_skipped,
+    })
+}
+
+fn build_summary(events: &[EventRow]) -> EventsSummary {
+    let mut by_type: BTreeMap<String, usize> = BTreeMap::new();
+    let mut by_instance: BTreeMap<String, BTreeMap<String, usize>> = BTreeMap::new();
+    for ev in events {
+        *by_type.entry(ev.event_type.clone()).or_insert(0) += 1;
+        *by_instance
+            .entry(ev.instance_id.clone())
+            .or_default()
+            .entry(ev.event_type.clone())
+            .or_insert(0) += 1;
+    }
+    EventsSummary {
+        instances: by_instance.len(),
+        total: events.len(),
+        by_type,
+        by_instance,
+    }
+}
+
+/// Discover candidate event-log files under `path`.
+///
+/// If `path` is a file it is used directly; if it is a directory it is walked
+/// recursively for `*.jsonl` files. Results are sorted for deterministic output.
+fn discover_event_files(path: &Path) -> Result<Vec<PathBuf>, Error> {
+    if path.is_file() {
+        return Ok(vec![path.to_path_buf()]);
+    }
+    let mut out = Vec::new();
+    collect_jsonl(path, &mut out)?;
+    out.sort();
+    Ok(out)
+}
+
+fn collect_jsonl(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), Error> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let p = entry.path();
+        if p.is_dir() {
+            collect_jsonl(&p, out)?;
+        } else if p
+            .extension()
+            .and_then(std::ffi::OsStr::to_str)
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonl"))
+        {
+            out.push(p);
+        }
+    }
+    Ok(())
+}
+
+fn parse_bound(raw: Option<&str>, flag: &str) -> Result<Option<DateTime<Utc>>, Error> {
+    match raw {
+        None => Ok(None),
+        Some(s) => parse_ts(s).map(Some).ok_or_else(|| {
+            Error::Config(ConfigError::Invalid(format!(
+                "events: invalid {flag} timestamp `{s}`; expected RFC3339 (e.g. 2026-01-01T00:00:00Z)"
+            )))
+        }),
+    }
+}
+
+fn parse_ts(raw: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(std::convert::Into::into)
+}
+
+// ── rendering ─────────────────────────────────────────────────────────────────
+
+/// Human-readable table of individual events (default `--format table`).
+#[must_use]
+pub fn render_table(report: &EventsReport) -> String {
+    if report.events.is_empty() {
+        // Nothing to list (summary mode or a filter matched nothing) — fall back
+        // to the count view so the command always prints something useful.
+        return render_summary_table(report);
+    }
+    let mut out = String::new();
+    for ev in &report.events {
+        let _ = writeln!(out, "{}\t{}\t{}", ev.ts, ev.instance_id, ev.event_type);
+    }
+    out
+}
+
+/// Per-type (and, for multi-instance logs, per-instance) counts.
+#[must_use]
+pub fn render_summary_table(report: &EventsReport) -> String {
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "{} event(s) across {} instance(s)",
+        report.summary.total, report.summary.instances
+    );
+    out.push_str("by type:\n");
+    if report.summary.by_type.is_empty() {
+        out.push_str("  (none)\n");
+    } else {
+        for (ty, count) in &report.summary.by_type {
+            let _ = writeln!(out, "  {ty}: {count}");
+        }
+    }
+    if report.summary.instances > 1 {
+        out.push_str("by instance:\n");
+        for (instance, types) in &report.summary.by_instance {
+            let total: usize = types.values().sum();
+            let _ = writeln!(out, "  {instance}: {total}");
+            for (ty, count) in types {
+                let _ = writeln!(out, "    {ty}: {count}");
+            }
+        }
+    }
+    out
+}
+
+/// Single schema-versioned JSON object (`--format json`).
+pub fn render_json(report: &EventsReport) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(report)
+}
+
+/// One matched event per line (`--format jsonl`). Empty in `--summary` mode.
+pub fn render_jsonl(report: &EventsReport) -> Result<String, serde_json::Error> {
+    let mut lines = Vec::with_capacity(report.events.len());
+    for ev in &report.events {
+        lines.push(serde_json::to_string(ev)?);
+    }
+    Ok(lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+
+    fn ev(ts: &str, instance: &str, ty: &str) -> EventRow {
+        EventRow {
+            instance_id: instance.to_owned(),
+            ts: ts.to_owned(),
+            event_type: ty.to_owned(),
+            raw: serde_json::json!({"event_type": ty, "instance_id": instance, "ts": ts}),
+        }
+    }
+
+    #[test]
+    fn validate_types_accepts_all_known() {
+        let all: Vec<String> = ALL_EVENT_TYPES.iter().map(|s| (*s).to_owned()).collect();
+        assert!(validate_types(&all).is_ok());
+    }
+
+    #[test]
+    fn validate_types_rejects_unknown() {
+        assert!(validate_types(&["nope".to_owned()]).is_err());
+    }
+
+    #[test]
+    fn summary_counts_per_type_and_instance() {
+        let events = vec![
+            ev("t1", "a", "run_started"),
+            ev("t2", "a", "run_ended"),
+            ev("t3", "b", "run_ended"),
+        ];
+        let s = build_summary(&events);
+        assert_eq!(s.total, 3);
+        assert_eq!(s.instances, 2);
+        assert_eq!(s.by_type.get("run_ended"), Some(&2));
+        assert_eq!(s.by_instance["a"].get("run_started"), Some(&1));
+    }
+
+    #[test]
+    fn jsonl_round_trips_event_fields() {
+        let report = EventsReport {
+            schema: QUERY_SCHEMA.to_owned(),
+            path: ".".to_owned(),
+            events: vec![ev("t1", "a", "bash_result")],
+            summary: EventsSummary::default(),
+            files_scanned: 1,
+            lines_skipped: 0,
+        };
+        let jsonl = render_jsonl(&report).unwrap();
+        let v: Value = serde_json::from_str(jsonl.trim()).unwrap();
+        assert_eq!(v["event_type"], "bash_result");
+        assert_eq!(v["instance_id"], "a");
+    }
+}

--- a/src/run/events.rs
+++ b/src/run/events.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::Write as _;
+use std::io::BufRead as _;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
@@ -58,7 +59,9 @@ pub struct EventsArgs {
 /// One matched event. Serializes as the full original line object (`raw`, after
 /// redaction) so machine-readable output is lossless and free of duplicate keys;
 /// the typed `instance_id`/`ts`/`event_type` are decoded copies kept only for
-/// in-process filtering, sorting, and aggregation.
+/// in-process filtering, sorting, and aggregation. `instance_id`/`raw` hold the
+/// redacted view used for display; `parsed_ts` is the decoded instant used for
+/// correct chronological ordering regardless of RFC3339 subsecond precision.
 #[derive(Debug, Clone, Serialize)]
 pub struct EventRow {
     #[serde(skip)]
@@ -67,6 +70,8 @@ pub struct EventRow {
     pub ts: String,
     #[serde(skip)]
     pub event_type: String,
+    #[serde(skip)]
+    pub parsed_ts: Option<DateTime<Utc>>,
     #[serde(flatten)]
     pub raw: Value,
 }
@@ -143,13 +148,16 @@ pub fn run(args: &EventsArgs) -> Result<EventsReport, Error> {
     let mut lines_skipped = 0usize;
 
     for file in &files {
-        let text = std::fs::read_to_string(file)?;
+        // Stream line-by-line: a completed sweep can share one `--event-log`,
+        // so the file may be very large — never load it whole into memory.
+        let reader = std::io::BufReader::new(std::fs::File::open(file)?);
         files_scanned += 1;
-        for line in text.lines() {
+        for line in reader.lines() {
+            let line = line?;
             if line.trim().is_empty() {
                 continue;
             }
-            let Ok(mut value) = serde_json::from_str::<Value>(line) else {
+            let Ok(mut value) = serde_json::from_str::<Value>(&line) else {
                 lines_skipped += 1;
                 continue;
             };
@@ -170,7 +178,11 @@ pub fn run(args: &EventsArgs) -> Result<EventsReport, Error> {
                 }
             }
 
-            let instance_id = value
+            // Raw (un-redacted) id is used only for filtering against the
+            // operator-supplied `--instance` values; the displayed/aggregated id
+            // is taken from the redacted object below so a secret-shaped instance
+            // id can't leak through the table or the per-instance summary.
+            let raw_instance_id = value
                 .get("instance_id")
                 .and_then(Value::as_str)
                 .unwrap_or("")
@@ -180,6 +192,10 @@ pub fn run(args: &EventsArgs) -> Result<EventsReport, Error> {
                 .and_then(Value::as_str)
                 .unwrap_or("")
                 .to_owned();
+            // Parse the timestamp once and keep it for both window-filtering and
+            // chronological sorting; lexical RFC3339 comparison mis-orders events
+            // whose subsecond precision or offset formatting differs.
+            let parsed_ts = parse_ts(&ts);
 
             if let Some(ref keep) = type_set {
                 if !keep.contains(event_type.as_str()) {
@@ -187,12 +203,12 @@ pub fn run(args: &EventsArgs) -> Result<EventsReport, Error> {
                 }
             }
             if let Some(ref keep) = instance_set {
-                if !keep.contains(instance_id.as_str()) {
+                if !keep.contains(raw_instance_id.as_str()) {
                     continue;
                 }
             }
             if since.is_some() || until.is_some() {
-                let Some(parsed) = parse_ts(&ts) else {
+                let Some(parsed) = parsed_ts else {
                     // Cannot place the event in the window — exclude it.
                     continue;
                 };
@@ -209,17 +225,25 @@ pub fn run(args: &EventsArgs) -> Result<EventsReport, Error> {
             }
 
             redactor.redact_json_value(&mut value, surface::INSPECT);
+            let instance_id = value
+                .get("instance_id")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_owned();
             events.push(EventRow {
                 instance_id,
                 ts,
                 event_type,
+                parsed_ts,
                 raw: value,
             });
         }
     }
 
     events.sort_by(|a, b| {
-        a.ts.cmp(&b.ts)
+        a.parsed_ts
+            .cmp(&b.parsed_ts)
+            .then_with(|| a.ts.cmp(&b.ts))
             .then_with(|| a.instance_id.cmp(&b.instance_id))
             .then_with(|| a.event_type.cmp(&b.event_type))
     });
@@ -273,7 +297,9 @@ fn collect_jsonl(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), Error> {
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let p = entry.path();
-        if p.is_dir() {
+        // Use the directory entry's own file type (does not follow symlinks) so a
+        // circular symlink can't drive infinite recursion / stack overflow.
+        if entry.file_type()?.is_dir() {
             collect_jsonl(&p, out)?;
         } else if p
             .extension()
@@ -374,6 +400,7 @@ mod tests {
             instance_id: instance.to_owned(),
             ts: ts.to_owned(),
             event_type: ty.to_owned(),
+            parsed_ts: parse_ts(ts),
             raw: serde_json::json!({"event_type": ty, "instance_id": instance, "ts": ts}),
         }
     }

--- a/src/run/events.rs
+++ b/src/run/events.rs
@@ -368,7 +368,7 @@ fn build_summary(events: &[EventRow]) -> EventsSummary {
 /// *next to* the output dir (`--output runs/sweep --event-log
 /// runs/sweep.events.jsonl`) rather than inside it. Results are deduplicated and
 /// sorted for deterministic output.
-fn discover_event_files(path: &Path) -> Result<Vec<PathBuf>, Error> {
+pub(crate) fn discover_event_files(path: &Path) -> Result<Vec<PathBuf>, Error> {
     if path.is_file() {
         return Ok(vec![path.to_path_buf()]);
     }

--- a/src/run/events.rs
+++ b/src/run/events.rs
@@ -66,9 +66,11 @@ pub struct EventsArgs {
     /// — notably `instance_id` (see `crate::stream::event_log::EventLogSink`) —
     /// carry the run's raw values, so a configured `secret_literals` /
     /// `custom_patterns` must be applied here to keep a secret-shaped id from
-    /// leaking into rows and summaries. The CLI seeds this from `--config`
-    /// unioned with the run/sweep's recorded resolved policy; `default()`
-    /// reproduces the prior default/env-only behavior.
+    /// leaking into rows and summaries. The CLI seeds this from `--config` (the
+    /// reliable lever — recorded `secret_literals` are stored already-redacted
+    /// and so cannot be recovered from artifacts) unioned with the run/sweep's
+    /// best-effort recorded policy (recovers `custom_patterns`/`enabled`);
+    /// `default()` reproduces the prior default/env-only behavior.
     pub redaction: RedactionCfg,
 }
 

--- a/src/run/events.rs
+++ b/src/run/events.rs
@@ -54,6 +54,11 @@ pub struct EventsArgs {
     pub until: Option<String>,
     /// Emit per-type/per-instance counts instead of individual rows.
     pub summary: bool,
+    /// Retain each event's full (redacted) raw payload on the returned rows.
+    /// Only `--format json`/`jsonl` serialize the payload; `table` prints just
+    /// `ts`/`instance_id`/`event_type`, so the CLI sets this `false` there to
+    /// avoid allocating large assistant content / bash output for every event.
+    pub include_payloads: bool,
 }
 
 /// One matched event. Serializes as the full original line object (`raw`, after
@@ -247,12 +252,20 @@ pub fn run(args: &EventsArgs) -> Result<EventsReport, Error> {
                     .entry(event_type)
                     .or_insert(0) += 1;
             } else {
+                // Only json/jsonl serialize the payload; for table output the
+                // renderer needs just the typed fields, so drop the raw value to
+                // keep memory bounded on large logs.
+                let raw = if args.include_payloads {
+                    value
+                } else {
+                    Value::Null
+                };
                 events.push(EventRow {
                     instance_id,
                     ts,
                     event_type,
                     parsed_ts,
-                    raw: value,
+                    raw,
                 });
             }
         }
@@ -276,9 +289,16 @@ pub fn run(args: &EventsArgs) -> Result<EventsReport, Error> {
         build_summary(&events)
     };
 
+    // Redact the reported path: an operator-chosen event-log path or temp dir
+    // name can itself be secret-shaped, and this string is copied into the
+    // shareable JSON report alongside the (already redacted) payloads.
+    let path = redactor
+        .redact_text(&args.path.display().to_string(), surface::INSPECT)
+        .text;
+
     Ok(EventsReport {
         schema: QUERY_SCHEMA.to_owned(),
-        path: args.path.display().to_string(),
+        path,
         events,
         summary,
         files_scanned,
@@ -307,15 +327,27 @@ fn build_summary(events: &[EventRow]) -> EventsSummary {
 
 /// Discover candidate event-log files under `path`.
 ///
-/// If `path` is a file it is used directly; if it is a directory it is walked
-/// recursively for `*.jsonl` files. Results are sorted for deterministic output.
+/// If `path` is a file it is used directly. If it is a directory it is walked
+/// recursively for `*.jsonl` files; additionally, the sibling `{dir}.events.jsonl`
+/// is included when present, because the documented sweep pattern writes the log
+/// *next to* the output dir (`--output runs/sweep --event-log
+/// runs/sweep.events.jsonl`) rather than inside it. Results are deduplicated and
+/// sorted for deterministic output.
 fn discover_event_files(path: &Path) -> Result<Vec<PathBuf>, Error> {
     if path.is_file() {
         return Ok(vec![path.to_path_buf()]);
     }
     let mut out = Vec::new();
     collect_jsonl(path, &mut out)?;
+    // Probe the conventional sibling log `{dir}.events.jsonl`.
+    let mut sibling = path.as_os_str().to_owned();
+    sibling.push(".events.jsonl");
+    let sibling = PathBuf::from(sibling);
+    if sibling.is_file() {
+        out.push(sibling);
+    }
     out.sort();
+    out.dedup();
     Ok(out)
 }
 
@@ -324,13 +356,16 @@ fn collect_jsonl(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), Error> {
         let entry = entry?;
         let p = entry.path();
         // Use the directory entry's own file type (does not follow symlinks) so a
-        // circular symlink can't drive infinite recursion / stack overflow.
-        if entry.file_type()?.is_dir() {
+        // circular symlink can't drive infinite recursion / stack overflow, and
+        // non-regular entries (symlinks, FIFOs, devices) are skipped — a FIFO
+        // would block `File::open` and a symlink could escape the artifact tree.
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
             collect_jsonl(&p, out)?;
-        } else if p
-            .extension()
-            .and_then(std::ffi::OsStr::to_str)
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonl"))
+        } else if file_type.is_file()
+            && p.extension()
+                .and_then(std::ffi::OsStr::to_str)
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonl"))
         {
             out.push(p);
         }

--- a/src/run/events.rs
+++ b/src/run/events.rs
@@ -386,10 +386,7 @@ fn discover_event_files(path: &Path) -> Result<Vec<PathBuf>, Error> {
         // `symlink_metadata` does not follow symlinks, so a symlinked sibling
         // (which could escape the artifact tree or point at a blocking FIFO) is
         // not picked up — consistent with the symlink-safe `collect_jsonl` walk.
-        if std::fs::symlink_metadata(&sibling)
-            .map(|m| m.file_type().is_file())
-            .unwrap_or(false)
-        {
+        if std::fs::symlink_metadata(&sibling).is_ok_and(|m| m.file_type().is_file()) {
             out.push(sibling);
         }
     }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -32,6 +32,7 @@ pub mod eval_flake;
 pub mod eval_parity;
 pub mod evaluate;
 pub mod evaluator_selftest;
+pub mod events;
 pub mod export_ci;
 pub mod export_otlp;
 pub mod failure_digest;

--- a/src/run/redact_audit.rs
+++ b/src/run/redact_audit.rs
@@ -458,7 +458,7 @@ struct ResolvedRedactionConfig {
 /// entries are *added* to the CLI config (union, not replace), so an explicit
 /// `--config` is never weakened. Redaction markers and uncompilable patterns are
 /// skipped. Best-effort: missing or malformed provenance leaves `cfg` unchanged.
-fn merge_recorded_sweep_redaction(dir: &Path, cfg: &mut RedactionCfg) {
+pub(crate) fn merge_recorded_sweep_redaction(dir: &Path, cfg: &mut RedactionCfg) {
     let mut existing_literals: BTreeSet<String> = cfg.secret_literals.iter().cloned().collect();
     let mut existing_patterns: BTreeSet<String> = cfg.custom_patterns.iter().cloned().collect();
 

--- a/tests/bench_events.rs
+++ b/tests/bench_events.rs
@@ -31,6 +31,9 @@ fn base_args(path: PathBuf) -> EventsArgs {
         since: None,
         until: None,
         summary: false,
+        // Full-fidelity by default for direct API callers/tests; the CLI sets
+        // this per output format.
+        include_payloads: true,
     }
 }
 
@@ -244,6 +247,99 @@ fn unit_redacts_secret_shaped_instance_id_in_display_and_summary() {
             "per-instance summary key must not leak the raw secret-shaped id: {key}"
         );
     }
+}
+
+#[test]
+fn unit_discovers_sibling_sweep_event_log() {
+    // Documented sweep pattern: `--output runs/sweep --event-log runs/sweep.events.jsonl`,
+    // i.e. the log is a sibling of the sweep dir. Passing the dir must still find it.
+    let tmp = tempfile::tempdir().unwrap();
+    let sweep = tmp.path().join("sweep");
+    std::fs::create_dir(&sweep).unwrap();
+    std::fs::write(
+        tmp.path().join("sweep.events.jsonl"),
+        "{\"schema\":\"event-log-v1\",\"ts\":\"2026-01-01T00:00:00Z\",\"event_type\":\"run_started\",\"instance_id\":\"x\"}\n",
+    )
+    .unwrap();
+
+    let report = events_run(&base_args(sweep)).unwrap();
+    assert_eq!(
+        report.events.len(),
+        1,
+        "the sibling sweep.events.jsonl must be discovered"
+    );
+    assert_eq!(report.events[0].instance_id, "x");
+}
+
+#[test]
+fn unit_table_mode_does_not_retain_payloads() {
+    let mut args = base_args(fixture_sweep());
+    args.include_payloads = false; // table/summary CLI path
+    let report = events_run(&args).unwrap();
+    assert!(!report.events.is_empty());
+    // Typed columns are kept (table renders these); raw payload is dropped.
+    for ev in &report.events {
+        assert!(!ev.event_type.is_empty());
+        assert!(
+            ev.raw.is_null(),
+            "table-mode rows must not retain the payload"
+        );
+    }
+}
+
+#[test]
+fn unit_json_mode_retains_payloads() {
+    let mut args = base_args(fixture_sweep());
+    args.include_payloads = true; // json/jsonl CLI path
+    let report = events_run(&args).unwrap();
+    assert!(
+        report.events.iter().any(|e| !e.raw.is_null()),
+        "json/jsonl mode must retain the raw payload"
+    );
+}
+
+#[test]
+fn unit_reported_path_is_redacted() {
+    // A secret-shaped segment in the path must not leak into the shareable report.
+    let fake_token = "ghp_0123456789ABCDEF0123456789ABCDEF0123";
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join(format!("run-{fake_token}"));
+    std::fs::create_dir(&dir).unwrap();
+    std::fs::write(
+        dir.join("e.jsonl"),
+        "{\"schema\":\"event-log-v1\",\"ts\":\"2026-01-01T00:00:00Z\",\"event_type\":\"run_started\",\"instance_id\":\"x\"}\n",
+    )
+    .unwrap();
+
+    let report = events_run(&base_args(dir)).unwrap();
+    assert!(
+        !report.path.contains(fake_token),
+        "reported query path must be redacted, got: {}",
+        report.path
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn unit_skips_symlinked_jsonl_during_discovery() {
+    // A symlinked *.jsonl entry inside the dir must be skipped (is_file() is false
+    // for symlinks), so discovery can't follow links outside the artifact tree.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("sweep");
+    std::fs::create_dir(&dir).unwrap();
+    let real = tmp.path().join("outside.jsonl");
+    std::fs::write(
+        &real,
+        "{\"schema\":\"event-log-v1\",\"ts\":\"2026-01-01T00:00:00Z\",\"event_type\":\"run_started\",\"instance_id\":\"leak\"}\n",
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(&real, dir.join("link.jsonl")).unwrap();
+
+    let report = events_run(&base_args(dir)).unwrap();
+    assert!(
+        report.events.is_empty(),
+        "symlinked jsonl must not be followed during discovery"
+    );
 }
 
 // ── CLI integration tests ─────────────────────────────────────────────────────

--- a/tests/bench_events.rs
+++ b/tests/bench_events.rs
@@ -654,16 +654,11 @@ fn cli_does_not_mutate_the_event_log_dir() {
     assert_eq!(after_files, before.len(), "no files added or removed");
 }
 
-#[test]
-fn cli_auto_recovers_sweep_redaction_policy() {
-    // A sweep launched with a configured literal records it (plaintext) in its
-    // manifest. `bench events` must recover that policy and mask a matching
-    // instance id WITHOUT the operator re-supplying `--config`.
-    let secret = "sw33tcustomliteral";
-    let tmp = tempfile::tempdir().unwrap();
-    let dir = tmp.path().join("sweep");
+/// Write a sweep dir whose `manifest.json` records `resolved` (a `[redaction]`
+/// TOML block) and an event log with one event for `instance_id`. Returns the dir.
+fn write_sweep(tmp: &Path, resolved: &str, instance_id: &str) -> PathBuf {
+    let dir = tmp.join("sweep");
     std::fs::create_dir_all(&dir).unwrap();
-    let resolved = format!("[redaction]\nenabled = true\nsecret_literals = [\"{secret}\"]\n");
     std::fs::write(
         dir.join("manifest.json"),
         serde_json::json!({ "config": { "resolved": resolved } }).to_string(),
@@ -672,10 +667,68 @@ fn cli_auto_recovers_sweep_redaction_policy() {
     std::fs::write(
         dir.join("run.events.jsonl"),
         format!(
-            "{{\"schema\":\"event-log-v1\",\"ts\":\"2026-01-01T00:00:00Z\",\"event_type\":\"run_started\",\"instance_id\":\"{secret}\"}}\n"
+            "{{\"schema\":\"event-log-v1\",\"ts\":\"2026-01-01T00:00:00Z\",\"event_type\":\"run_started\",\"instance_id\":\"{instance_id}\"}}\n"
         ),
     )
     .unwrap();
+    dir
+}
+
+#[test]
+fn cli_sweep_redacted_literal_needs_config() {
+    // Production sweeps redact secret_literals in their manifest (build_manifest,
+    // src/run/swebench.rs), storing `[REDACTED:…]`. `merge_recorded_sweep_redaction`
+    // skips those, so auto-recovery CANNOT mask a literal-shaped id — `--config` is
+    // the reliable lever. This characterizes that limitation honestly.
+    let secret = "sw33tcustomliteral";
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = write_sweep(
+        tmp.path(),
+        "[redaction]\nenabled = true\nsecret_literals = [\"[REDACTED:configured_literal]\"]\n",
+        secret,
+    );
+
+    // Without --config the redacted manifest yields nothing recoverable: the raw id
+    // is still rendered (json so the per-instance map is always serialized).
+    let bare = run_cli(&[dir.to_str().unwrap(), "--summary", "--format", "json"]);
+    assert!(
+        String::from_utf8(bare.stdout).unwrap().contains(secret),
+        "a redacted-in-manifest literal cannot be auto-recovered; id remains until --config"
+    );
+
+    // --config supplying the real literal masks it.
+    let cfg = tmp.path().join("cfg.toml");
+    std::fs::write(
+        &cfg,
+        format!("[redaction]\nsecret_literals = [\"{secret}\"]\n"),
+    )
+    .unwrap();
+    let out = run_cli(&[
+        dir.to_str().unwrap(),
+        "--summary",
+        "--format",
+        "json",
+        "--config",
+        cfg.to_str().unwrap(),
+    ]);
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        !String::from_utf8(out.stdout).unwrap().contains(secret),
+        "--config must mask the literal-shaped instance id"
+    );
+}
+
+#[test]
+fn cli_auto_recovers_sweep_custom_pattern() {
+    // Unlike literals, a `custom_patterns` regex *source* is stored plaintext in the
+    // manifest (it does not match its own regex), so it IS auto-recovered and masks
+    // a matching instance id with no `--config`.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = write_sweep(
+        tmp.path(),
+        "[redaction]\nenabled = true\ncustom_patterns = [\"inst-[0-9]+\"]\n",
+        "inst-12345",
+    );
 
     let out = run_cli(&[dir.to_str().unwrap(), "--summary", "--format", "json"]);
     assert_eq!(out.status.code(), Some(0));
@@ -685,8 +738,8 @@ fn cli_auto_recovers_sweep_redaction_policy() {
         "the recorded event should still be counted: {stdout}"
     );
     assert!(
-        !stdout.contains(secret),
-        "the sweep's recorded literal must mask the matching instance id: {stdout}"
+        !stdout.contains("inst-12345"),
+        "the sweep's recorded custom_pattern must mask the matching id: {stdout}"
     );
 }
 

--- a/tests/bench_events.rs
+++ b/tests/bench_events.rs
@@ -13,6 +13,7 @@ use std::process::Command;
 mod support;
 use support::binary_path;
 
+use maxwells_daemon::config::RedactionCfg;
 use maxwells_daemon::run::events::{
     ALL_EVENT_TYPES, EventsArgs, run as events_run, validate_types,
 };
@@ -34,6 +35,9 @@ fn base_args(path: PathBuf) -> EventsArgs {
         // Full-fidelity by default for direct API callers/tests; the CLI sets
         // this per output format.
         include_payloads: true,
+        // Default policy (enabled, no configured literals) reproduces the prior
+        // default/env-only redaction; individual tests override as needed.
+        redaction: RedactionCfg::default(),
     }
 }
 
@@ -245,6 +249,47 @@ fn unit_redacts_secret_shaped_instance_id_in_display_and_summary() {
         assert!(
             !key.contains(fake_token),
             "per-instance summary key must not leak the raw secret-shaped id: {key}"
+        );
+    }
+}
+
+#[test]
+fn unit_applies_configured_literal_to_instance_id() {
+    // A plain word the *default* rules never touch but a configured
+    // `secret_literals` does. The writer injects `instance_id` after the runtime
+    // RedactingSink, so the on-disk id is raw and only the query-time redactor can
+    // mask it — proving `bench events` must honor the run's configured policy.
+    let secret = "sw33tcustomliteral";
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("e.jsonl");
+    std::fs::write(
+        &path,
+        format!(
+            "{{\"schema\":\"event-log-v1\",\"ts\":\"2026-01-01T00:00:00Z\",\"event_type\":\"run_started\",\"instance_id\":\"{secret}\"}}\n"
+        ),
+    )
+    .unwrap();
+
+    // Default policy: nothing matches, so the id passes through verbatim.
+    let mut args = base_args(path);
+    args.summary = true;
+    let report = events_run(&args).unwrap();
+    assert!(
+        report.summary.by_instance.contains_key(secret),
+        "default rules should leave a non-secret-shaped id unchanged"
+    );
+
+    // Configured literal: the id must be masked in the per-instance summary.
+    args.redaction = RedactionCfg {
+        enabled: true,
+        secret_literals: vec![secret.to_owned()],
+        ..RedactionCfg::default()
+    };
+    let report = events_run(&args).unwrap();
+    for key in report.summary.by_instance.keys() {
+        assert!(
+            !key.contains(secret),
+            "configured literal must not survive in the per-instance summary: {key}"
         );
     }
 }
@@ -607,6 +652,89 @@ fn cli_does_not_mutate_the_event_log_dir() {
         assert_eq!(&bytes, orig, "file contents must be unchanged");
     }
     assert_eq!(after_files, before.len(), "no files added or removed");
+}
+
+#[test]
+fn cli_auto_recovers_sweep_redaction_policy() {
+    // A sweep launched with a configured literal records it (plaintext) in its
+    // manifest. `bench events` must recover that policy and mask a matching
+    // instance id WITHOUT the operator re-supplying `--config`.
+    let secret = "sw33tcustomliteral";
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("sweep");
+    std::fs::create_dir_all(&dir).unwrap();
+    let resolved = format!("[redaction]\nenabled = true\nsecret_literals = [\"{secret}\"]\n");
+    std::fs::write(
+        dir.join("manifest.json"),
+        serde_json::json!({ "config": { "resolved": resolved } }).to_string(),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("run.events.jsonl"),
+        format!(
+            "{{\"schema\":\"event-log-v1\",\"ts\":\"2026-01-01T00:00:00Z\",\"event_type\":\"run_started\",\"instance_id\":\"{secret}\"}}\n"
+        ),
+    )
+    .unwrap();
+
+    let out = run_cli(&[dir.to_str().unwrap(), "--summary", "--format", "json"]);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("\"total\": 1") || stdout.contains("\"total\":1"),
+        "the recorded event should still be counted: {stdout}"
+    );
+    assert!(
+        !stdout.contains(secret),
+        "the sweep's recorded literal must mask the matching instance id: {stdout}"
+    );
+}
+
+#[test]
+fn cli_config_flag_masks_instance_id_for_bare_log() {
+    // A bare event-log file outside any sweep dir: no manifest to recover from, so
+    // `--config` is the operator's lever to apply the run's redaction policy.
+    let secret = "sw33tcustomliteral";
+    let tmp = tempfile::tempdir().unwrap();
+    let log = tmp.path().join("e.jsonl");
+    std::fs::write(
+        &log,
+        format!(
+            "{{\"schema\":\"event-log-v1\",\"ts\":\"2026-01-01T00:00:00Z\",\"event_type\":\"run_started\",\"instance_id\":\"{secret}\"}}\n"
+        ),
+    )
+    .unwrap();
+    let cfg = tmp.path().join("cfg.toml");
+    std::fs::write(
+        &cfg,
+        format!("[redaction]\nsecret_literals = [\"{secret}\"]\n"),
+    )
+    .unwrap();
+
+    // Without --config (and no manifest), the id passes through verbatim. Use
+    // json so the per-instance map is always serialized (a single-instance
+    // summary table omits the per-instance breakdown).
+    let bare = run_cli(&[log.to_str().unwrap(), "--summary", "--format", "json"]);
+    assert!(
+        String::from_utf8(bare.stdout).unwrap().contains(secret),
+        "control: default policy leaves the id unchanged"
+    );
+
+    // With --config, the configured literal masks it.
+    let out = run_cli(&[
+        log.to_str().unwrap(),
+        "--summary",
+        "--format",
+        "json",
+        "--config",
+        cfg.to_str().unwrap(),
+    ]);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        !stdout.contains(secret),
+        "--config literal must mask the matching instance id: {stdout}"
+    );
 }
 
 // ── performance smoke ─────────────────────────────────────────────────────────

--- a/tests/bench_events.rs
+++ b/tests/bench_events.rs
@@ -1,0 +1,396 @@
+//! `bench events`: query the structured per-run event log after a run/sweep.
+//!
+//! Covers the issue #531 acceptance criteria over checked-in event-log fixtures:
+//! type/instance/time filters, table/json/jsonl output, `--summary` mode,
+//! unknown-`--type` usage errors, exit-code mapping, and read-only behavior.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+mod support;
+use support::binary_path;
+
+use maxwells_daemon::run::events::{
+    ALL_EVENT_TYPES, EventsArgs, run as events_run, validate_types,
+};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn fixture_sweep() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/events/sweep")
+}
+
+fn base_args(path: PathBuf) -> EventsArgs {
+    EventsArgs {
+        path,
+        types: vec![],
+        instances: vec![],
+        since: None,
+        until: None,
+        summary: false,
+    }
+}
+
+// ── unit tests (library core) ─────────────────────────────────────────────────
+
+#[test]
+fn unit_reads_events_from_all_instances_in_a_sweep() {
+    let report = events_run(&base_args(fixture_sweep())).unwrap();
+    // instance-a has 5 events, instance-b has 3 (+2 skipped lines).
+    assert_eq!(report.events.len(), 8, "should read all 8 valid events");
+    assert!(report.events.iter().any(|e| e.instance_id == "instance-a"));
+    assert!(report.events.iter().any(|e| e.instance_id == "instance-b"));
+    assert!(report.files_scanned >= 2, "both fixture files scanned");
+}
+
+#[test]
+fn unit_malformed_lines_are_skipped_not_fatal() {
+    let report = events_run(&base_args(fixture_sweep())).unwrap();
+    assert!(
+        report.lines_skipped >= 2,
+        "the non-json and event_type-less lines must be skipped, got {}",
+        report.lines_skipped
+    );
+}
+
+#[test]
+fn unit_events_sorted_by_timestamp() {
+    let report = events_run(&base_args(fixture_sweep())).unwrap();
+    let ts: Vec<&str> = report.events.iter().map(|e| e.ts.as_str()).collect();
+    let mut sorted = ts.clone();
+    sorted.sort_unstable();
+    assert_eq!(ts, sorted, "events should be ordered by ts");
+}
+
+#[test]
+fn unit_type_filter_restricts_to_format_error() {
+    let mut args = base_args(fixture_sweep());
+    args.types = vec!["format_error".into()];
+    let report = events_run(&args).unwrap();
+    assert!(!report.events.is_empty(), "format_error exists in fixture");
+    assert!(
+        report.events.iter().all(|e| e.event_type == "format_error"),
+        "only format_error events should remain"
+    );
+    assert!(
+        report.events.iter().all(|e| e.instance_id == "instance-a"),
+        "only instance-a emitted format_error in the fixture"
+    );
+}
+
+#[test]
+fn unit_type_filter_is_a_union_when_repeated() {
+    let mut args = base_args(fixture_sweep());
+    args.types = vec!["format_error".into(), "run_ended".into()];
+    let report = events_run(&args).unwrap();
+    assert!(
+        report
+            .events
+            .iter()
+            .all(|e| { e.event_type == "format_error" || e.event_type == "run_ended" })
+    );
+    assert!(report.events.iter().any(|e| e.event_type == "run_ended"));
+    assert!(report.events.iter().any(|e| e.event_type == "format_error"));
+}
+
+#[test]
+fn unit_instance_filter_restricts_to_one_instance() {
+    let mut args = base_args(fixture_sweep());
+    args.instances = vec!["instance-b".into()];
+    let report = events_run(&args).unwrap();
+    assert!(!report.events.is_empty());
+    assert!(
+        report.events.iter().all(|e| e.instance_id == "instance-b"),
+        "only instance-b events should remain"
+    );
+}
+
+#[test]
+fn unit_since_filter_includes_only_later_events() {
+    let mut args = base_args(fixture_sweep());
+    args.since = Some("2026-01-01T00:30:00Z".into());
+    let report = events_run(&args).unwrap();
+    assert!(!report.events.is_empty());
+    assert!(
+        report.events.iter().all(|e| e.instance_id == "instance-b"),
+        "instance-a events predate --since and must be excluded"
+    );
+}
+
+#[test]
+fn unit_until_filter_includes_only_earlier_events() {
+    let mut args = base_args(fixture_sweep());
+    args.until = Some("2026-01-01T00:30:00Z".into());
+    let report = events_run(&args).unwrap();
+    assert!(!report.events.is_empty());
+    assert!(
+        report.events.iter().all(|e| e.instance_id == "instance-a"),
+        "instance-b events postdate --until and must be excluded"
+    );
+}
+
+#[test]
+fn unit_summary_counts_per_type_and_per_instance() {
+    let mut args = base_args(fixture_sweep());
+    args.summary = true;
+    let report = events_run(&args).unwrap();
+    assert_eq!(report.summary.by_type.get("run_ended"), Some(&2));
+    assert_eq!(report.summary.by_type.get("format_error"), Some(&1));
+    assert_eq!(report.summary.instances, 2);
+    // per-instance breakdown present for a multi-instance sweep
+    let a = report.summary.by_instance.get("instance-a").unwrap();
+    assert_eq!(a.get("format_error"), Some(&1));
+    let b = report.summary.by_instance.get("instance-b").unwrap();
+    assert!(b.get("format_error").is_none());
+}
+
+#[test]
+fn unit_unknown_type_is_a_usage_error() {
+    assert!(validate_types(&["totally_bogus".into()]).is_err());
+}
+
+#[test]
+fn unit_all_documented_types_validate() {
+    let all: Vec<String> = ALL_EVENT_TYPES.iter().map(|s| (*s).to_owned()).collect();
+    validate_types(&all).expect("every catalogued event type must validate");
+}
+
+#[test]
+fn unit_all_event_types_matches_stream_event_names() {
+    // Guard: keep the selectable --type list in sync with what the writer emits.
+    let expected = [
+        "run_started",
+        "assistant_message",
+        "bash_start",
+        "bash_result",
+        "observation",
+        "format_error",
+        "run_ended",
+        "auto_approve_rule_created",
+    ];
+    let mut got: Vec<&str> = ALL_EVENT_TYPES.to_vec();
+    got.sort_unstable();
+    let mut want: Vec<&str> = expected.to_vec();
+    want.sort_unstable();
+    assert_eq!(got, want, "ALL_EVENT_TYPES must equal the 8 emitted names");
+}
+
+#[test]
+fn unit_missing_path_returns_error() {
+    let mut args = base_args(PathBuf::from("/tmp/nonexistent-events-dir-xyz-531"));
+    args.summary = true;
+    assert!(events_run(&args).is_err());
+}
+
+#[test]
+fn unit_accepts_a_single_event_log_file() {
+    let report = events_run(&base_args(fixture_sweep().join("instance-a.events.jsonl"))).unwrap();
+    assert_eq!(report.events.len(), 5);
+    assert!(report.events.iter().all(|e| e.instance_id == "instance-a"));
+}
+
+// ── CLI integration tests ─────────────────────────────────────────────────────
+
+fn run_cli(args: &[&str]) -> std::process::Output {
+    let mut full = vec!["--log", "error", "bench", "events"];
+    full.extend_from_slice(args);
+    Command::new(binary_path()).args(&full).output().unwrap()
+}
+
+#[test]
+fn cli_table_default_lists_rows_and_exits_0() {
+    let sweep = fixture_sweep();
+    let out = run_cli(&[sweep.to_str().unwrap()]);
+    assert_eq!(out.status.code(), Some(0), "happy path exits 0");
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains("instance-a"));
+    assert!(stdout.contains("format_error"));
+}
+
+#[test]
+fn cli_summary_prints_counts_not_rows() {
+    let sweep = fixture_sweep();
+    let out = run_cli(&[sweep.to_str().unwrap(), "--summary"]);
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains("run_ended"));
+    assert!(stdout.contains("format_error"));
+}
+
+#[test]
+fn cli_json_emits_single_schema_versioned_object() {
+    let sweep = fixture_sweep();
+    let out = run_cli(&[sweep.to_str().unwrap(), "--format", "json"]);
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(v["schema"], "events-query-v1");
+    assert!(v["events"].is_array());
+    assert!(v["summary"].is_object());
+}
+
+#[test]
+fn cli_jsonl_emits_one_event_per_line() {
+    let sweep = fixture_sweep();
+    let out = run_cli(&[sweep.to_str().unwrap(), "--format", "jsonl"]);
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let mut count = 0;
+    for line in stdout.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let obj: serde_json::Value = serde_json::from_str(line).expect("each line is JSON");
+        assert!(obj["event_type"].is_string());
+        assert!(obj["instance_id"].is_string());
+        count += 1;
+    }
+    assert_eq!(count, 8, "all 8 events emitted, one per line");
+}
+
+#[test]
+fn cli_type_filter_restricts_output() {
+    let sweep = fixture_sweep();
+    let out = run_cli(&[
+        sweep.to_str().unwrap(),
+        "--format",
+        "jsonl",
+        "--type",
+        "format_error",
+    ]);
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    for line in stdout.lines().filter(|l| !l.trim().is_empty()) {
+        let obj: serde_json::Value = serde_json::from_str(line).unwrap();
+        assert_eq!(obj["event_type"], "format_error");
+    }
+}
+
+#[test]
+fn cli_unknown_type_exits_2_and_lists_valid_types() {
+    let sweep = fixture_sweep();
+    let out = run_cli(&[sweep.to_str().unwrap(), "--type", "totally_bogus"]);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "unknown --type is a usage error (exit 2)"
+    );
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("format_error") && stderr.contains("run_ended"),
+        "error should list valid event types; got: {stderr}"
+    );
+}
+
+#[test]
+fn cli_bad_format_exits_2() {
+    let sweep = fixture_sweep();
+    let out = run_cli(&[sweep.to_str().unwrap(), "--format", "yaml"]);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "unknown --format is usage error"
+    );
+}
+
+#[test]
+fn cli_bad_timestamp_exits_2() {
+    let sweep = fixture_sweep();
+    let out = run_cli(&[sweep.to_str().unwrap(), "--since", "not-a-timestamp"]);
+    assert_eq!(out.status.code(), Some(2), "invalid --since is usage error");
+}
+
+#[test]
+fn cli_missing_path_exits_1() {
+    let out = run_cli(&["/tmp/nonexistent-events-dir-xyz-531"]);
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "missing/unreadable artifact exits 1 (internal_error)"
+    );
+}
+
+#[test]
+fn cli_help_mentions_zero_cost_or_read_only() {
+    let out = Command::new(binary_path())
+        .args(["bench", "events", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap().to_lowercase();
+    assert!(
+        stdout.contains("zero-cost")
+            || stdout.contains("read-only")
+            || stdout.contains("never calls a model"),
+        "help should advertise the read-only / zero-cost guarantee: {stdout}"
+    );
+}
+
+#[test]
+fn cli_does_not_mutate_the_event_log_dir() {
+    // Copy the fixture, snapshot file bytes, run the command, assert unchanged.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("sweep");
+    std::fs::create_dir_all(&dir).unwrap();
+    let mut before = Vec::new();
+    for entry in std::fs::read_dir(fixture_sweep()).unwrap() {
+        let entry = entry.unwrap();
+        let bytes = std::fs::read(entry.path()).unwrap();
+        std::fs::write(dir.join(entry.file_name()), &bytes).unwrap();
+        before.push((entry.file_name(), bytes));
+    }
+
+    let out = run_cli(&[dir.to_str().unwrap(), "--summary"]);
+    assert!(out.status.success());
+
+    let mut after_files = 0;
+    for entry in std::fs::read_dir(&dir).unwrap() {
+        let entry = entry.unwrap();
+        after_files += 1;
+        let bytes = std::fs::read(entry.path()).unwrap();
+        let (_, orig) = before
+            .iter()
+            .find(|(name, _)| name == &entry.file_name())
+            .expect("no new files created");
+        assert_eq!(&bytes, orig, "file contents must be unchanged");
+    }
+    assert_eq!(after_files, before.len(), "no files added or removed");
+}
+
+// ── performance smoke ─────────────────────────────────────────────────────────
+
+#[test]
+fn cli_300_instance_summary_is_fast() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("sweep");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // One event-log file per instance, a handful of events each.
+    for i in 0..300usize {
+        let id = format!("perf-{i:03}");
+        let mut buf = String::new();
+        for (k, ev) in ["run_started", "bash_result", "format_error", "run_ended"]
+            .iter()
+            .enumerate()
+        {
+            let _ = writeln!(
+                buf,
+                "{{\"schema\":\"event-log-v1\",\"ts\":\"2026-01-01T00:00:{k:02}Z\",\"event_type\":\"{ev}\",\"instance_id\":\"{id}\",\"step\":1}}"
+            );
+        }
+        std::fs::write(dir.join(format!("{id}.events.jsonl")), buf).unwrap();
+    }
+
+    let start = std::time::Instant::now();
+    let out = run_cli(&[dir.to_str().unwrap(), "--summary"]);
+    let elapsed = start.elapsed();
+    assert!(out.status.success());
+    assert!(
+        elapsed.as_secs_f64() < 2.0,
+        "summary over 300-instance log must be under 2s, took {:.2}s",
+        elapsed.as_secs_f64()
+    );
+}

--- a/tests/bench_events.rs
+++ b/tests/bench_events.rs
@@ -192,6 +192,54 @@ fn unit_accepts_a_single_event_log_file() {
     assert!(report.events.iter().all(|e| e.instance_id == "instance-a"));
 }
 
+#[test]
+fn unit_sorts_by_instant_not_lexical_string() {
+    // Two events for one instance whose lexical `ts` order is the REVERSE of
+    // their chronological order: "…00.500Z" < "…00Z" as strings ('.' < 'Z'),
+    // but 00.5s is later than 00s. The parsed-instant sort must order them right.
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("e.jsonl");
+    std::fs::write(
+        &path,
+        "{\"schema\":\"event-log-v1\",\"ts\":\"2026-01-01T00:00:00.500Z\",\"event_type\":\"bash_result\",\"instance_id\":\"x\"}\n\
+         {\"schema\":\"event-log-v1\",\"ts\":\"2026-01-01T00:00:00Z\",\"event_type\":\"run_started\",\"instance_id\":\"x\"}\n",
+    )
+    .unwrap();
+
+    let report = events_run(&base_args(path)).unwrap();
+    assert_eq!(report.events.len(), 2);
+    assert_eq!(
+        report.events[0].event_type, "run_started",
+        "the 00Z event is earlier and must sort first"
+    );
+    assert_eq!(report.events[1].event_type, "bash_result");
+}
+
+#[test]
+fn unit_redacts_secret_shaped_instance_id_in_display_and_summary() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("e.jsonl");
+    // A fake GitHub token shape the default redactor masks, used AS the instance id.
+    let fake_token = "ghp_0123456789ABCDEF0123456789ABCDEF0123";
+    std::fs::write(
+        &path,
+        format!(
+            "{{\"schema\":\"event-log-v1\",\"ts\":\"2026-01-01T00:00:00Z\",\"event_type\":\"run_started\",\"instance_id\":\"{fake_token}\"}}\n"
+        ),
+    )
+    .unwrap();
+
+    let mut args = base_args(path);
+    args.summary = true;
+    let report = events_run(&args).unwrap();
+    for key in report.summary.by_instance.keys() {
+        assert!(
+            !key.contains(fake_token),
+            "per-instance summary key must not leak the raw secret-shaped id: {key}"
+        );
+    }
+}
+
 // ── CLI integration tests ─────────────────────────────────────────────────────
 
 fn run_cli(args: &[&str]) -> std::process::Output {

--- a/tests/bench_events.rs
+++ b/tests/bench_events.rs
@@ -744,6 +744,83 @@ fn cli_auto_recovers_sweep_custom_pattern() {
 }
 
 #[test]
+fn cli_config_enabled_false_overrides_recorded_policy() {
+    // A `--config` with `enabled = false` is authoritative: auto-recovery must not
+    // silently re-enable redaction (so an operator can inspect raw instance ids),
+    // even though the sweep manifest records `enabled = true` + a matching pattern.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = write_sweep(
+        tmp.path(),
+        "[redaction]\nenabled = true\ncustom_patterns = [\"inst-[0-9]+\"]\n",
+        "inst-12345",
+    );
+
+    // Sanity: with no --config the recorded pattern masks the id.
+    let masked = run_cli(&[dir.to_str().unwrap(), "--summary", "--format", "json"]);
+    assert!(
+        !String::from_utf8(masked.stdout)
+            .unwrap()
+            .contains("inst-12345"),
+        "auto-recovery should mask the id without --config"
+    );
+
+    // With `--config enabled = false`, redaction is off and the id is shown raw.
+    let cfg = tmp.path().join("off.toml");
+    std::fs::write(&cfg, "[redaction]\nenabled = false\n").unwrap();
+    let out = run_cli(&[
+        dir.to_str().unwrap(),
+        "--summary",
+        "--format",
+        "json",
+        "--config",
+        cfg.to_str().unwrap(),
+    ]);
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        String::from_utf8(out.stdout)
+            .unwrap()
+            .contains("inst-12345"),
+        "--config enabled=false must not be overridden by the recorded policy"
+    );
+}
+
+#[test]
+fn cli_recovers_nested_sweep_policy_under_parent() {
+    // A parent dir holds a sibling-style log `foo.events.jsonl` whose governing
+    // manifest lives in the sibling subdir `foo/`. Passing the parent must still
+    // recover that policy (config-dir discovery follows the discovered logs, not
+    // just the path argument) and mask the matching instance id.
+    let tmp = tempfile::tempdir().unwrap();
+    let parent = tmp.path().join("runs");
+    std::fs::create_dir_all(parent.join("foo")).unwrap();
+    std::fs::write(
+        parent.join("foo/manifest.json"),
+        serde_json::json!({
+            "config": { "resolved": "[redaction]\nenabled = true\ncustom_patterns = [\"inst-[0-9]+\"]\n" }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    std::fs::write(
+        parent.join("foo.events.jsonl"),
+        "{\"schema\":\"event-log-v1\",\"ts\":\"2026-01-01T00:00:00Z\",\"event_type\":\"run_started\",\"instance_id\":\"inst-12345\"}\n",
+    )
+    .unwrap();
+
+    let out = run_cli(&[parent.to_str().unwrap(), "--summary", "--format", "json"]);
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("\"total\": 1") || stdout.contains("\"total\":1"),
+        "the nested sweep's log should be discovered and counted: {stdout}"
+    );
+    assert!(
+        !stdout.contains("inst-12345"),
+        "the nested sweep's recorded policy must mask the matching id: {stdout}"
+    );
+}
+
+#[test]
 fn cli_config_flag_masks_instance_id_for_bare_log() {
     // A bare event-log file outside any sweep dir: no manifest to recover from, so
     // `--config` is the operator's lever to apply the run's redaction policy.

--- a/tests/bench_events.rs
+++ b/tests/bench_events.rs
@@ -342,6 +342,105 @@ fn unit_skips_symlinked_jsonl_during_discovery() {
     );
 }
 
+#[test]
+fn unit_non_string_schema_is_skipped() {
+    // A present-but-non-string `schema` (e.g. `{}`) means the line is not one of
+    // our events; it must be skipped, not waved through because `as_str()` is None.
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("e.jsonl");
+    std::fs::write(
+        &path,
+        "{\"schema\":{},\"event_type\":\"run_started\",\"instance_id\":\"x\",\"ts\":\"2026-01-01T00:00:00Z\"}\n\
+         {\"schema\":\"event-log-v1\",\"event_type\":\"run_ended\",\"instance_id\":\"x\",\"ts\":\"2026-01-01T00:00:01Z\"}\n",
+    )
+    .unwrap();
+
+    let report = events_run(&base_args(path)).unwrap();
+    assert_eq!(
+        report.events.len(),
+        1,
+        "only the valid event-log-v1 line should be kept"
+    );
+    assert_eq!(report.events[0].event_type, "run_ended");
+    assert!(
+        report.lines_skipped >= 1,
+        "the non-string-schema line must be counted as skipped"
+    );
+}
+
+#[test]
+fn unit_invalid_utf8_line_is_skipped_not_fatal() {
+    // A non-UTF-8 byte line must not abort the query over an otherwise valid log.
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("e.jsonl");
+    let mut bytes: Vec<u8> = Vec::new();
+    bytes.extend_from_slice(
+        b"{\"schema\":\"event-log-v1\",\"event_type\":\"run_started\",\"instance_id\":\"x\",\"ts\":\"2026-01-01T00:00:00Z\"}\n",
+    );
+    bytes.extend_from_slice(&[0xff, 0xfe, 0x00, b'\n']); // invalid UTF-8 line
+    bytes.extend_from_slice(
+        b"{\"schema\":\"event-log-v1\",\"event_type\":\"run_ended\",\"instance_id\":\"x\",\"ts\":\"2026-01-01T00:00:01Z\"}\n",
+    );
+    std::fs::write(&path, bytes).unwrap();
+
+    let report = events_run(&base_args(path)).unwrap();
+    assert_eq!(
+        report.events.len(),
+        2,
+        "both valid events survive an interleaved non-UTF-8 line"
+    );
+    assert!(
+        report.lines_skipped >= 1,
+        "the invalid-UTF-8 line must be counted as skipped"
+    );
+}
+
+#[test]
+fn unit_discovers_sibling_with_trailing_separator() {
+    // A dir passed with a trailing separator (shell tab-completion) must still
+    // resolve its sibling `{dir}.events.jsonl`, not `{dir}/.events.jsonl`.
+    let tmp = tempfile::tempdir().unwrap();
+    let sweep = tmp.path().join("sweep");
+    std::fs::create_dir(&sweep).unwrap();
+    std::fs::write(
+        tmp.path().join("sweep.events.jsonl"),
+        "{\"schema\":\"event-log-v1\",\"ts\":\"2026-01-01T00:00:00Z\",\"event_type\":\"run_started\",\"instance_id\":\"x\"}\n",
+    )
+    .unwrap();
+
+    // Append a separator so the path ends in `/`.
+    let with_sep = PathBuf::from(format!("{}/", sweep.display()));
+    let report = events_run(&base_args(with_sep)).unwrap();
+    assert_eq!(
+        report.events.len(),
+        1,
+        "sibling must be found even with a trailing separator"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn unit_skips_symlinked_sibling_event_log() {
+    // A symlinked `{dir}.events.jsonl` sibling must not be followed (it could
+    // escape the artifact tree or point at a blocking FIFO).
+    let tmp = tempfile::tempdir().unwrap();
+    let sweep = tmp.path().join("sweep");
+    std::fs::create_dir(&sweep).unwrap();
+    let real = tmp.path().join("outside.jsonl");
+    std::fs::write(
+        &real,
+        "{\"schema\":\"event-log-v1\",\"ts\":\"2026-01-01T00:00:00Z\",\"event_type\":\"run_started\",\"instance_id\":\"leak\"}\n",
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(&real, tmp.path().join("sweep.events.jsonl")).unwrap();
+
+    let report = events_run(&base_args(sweep)).unwrap();
+    assert!(
+        report.events.is_empty(),
+        "symlinked sibling event log must not be followed"
+    );
+}
+
 // ── CLI integration tests ─────────────────────────────────────────────────────
 
 fn run_cli(args: &[&str]) -> std::process::Output {

--- a/tests/bench_events.rs
+++ b/tests/bench_events.rs
@@ -145,6 +145,12 @@ fn unit_summary_counts_per_type_and_per_instance() {
     assert_eq!(a.get("format_error"), Some(&1));
     let b = report.summary.by_instance.get("instance-b").unwrap();
     assert!(b.get("format_error").is_none());
+    // Summary mode must not retain raw event payloads (memory-bounded scan).
+    assert!(
+        report.events.is_empty(),
+        "summary mode should aggregate counts without retaining raw events"
+    );
+    assert_eq!(report.summary.total, 8);
 }
 
 #[test]

--- a/tests/fixtures/events/sweep/instance-a.events.jsonl
+++ b/tests/fixtures/events/sweep/instance-a.events.jsonl
@@ -1,0 +1,5 @@
+{"schema":"event-log-v1","ts":"2026-01-01T00:00:00Z","event_type":"run_started","instance_id":"instance-a","task":"fix bug","model":"fixture-model","started_at":"2026-01-01T00:00:00Z"}
+{"schema":"event-log-v1","ts":"2026-01-01T00:00:01Z","event_type":"bash_start","instance_id":"instance-a","step":1,"command":"pytest -x","timestamp":"2026-01-01T00:00:01Z"}
+{"schema":"event-log-v1","ts":"2026-01-01T00:00:02Z","event_type":"bash_result","instance_id":"instance-a","step":1,"exit_code":1,"stdout":"","stderr":"ImportError: no module named foo","timed_out":false,"timestamp":"2026-01-01T00:00:02Z"}
+{"schema":"event-log-v1","ts":"2026-01-01T00:00:03Z","event_type":"format_error","instance_id":"instance-a","step":2,"content":"malformed model output","timestamp":"2026-01-01T00:00:03Z"}
+{"schema":"event-log-v1","ts":"2026-01-01T00:00:04Z","event_type":"run_ended","instance_id":"instance-a","exit_reason":"submitted","final_output":"done","steps":2,"total_cost_usd":0.01,"ended_at":"2026-01-01T00:00:04Z"}

--- a/tests/fixtures/events/sweep/instance-b.events.jsonl
+++ b/tests/fixtures/events/sweep/instance-b.events.jsonl
@@ -1,0 +1,5 @@
+{"schema":"event-log-v1","ts":"2026-01-01T01:00:00Z","event_type":"run_started","instance_id":"instance-b","task":"fix other bug","model":"fixture-model","started_at":"2026-01-01T01:00:00Z"}
+{"schema":"event-log-v1","ts":"2026-01-01T01:00:01Z","event_type":"bash_result","instance_id":"instance-b","step":1,"exit_code":0,"stdout":"1 passed","stderr":"","timed_out":false,"timestamp":"2026-01-01T01:00:01Z"}
+{"schema":"event-log-v1","ts":"2026-01-01T01:00:02Z","event_type":"run_ended","instance_id":"instance-b","exit_reason":"submitted","final_output":"done","steps":1,"total_cost_usd":0.02,"ended_at":"2026-01-01T01:00:02Z"}
+this line is not json at all and must be skipped
+{"some_other":"json","but_no":"event_type"}


### PR DESCRIPTION
## Summary

Implements the `bench events` command, a zero-cost, read-only tool for querying structured per-run event logs written by `bench mini` and `bench swebench` with the `--event-log` flag. This command filters and aggregates events by type, instance ID, and time window, providing both human-readable and machine-readable output formats.

## Key Changes

- **New module `src/run/events.rs`**: Core event log querying logic
  - Discovers and reads JSONL event-log files from single-run or sweep directories
  - Filters events by type (`--type`), instance ID (`--instance`), and RFC3339 time bounds (`--since`, `--until`)
  - Aggregates event counts by type and instance with `--summary` mode
  - Validates event types against the canonical `ALL_EVENT_TYPES` list
  - Applies redaction to event payloads before output
  - Provides three output renderers: table (default), JSON (schema-versioned), and JSONL

- **CLI integration in `src/cli/mod.rs` and `src/cli/args.rs`**:
  - New `EventsCmd` struct with arguments for path, type/instance filters, time bounds, summary mode, and output format
  - New `bench_events()` handler that validates format and delegates to the events module
  - Proper error handling mapping to exit codes (0 = success, 1 = internal error, 2 = usage error)

- **Comprehensive test suite in `tests/bench_events.rs`**:
  - Unit tests covering filtering (type, instance, time), sorting, summary aggregation, and validation
  - CLI integration tests for all output formats, error cases, and exit codes
  - Performance smoke test verifying 300-instance summary completes in <2 seconds
  - Mutation test confirming read-only behavior (no artifacts modified)

- **Test fixtures**: Two sample event-log files (`instance-a.events.jsonl`, `instance-b.events.jsonl`) with realistic event sequences

- **Documentation in `docs/spec-events.md`**:
  - Complete command synopsis and usage guide
  - Filter semantics and valid event type values
  - Output format specifications with examples
  - Exit code reference

- **Minor updates**:
  - Updated `docs/spec-event-log.md` to reference the new `auto_approve_rule_created` event type
  - Added `bench events` entry to the command catalog in `src/cli/catalog.rs`
  - Exported new `events` module from `src/run/mod.rs`

## Implementation Details

- **Robust event discovery**: Any `.jsonl` file with lines carrying a string `event_type` field (and optional `event-log-v*` schema) is treated as an event log; malformed lines are skipped rather than failing
- **Deterministic output**: Events sorted by `(ts, instance_id, event_type)` for stable, reproducible results
- **Lossless JSON serialization**: Event objects flatten the original JSONL lines, preserving all fields after redaction
- **Guard test**: `unit_all_event_types_matches_stream_event_names()` ensures the selectable `--type` list stays in sync with `StreamEvent::event_name` in the writer

https://claude.ai/code/session_01Tok3HnpBFaGd6eKbdjnP8c