### PR TITLE
🗺️ Atlas: Break circular dependency in stream and redaction

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -28,8 +28,9 @@ use crate::model::{
 };
 use crate::policy::{PolicyDecision, PolicyEngine, PolicyProfile};
 use crate::prompt_guard::{PromptGuard, UntrustedKind};
-use crate::redaction::{RedactingSink, Redactor, surface};
+use crate::redaction::{Redactor, surface};
 use crate::stagnation::StagnationDetector;
+use crate::stream::RedactingSink;
 use crate::stream::{NullSink, StreamEvent, StreamSink};
 use crate::template::Renderer;
 use crate::tool::{

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -527,17 +527,14 @@ mod tests {
     // ── Network mode RED-phase tests ─────────────────────────────────────────
 
     #[test]
+    #[allow(clippy::expect_used)]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let network_pos = args
+            .iter()
+            .position(|a| a == "--network")
+            .expect("expected --network flag in args");
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -550,6 +547,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network").unwrap();

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::config::RedactionCfg;
-use crate::stream::{StreamEvent, StreamSink};
 
 // ── Public check types ────────────────────────────────────────────────────────
 
@@ -613,110 +612,6 @@ impl Redactor {
             }
             _ => false,
         }
-    }
-}
-
-pub struct RedactingSink {
-    inner: Arc<dyn StreamSink>,
-    redactor: Redactor,
-}
-
-impl RedactingSink {
-    pub fn new(inner: Arc<dyn StreamSink>, redactor: Redactor) -> Self {
-        Self { inner, redactor }
-    }
-}
-
-impl StreamSink for RedactingSink {
-    fn emit(&self, event: StreamEvent) {
-        self.inner.emit(redact_stream_event(&event, &self.redactor));
-    }
-}
-
-pub fn redact_stream_event(event: &StreamEvent, redactor: &Redactor) -> StreamEvent {
-    match event {
-        StreamEvent::RunStarted {
-            task,
-            model,
-            started_at,
-        } => StreamEvent::RunStarted {
-            task: redactor.redact_text(task, surface::STREAM).text,
-            model: redactor.redact_text(model, surface::STREAM).text,
-            started_at: started_at.clone(),
-        },
-        StreamEvent::AssistantMessage {
-            step,
-            content,
-            cost_usd,
-            timestamp,
-        } => StreamEvent::AssistantMessage {
-            step: *step,
-            content: redactor.redact_text(content, surface::STREAM).text,
-            cost_usd: *cost_usd,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::BashStart {
-            step,
-            command,
-            timestamp,
-        } => StreamEvent::BashStart {
-            step: *step,
-            command: redactor.redact_text(command, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::BashResult {
-            step,
-            exit_code,
-            stdout,
-            stderr,
-            timed_out,
-            timestamp,
-        } => StreamEvent::BashResult {
-            step: *step,
-            exit_code: *exit_code,
-            stdout: redactor.redact_text(stdout, surface::STREAM).text,
-            stderr: redactor.redact_text(stderr, surface::STREAM).text,
-            timed_out: *timed_out,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::Observation {
-            step,
-            content,
-            timestamp,
-        } => StreamEvent::Observation {
-            step: *step,
-            content: redactor.redact_text(content, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::FormatError {
-            step,
-            content,
-            timestamp,
-        } => StreamEvent::FormatError {
-            step: *step,
-            content: redactor.redact_text(content, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::RunEnded {
-            exit_reason,
-            failure_category,
-            final_output,
-            steps,
-            total_cost_usd,
-            ended_at,
-        } => StreamEvent::RunEnded {
-            exit_reason: exit_reason.clone(),
-            failure_category: *failure_category,
-            final_output: final_output
-                .as_ref()
-                .map(|value| redactor.redact_text(value, surface::STREAM).text),
-            steps: *steps,
-            total_cost_usd: *total_cost_usd,
-            ended_at: ended_at.clone(),
-        },
-        StreamEvent::AutoApproveRuleCreated { scope } => StreamEvent::AutoApproveRuleCreated {
-            scope: redactor.redact_text(scope, surface::STREAM).text,
-        },
     }
 }
 

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -978,7 +978,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         // one from the config. The agent will build its own for trajectory/model
         // surfaces; this one covers the stream surface only.
         let redactor = crate::redaction::Redactor::from_config_lossy(&args.config.root.redaction);
-        Arc::new(crate::redaction::RedactingSink::new(ws, redactor)) as Arc<dyn StreamSink>
+        Arc::new(crate::stream::RedactingSink::new(ws, redactor)) as Arc<dyn StreamSink>
     });
     let event_log_sink: Option<Arc<dyn StreamSink>> = args.event_log.as_ref().and_then(|path| {
         match EventLogSink::new(
@@ -1003,10 +1003,10 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
                 }
                 let redactor =
                     crate::redaction::Redactor::from_config_lossy(&args.config.root.redaction);
-                Some(Arc::new(crate::redaction::RedactingSink::new(
-                    Arc::new(sink),
-                    redactor,
-                )) as Arc<dyn StreamSink>)
+                Some(
+                    Arc::new(crate::stream::RedactingSink::new(Arc::new(sink), redactor))
+                        as Arc<dyn StreamSink>,
+                )
             }
             Err(err) => {
                 let _ = std::io::Write::write_all(

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -15,6 +15,7 @@ use serde::Serialize;
 
 pub mod broadcast;
 pub mod event_log;
+pub mod redacting;
 pub mod sse;
 #[cfg(feature = "webhook")]
 pub mod sweep_webhook;
@@ -23,6 +24,8 @@ pub mod webhook;
 
 pub use broadcast::BroadcastSink;
 pub use event_log::EventLogSink;
+pub use redacting::RedactingSink;
+pub use redacting::redact_stream_event;
 pub use sse::SseServer;
 #[cfg(feature = "webhook")]
 pub use sweep_webhook::{

--- a/src/stream/redacting.rs
+++ b/src/stream/redacting.rs
@@ -1,0 +1,107 @@
+use crate::redaction::{Redactor, surface};
+use crate::stream::{StreamEvent, StreamSink};
+use std::sync::Arc;
+
+pub struct RedactingSink {
+    inner: Arc<dyn StreamSink>,
+    redactor: Redactor,
+}
+
+impl RedactingSink {
+    pub fn new(inner: Arc<dyn StreamSink>, redactor: Redactor) -> Self {
+        Self { inner, redactor }
+    }
+}
+
+impl StreamSink for RedactingSink {
+    fn emit(&self, event: StreamEvent) {
+        self.inner.emit(redact_stream_event(&event, &self.redactor));
+    }
+}
+
+pub fn redact_stream_event(event: &StreamEvent, redactor: &Redactor) -> StreamEvent {
+    match event {
+        StreamEvent::RunStarted {
+            task,
+            model,
+            started_at,
+        } => StreamEvent::RunStarted {
+            task: redactor.redact_text(task, surface::STREAM).text,
+            model: redactor.redact_text(model, surface::STREAM).text,
+            started_at: started_at.clone(),
+        },
+        StreamEvent::AssistantMessage {
+            step,
+            content,
+            cost_usd,
+            timestamp,
+        } => StreamEvent::AssistantMessage {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            cost_usd: *cost_usd,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::BashStart {
+            step,
+            command,
+            timestamp,
+        } => StreamEvent::BashStart {
+            step: *step,
+            command: redactor.redact_text(command, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::BashResult {
+            step,
+            exit_code,
+            stdout,
+            stderr,
+            timed_out,
+            timestamp,
+        } => StreamEvent::BashResult {
+            step: *step,
+            exit_code: *exit_code,
+            stdout: redactor.redact_text(stdout, surface::STREAM).text,
+            stderr: redactor.redact_text(stderr, surface::STREAM).text,
+            timed_out: *timed_out,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::Observation {
+            step,
+            content,
+            timestamp,
+        } => StreamEvent::Observation {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::FormatError {
+            step,
+            content,
+            timestamp,
+        } => StreamEvent::FormatError {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::RunEnded {
+            exit_reason,
+            failure_category,
+            final_output,
+            steps,
+            total_cost_usd,
+            ended_at,
+        } => StreamEvent::RunEnded {
+            exit_reason: exit_reason.clone(),
+            failure_category: *failure_category,
+            final_output: final_output
+                .as_ref()
+                .map(|value| redactor.redact_text(value, surface::STREAM).text),
+            steps: *steps,
+            total_cost_usd: *total_cost_usd,
+            ended_at: ended_at.clone(),
+        },
+        StreamEvent::AutoApproveRuleCreated { scope } => StreamEvent::AutoApproveRuleCreated {
+            scope: redactor.redact_text(scope, surface::STREAM).text,
+        },
+    }
+}


### PR DESCRIPTION
🕸️ Tangle: Circular dependency between `stream` and `redaction` modules. `stream` exposed `RedactingSink` which lived in `redaction.rs`, and `redaction.rs` imported `StreamSink` and `StreamEvent` from `stream`.
📐 Blueprint: Extracted `RedactingSink` from `src/redaction.rs` to a new submodule `src/stream/redacting.rs`.
🧱 Stability: Enforces unidirectional dependencies (`stream` -> `redaction`) and removes the structural cycles in the module graph.
🔬 Verification: Builds successfully, strict separation enforced. Tested `stream`, `redaction`, `env`, `run`, and `agent` domains.

---
*PR created automatically by Jules for task [5698931435135654859](https://jules.google.com/task/5698931435135654859) started by @madmax983*