### PR TITLE
👺 Havoc: Fix OOM Vulnerability in Environment Pipe Buffers

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -366,15 +366,22 @@ where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut chunk = [0u8; 8192];
+    let max_size = 16 * 1024 * 1024;
     loop {
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {
             return Ok(());
         }
-        buffer
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .extend_from_slice(&chunk[..n]);
+        let mut lock = buffer.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if lock.len() + n > max_size {
+            let remain = max_size.saturating_sub(lock.len());
+            if remain > 0 {
+                lock.extend_from_slice(&chunk[..remain]);
+            }
+            lock.extend_from_slice(b"\n[Output truncated due to 16MB size limit]");
+            return Ok(());
+        }
+        lock.extend_from_slice(&chunk[..n]);
     }
 }
 

--- a/src/env/local.rs
+++ b/src/env/local.rs
@@ -255,15 +255,22 @@ where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut chunk = [0u8; 8192];
+    let max_size = 16 * 1024 * 1024;
     loop {
         let n = pipe.read(&mut chunk).await.map_err(EnvError::Io)?;
         if n == 0 {
             return Ok(());
         }
-        buffer
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .extend_from_slice(&chunk[..n]);
+        let mut lock = buffer.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if lock.len() + n > max_size {
+            let remain = max_size.saturating_sub(lock.len());
+            if remain > 0 {
+                lock.extend_from_slice(&chunk[..remain]);
+            }
+            lock.extend_from_slice(b"\n[Output truncated due to 16MB size limit]");
+            return Ok(());
+        }
+        lock.extend_from_slice(&chunk[..n]);
     }
 }
 


### PR DESCRIPTION
* 🧨 **The Trigger:** Infinite or excessively large streams from `&mut pipe` causing unbounded allocation in `Vec<u8>` when using commands that spam stdout/stderr continuously.
* 📉 **The Stack Trace:** Panic (Out Of Memory) due to memory exhaustion when endlessly extending the pipe buffer.
* 🧪 **Reproduction:** Demonstrated by creating a test harness with an `InfinitePipe` stream simulating endless output into `read_pipe_to_buffer`.
* 😈 **Comment:** You assumed the buffer would never be larger than RAM. You were wrong.

---
*PR created automatically by Jules for task [2294372671996979723](https://jules.google.com/task/2294372671996979723) started by @madmax983*