### PR TITLE
Add in-flight activity indicator with stall detection

### DIFF
--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -537,6 +537,36 @@ impl StreamSink for RatatuiDashboard {
                 );
                 self.append(kind, summary);
             }
+            StreamEvent::ToolStart { step, label, .. } => {
+                {
+                    let mut s = self
+                        .state
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    // A non-bash tool/hook/driver operation is in flight: render
+                    // it like a bash run so a slow one escalates to the stall
+                    // indicator instead of the static idle footer (issue #649).
+                    s.activity = Activity::Running {
+                        since: Instant::now(),
+                        command: label.clone(),
+                    };
+                }
+                self.append(LineKind::BashRun, format!("step {step} tool: {label}"));
+            }
+            StreamEvent::ToolEnd { .. } => {
+                {
+                    let mut s = self
+                        .state
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    // The tool finished; like `BashResult`, the gap until the
+                    // next observation/assistant message is idle (issue #649).
+                    s.activity = Activity::Idle;
+                }
+                // No log line — the following observation/result carries the
+                // detail — but wake the renderer so the footer clears promptly.
+                self.notify.notify_waiters();
+            }
             StreamEvent::Observation { step, content, .. } => {
                 {
                     let mut s = self

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -656,11 +656,14 @@ async fn renderer_loop(
     mut shutdown: oneshot::Receiver<()>,
 ) {
     let mut events = EventStream::new();
-    // Spinner cadence while an operation is in flight (issue #649). The tick is
-    // only awaited when `activity.is_active()`, so an idle/finished dashboard
-    // redraws solely on `Notify`/keystrokes — zero animation frames, no CPU
-    // spin while nothing is happening (AC3).
+    // Spinner cadence while an operation is in flight (issue #649). The tick
+    // branch is guarded by `if active`, so an idle/finished dashboard redraws
+    // solely on `Notify`/keystrokes — zero animation frames, no CPU spin while
+    // nothing is happening (AC3). `Skip` prevents the default `Burst` behaviour
+    // from firing a flurry of catch-up ticks when an operation resumes after an
+    // idle gap during which the interval was never awaited.
     let mut tick = tokio::time::interval(Duration::from_millis(100));
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
         let (exit, active) = {
             let s = dash
@@ -676,33 +679,17 @@ async fn renderer_loop(
         if let Err(err) = draw_frame(&dash, &mut terminal) {
             tracing::warn!(?err, "ratatui draw failed");
         }
-        if active {
-            tokio::select! {
-                _ = &mut shutdown => break,
-                () = dash.notify.notified() => {}
-                _ = tick.tick() => {}
-                ev = events.next() => {
-                    match ev {
-                        Some(Ok(Event::Key(key))) => handle_key(&dash, key),
-                        Some(Err(err)) => {
-                            tracing::warn!(?err, "ratatui event stream error");
-                        }
-                        _ => {}
+        tokio::select! {
+            _ = &mut shutdown => break,
+            () = dash.notify.notified() => {}
+            _ = tick.tick(), if active => {}
+            ev = events.next() => {
+                match ev {
+                    Some(Ok(Event::Key(key))) => handle_key(&dash, key),
+                    Some(Err(err)) => {
+                        tracing::warn!(?err, "ratatui event stream error");
                     }
-                }
-            }
-        } else {
-            tokio::select! {
-                _ = &mut shutdown => break,
-                () = dash.notify.notified() => {}
-                ev = events.next() => {
-                    match ev {
-                        Some(Ok(Event::Key(key))) => handle_key(&dash, key),
-                        Some(Err(err)) => {
-                            tracing::warn!(?err, "ratatui event stream error");
-                        }
-                        _ => {}
-                    }
+                    _ => {}
                 }
             }
         }

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -9,7 +9,7 @@
 use std::collections::{HashSet, VecDeque};
 use std::io::{Stdout, Write as _};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -135,6 +135,12 @@ struct DashboardState {
     /// (a long no-newline rationale wraps to many rows).
     last_rationale_total_rows: usize,
     last_rationale_visible_rows: usize,
+    /// What the agent is doing right now, for the in-flight activity indicator
+    /// (issue #649). Driven by `StreamEvent` transitions in `emit()`.
+    activity: Activity,
+    /// Elapsed-time threshold past which the activity indicator escalates to
+    /// flag a likely stall (issue #649). Default 60s; configurable.
+    stall_threshold: Duration,
 }
 
 impl Default for DashboardState {
@@ -162,6 +168,8 @@ impl Default for DashboardState {
             rationale_scroll: 0,
             last_rationale_total_rows: 0,
             last_rationale_visible_rows: 0,
+            activity: Activity::Idle,
+            stall_threshold: Duration::from_secs(DEFAULT_STALL_THRESHOLD_SECS),
         }
     }
 }
@@ -209,6 +217,100 @@ enum LineKind {
 struct PendingPrompt {
     ctx: ConfirmContext,
     responder: oneshot::Sender<ConfirmDecision>,
+}
+
+/// Default stall threshold (issue #649): once the current operation exceeds
+/// this, the activity indicator escalates (yellow) to flag a likely hang.
+/// Overridable via the `MAXWELL_STALL_THRESHOLD_SECS` env var at `start()`.
+const DEFAULT_STALL_THRESHOLD_SECS: u64 = 60;
+
+/// Resolve the stall threshold from `MAXWELL_STALL_THRESHOLD_SECS`, falling
+/// back to [`DEFAULT_STALL_THRESHOLD_SECS`] when unset or unparsable (AC6:
+/// "configurable").
+fn stall_threshold_from_env() -> Duration {
+    let secs = std::env::var("MAXWELL_STALL_THRESHOLD_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_STALL_THRESHOLD_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Braille spinner frames for the in-flight activity indicator (issue #649).
+const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Milliseconds per spinner frame. At 100ms the frame advances 10×/sec, so it
+/// is always visibly changing within any one-second window (AC4): a frozen
+/// render is distinguishable from a live one.
+const SPINNER_FRAME_MS: u128 = 100;
+
+/// What the agent is doing *right now*, inferred from the `StreamEvent` gap
+/// (issue #649). There is no `model-call-started` event — the model-thinking
+/// window is the span between a step boundary (`RunStarted` / `Observation` /
+/// `FormatError`) and the next `AssistantMessage`. `since` anchors the
+/// per-operation elapsed counter, which resets at every transition.
+enum Activity {
+    /// No operation in flight: awaiting a confirm decision, or run finished.
+    /// Rendered as the static hint with no animation (AC3).
+    Idle,
+    /// A model call is in flight (step boundary → next `AssistantMessage`).
+    Thinking { since: Instant },
+    /// A bash command is executing (`BashStart` → `BashResult`).
+    Running { since: Instant, command: String },
+}
+
+impl Activity {
+    /// True while an operation is in flight, i.e. the renderer should keep
+    /// ticking so the spinner advances. `Idle` returns `false` so the loop
+    /// rests and adds zero animation frames (AC3).
+    fn is_active(&self) -> bool {
+        !matches!(self, Self::Idle)
+    }
+}
+
+/// Per-frame snapshot of [`Activity`] with elapsed time already resolved, so
+/// the pure render path (and `TestBackend` tests) is a deterministic function
+/// of `elapsed` rather than reading the wall clock itself.
+#[derive(Clone)]
+enum ActivitySnapshot {
+    Idle,
+    Thinking { elapsed: Duration },
+    Running { elapsed: Duration, command: String },
+}
+
+impl ActivitySnapshot {
+    /// Resolve a live [`Activity`] into a snapshot, capturing wall-clock
+    /// elapsed for the active operation.
+    fn from_activity(activity: &Activity) -> Self {
+        match activity {
+            Activity::Idle => Self::Idle,
+            Activity::Thinking { since } => Self::Thinking {
+                elapsed: since.elapsed(),
+            },
+            Activity::Running { since, command } => Self::Running {
+                elapsed: since.elapsed(),
+                command: command.clone(),
+            },
+        }
+    }
+}
+
+/// Spinner glyph for `elapsed`, advancing one frame per [`SPINNER_FRAME_MS`].
+fn spinner_frame(elapsed: Duration) -> &'static str {
+    // Reduce modulo the frame count in u128 first so the cast is always a
+    // small in-range index (no truncation).
+    let idx = ((elapsed.as_millis() / SPINNER_FRAME_MS) % SPINNER_FRAMES.len() as u128) as usize;
+    SPINNER_FRAMES[idx]
+}
+
+/// Style for an active-operation footer: bold, escalating to yellow once the
+/// operation outlives the stall threshold (issue #649, AC6).
+fn activity_style(elapsed: Duration, stall_threshold: Duration) -> Style {
+    let base = Style::default().add_modifier(Modifier::BOLD);
+    if elapsed >= stall_threshold {
+        base.fg(Color::Yellow)
+    } else {
+        base
+    }
 }
 
 pub struct RatatuiDashboardHandle {
@@ -301,6 +403,7 @@ impl RatatuiDashboard {
         let dash = Arc::new(Self {
             state: Mutex::new(DashboardState {
                 is_monitor,
+                stall_threshold: stall_threshold_from_env(),
                 ..DashboardState::default()
             }),
             notify: Notify::new(),
@@ -357,6 +460,12 @@ impl StreamSink for RatatuiDashboard {
                     s.task = Some(task.clone());
                     s.model = Some(model.clone());
                     s.started_at = Some(started_at);
+                    // The step-1 model call begins now (issue #649): there is
+                    // no `model-call-started` event, so the first model-thinking
+                    // window opens at run start and closes at `AssistantMessage`.
+                    s.activity = Activity::Thinking {
+                        since: Instant::now(),
+                    };
                 }
                 self.append(LineKind::Info, format!("run started: {model} :: {task}"));
             }
@@ -375,6 +484,10 @@ impl StreamSink for RatatuiDashboard {
                         s.cost_usd = cost;
                     }
                     s.step = step;
+                    // The model has returned: the thinking window closes. The
+                    // brief span before the next bash/confirm is genuinely idle
+                    // (issue #649, AC3).
+                    s.activity = Activity::Idle;
                 }
                 let preview = first_lines(&content, 6);
                 self.append(
@@ -383,6 +496,16 @@ impl StreamSink for RatatuiDashboard {
                 );
             }
             StreamEvent::BashStart { step, command, .. } => {
+                {
+                    let mut s = self
+                        .state
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    s.activity = Activity::Running {
+                        since: Instant::now(),
+                        command: command.clone(),
+                    };
+                }
                 self.append(LineKind::BashRun, format!("step {step} bash: {command}"));
             }
             StreamEvent::BashResult {
@@ -393,6 +516,15 @@ impl StreamSink for RatatuiDashboard {
                 timed_out,
                 ..
             } => {
+                {
+                    let mut s = self
+                        .state
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    // Bash finished: the next `Observation` will reopen the
+                    // thinking window; the gap until then is idle (issue #649).
+                    s.activity = Activity::Idle;
+                }
                 let kind = if exit_code == 0 && !timed_out {
                     LineKind::BashOk
                 } else {
@@ -406,6 +538,18 @@ impl StreamSink for RatatuiDashboard {
                 self.append(kind, summary);
             }
             StreamEvent::Observation { step, content, .. } => {
+                {
+                    let mut s = self
+                        .state
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    // The observation is the last event before the loop calls
+                    // the model again, so the next thinking window opens here
+                    // (issue #649): this is the inferred model-call-started.
+                    s.activity = Activity::Thinking {
+                        since: Instant::now(),
+                    };
+                }
                 let preview = first_lines(&content, 4);
                 self.append(
                     LineKind::Observation,
@@ -413,6 +557,17 @@ impl StreamSink for RatatuiDashboard {
                 );
             }
             StreamEvent::FormatError { step, content, .. } => {
+                {
+                    let mut s = self
+                        .state
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    // A malformed response triggers a re-query, so a fresh
+                    // model-thinking window opens here (issue #649).
+                    s.activity = Activity::Thinking {
+                        since: Instant::now(),
+                    };
+                }
                 let preview = first_lines(&content, 4);
                 self.append(
                     LineKind::Warn,
@@ -434,6 +589,8 @@ impl StreamSink for RatatuiDashboard {
                     s.cost_usd = total_cost_usd;
                     s.step = steps;
                     s.finished = Some(exit_reason.clone());
+                    // Run is over: no operation in flight (issue #649).
+                    s.activity = Activity::Idle;
                     was_running
                 };
                 // Signal the operator on the rising edge of the terminal
@@ -499,14 +656,18 @@ async fn renderer_loop(
     mut shutdown: oneshot::Receiver<()>,
 ) {
     let mut events = EventStream::new();
-    let mut tick = tokio::time::interval(Duration::from_millis(150));
+    // Spinner cadence while an operation is in flight (issue #649). The tick is
+    // only awaited when `activity.is_active()`, so an idle/finished dashboard
+    // redraws solely on `Notify`/keystrokes — zero animation frames, no CPU
+    // spin while nothing is happening (AC3).
+    let mut tick = tokio::time::interval(Duration::from_millis(100));
     loop {
-        let exit = {
+        let (exit, active) = {
             let s = dash
                 .state
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            s.should_exit
+            (s.should_exit, s.activity.is_active())
         };
         if exit {
             break;
@@ -515,17 +676,33 @@ async fn renderer_loop(
         if let Err(err) = draw_frame(&dash, &mut terminal) {
             tracing::warn!(?err, "ratatui draw failed");
         }
-        tokio::select! {
-            _ = &mut shutdown => break,
-            () = dash.notify.notified() => {}
-            _ = tick.tick() => {}
-            ev = events.next() => {
-                match ev {
-                    Some(Ok(Event::Key(key))) => handle_key(&dash, key),
-                    Some(Err(err)) => {
-                        tracing::warn!(?err, "ratatui event stream error");
+        if active {
+            tokio::select! {
+                _ = &mut shutdown => break,
+                () = dash.notify.notified() => {}
+                _ = tick.tick() => {}
+                ev = events.next() => {
+                    match ev {
+                        Some(Ok(Event::Key(key))) => handle_key(&dash, key),
+                        Some(Err(err)) => {
+                            tracing::warn!(?err, "ratatui event stream error");
+                        }
+                        _ => {}
                     }
-                    _ => {}
+                }
+            }
+        } else {
+            tokio::select! {
+                _ = &mut shutdown => break,
+                () = dash.notify.notified() => {}
+                ev = events.next() => {
+                    match ev {
+                        Some(Ok(Event::Key(key))) => handle_key(&dash, key),
+                        Some(Err(err)) => {
+                            tracing::warn!(?err, "ratatui event stream error");
+                        }
+                        _ => {}
+                    }
                 }
             }
         }
@@ -1080,6 +1257,8 @@ fn draw_frame(
             is_monitor: s.is_monitor,
             search: s.search.clone(),
             rationale_scroll: s.rationale_scroll,
+            activity: ActivitySnapshot::from_activity(&s.activity),
+            stall_threshold: s.stall_threshold,
         }
     };
     terminal.draw(|frame| draw(frame, &snapshot))?;
@@ -1105,6 +1284,8 @@ struct DashboardSnapshot {
     is_monitor: bool,
     search: Option<SearchState>,
     rationale_scroll: usize,
+    activity: ActivitySnapshot,
+    stall_threshold: Duration,
 }
 
 fn draw(frame: &mut ratatui::Frame, snap: &DashboardSnapshot) {
@@ -1251,7 +1432,11 @@ fn log_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
 }
 
 fn footer_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
-    let hint = if let Some(search) = &snap.search {
+    let bold = Style::default().add_modifier(Modifier::BOLD);
+    // Search / finished / edit / pending all take precedence over the activity
+    // cell — a raised confirm modal must show its decision keys, not a spinner
+    // (issue #649, AC3: awaiting a confirm decision is "genuinely idle").
+    let span = if let Some(search) = &snap.search {
         let max_lines = snap.log.len().min(MAX_LOG_LINES);
         let take_from = snap.log.len().saturating_sub(max_lines);
         let window: Vec<&LogLine> = snap.log[take_from..].iter().collect();
@@ -1261,7 +1446,7 @@ fn footer_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
         } else {
             search.current.min(total_matches - 1) + 1
         };
-        if search.editing {
+        let hint = if search.editing {
             format!(
                 "search: {}█   [Enter] find   [Esc] cancel   ({pos}/{total_matches})",
                 search.query
@@ -1271,23 +1456,48 @@ fn footer_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
                 "search: {}   [n] next   [N] prev   [/] new   [Esc] exit   ({pos}/{total_matches})",
                 search.query
             )
-        }
+        };
+        Span::styled(hint, bold)
     } else if snap.finished.is_some() {
-        "run complete — press 'q', Esc, or Ctrl-C to close  [scroll: ↑/↓/PgUp/PgDn/Home/End]  [/ search]"
-            .to_string()
+        Span::styled(
+            "run complete — press 'q', Esc, or Ctrl-C to close  [scroll: ↑/↓/PgUp/PgDn/Home/End]  [/ search]",
+            bold,
+        )
     } else if snap.edit_input.is_some() {
-        "[Enter] execute edit   [Esc] cancel".to_string()
+        Span::styled("[Enter] execute edit   [Esc] cancel", bold)
     } else if let Some(pending) = &snap.pending {
         let scope = pending.derive_scope();
-        format!("(y) approve   (n) reject   (e) edit   (a) abort   (A) auto-approve {scope}")
+        Span::styled(
+            format!("(y) approve   (n) reject   (e) edit   (a) abort   (A) auto-approve {scope}"),
+            bold,
+        )
     } else {
-        "waiting for next agent step…  [scroll: ↑/↓/PgUp/PgDn/Home/End]  [/ search]".to_string()
+        // No modal, no search, not finished: surface the in-flight activity so
+        // the operator can tell working from hung (issue #649).
+        match &snap.activity {
+            ActivitySnapshot::Thinking { elapsed } => Span::styled(
+                format!(
+                    "{} thinking… (model · {}s)",
+                    spinner_frame(*elapsed),
+                    elapsed.as_secs()
+                ),
+                activity_style(*elapsed, snap.stall_threshold),
+            ),
+            ActivitySnapshot::Running { elapsed, command } => Span::styled(
+                format!(
+                    "{} running: {command} ({}s)",
+                    spinner_frame(*elapsed),
+                    elapsed.as_secs()
+                ),
+                activity_style(*elapsed, snap.stall_threshold),
+            ),
+            ActivitySnapshot::Idle => Span::styled(
+                "waiting for next agent step…  [scroll: ↑/↓/PgUp/PgDn/Home/End]  [/ search]",
+                bold,
+            ),
+        }
     };
-    Paragraph::new(Line::from(Span::styled(
-        hint,
-        Style::default().add_modifier(Modifier::BOLD),
-    )))
-    .block(Block::default().borders(Borders::ALL))
+    Paragraph::new(Line::from(span)).block(Block::default().borders(Borders::ALL))
 }
 
 /// Render the confirm modal (issue #655).
@@ -2344,6 +2554,8 @@ mod tests {
             is_monitor: s.is_monitor,
             search: s.search.clone(),
             rationale_scroll: s.rationale_scroll,
+            activity: ActivitySnapshot::from_activity(&s.activity),
+            stall_threshold: s.stall_threshold,
         }
     }
 
@@ -2455,6 +2667,277 @@ mod tests {
         assert!(matches!(s.log[1].kind, LineKind::BashOk));
         assert!(matches!(s.log[2].kind, LineKind::BashErr));
         assert!(s.log[3].text.contains("timed_out"));
+    }
+
+    // ---- in-flight activity indicator (#649) ----
+
+    /// True if any cell in the bottom 3 rows (the footer) carries `color` as
+    /// its foreground — used to assert the stall escalation (yellow).
+    fn footer_has_fg(buf: &Buffer, color: Color) -> bool {
+        let h = buf.area.height;
+        let footer_top = h.saturating_sub(3);
+        for y in footer_top..h {
+            for x in 0..buf.area.width {
+                if buf[(x, y)].style().fg == Some(color) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// True if any spinner glyph is present anywhere in the buffer.
+    fn has_spinner(buf: &Buffer) -> bool {
+        let text = buffer_text(buf);
+        SPINNER_FRAMES.iter().any(|f| text.contains(f))
+    }
+
+    /// Force the dashboard's activity, simulating an operation that started
+    /// `elapsed` ago by anchoring `since` in the past.
+    fn set_activity(d: &Arc<RatatuiDashboard>, activity: Activity) {
+        let mut s = d.state.lock().unwrap();
+        s.activity = activity;
+        drop(s);
+    }
+
+    /// An `Instant` `secs` in the past, for simulating a long-running op. Test
+    /// values are always smaller than the process uptime, so the subtraction
+    /// is safe.
+    #[allow(clippy::unchecked_time_subtraction)]
+    fn ago(secs: u64) -> Instant {
+        Instant::now() - Duration::from_secs(secs)
+    }
+
+    /// Discriminant of the current activity as a stable label, read without
+    /// holding the state lock across assertions.
+    fn activity_label(d: &Arc<RatatuiDashboard>) -> &'static str {
+        let s = d.state.lock().unwrap();
+        let label = match s.activity {
+            Activity::Idle => "idle",
+            Activity::Thinking { .. } => "thinking",
+            Activity::Running { .. } => "running",
+        };
+        drop(s);
+        label
+    }
+
+    #[test]
+    fn thinking_state_renders_spinner_kind_and_elapsed() {
+        let d = make_dashboard();
+        set_activity(&d, Activity::Thinking { since: ago(12) });
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        let text = buffer_text(&buf);
+        assert!(text.contains("thinking"), "kind label present: {text}");
+        assert!(text.contains("model"), "operation source present: {text}");
+        assert!(text.contains("12s"), "elapsed seconds present: {text}");
+        assert!(has_spinner(&buf), "spinner glyph present: {text}");
+    }
+
+    #[test]
+    fn running_state_renders_command_and_elapsed() {
+        let d = make_dashboard();
+        set_activity(
+            &d,
+            Activity::Running {
+                since: ago(8),
+                command: "pytest -q".into(),
+            },
+        );
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        let text = buffer_text(&buf);
+        assert!(text.contains("running: pytest -q"), "running cmd: {text}");
+        assert!(text.contains("8s"), "elapsed seconds present: {text}");
+        assert!(has_spinner(&buf), "spinner glyph present: {text}");
+    }
+
+    #[test]
+    fn idle_state_renders_static_hint_no_spinner() {
+        let d = make_dashboard();
+        // Default activity is Idle.
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("waiting for next agent step"),
+            "static hint: {text}"
+        );
+        assert!(!has_spinner(&buf), "no spinner while idle: {text}");
+    }
+
+    #[test]
+    fn finished_state_has_no_spinner() {
+        let d = make_dashboard();
+        d.emit(run_ended_event());
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        assert!(!has_spinner(&buf), "no spinner once finished");
+    }
+
+    #[test]
+    fn run_started_enters_thinking() {
+        let d = make_dashboard();
+        d.emit(StreamEvent::RunStarted {
+            task: "t".into(),
+            model: "m".into(),
+            started_at: "s".into(),
+        });
+        assert_eq!(activity_label(&d), "thinking");
+    }
+
+    #[test]
+    fn observation_enters_thinking_for_next_model_call() {
+        let d = make_dashboard();
+        d.emit(StreamEvent::Observation {
+            step: 1,
+            content: "ok".into(),
+            timestamp: "t".into(),
+        });
+        assert_eq!(activity_label(&d), "thinking");
+    }
+
+    #[test]
+    fn assistant_message_returns_to_idle() {
+        let d = make_dashboard();
+        set_activity(
+            &d,
+            Activity::Thinking {
+                since: Instant::now(),
+            },
+        );
+        d.emit(StreamEvent::AssistantMessage {
+            step: 1,
+            content: "x".into(),
+            cost_usd: None,
+            timestamp: "t".into(),
+        });
+        assert_eq!(activity_label(&d), "idle");
+    }
+
+    #[test]
+    fn bash_start_enters_running_then_result_returns_to_idle() {
+        let d = make_dashboard();
+        d.emit(StreamEvent::BashStart {
+            step: 1,
+            command: "ls".into(),
+            timestamp: "t".into(),
+        });
+        assert_eq!(activity_label(&d), "running");
+        // The running command is carried through for the footer label.
+        let cmd = {
+            let s = d.state.lock().unwrap();
+            let command = match &s.activity {
+                Activity::Running { command, .. } => command.clone(),
+                Activity::Idle | Activity::Thinking { .. } => {
+                    panic!("expected Running after BashStart")
+                }
+            };
+            drop(s);
+            command
+        };
+        assert_eq!(cmd, "ls");
+        d.emit(StreamEvent::BashResult {
+            step: 1,
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+            timed_out: false,
+            timestamp: "t".into(),
+        });
+        assert_eq!(activity_label(&d), "idle");
+    }
+
+    #[test]
+    fn run_ended_returns_to_idle() {
+        let d = make_dashboard();
+        set_activity(
+            &d,
+            Activity::Thinking {
+                since: Instant::now(),
+            },
+        );
+        d.emit(run_ended_event());
+        assert_eq!(activity_label(&d), "idle");
+    }
+
+    #[test]
+    fn stalled_operation_escalates_to_yellow() {
+        let d = make_dashboard();
+        // Below threshold: no escalation.
+        set_activity(&d, Activity::Thinking { since: ago(5) });
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        assert!(
+            !footer_has_fg(&buf, Color::Yellow),
+            "no yellow before threshold"
+        );
+
+        // Past the 60s default threshold: escalate.
+        set_activity(&d, Activity::Thinking { since: ago(65) });
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        assert!(
+            footer_has_fg(&buf, Color::Yellow),
+            "yellow escalation past threshold"
+        );
+    }
+
+    #[test]
+    fn stall_threshold_is_configurable() {
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.stall_threshold = Duration::from_secs(5);
+            s.activity = Activity::Running {
+                since: ago(6),
+                command: "slow".into(),
+            };
+        }
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        assert!(
+            footer_has_fg(&buf, Color::Yellow),
+            "escalates at the configured 5s threshold"
+        );
+    }
+
+    #[test]
+    fn spinner_advances_within_one_second() {
+        // Two renders within the same wall-clock second must differ, so a
+        // frozen render is visually distinguishable from a live one (AC4).
+        let a = spinner_frame(Duration::from_millis(0));
+        let b = spinner_frame(Duration::from_millis(500));
+        assert_ne!(a, b, "spinner advances at least once per second");
+    }
+
+    #[test]
+    fn elapsed_counter_resets_per_operation() {
+        let d = make_dashboard();
+        // A long thinking phase...
+        set_activity(&d, Activity::Thinking { since: ago(90) });
+        // ...then a fresh bash op starts: its counter is independent.
+        d.emit(StreamEvent::BashStart {
+            step: 1,
+            command: "ls".into(),
+            timestamp: "t".into(),
+        });
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        let text = buffer_text(&buf);
+        assert!(text.contains("running: ls"), "running cmd: {text}");
+        assert!(text.contains("0s"), "elapsed reset to 0 for new op: {text}");
+        assert!(!text.contains("90s"), "no carryover from prior op: {text}");
+    }
+
+    #[test]
+    fn idle_activity_is_not_active() {
+        assert!(!Activity::Idle.is_active());
+        assert!(
+            Activity::Thinking {
+                since: Instant::now()
+            }
+            .is_active()
+        );
+        assert!(
+            Activity::Running {
+                since: Instant::now(),
+                command: "x".into()
+            }
+            .is_active()
+        );
     }
 
     #[test]
@@ -3180,9 +3663,11 @@ mod tests {
             text.contains("echo hi"),
             "bash line should appear in log; got:\n{text}"
         );
+        // A bash command is in flight, so the footer surfaces the live activity
+        // cell rather than the static idle hint (issue #649).
         assert!(
-            text.contains("waiting for next agent step"),
-            "footer hint should appear; got:\n{text}"
+            text.contains("running: echo hi"),
+            "footer should show the in-flight activity; got:\n{text}"
         );
     }
 

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -665,6 +665,20 @@ async fn renderer_loop(
     let mut tick = tokio::time::interval(Duration::from_millis(100));
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
+        // Register interest in the next state change *before* reading state and
+        // drawing. `Notify::notify_waiters()` only wakes waiters already
+        // registered at the time it is called (it stores no permit), so an
+        // emitter that flips idle→active in the window between this draw and
+        // the `select!` await would otherwise be lost — and without the old
+        // unconditional tick to mask it, an idle dashboard could stay frozen on
+        // the stale footer until a keystroke (issue #649). Enabling the
+        // `Notified` future up front closes that race: a notification that
+        // arrives after `enable()` marks it ready, so the `select!` returns
+        // immediately and the loop redraws with fresh state.
+        let notified = dash.notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
         let (exit, active) = {
             let s = dash
                 .state
@@ -681,7 +695,7 @@ async fn renderer_loop(
         }
         tokio::select! {
             _ = &mut shutdown => break,
-            () = dash.notify.notified() => {}
+            () = &mut notified => {}
             _ = tick.tick(), if active => {}
             ev = events.next() => {
                 match ev {

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -2295,13 +2295,40 @@ impl DefaultAgent {
         tool_input: &str,
         result: Option<&RunResult>,
     ) -> Result<Vec<ToolHookResult>, Error> {
-        let mut reports = Vec::new();
-        for hook in hooks {
-            reports.push(
-                self.run_tool_hook(phase, hook, tool_name, tool_input, result)
-                    .await?,
-            );
+        if hooks.is_empty() {
+            return Ok(Vec::new());
         }
+        // Configured hooks run real commands via `env.run`. Surface the phase as
+        // a generic tool-activity span so a long-running hook shows the in-flight
+        // (and stall) indicator on the dashboard (issue #649) instead of a static
+        // idle footer. `self.stream` is the RedactingSink, so the label is
+        // redacted on the stream surface.
+        self.stream.emit(StreamEvent::ToolStart {
+            step: self.steps,
+            label: format!("{} hooks: {tool_name}", phase.as_str()),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        });
+        let mut reports = Vec::new();
+        let mut outcome = Ok(());
+        for hook in hooks {
+            match self
+                .run_tool_hook(phase, hook, tool_name, tool_input, result)
+                .await
+            {
+                Ok(report) => reports.push(report),
+                Err(err) => {
+                    outcome = Err(err);
+                    break;
+                }
+            }
+        }
+        // Close the span even on a hook error, so the dashboard never sticks on
+        // a stale running footer.
+        self.stream.emit(StreamEvent::ToolEnd {
+            step: self.steps,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        });
+        outcome?;
         Ok(reports)
     }
 
@@ -2421,28 +2448,27 @@ impl DefaultAgent {
             req = req.with_cancellation(cancellation);
         }
         req.env = tool_process_env(&context)?;
-        // A configured command tool runs a real shell via `env.run` but, unlike
-        // the Bash tool, emits no bash lifecycle events. Surface them here so a
-        // dashboard that infers activity from BashStart/BashResult (issue #649)
-        // shows the in-flight command — and the stall indicator for a slow one —
-        // instead of the static idle footer. `self.stream` is the RedactingSink,
-        // so the raw command/output are redacted on the stream surface, matching
-        // the Bash path.
-        self.stream.emit(StreamEvent::BashStart {
+        // A configured command tool runs a real shell via `env.run` but is a
+        // distinct tool type from the Bash tool, so surface it as a generic
+        // tool-activity span rather than bash telemetry: a dashboard that infers
+        // liveness (issue #649) shows the in-flight command — and the stall
+        // indicator for a slow one — while `--event-log`/SSE/webhook consumers
+        // that audit bash commands are unaffected. `self.stream` is the
+        // RedactingSink, so the raw command label is redacted on the stream
+        // surface.
+        self.stream.emit(StreamEvent::ToolStart {
             step: self.steps,
-            command: rendered_command,
+            label: rendered_command,
             timestamp: chrono::Utc::now().to_rfc3339(),
         });
-        let result = self.env.run(req).await?;
-        self.stream.emit(StreamEvent::BashResult {
+        let result = self.env.run(req).await;
+        // Close the span even if the run errored, so the dashboard never sticks
+        // on a stale running footer.
+        self.stream.emit(StreamEvent::ToolEnd {
             step: self.steps,
-            exit_code: result.exit_code,
-            stdout: result.stdout.clone(),
-            stderr: result.stderr.clone(),
-            timed_out: result.timed_out,
             timestamp: chrono::Utc::now().to_rfc3339(),
         });
-        Ok(result)
+        result.map_err(Into::into)
     }
 
     async fn run_non_bash_tool(

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -2492,10 +2492,28 @@ impl DefaultAgent {
             step: self.steps,
             total_cost_usd: self.total_cost_usd,
         };
-        Ok(provider
+        // A runtime/MCP provider tool does real work — an MCP server runs a
+        // command via `env.run` — but, unlike a command tool, exposes no
+        // rendered command. Wrap the call in the same generic tool-activity span
+        // so a slow provider call escalates to the stall indicator (issue #649)
+        // instead of rendering as a static idle footer; the tool name is the
+        // best available label. `self.stream` is the RedactingSink, so the label
+        // is redacted on the stream surface.
+        self.stream.emit(StreamEvent::ToolStart {
+            step: self.steps,
+            label: format!("tool: {tool_name}"),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        });
+        let result = provider
             .call(self.env.as_ref(), invocation, self.cancellation.clone())
-            .await?
-            .into())
+            .await;
+        // Close the span even if the call errored, so the dashboard never sticks
+        // on a stale running footer.
+        self.stream.emit(StreamEvent::ToolEnd {
+            step: self.steps,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        });
+        Ok(result?.into())
     }
 
     fn command_tool_context(&self, tool: &CommandTool, tool_input: &str) -> serde_json::Value {

--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -2414,14 +2414,35 @@ impl DefaultAgent {
         let timeout_secs = tool
             .timeout_secs
             .unwrap_or(self.config.root.environment.timeout_secs);
-        let mut req = RunRequest::new(rendered_command)
+        let mut req = RunRequest::new(rendered_command.clone())
             .with_timeout(Duration::from_secs(timeout_secs))
             .with_stdin(tool_input.to_owned());
         if let Some(cancellation) = self.cancellation.clone() {
             req = req.with_cancellation(cancellation);
         }
         req.env = tool_process_env(&context)?;
-        Ok(self.env.run(req).await?)
+        // A configured command tool runs a real shell via `env.run` but, unlike
+        // the Bash tool, emits no bash lifecycle events. Surface them here so a
+        // dashboard that infers activity from BashStart/BashResult (issue #649)
+        // shows the in-flight command — and the stall indicator for a slow one —
+        // instead of the static idle footer. `self.stream` is the RedactingSink,
+        // so the raw command/output are redacted on the stream surface, matching
+        // the Bash path.
+        self.stream.emit(StreamEvent::BashStart {
+            step: self.steps,
+            command: rendered_command,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        });
+        let result = self.env.run(req).await?;
+        self.stream.emit(StreamEvent::BashResult {
+            step: self.steps,
+            exit_code: result.exit_code,
+            stdout: result.stdout.clone(),
+            stderr: result.stderr.clone(),
+            timed_out: result.timed_out,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        });
+        Ok(result)
     }
 
     async fn run_non_bash_tool(

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -679,6 +679,19 @@ pub fn redact_stream_event(event: &StreamEvent, redactor: &Redactor) -> StreamEv
             timed_out: *timed_out,
             timestamp: timestamp.clone(),
         },
+        StreamEvent::ToolStart {
+            step,
+            label,
+            timestamp,
+        } => StreamEvent::ToolStart {
+            step: *step,
+            label: redactor.redact_text(label, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::ToolEnd { step, timestamp } => StreamEvent::ToolEnd {
+            step: *step,
+            timestamp: timestamp.clone(),
+        },
         StreamEvent::Observation {
             step,
             content,

--- a/src/run/claude_driver.rs
+++ b/src/run/claude_driver.rs
@@ -860,9 +860,9 @@ fn handle_assistant(
         timestamp: Some(ts.clone()),
         ..Default::default()
     };
-    // Representative label for the bash lifecycle event emitted after the
+    // Representative label for the tool-activity event emitted after the
     // assistant message (set only when the turn issued tools).
-    let mut bash_label: Option<String> = None;
+    let mut tool_label: Option<String> = None;
     if !actions.is_empty() {
         // Redact action labels (bash commands, file paths) on the trajectory
         // surface, matching the built-in loop — a tool call can carry a
@@ -870,7 +870,7 @@ fn handle_assistant(
         for action in &mut actions {
             *action = agent.redactor.redact_text(action, surface::TRAJECTORY).text;
         }
-        bash_label = tool_bash_label(&actions);
+        tool_label = tool_activity_label(&actions);
         extra.actions = Some(actions);
     }
     if !thinking_parts.is_empty() {
@@ -894,14 +894,16 @@ fn handle_assistant(
         cost_usd: None,
         timestamp: ts.clone(),
     });
-    emit_tool_bash_start(agent, parsed.steps, bash_label, ts);
+    emit_tool_start(agent, parsed.steps, tool_label, ts);
 }
 
-/// Representative footer label for a turn's tool calls, used by the BashStart
-/// lifecycle event so an activity-inferring dashboard (issue #649) shows the
+/// Representative footer label for a turn's tool calls, used by the ToolStart
+/// activity event so an activity-inferring dashboard (issue #649) shows the
 /// in-flight tool. `None` when the turn issued no tools — a text/thinking-only
-/// turn is genuinely idle. Expects already-redacted action labels.
-fn tool_bash_label(actions: &[String]) -> Option<String> {
+/// turn is genuinely idle. A turn's parallel tool calls are summarized into one
+/// label; ToolStart is liveness, not command telemetry, so summarizing does not
+/// drop any audited shell-command record. Expects already-redacted labels.
+fn tool_activity_label(actions: &[String]) -> Option<String> {
     match actions {
         [] => None,
         [only] => Some(only.clone()),
@@ -909,16 +911,16 @@ fn tool_bash_label(actions: &[String]) -> Option<String> {
     }
 }
 
-/// Emit the BashStart half of the tool lifecycle for a Claude-driver turn so
-/// activity-inferring dashboards (issue #649) render the in-flight tool instead
-/// of a static idle footer. The matching BashResult is emitted from
+/// Emit the ToolStart half of the tool-activity span for a Claude-driver turn
+/// so activity-inferring dashboards (issue #649) render the in-flight tool
+/// instead of a static idle footer. The matching ToolEnd is emitted from
 /// `handle_user`. The driver stream is not wrapped in RedactingSink, so `label`
 /// must already be redacted.
-fn emit_tool_bash_start(agent: &DefaultAgent, step: u32, label: Option<String>, ts: String) {
-    if let Some(command) = label {
-        agent.stream.emit(StreamEvent::BashStart {
+fn emit_tool_start(agent: &DefaultAgent, step: u32, label: Option<String>, ts: String) {
+    if let Some(label) = label {
+        agent.stream.emit(StreamEvent::ToolStart {
             step,
-            command,
+            label,
             timestamp: ts,
         });
     }
@@ -1022,7 +1024,7 @@ fn handle_user(agent: &mut DefaultAgent, parsed: &mut Parsed, msg: &Value) {
     // output-byte telemetry) treat driver observations the same. The exit code
     // is derived from the tool_result's `is_error`; output is the redacted text.
     let run_result = crate::env::RunResult {
-        stdout: redacted_raw.clone(),
+        stdout: redacted_raw,
         stderr: String::new(),
         exit_code: i32::from(has_error),
         timed_out: false,
@@ -1034,17 +1036,11 @@ fn handle_user(agent: &mut DefaultAgent, parsed: &mut Parsed, msg: &Value) {
     agent
         .trajectory
         .record_with_extra(&Message::user(redacted.clone()), extra);
-    // Close the bash lifecycle opened in `handle_assistant` so the dashboard's
-    // activity inference (issue #649) leaves the running state before the
-    // observation reopens the thinking window. Claude Code's tool_result carries
-    // `is_error`, not an exit code, so map it to 0/1. The driver stream is not
-    // wrapped in RedactingSink, so emit the already-redacted output.
-    agent.stream.emit(StreamEvent::BashResult {
+    // Close the tool-activity span opened in `handle_assistant` so the dashboard
+    // (issue #649) leaves the running state before the observation reopens the
+    // thinking window.
+    agent.stream.emit(StreamEvent::ToolEnd {
         step: parsed.steps,
-        exit_code: i32::from(has_error),
-        stdout: redacted_raw,
-        stderr: String::new(),
-        timed_out: false,
         timestamp: ts.clone(),
     });
     // Emit the per-step observation event for live consumers, mirroring the

--- a/src/run/claude_driver.rs
+++ b/src/run/claude_driver.rs
@@ -860,6 +860,9 @@ fn handle_assistant(
         timestamp: Some(ts.clone()),
         ..Default::default()
     };
+    // Representative label for the bash lifecycle event emitted after the
+    // assistant message (set only when the turn issued tools).
+    let mut bash_label: Option<String> = None;
     if !actions.is_empty() {
         // Redact action labels (bash commands, file paths) on the trajectory
         // surface, matching the built-in loop — a tool call can carry a
@@ -867,6 +870,7 @@ fn handle_assistant(
         for action in &mut actions {
             *action = agent.redactor.redact_text(action, surface::TRAJECTORY).text;
         }
+        bash_label = tool_bash_label(&actions);
         extra.actions = Some(actions);
     }
     if !thinking_parts.is_empty() {
@@ -888,8 +892,36 @@ fn handle_assistant(
         step: parsed.steps,
         content: redacted,
         cost_usd: None,
-        timestamp: ts,
+        timestamp: ts.clone(),
     });
+    emit_tool_bash_start(agent, parsed.steps, bash_label, ts);
+}
+
+/// Representative footer label for a turn's tool calls, used by the BashStart
+/// lifecycle event so an activity-inferring dashboard (issue #649) shows the
+/// in-flight tool. `None` when the turn issued no tools — a text/thinking-only
+/// turn is genuinely idle. Expects already-redacted action labels.
+fn tool_bash_label(actions: &[String]) -> Option<String> {
+    match actions {
+        [] => None,
+        [only] => Some(only.clone()),
+        [first, rest @ ..] => Some(format!("{first} (+{} more)", rest.len())),
+    }
+}
+
+/// Emit the BashStart half of the tool lifecycle for a Claude-driver turn so
+/// activity-inferring dashboards (issue #649) render the in-flight tool instead
+/// of a static idle footer. The matching BashResult is emitted from
+/// `handle_user`. The driver stream is not wrapped in RedactingSink, so `label`
+/// must already be redacted.
+fn emit_tool_bash_start(agent: &DefaultAgent, step: u32, label: Option<String>, ts: String) {
+    if let Some(command) = label {
+        agent.stream.emit(StreamEvent::BashStart {
+            step,
+            command,
+            timestamp: ts,
+        });
+    }
 }
 
 /// Build a one-line action label for a `tool_use` block, mirroring the
@@ -990,7 +1022,7 @@ fn handle_user(agent: &mut DefaultAgent, parsed: &mut Parsed, msg: &Value) {
     // output-byte telemetry) treat driver observations the same. The exit code
     // is derived from the tool_result's `is_error`; output is the redacted text.
     let run_result = crate::env::RunResult {
-        stdout: redacted_raw,
+        stdout: redacted_raw.clone(),
         stderr: String::new(),
         exit_code: i32::from(has_error),
         timed_out: false,
@@ -1002,6 +1034,19 @@ fn handle_user(agent: &mut DefaultAgent, parsed: &mut Parsed, msg: &Value) {
     agent
         .trajectory
         .record_with_extra(&Message::user(redacted.clone()), extra);
+    // Close the bash lifecycle opened in `handle_assistant` so the dashboard's
+    // activity inference (issue #649) leaves the running state before the
+    // observation reopens the thinking window. Claude Code's tool_result carries
+    // `is_error`, not an exit code, so map it to 0/1. The driver stream is not
+    // wrapped in RedactingSink, so emit the already-redacted output.
+    agent.stream.emit(StreamEvent::BashResult {
+        step: parsed.steps,
+        exit_code: i32::from(has_error),
+        stdout: redacted_raw,
+        stderr: String::new(),
+        timed_out: false,
+        timestamp: ts.clone(),
+    });
     // Emit the per-step observation event for live consumers, mirroring the
     // built-in loop's post-bash Observation event.
     agent.stream.emit(StreamEvent::Observation {

--- a/src/run/codex_driver.rs
+++ b/src/run/codex_driver.rs
@@ -434,8 +434,19 @@ fn handle_local_shell_call(
         .record_with_extra(&Message::assistant(String::new()), extra);
     agent.stream.emit(StreamEvent::AssistantMessage {
         step: parsed.steps,
-        content: action_label,
+        content: action_label.clone(),
         cost_usd: None,
+        timestamp: ts.clone(),
+    });
+    // Surface the shell call as a bash lifecycle event. The driver otherwise
+    // emits only AssistantMessage/Observation, so a dashboard that infers
+    // activity from BashStart/BashResult (issue #649) would render a long
+    // external command as a static idle footer; the matching BashResult is
+    // emitted from the call-output handler. Reuse the already-redacted
+    // `action_label` since the driver stream is not wrapped in RedactingSink.
+    agent.stream.emit(StreamEvent::BashStart {
+        step: parsed.steps,
+        command: action_label,
         timestamp: ts,
     });
 }
@@ -494,7 +505,7 @@ fn handle_local_shell_call_output(agent: &mut DefaultAgent, parsed: &mut Parsed,
         extra.other.insert("tool_error".into(), Value::Bool(true));
     }
     let run_result = crate::env::RunResult {
-        stdout: redacted_raw,
+        stdout: redacted_raw.clone(),
         stderr: String::new(),
         exit_code,
         timed_out: false,
@@ -506,6 +517,18 @@ fn handle_local_shell_call_output(agent: &mut DefaultAgent, parsed: &mut Parsed,
     agent
         .trajectory
         .record_with_extra(&Message::user(redacted.clone()), extra);
+    // Close the bash lifecycle opened in `handle_local_shell_call` so the
+    // dashboard's activity inference (issue #649) leaves the running state
+    // before the observation reopens the thinking window. The driver stream is
+    // not wrapped in RedactingSink, so emit the already-redacted output.
+    agent.stream.emit(StreamEvent::BashResult {
+        step: parsed.steps,
+        exit_code,
+        stdout: redacted_raw,
+        stderr: String::new(),
+        timed_out: false,
+        timestamp: ts.clone(),
+    });
     agent.stream.emit(StreamEvent::Observation {
         step: parsed.steps,
         content: redacted,

--- a/src/run/codex_driver.rs
+++ b/src/run/codex_driver.rs
@@ -438,15 +438,16 @@ fn handle_local_shell_call(
         cost_usd: None,
         timestamp: ts.clone(),
     });
-    // Surface the shell call as a bash lifecycle event. The driver otherwise
-    // emits only AssistantMessage/Observation, so a dashboard that infers
-    // activity from BashStart/BashResult (issue #649) would render a long
-    // external command as a static idle footer; the matching BashResult is
-    // emitted from the call-output handler. Reuse the already-redacted
-    // `action_label` since the driver stream is not wrapped in RedactingSink.
-    agent.stream.emit(StreamEvent::BashStart {
+    // Surface the shell call as a generic tool-activity event. The driver
+    // otherwise emits only AssistantMessage/Observation, so a dashboard that
+    // infers liveness (issue #649) would render a long external command as a
+    // static idle footer; the matching ToolEnd is emitted from the call-output
+    // handler. ToolStart is not bash-command telemetry, so consumers that audit
+    // shell commands ignore it. Reuse the already-redacted `action_label` since
+    // the driver stream is not wrapped in RedactingSink.
+    agent.stream.emit(StreamEvent::ToolStart {
         step: parsed.steps,
-        command: action_label,
+        label: action_label,
         timestamp: ts,
     });
 }
@@ -505,7 +506,7 @@ fn handle_local_shell_call_output(agent: &mut DefaultAgent, parsed: &mut Parsed,
         extra.other.insert("tool_error".into(), Value::Bool(true));
     }
     let run_result = crate::env::RunResult {
-        stdout: redacted_raw.clone(),
+        stdout: redacted_raw,
         stderr: String::new(),
         exit_code,
         timed_out: false,
@@ -517,16 +518,11 @@ fn handle_local_shell_call_output(agent: &mut DefaultAgent, parsed: &mut Parsed,
     agent
         .trajectory
         .record_with_extra(&Message::user(redacted.clone()), extra);
-    // Close the bash lifecycle opened in `handle_local_shell_call` so the
-    // dashboard's activity inference (issue #649) leaves the running state
-    // before the observation reopens the thinking window. The driver stream is
-    // not wrapped in RedactingSink, so emit the already-redacted output.
-    agent.stream.emit(StreamEvent::BashResult {
+    // Close the tool-activity span opened in `handle_local_shell_call` so the
+    // dashboard (issue #649) leaves the running state before the observation
+    // reopens the thinking window.
+    agent.stream.emit(StreamEvent::ToolEnd {
         step: parsed.steps,
-        exit_code,
-        stdout: redacted_raw,
-        stderr: String::new(),
-        timed_out: false,
         timestamp: ts.clone(),
     });
     agent.stream.emit(StreamEvent::Observation {

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -70,6 +70,20 @@ pub enum StreamEvent {
         timed_out: bool,
         timestamp: String,
     },
+    /// A non-bash tool or external operation began (driver tool call, command
+    /// tool, or tool hook). A generic liveness signal for activity-inferring
+    /// dashboards (issue #649); unlike `BashStart`/`BashResult` it is *not*
+    /// shell-command telemetry, so `--event-log`/SSE/webhook consumers that
+    /// count or audit bash commands ignore it. `label` is a human-readable
+    /// description of the in-flight operation (a command, `Tool(target)`, or
+    /// hook name).
+    ToolStart {
+        step: u32,
+        label: String,
+        timestamp: String,
+    },
+    /// The operation announced by the matching `ToolStart` finished.
+    ToolEnd { step: u32, timestamp: String },
     /// Observation message recorded into the trajectory after a bash run.
     Observation {
         step: u32,
@@ -105,6 +119,8 @@ impl StreamEvent {
             Self::AssistantMessage { .. } => "assistant_message",
             Self::BashStart { .. } => "bash_start",
             Self::BashResult { .. } => "bash_result",
+            Self::ToolStart { .. } => "tool_start",
+            Self::ToolEnd { .. } => "tool_end",
             Self::Observation { .. } => "observation",
             Self::FormatError { .. } => "format_error",
             Self::RunEnded { .. } => "run_ended",
@@ -208,6 +224,26 @@ mod tests {
         assert_eq!(json["type"], "bash_start");
         assert_eq!(json["step"], 3);
         assert_eq!(json["command"], "echo hi");
+    }
+
+    #[test]
+    fn tool_events_carry_generic_wire_names() {
+        let start = StreamEvent::ToolStart {
+            step: 2,
+            label: "diagnose-helper".into(),
+            timestamp: "t".into(),
+        };
+        assert_eq!(start.event_name(), "tool_start");
+        let json = serde_json::to_value(&start).unwrap();
+        assert_eq!(json["type"], "tool_start");
+        assert_eq!(json["label"], "diagnose-helper");
+
+        let end = StreamEvent::ToolEnd {
+            step: 2,
+            timestamp: "t".into(),
+        };
+        assert_eq!(end.event_name(), "tool_end");
+        assert_eq!(serde_json::to_value(&end).unwrap()["type"], "tool_end");
     }
 
     #[test]

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -653,7 +653,9 @@ timeout_secs = 3
         "command tool should emit ToolStart with the rendered command: {events:#?}"
     );
     assert!(
-        events.iter().any(|e| matches!(e, StreamEvent::ToolEnd { .. })),
+        events
+            .iter()
+            .any(|e| matches!(e, StreamEvent::ToolEnd { .. })),
         "command tool should emit ToolEnd to close the activity span: {events:#?}"
     );
     assert!(

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use maxwells_daemon::agent::default::{DefaultAgentBuilder, retag_cache_hints};
 use maxwells_daemon::env::CancellationToken;
 use maxwells_daemon::error::EnvError;
+use maxwells_daemon::stream::{BroadcastSink, StreamEvent, StreamSink};
 use maxwells_daemon::{
     Agent, CacheHint, Config, DeterministicModel, Environment, Error, ExitReason, LocalEnvironment,
     McpServerCfg, McpStdioServer, Message, Model, ModelResponse, ModelUsage, QueryOpts, Role,
@@ -595,6 +596,7 @@ timeout_secs = 3
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn command_tool_adapter_executes_from_matching_fenced_block() {
     let cfg = Config::from_toml_str(
         r#"
@@ -616,6 +618,8 @@ timeout_secs = 3
     ]));
     let env = PluginToolEnv::default();
     let calls = Arc::clone(&env.calls);
+    let bcast = Arc::new(BroadcastSink::default());
+    let mut rx = bcast.subscribe();
     let mut agent = DefaultAgentBuilder {
         config: cfg,
         model,
@@ -623,7 +627,7 @@ timeout_secs = 3
         task: "round trip".into(),
         extra_context: None,
         renderer: None,
-        stream: None,
+        stream: Some(bcast.clone() as Arc<dyn StreamSink>),
         resume_from: None,
         read_only: false,
     }
@@ -632,6 +636,28 @@ timeout_secs = 3
 
     let exit = agent.run().await.unwrap();
     assert!(matches!(exit, ExitReason::Submitted { .. }));
+
+    // A command tool runs a real shell via `env.run`; it must surface bash
+    // lifecycle events so activity-inferring consumers (the ratatui dashboard,
+    // issue #649) see the in-flight command rather than a static idle footer.
+    let mut events = Vec::new();
+    while let Ok(e) = rx.try_recv() {
+        events.push(e);
+    }
+    assert!(
+        events.iter().any(
+            |e| matches!(e, StreamEvent::BashStart { command, .. } if command == "diagnose-helper")
+        ),
+        "command tool should emit BashStart with the rendered command: {events:#?}"
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            StreamEvent::BashResult { exit_code: 0, stdout, .. }
+                if stdout.contains("diagnose saw check flaky test")
+        )),
+        "command tool should emit BashResult with its output: {events:#?}"
+    );
 
     let calls = calls.lock().unwrap().clone();
     assert_eq!(calls.len(), 1);

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -637,26 +637,39 @@ timeout_secs = 3
     let exit = agent.run().await.unwrap();
     assert!(matches!(exit, ExitReason::Submitted { .. }));
 
-    // A command tool runs a real shell via `env.run`; it must surface bash
-    // lifecycle events so activity-inferring consumers (the ratatui dashboard,
+    // A command tool runs a real shell via `env.run`; it must surface a generic
+    // tool-activity span so activity-inferring consumers (the ratatui dashboard,
     // issue #649) see the in-flight command rather than a static idle footer.
+    // BashStart/BashResult stay reserved for the Bash tool, so bash-command
+    // telemetry is not polluted by other tool types.
     let mut events = Vec::new();
     while let Ok(e) = rx.try_recv() {
         events.push(e);
     }
     assert!(
         events.iter().any(
-            |e| matches!(e, StreamEvent::BashStart { command, .. } if command == "diagnose-helper")
+            |e| matches!(e, StreamEvent::ToolStart { label, .. } if label == "diagnose-helper")
         ),
-        "command tool should emit BashStart with the rendered command: {events:#?}"
+        "command tool should emit ToolStart with the rendered command: {events:#?}"
+    );
+    assert!(
+        events.iter().any(|e| matches!(e, StreamEvent::ToolEnd { .. })),
+        "command tool should emit ToolEnd to close the activity span: {events:#?}"
+    );
+    assert!(
+        !events.iter().any(|e| matches!(
+            e,
+            StreamEvent::BashStart { .. } | StreamEvent::BashResult { .. }
+        )),
+        "command tool must not emit bash-command telemetry: {events:#?}"
     );
     assert!(
         events.iter().any(|e| matches!(
             e,
-            StreamEvent::BashResult { exit_code: 0, stdout, .. }
-                if stdout.contains("diagnose saw check flaky test")
+            StreamEvent::Observation { content, .. }
+                if content.contains("diagnose saw check flaky test")
         )),
-        "command tool should emit BashResult with its output: {events:#?}"
+        "command tool output should surface in an Observation: {events:#?}"
     );
 
     let calls = calls.lock().unwrap().clone();

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -805,6 +805,8 @@ async fn runtime_tool_provider_executes_without_command_tool_config() {
     ]));
     let provider = Arc::new(InMemoryToolProvider::new("diagnose"));
     let calls = Arc::clone(&provider.calls);
+    let bcast = Arc::new(BroadcastSink::default());
+    let mut rx = bcast.subscribe();
     let mut agent = DefaultAgentBuilder {
         config: cfg,
         model,
@@ -812,7 +814,7 @@ async fn runtime_tool_provider_executes_without_command_tool_config() {
         task: "round trip".into(),
         extra_context: None,
         renderer: None,
-        stream: None,
+        stream: Some(bcast.clone() as Arc<dyn StreamSink>),
         resume_from: None,
         read_only: false,
     }
@@ -821,6 +823,34 @@ async fn runtime_tool_provider_executes_without_command_tool_config() {
 
     let exit = agent.run().await.unwrap();
     assert!(matches!(exit, ExitReason::Submitted { .. }));
+
+    // A runtime/MCP provider tool runs real work (an MCP server runs a command
+    // via `env.run`); like a command tool it must surface a generic activity
+    // span so a slow call reaches the stall indicator (issue #649) instead of a
+    // static idle footer, without polluting bash-command telemetry.
+    let mut events = Vec::new();
+    while let Ok(e) = rx.try_recv() {
+        events.push(e);
+    }
+    assert!(
+        events.iter().any(
+            |e| matches!(e, StreamEvent::ToolStart { label, .. } if label == "tool: diagnose")
+        ),
+        "provider tool should emit ToolStart labeled with the tool name: {events:#?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, StreamEvent::ToolEnd { .. })),
+        "provider tool should emit ToolEnd to close the activity span: {events:#?}"
+    );
+    assert!(
+        !events.iter().any(|e| matches!(
+            e,
+            StreamEvent::BashStart { .. } | StreamEvent::BashResult { .. }
+        )),
+        "provider tool must not emit bash-command telemetry: {events:#?}"
+    );
 
     let calls = calls.lock().unwrap().clone();
     assert_eq!(calls.len(), 1);

--- a/tests/claude_driver.rs
+++ b/tests/claude_driver.rs
@@ -234,13 +234,15 @@ async fn claude_driver_produces_valid_trajectory() {
     assert_eq!(contents, "line one\nline two\n");
 }
 
-/// The claude-code driver surfaces tool calls as BashStart/BashResult lifecycle
+/// The claude-code driver surfaces tool calls as ToolStart/ToolEnd activity
 /// events so activity-inferring consumers (the ratatui dashboard, issue #649)
 /// see the in-flight tool instead of a static idle footer; the driver otherwise
-/// emits only AssistantMessage/Observation.
+/// emits only AssistantMessage/Observation. These are generic liveness events,
+/// not bash-command telemetry, so non-Bash tools (Edit/Write/WebSearch) do not
+/// get miscounted as shell commands.
 #[tokio::test]
 #[cfg(unix)]
-async fn claude_driver_emits_bash_lifecycle_events() {
+async fn claude_driver_emits_tool_activity_events() {
     let repo = tempfile::tempdir().unwrap();
     let out = tempfile::tempdir().unwrap();
     init_repo(repo.path());
@@ -263,31 +265,36 @@ async fn claude_driver_emits_bash_lifecycle_events() {
         .map(|e| e["event_type"].as_str().unwrap())
         .collect();
 
-    // Two Bash tool_use turns in the fixture (pytest + echo), each paired with a
-    // tool_result → a BashStart/BashResult pair per tool call.
+    // Two single-Bash tool_use turns in the fixture (pytest + echo), each paired
+    // with a tool_result → one ToolStart/ToolEnd span per turn.
     assert_eq!(
-        types.iter().filter(|t| **t == "bash_start").count(),
+        types.iter().filter(|t| **t == "tool_start").count(),
         2,
-        "expected a bash_start per tool call: {types:?}"
+        "expected a tool_start per tool turn: {types:?}"
     );
     assert_eq!(
-        types.iter().filter(|t| **t == "bash_result").count(),
+        types.iter().filter(|t| **t == "tool_end").count(),
         2,
-        "expected a bash_result per tool call: {types:?}"
+        "expected a tool_end per tool turn: {types:?}"
+    );
+    // Tool calls are never mislabeled as bash-command telemetry.
+    assert!(
+        !types.iter().any(|t| *t == "bash_start" || *t == "bash_result"),
+        "driver must not emit bash telemetry: {types:?}"
     );
 
-    // The tool label rides on BashStart so the dashboard can label the footer,
-    // and each BashStart precedes its BashResult.
+    // The tool label rides on ToolStart so the dashboard can label the footer,
+    // and each ToolStart precedes its ToolEnd.
     let start = events
         .iter()
-        .position(|e| e["event_type"] == "bash_start" && e["command"] == "echo 'line two' >> a.txt")
-        .expect("bash_start for the echo command");
-    let result = events
+        .position(|e| e["event_type"] == "tool_start" && e["label"] == "echo 'line two' >> a.txt")
+        .expect("tool_start for the echo command");
+    let end = events
         .iter()
         .skip(start)
-        .position(|e| e["event_type"] == "bash_result")
-        .expect("a bash_result after the echo bash_start");
-    assert!(result > 0, "bash_result should follow its bash_start");
+        .position(|e| e["event_type"] == "tool_end")
+        .expect("a tool_end after the echo tool_start");
+    assert!(end > 0, "tool_end should follow its tool_start");
 }
 
 /// `--driver claude-code` is rejected with `--env docker` (the CLI edits the

--- a/tests/claude_driver.rs
+++ b/tests/claude_driver.rs
@@ -234,6 +234,62 @@ async fn claude_driver_produces_valid_trajectory() {
     assert_eq!(contents, "line one\nline two\n");
 }
 
+/// The claude-code driver surfaces tool calls as BashStart/BashResult lifecycle
+/// events so activity-inferring consumers (the ratatui dashboard, issue #649)
+/// see the in-flight tool instead of a static idle footer; the driver otherwise
+/// emits only AssistantMessage/Observation.
+#[tokio::test]
+#[cfg(unix)]
+async fn claude_driver_emits_bash_lifecycle_events() {
+    let repo = tempfile::tempdir().unwrap();
+    let out = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+    ensure_fake_claude();
+
+    let log = out.path().join("events.jsonl");
+    let mut args = base_args(repo.path(), out.path(), "cc-events");
+    args.event_log = Some(log.clone());
+    args.event_log_instance_id = Some("cc".into());
+
+    run(args).await.expect("claude driver run should succeed");
+
+    let events: Vec<serde_json::Value> = std::fs::read_to_string(&log)
+        .unwrap()
+        .lines()
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+    let types: Vec<&str> = events
+        .iter()
+        .map(|e| e["event_type"].as_str().unwrap())
+        .collect();
+
+    // Two Bash tool_use turns in the fixture (pytest + echo), each paired with a
+    // tool_result → a BashStart/BashResult pair per tool call.
+    assert_eq!(
+        types.iter().filter(|t| **t == "bash_start").count(),
+        2,
+        "expected a bash_start per tool call: {types:?}"
+    );
+    assert_eq!(
+        types.iter().filter(|t| **t == "bash_result").count(),
+        2,
+        "expected a bash_result per tool call: {types:?}"
+    );
+
+    // The tool label rides on BashStart so the dashboard can label the footer,
+    // and each BashStart precedes its BashResult.
+    let start = events
+        .iter()
+        .position(|e| e["event_type"] == "bash_start" && e["command"] == "echo 'line two' >> a.txt")
+        .expect("bash_start for the echo command");
+    let result = events
+        .iter()
+        .skip(start)
+        .position(|e| e["event_type"] == "bash_result")
+        .expect("a bash_result after the echo bash_start");
+    assert!(result > 0, "bash_result should follow its bash_start");
+}
+
 /// `--driver claude-code` is rejected with `--env docker` (the CLI edits the
 /// host tree and has no path into a container).
 #[tokio::test]

--- a/tests/claude_driver.rs
+++ b/tests/claude_driver.rs
@@ -279,7 +279,9 @@ async fn claude_driver_emits_tool_activity_events() {
     );
     // Tool calls are never mislabeled as bash-command telemetry.
     assert!(
-        !types.iter().any(|t| *t == "bash_start" || *t == "bash_result"),
+        !types
+            .iter()
+            .any(|t| *t == "bash_start" || *t == "bash_result"),
         "driver must not emit bash telemetry: {types:?}"
     );
 

--- a/tests/codex_driver.rs
+++ b/tests/codex_driver.rs
@@ -217,6 +217,62 @@ async fn codex_driver_produces_valid_trajectory() {
     assert_eq!(contents, "line one\nline two\n");
 }
 
+/// The codex driver surfaces shell calls as BashStart/BashResult lifecycle
+/// events so activity-inferring consumers (the ratatui dashboard, issue #649)
+/// see the in-flight command instead of a static idle footer; the driver
+/// otherwise emits only AssistantMessage/Observation.
+#[tokio::test]
+#[cfg(unix)]
+async fn codex_driver_emits_bash_lifecycle_events() {
+    let repo = tempfile::tempdir().unwrap();
+    let out = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+    ensure_fake_codex();
+
+    let log = out.path().join("events.jsonl");
+    let mut args = base_args(repo.path(), out.path(), "cx-events");
+    args.event_log = Some(log.clone());
+    args.event_log_instance_id = Some("cx".into());
+
+    run(args).await.expect("codex driver run should succeed");
+
+    let events: Vec<serde_json::Value> = std::fs::read_to_string(&log)
+        .unwrap()
+        .lines()
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+    let types: Vec<&str> = events
+        .iter()
+        .map(|e| e["event_type"].as_str().unwrap())
+        .collect();
+
+    // Two local_shell_call blocks in the fixture → a BashStart/BashResult pair
+    // for each.
+    assert_eq!(
+        types.iter().filter(|t| **t == "bash_start").count(),
+        2,
+        "expected a bash_start per shell call: {types:?}"
+    );
+    assert_eq!(
+        types.iter().filter(|t| **t == "bash_result").count(),
+        2,
+        "expected a bash_result per shell call: {types:?}"
+    );
+
+    // The running command rides on BashStart so the dashboard can label the
+    // footer, and each BashStart precedes its BashResult.
+    let start = events
+        .iter()
+        .position(|e| e["event_type"] == "bash_start" && e["command"] == "echo 'line two' >> a.txt")
+        .expect("bash_start for the echo command");
+    let result = events
+        .iter()
+        .skip(start)
+        .position(|e| e["event_type"] == "bash_result")
+        .expect("a bash_result after the echo bash_start");
+    assert!(result > 0, "bash_result should follow its bash_start");
+}
+
 /// `--driver codex` is rejected with `--env docker`.
 #[tokio::test]
 async fn codex_driver_rejects_docker_env() {

--- a/tests/codex_driver.rs
+++ b/tests/codex_driver.rs
@@ -217,13 +217,14 @@ async fn codex_driver_produces_valid_trajectory() {
     assert_eq!(contents, "line one\nline two\n");
 }
 
-/// The codex driver surfaces shell calls as BashStart/BashResult lifecycle
-/// events so activity-inferring consumers (the ratatui dashboard, issue #649)
-/// see the in-flight command instead of a static idle footer; the driver
-/// otherwise emits only AssistantMessage/Observation.
+/// The codex driver surfaces shell calls as ToolStart/ToolEnd activity events
+/// so activity-inferring consumers (the ratatui dashboard, issue #649) see the
+/// in-flight command instead of a static idle footer; the driver otherwise
+/// emits only AssistantMessage/Observation. These are generic liveness events,
+/// not bash-command telemetry.
 #[tokio::test]
 #[cfg(unix)]
-async fn codex_driver_emits_bash_lifecycle_events() {
+async fn codex_driver_emits_tool_activity_events() {
     let repo = tempfile::tempdir().unwrap();
     let out = tempfile::tempdir().unwrap();
     init_repo(repo.path());
@@ -246,31 +247,36 @@ async fn codex_driver_emits_bash_lifecycle_events() {
         .map(|e| e["event_type"].as_str().unwrap())
         .collect();
 
-    // Two local_shell_call blocks in the fixture → a BashStart/BashResult pair
+    // Two local_shell_call blocks in the fixture → a ToolStart/ToolEnd pair
     // for each.
     assert_eq!(
-        types.iter().filter(|t| **t == "bash_start").count(),
+        types.iter().filter(|t| **t == "tool_start").count(),
         2,
-        "expected a bash_start per shell call: {types:?}"
+        "expected a tool_start per shell call: {types:?}"
     );
     assert_eq!(
-        types.iter().filter(|t| **t == "bash_result").count(),
+        types.iter().filter(|t| **t == "tool_end").count(),
         2,
-        "expected a bash_result per shell call: {types:?}"
+        "expected a tool_end per shell call: {types:?}"
+    );
+    // The shell call is never mislabeled as bash-command telemetry.
+    assert!(
+        !types.iter().any(|t| *t == "bash_start" || *t == "bash_result"),
+        "driver must not emit bash telemetry: {types:?}"
     );
 
-    // The running command rides on BashStart so the dashboard can label the
-    // footer, and each BashStart precedes its BashResult.
+    // The running command rides on ToolStart so the dashboard can label the
+    // footer, and each ToolStart precedes its ToolEnd.
     let start = events
         .iter()
-        .position(|e| e["event_type"] == "bash_start" && e["command"] == "echo 'line two' >> a.txt")
-        .expect("bash_start for the echo command");
-    let result = events
+        .position(|e| e["event_type"] == "tool_start" && e["label"] == "echo 'line two' >> a.txt")
+        .expect("tool_start for the echo command");
+    let end = events
         .iter()
         .skip(start)
-        .position(|e| e["event_type"] == "bash_result")
-        .expect("a bash_result after the echo bash_start");
-    assert!(result > 0, "bash_result should follow its bash_start");
+        .position(|e| e["event_type"] == "tool_end")
+        .expect("a tool_end after the echo tool_start");
+    assert!(end > 0, "tool_end should follow its tool_start");
 }
 
 /// `--driver codex` is rejected with `--env docker`.

--- a/tests/codex_driver.rs
+++ b/tests/codex_driver.rs
@@ -261,7 +261,9 @@ async fn codex_driver_emits_tool_activity_events() {
     );
     // The shell call is never mislabeled as bash-command telemetry.
     assert!(
-        !types.iter().any(|t| *t == "bash_start" || *t == "bash_result"),
+        !types
+            .iter()
+            .any(|t| *t == "bash_start" || *t == "bash_result"),
         "driver must not emit bash telemetry: {types:?}"
     );
 


### PR DESCRIPTION
## Summary
Implements an in-flight activity indicator for the TUI dashboard that displays what the agent is currently doing (thinking or running bash) with elapsed time and a spinner animation. Includes automatic stall detection that escalates the indicator to yellow when an operation exceeds a configurable threshold (default 60s).

## Key Changes
- **Activity tracking**: Added `Activity` enum to track three states: `Idle`, `Thinking` (model inference), and `Running` (bash execution), each with a `since: Instant` timestamp for elapsed time calculation
- **Stall detection**: Operations exceeding `stall_threshold` (configurable via `MAXWELL_STALL_THRESHOLD_SECS` env var) are highlighted in yellow to flag likely hangs
- **Spinner animation**: Implemented braille spinner with 10 frames advancing every 100ms, visible only when operations are in flight
- **Activity state machine**: Transitions tracked across `StreamEvent` handlers:
  - `RunStarted` → `Thinking`
  - `AssistantMessage` → `Idle`
  - `BashStart` → `Running`
  - `BashResult` → `Idle`
  - `Observation`/`FormatError` → `Thinking` (inferred model-call-started)
  - `RunEnded` → `Idle`
- **Optimized rendering loop**: Spinner tick (100ms) only awaited when `activity.is_active()`, eliminating animation frames and CPU spin during idle periods
- **Footer UI**: Activity indicator replaces static "waiting for next agent step" hint when no modal/search/finished state is active; modals take precedence (confirm decisions are "genuinely idle")
- **Snapshot pattern**: `ActivitySnapshot` captures elapsed time at render time for deterministic, testable rendering independent of wall-clock reads

## Notable Implementation Details
- `ActivitySnapshot` decouples live `Activity` from rendering, enabling pure deterministic tests via `elapsed` parameter rather than mocking `Instant`
- Spinner frame calculation uses modulo arithmetic in `u128` before casting to avoid truncation
- Dual `tokio::select!` branches in renderer loop: active operations include `tick.tick()`, idle state omits it
- Comprehensive test coverage including state transitions, stall escalation, spinner visibility, and elapsed counter resets per operation

https://claude.ai/code/session_01Dk6QwerrgSCsXUpBiYrSt6