### PR TITLE
🎨 Mosaic: UI Polish for policy-check output

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -527,6 +527,7 @@ mod tests {
     // ── Network mode RED-phase tests ─────────────────────────────────────────
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
@@ -550,6 +551,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network").unwrap();

--- a/src/run/policy_check.rs
+++ b/src/run/policy_check.rs
@@ -4,6 +4,7 @@
 //! config and reports the per-command verdict (allow / ask / deny) plus the
 //! matching rule label. No model call is made and no environment is launched.
 
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 use std::io::Read as _;
 use std::path::PathBuf;
 
@@ -260,53 +261,17 @@ pub fn format_text(output: &PolicyCheckOutput) -> String {
         return out;
     }
 
-    let cmd_width = output
-        .verdicts
-        .iter()
-        .map(|v| v.command.len())
-        .max()
-        .unwrap_or(7)
-        .max(7); // min width: "command"
-    let rule_width = output
-        .verdicts
-        .iter()
-        .map(|v| v.matching_rule.len())
-        .max()
-        .unwrap_or(12)
-        .max(12); // min width: "matching_rule"
-
-    let mut out = String::new();
-    let _ = writeln!(
-        out,
-        "{:<width$}  {:<8}  {:<rule_w$}  profile",
-        "command",
-        "verdict",
-        "matching_rule",
-        width = cmd_width,
-        rule_w = rule_width,
-    );
-    let _ = writeln!(
-        out,
-        "{:-<width$}  {:-<8}  {:-<rule_w$}  -------",
-        "",
-        "",
-        "",
-        width = cmd_width,
-        rule_w = rule_width,
-    );
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(["Command", "Verdict", "Matching Rule", "Profile"]);
 
     for v in &output.verdicts {
-        let _ = writeln!(
-            out,
-            "{:<width$}  {:<8}  {:<rule_w$}  {}",
-            v.command,
-            v.verdict.as_str(),
-            v.matching_rule,
-            v.profile,
-            width = cmd_width,
-            rule_w = rule_width,
-        );
+        table.add_row([v.command.as_str(), v.verdict.as_str(), v.matching_rule.as_str(), v.profile.as_str()]);
     }
+
+    let mut out = format!("{table}\n");
 
     if !output.mismatches.is_empty() {
         out.push('\n');


### PR DESCRIPTION
🖌️ **Before:** The `policy-check` text output used custom-spaced raw text padding to print a list, making it hard to read and visually inconsistent with other CLI command outputs across the application.

✨ **After:** The `policy-check` command now formats its output as a proper table using `comfy_table`, consistent with other catalog commands.

🖼️ **Visuals:** The `policy-check` table now features rounded corners and high-contrast bounding lines, cleanly grouping commands and outputs into an easily scannable format.

---
*PR created automatically by Jules for task [15500046877156421987](https://jules.google.com/task/15500046877156421987) started by @madmax983*