### PR TITLE
Add stable failure signatures to single-instance digest

### DIFF
--- a/docs/spec-failure-signature.md
+++ b/docs/spec-failure-signature.md
@@ -1,0 +1,120 @@
+# `failure-signature` Spec
+
+`bench failure-digest` summarizes a single instance's terminal failure. As of
+schema `1.1` every digest also carries a stable, redaction-safe **failure
+signature** so a downstream consumer (the nightly smoke, a `bench retry`, or a
+rerun) can deterministically tell a *known recurring* failure apart from a *new*
+regression without re-reading the trajectory.
+
+The signature reuses the same `FailureSignature` primitive that powers
+multi-instance clustering in [`bench triage`](spec-triage.md); this document
+specifies how it is surfaced for the single-instance digest and the stability
+guarantees that hold there.
+
+## Surfaces
+
+### JSON (`--format json`)
+
+The digest gains a `failure_signature` object and, when a baseline is supplied,
+a `recurrence` object:
+
+```json
+{
+  "schema_version": "1.1",
+  "instance_id": "error-1",
+  "outcome": "error",
+  "failure_category": "model_parse",
+  "failure_signature": {
+    "signature_id": "aabbccdd11223344",
+    "failure_category": "model_parse",
+    "assistant_tail": "i tried to parse the model response but failed ...",
+    "bash_exit_code": 1,
+    "stderr_line": "model parse error: unexpected token at position <num>",
+    "summary": "assistant=\"...\" exit=1 stderr=\"...\""
+  },
+  "recurrence": {
+    "baseline_signature_id": "aabbccdd11223344",
+    "verdict": "recurring"
+  }
+}
+```
+
+`recurrence` is omitted entirely when `--baseline-signature` is not supplied.
+
+### Markdown (default)
+
+A stable, greppable line is rendered directly under the headline:
+
+```text
+failure_signature: aabbccdd11223344
+recurrence: recurring
+```
+
+The `recurrence:` line is present only when a baseline was supplied. CI logs and
+humans can match a failure with a plain `grep 'failure_signature: '`.
+
+## Signature Inputs
+
+`signature_id` is the first 16 lowercase hex characters of SHA-256 over a stable
+key built from four fields:
+
+1. `failure_category` — the digest's failure category, or `none` when the
+   instance has no failure category. See
+   [`docs/failure-categories.md`](failure-categories.md) for the vocabulary.
+2. The last assistant message tail, capped at the final 500 Unicode scalar
+   values.
+3. The last bash exit code, or `none` when no bash result is present.
+4. The last non-empty stderr line from the last bash result.
+
+The text fields are normalized before hashing exactly as in `bench triage`
+(lowercase; collapse whitespace; `<path>` for path-like tokens; `<num>` for
+number runs). The `summary` is a short (≤160 char) human rendering of the
+assistant tail, exit code, and stderr line. This is the identical
+`FailureSignature` computation documented in
+[`spec-triage.md`](spec-triage.md#signature-function); two failures collide only
+when all four normalized fields match.
+
+## Stability Guarantees
+
+- **Determinism.** Two independent runs whose terminal failure matches on all
+  four signature inputs produce an identical `signature_id`.
+- **Discrimination.** A differing terminal failure — different category, exit
+  code, or stderr tail — produces a different `signature_id`.
+- **Redaction-safe.** The signature is computed *only* from the already-redacted
+  terminal fields the digest emits (assistant message and tool stderr are passed
+  through the `Redactor` before the signature is built). No raw secret material
+  can appear in `signature_id` or `summary`.
+- **Stable across record/replay.** Per-run redaction markers carry a run-specific
+  salt (`[REDACTED:kind:size:salt]`). The signature inputs are passed through
+  [`fingerprint::normalize_redaction_markers`](../src/fingerprint.rs) — which
+  strips the salt suffix to `[REDACTED:kind:size]` — so a recording run and its
+  replay of the same failure yield the same `signature_id`.
+
+## Baseline Recurrence Verdict
+
+`--baseline-signature <SIGNATURE_ID>` classifies the current failure against a
+known baseline:
+
+| Condition | `verdict` |
+| --- | --- |
+| Computed `signature_id` equals the baseline | `recurring` |
+| Otherwise | `new` |
+
+The verdict is **informational only**. It is reflected in both the JSON and
+markdown output but **never changes the process exit code** — `bench
+failure-digest` still exits `0` on a successful digest regardless of the verdict.
+
+## Success Metric
+
+Over a rolling 7-day window of nightly failures with an unchanged underlying
+terminal failure, the number of **distinct** `signature_id` values equals **1**
+(false-new rate < 1%). This lets a downstream consumer dedup N duplicate issues
+into one recurrence-counted issue.
+
+## Out of Scope
+
+- The nightly workflow's issue-filing/dedup logic that *consumes* this signature.
+- Cross-instance clustering or sweep-vs-sweep cluster deltas — served by
+  [`bench triage`](spec-triage.md) and `bench triage-diff`.
+- Multi-instance aggregation; the digest and its signature stay single-instance.
+- Any persistent signature-history datastore.

--- a/docs/spec-failure-signature.md
+++ b/docs/spec-failure-signature.md
@@ -111,6 +111,26 @@ terminal failure, the number of **distinct** `signature_id` values equals **1**
 (false-new rate < 1%). This lets a downstream consumer dedup N duplicate issues
 into one recurrence-counted issue.
 
+## Cross-tool Divergence
+
+`bench triage` (multi-instance sweep) computes cluster IDs over **raw** trajectory text —
+it does not pass fields through a `Redactor`. `bench failure-digest` computes
+`signature_id` over **already-redacted, marker-normalized** text.
+
+For instances where no secrets appear in the terminal fields the two IDs are identical.
+When a secret (e.g. an API key) appears in stderr or the last assistant message, the IDs
+diverge because:
+- `bench triage` hashes the raw string (contains the literal secret).
+- `bench failure-digest` hashes the redacted-then-marker-normalized string
+  (e.g. `[REDACTED:api_key:32]`).
+
+**Practical guidance:**
+- Use `bench failure-digest` `signature_id` for cross-run recurrence matching and as the
+  stable greppable identity in CI; it is the only surface that is record/replay-stable
+  when secrets are present.
+- `bench triage` cluster IDs are suitable for same-run cross-instance dedup. Do **not**
+  cross-reference them against `failure-digest` signature IDs when runs involve secrets.
+
 ## Out of Scope
 
 - The nightly workflow's issue-filing/dedup logic that *consumes* this signature.

--- a/docs/spec-triage.md
+++ b/docs/spec-triage.md
@@ -92,6 +92,12 @@ stderr_line=<normalized stderr line>
 
 Two failures collide only when all four normalized fields match.
 
+The same `FailureSignature` primitive is surfaced per-instance by
+`bench failure-digest` as a stable `signature_id`; see
+[`docs/spec-failure-signature.md`](spec-failure-signature.md) for the
+single-instance digest surface and its redaction/record-replay stability
+guarantees.
+
 ## Output Schema
 
 `bench triage` writes `<sweep>/triage.json`:

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1665,6 +1665,13 @@ pub struct FailureDigestCmd {
     /// Truncation preserves the headline and triage cluster footer.
     #[arg(long, default_value_t = 8000)]
     pub max_chars: usize,
+
+    /// Optional baseline `signature_id` to compare this failure against. When
+    /// supplied, the digest classifies the failure as `recurring` (the computed
+    /// signature matches the baseline) or `new`. The verdict is informational
+    /// and never changes the process exit code.
+    #[arg(long, value_name = "SIGNATURE_ID")]
+    pub baseline_signature: Option<String>,
 }
 
 /// `bench eval-flake` — quantify evaluator-side verdict noise on a completed sweep.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6388,6 +6388,7 @@ fn bench_failure_digest(f: args::FailureDigestCmd) -> Result<(), Error> {
         instance: f.instance,
         format,
         max_chars,
+        baseline_signature: f.baseline_signature,
     })?;
     match format {
         crate::run::failure_digest::DigestFormat::Markdown => {

--- a/src/run/failure_digest.rs
+++ b/src/run/failure_digest.rs
@@ -12,7 +12,8 @@ use crate::redaction::{Redactor, surface};
 use crate::run::compare::load_sweep;
 use crate::run::swebench::InstanceResult;
 use crate::run::triage::{
-    FailureSignature, TriageReport, failure_label, load_trajectory, resolve_trajectory_path,
+    FailureSignature, TriageReport, failure_label, last_non_empty_line, load_trajectory,
+    resolve_trajectory_path,
 };
 use crate::trajectory::FailureCategory;
 
@@ -102,16 +103,40 @@ pub struct FailureSignatureView {
     pub summary: String,
 }
 
+/// Outcome of a baseline recurrence check.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecurrenceVerdict {
+    Recurring,
+    New,
+}
+
+impl std::fmt::Display for RecurrenceVerdict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Recurring => f.write_str("recurring"),
+            Self::New => f.write_str("new"),
+        }
+    }
+}
+
 /// Recurrence verdict: does the current failure match a known baseline signature?
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecurrenceView {
     pub baseline_signature_id: String,
-    /// `"recurring"` when the current `signature_id` matches the baseline,
-    /// otherwise `"new"`.
-    pub verdict: String,
+    pub verdict: RecurrenceVerdict,
 }
 
 pub fn run(args: &FailureDigestArgs) -> Result<FailureDigest, Error> {
+    if let Some(ref baseline) = args.baseline_signature {
+        if !is_valid_signature_id(baseline) {
+            return Err(Error::Trajectory(format!(
+                "--baseline-signature {baseline:?} is not a valid signature id \
+                 (expected 16 hex chars)"
+            )));
+        }
+    }
+
     let results_path = args.sweep_dir.join("results.json");
     if !results_path.exists() {
         return Err(Error::Trajectory(format!(
@@ -192,14 +217,14 @@ pub fn run(args: &FailureDigestArgs) -> Result<FailureDigest, Error> {
     );
 
     let recurrence = args.baseline_signature.as_ref().map(|baseline| {
-        let verdict = if *baseline == failure_signature.signature_id {
-            "recurring"
+        let verdict = if baseline.to_lowercase() == failure_signature.signature_id {
+            RecurrenceVerdict::Recurring
         } else {
-            "new"
+            RecurrenceVerdict::New
         };
         RecurrenceView {
             baseline_signature_id: baseline.clone(),
-            verdict: verdict.to_owned(),
+            verdict,
         }
     });
 
@@ -235,16 +260,12 @@ fn build_failure_signature(
     let category = failure_category.unwrap_or("none");
     let assistant = crate::fingerprint::normalize_redaction_markers(redacted_assistant);
     let stderr_norm = crate::fingerprint::normalize_redaction_markers(redacted_stderr);
-    let stderr_line = stderr_norm
-        .lines()
-        .rev()
-        .find(|line| !line.trim().is_empty())
-        .unwrap_or_default();
+    let stderr_line = last_non_empty_line(&stderr_norm);
 
     let signature = FailureSignature::from_parts(category, &assistant, bash_exit_code, stderr_line);
 
     FailureSignatureView {
-        signature_id: signature.signature_id(),
+        signature_id: signature.cluster_id(),
         failure_category: signature.failure_category().to_owned(),
         assistant_tail: signature.assistant_tail().to_owned(),
         bash_exit_code: signature.bash_exit_code(),
@@ -278,7 +299,8 @@ pub fn render_markdown(digest: &FailureDigest, max_chars: usize) -> String {
         let _ = writeln!(out, "### Triage cluster");
         let _ = writeln!(out);
         out.push_str(triage_label);
-        return truncate_preserving_ends(&out, max_chars, &headline, triage_label);
+        let protected = format!("{headline}\n{signature_lines}");
+        return truncate_preserving_ends(&out, max_chars, &protected, triage_label);
     }
 
     let ast_excerpt = excerpt_head_tail(&digest.last_assistant_message, EXCERPT_MAX_CHARS);
@@ -322,7 +344,8 @@ pub fn render_markdown(digest: &FailureDigest, max_chars: usize) -> String {
     let _ = writeln!(out);
     out.push_str(triage_label);
 
-    truncate_preserving_ends(&out, max_chars, &headline, triage_label)
+    let protected = format!("{headline}\n{signature_lines}");
+    truncate_preserving_ends(&out, max_chars, &protected, triage_label)
 }
 
 fn build_headline(digest: &FailureDigest) -> String {
@@ -500,12 +523,16 @@ fn load_triage_cluster_label(sweep_dir: &Path, instance_id: &str) -> Option<Stri
     })
 }
 
-/// Truncate markdown to `max_chars` while preserving the first line (headline)
-/// and the triage cluster footer.
+fn is_valid_signature_id(s: &str) -> bool {
+    s.len() == 16 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Truncate markdown to `max_chars` while preserving `protected_header` (headline +
+/// greppable signature lines) and the triage cluster footer.
 fn truncate_preserving_ends(
     text: &str,
     max_chars: usize,
-    headline: &str,
+    protected_header: &str,
     triage_label: &str,
 ) -> String {
     if text.chars().count() <= max_chars {
@@ -513,7 +540,8 @@ fn truncate_preserving_ends(
     }
 
     let footer_section = format!("\n\n### Triage cluster\n\n{triage_label}");
-    let header = format!("{headline}\n");
+    // `protected_header` already ends with '\n' (signature_lines trailing newline).
+    let header = protected_header.to_owned();
     let marker = "\n\n... [digest truncated for length] ...\n";
 
     let fixed_len =
@@ -525,9 +553,10 @@ fn truncate_preserving_ends(
     }
 
     let middle_budget = max_chars - fixed_len;
+    // Skip the protected header bytes (all ASCII) then trim any leading blank lines.
     let rest = text
-        .split_once('\n')
-        .map_or("", |x| x.1)
+        .get(header.len()..)
+        .unwrap_or("")
         .trim_start_matches('\n');
     let middle: String = rest.chars().take(middle_budget).collect();
 

--- a/src/run/failure_digest.rs
+++ b/src/run/failure_digest.rs
@@ -216,17 +216,10 @@ pub fn run(args: &FailureDigestArgs) -> Result<FailureDigest, Error> {
         &last_tool_stderr,
     );
 
-    let recurrence = args.baseline_signature.as_ref().map(|baseline| {
-        let verdict = if baseline.to_lowercase() == failure_signature.signature_id {
-            RecurrenceVerdict::Recurring
-        } else {
-            RecurrenceVerdict::New
-        };
-        RecurrenceView {
-            baseline_signature_id: baseline.clone(),
-            verdict,
-        }
-    });
+    let recurrence = compute_recurrence(
+        args.baseline_signature.as_deref(),
+        &failure_signature.signature_id,
+    );
 
     Ok(FailureDigest {
         schema_version: "1.1".into(),
@@ -272,6 +265,22 @@ fn build_failure_signature(
         stderr_line: signature.stderr_line().to_owned(),
         summary: signature.summary(),
     }
+}
+
+/// Classify the current `signature_id` against an optional baseline. The baseline
+/// is normalized to lowercase once (matching the lowercase-hex `signature_id`
+/// format) and reused as the reported `baseline_signature_id`.
+fn compute_recurrence(baseline: Option<&str>, signature_id: &str) -> Option<RecurrenceView> {
+    let baseline_signature_id = baseline?.to_lowercase();
+    let verdict = if baseline_signature_id == signature_id {
+        RecurrenceVerdict::Recurring
+    } else {
+        RecurrenceVerdict::New
+    };
+    Some(RecurrenceView {
+        baseline_signature_id,
+        verdict,
+    })
 }
 
 /// Render the digest as markdown, truncating to `max_chars` while preserving
@@ -553,9 +562,9 @@ fn truncate_preserving_ends(
     }
 
     let middle_budget = max_chars - fixed_len;
-    // Skip the protected header bytes (all ASCII) then trim any leading blank lines.
+    // Skip the protected header then trim any leading blank lines.
     let rest = text
-        .get(header.len()..)
+        .strip_prefix(&header)
         .unwrap_or("")
         .trim_start_matches('\n');
     let middle: String = rest.chars().take(middle_budget).collect();

--- a/src/run/failure_digest.rs
+++ b/src/run/failure_digest.rs
@@ -11,7 +11,9 @@ use crate::error::Error;
 use crate::redaction::{Redactor, surface};
 use crate::run::compare::load_sweep;
 use crate::run::swebench::InstanceResult;
-use crate::run::triage::{TriageReport, failure_label, load_trajectory, resolve_trajectory_path};
+use crate::run::triage::{
+    FailureSignature, TriageReport, failure_label, load_trajectory, resolve_trajectory_path,
+};
 use crate::trajectory::FailureCategory;
 
 /// Characters per section excerpt (1.5 KB).
@@ -24,6 +26,10 @@ pub struct FailureDigestArgs {
     pub instance: Option<String>,
     pub format: DigestFormat,
     pub max_chars: usize,
+    /// Optional baseline `signature_id` to compare against. When present the
+    /// digest carries a recurrence verdict (`recurring` / `new`). The verdict is
+    /// informational and never changes the process exit code.
+    pub baseline_signature: Option<String>,
 }
 
 /// Output format for the digest.
@@ -54,7 +60,7 @@ impl PatchStatus {
     }
 }
 
-/// The structured failure digest (stable JSON schema version 1.0).
+/// The structured failure digest (stable JSON schema version 1.1).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FailureDigest {
     pub schema_version: String,
@@ -76,6 +82,33 @@ pub struct FailureDigest {
     pub patch_apply_stderr: Option<String>,
     pub triage_cluster_label: Option<String>,
     pub redacted: bool,
+    /// Stable, redaction-safe failure signature for deterministic dedup.
+    pub failure_signature: FailureSignatureView,
+    /// Recurrence verdict against an optional baseline signature. Present only
+    /// when `--baseline-signature` is supplied.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recurrence: Option<RecurrenceView>,
+}
+
+/// Serializable view of a [`FailureSignature`]: a stable `signature_id` plus the
+/// constituent fields it is derived from and a short human `summary`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailureSignatureView {
+    pub signature_id: String,
+    pub failure_category: String,
+    pub assistant_tail: String,
+    pub bash_exit_code: Option<i32>,
+    pub stderr_line: String,
+    pub summary: String,
+}
+
+/// Recurrence verdict: does the current failure match a known baseline signature?
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecurrenceView {
+    pub baseline_signature_id: String,
+    /// `"recurring"` when the current `signature_id` matches the baseline,
+    /// otherwise `"new"`.
+    pub verdict: String,
 }
 
 pub fn run(args: &FailureDigestArgs) -> Result<FailureDigest, Error> {
@@ -92,11 +125,11 @@ pub fn run(args: &FailureDigestArgs) -> Result<FailureDigest, Error> {
     let instance_id = instance.instance_id.clone();
 
     let traj_path = resolve_terminal_trajectory_path(&args.sweep_dir, &instance_id);
-    let (last_assistant_message, last_tool_stderr, last_tool_stdout) =
+    let (last_assistant_message, last_tool_stderr, last_tool_stdout, bash_exit_code) =
         if let Some(ref path) = traj_path {
             extract_terminal_signals(path)?
         } else {
-            (String::new(), String::new(), String::new())
+            (String::new(), String::new(), String::new(), None)
         };
 
     let patch_status = derive_patch_status(instance);
@@ -143,13 +176,38 @@ pub fn run(args: &FailureDigestArgs) -> Result<FailureDigest, Error> {
         ));
     }
 
+    let failure_category = instance
+        .failure_category
+        .map(|c| failure_label(c).to_owned());
+
+    // Compute the failure signature from the already-redacted terminal fields so
+    // no raw secret material can leak into `signature_id` or `summary`. Marker
+    // salts are normalized (consistent with `fingerprint::normalize_redaction_markers`)
+    // so the signature is stable across record/replay.
+    let failure_signature = build_failure_signature(
+        failure_category.as_deref(),
+        &last_assistant_message,
+        bash_exit_code,
+        &last_tool_stderr,
+    );
+
+    let recurrence = args.baseline_signature.as_ref().map(|baseline| {
+        let verdict = if *baseline == failure_signature.signature_id {
+            "recurring"
+        } else {
+            "new"
+        };
+        RecurrenceView {
+            baseline_signature_id: baseline.clone(),
+            verdict: verdict.to_owned(),
+        }
+    });
+
     Ok(FailureDigest {
-        schema_version: "1.0".into(),
+        schema_version: "1.1".into(),
         instance_id,
         outcome: instance.outcome.clone().unwrap_or_else(|| "unknown".into()),
-        failure_category: instance
-            .failure_category
-            .map(|c| failure_label(c).to_owned()),
+        failure_category,
         total_cost_usd: instance.actual_cost_usd(),
         step_count: instance.steps,
         task_duration_secs: instance.duration_secs,
@@ -160,7 +218,39 @@ pub fn run(args: &FailureDigestArgs) -> Result<FailureDigest, Error> {
         patch_apply_stderr,
         triage_cluster_label,
         redacted,
+        failure_signature,
+        recurrence,
     })
+}
+
+/// Build a redaction-safe [`FailureSignatureView`] from already-redacted terminal
+/// fields. Redaction markers are salt-normalized before hashing so the
+/// `signature_id` is identical across record/replay of the same failure.
+fn build_failure_signature(
+    failure_category: Option<&str>,
+    redacted_assistant: &str,
+    bash_exit_code: Option<i32>,
+    redacted_stderr: &str,
+) -> FailureSignatureView {
+    let category = failure_category.unwrap_or("none");
+    let assistant = crate::fingerprint::normalize_redaction_markers(redacted_assistant);
+    let stderr_norm = crate::fingerprint::normalize_redaction_markers(redacted_stderr);
+    let stderr_line = stderr_norm
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or_default();
+
+    let signature = FailureSignature::from_parts(category, &assistant, bash_exit_code, stderr_line);
+
+    FailureSignatureView {
+        signature_id: signature.signature_id(),
+        failure_category: signature.failure_category().to_owned(),
+        assistant_tail: signature.assistant_tail().to_owned(),
+        bash_exit_code: signature.bash_exit_code(),
+        stderr_line: signature.stderr_line().to_owned(),
+        summary: signature.summary(),
+    }
 }
 
 /// Render the digest as markdown, truncating to `max_chars` while preserving
@@ -168,6 +258,7 @@ pub fn run(args: &FailureDigestArgs) -> Result<FailureDigest, Error> {
 pub fn render_markdown(digest: &FailureDigest, max_chars: usize) -> String {
     let headline = build_headline(digest);
     let cost_line = build_cost_line(digest);
+    let signature_lines = build_signature_lines(digest);
     let triage_label = digest
         .triage_cluster_label
         .as_deref()
@@ -178,6 +269,7 @@ pub fn render_markdown(digest: &FailureDigest, max_chars: usize) -> String {
     if is_submitted {
         let mut out = String::new();
         let _ = writeln!(out, "{headline}");
+        let _ = write!(out, "{signature_lines}");
         let _ = writeln!(out);
         let _ = writeln!(out, "{cost_line}");
         let _ = writeln!(out);
@@ -196,6 +288,7 @@ pub fn render_markdown(digest: &FailureDigest, max_chars: usize) -> String {
 
     let mut out = String::new();
     let _ = writeln!(out, "{headline}");
+    let _ = write!(out, "{signature_lines}");
     let _ = writeln!(out);
     let _ = writeln!(out, "{cost_line}");
     let _ = writeln!(out);
@@ -239,6 +332,20 @@ fn build_headline(digest: &FailureDigest) -> String {
         digest.outcome,
         digest.failure_category.as_deref().unwrap_or("none")
     )
+}
+
+/// Stable, greppable signature line(s) emitted directly under the headline so
+/// CI logs and humans can match a failure deterministically. When a baseline was
+/// supplied, a `recurrence: ` line follows.
+fn build_signature_lines(digest: &FailureDigest) -> String {
+    let mut s = format!(
+        "failure_signature: {}\n",
+        digest.failure_signature.signature_id
+    );
+    if let Some(ref recurrence) = digest.recurrence {
+        let _ = writeln!(s, "recurrence: {}", recurrence.verdict);
+    }
+    s
 }
 
 fn build_cost_line(digest: &FailureDigest) -> String {
@@ -331,7 +438,7 @@ fn resolve_terminal_trajectory_path(sweep_dir: &Path, instance_id: &str) -> Opti
     resolve_trajectory_path(sweep_dir, instance_id)
 }
 
-fn extract_terminal_signals(path: &Path) -> Result<(String, String, String), Error> {
+fn extract_terminal_signals(path: &Path) -> Result<(String, String, String, Option<i32>), Error> {
     let trajectory = load_trajectory(path)?;
 
     let last_assistant = trajectory
@@ -351,10 +458,11 @@ fn extract_terminal_signals(path: &Path) -> Result<(String, String, String), Err
             .and_then(|v| serde_json::from_value::<RunResult>(v.clone()).ok())
     });
 
-    let (stderr, stdout) =
-        last_run.map_or((String::new(), String::new()), |r| (r.stderr, r.stdout));
+    let (stderr, stdout, exit_code) = last_run.map_or((String::new(), String::new(), None), |r| {
+        (r.stderr, r.stdout, Some(r.exit_code))
+    });
 
-    Ok((last_assistant, stderr, stdout))
+    Ok((last_assistant, stderr, stdout, exit_code))
 }
 
 fn derive_patch_status(instance: &InstanceResult) -> PatchStatus {

--- a/src/run/triage.rs
+++ b/src/run/triage.rs
@@ -124,6 +124,29 @@ impl FailureSignature {
     pub fn failure_category(&self) -> &str {
         &self.failure_category
     }
+
+    /// Stable hex identity for this signature. Alias of [`Self::cluster_id`],
+    /// named for the single-instance `failure-digest` surface where it is
+    /// presented as a per-failure `signature_id` rather than a cluster id.
+    #[must_use]
+    pub fn signature_id(&self) -> String {
+        self.cluster_id()
+    }
+
+    #[must_use]
+    pub fn assistant_tail(&self) -> &str {
+        &self.assistant_tail
+    }
+
+    #[must_use]
+    pub fn bash_exit_code(&self) -> Option<i32> {
+        self.bash_exit_code
+    }
+
+    #[must_use]
+    pub fn stderr_line(&self) -> &str {
+        &self.stderr_line
+    }
 }
 
 pub fn extract_instance_signature(
@@ -733,5 +756,32 @@ mod tests {
     fn message_tail_limits_by_chars() {
         assert_eq!(message_tail("abcdef", 3), "def");
         assert_eq!(message_tail("abc", 3), "abc");
+    }
+
+    #[test]
+    fn signature_id_aliases_cluster_id_and_accessors_expose_normalized_fields() {
+        let sig = FailureSignature::from_parts(
+            "model_parse",
+            "Parser failed in /tmp/swe/task-101/src/main.py line 33",
+            Some(2),
+            "SyntaxError: unexpected token 404",
+        );
+
+        // signature_id is exactly the cluster_id hash, just a single-instance name.
+        assert_eq!(sig.signature_id(), sig.cluster_id());
+
+        // Accessors expose the normalized constituent fields used in the hash.
+        assert_eq!(sig.failure_category(), "model_parse");
+        assert_eq!(sig.bash_exit_code(), Some(2));
+        assert!(
+            sig.assistant_tail().contains("<path>") && sig.assistant_tail().contains("<num>"),
+            "assistant_tail should be normalized: {}",
+            sig.assistant_tail()
+        );
+        assert!(
+            sig.stderr_line().contains("<num>"),
+            "stderr_line should be normalized: {}",
+            sig.stderr_line()
+        );
     }
 }

--- a/src/run/triage.rs
+++ b/src/run/triage.rs
@@ -125,14 +125,6 @@ impl FailureSignature {
         &self.failure_category
     }
 
-    /// Stable hex identity for this signature. Alias of [`Self::cluster_id`],
-    /// named for the single-instance `failure-digest` surface where it is
-    /// presented as a per-failure `signature_id` rather than a cluster id.
-    #[must_use]
-    pub fn signature_id(&self) -> String {
-        self.cluster_id()
-    }
-
     #[must_use]
     pub fn assistant_tail(&self) -> &str {
         &self.assistant_tail
@@ -218,6 +210,14 @@ pub struct TerminalSignals {
     pub assistant_message: String,
     pub bash_exit_code: Option<i32>,
     pub stderr_line: String,
+}
+
+/// Return the last non-empty line of `s`, or `""` if every line is blank.
+pub(crate) fn last_non_empty_line(s: &str) -> &str {
+    s.lines()
+        .rev()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or_default()
 }
 
 /// Normalize one textual signature component.
@@ -661,12 +661,7 @@ pub fn terminal_signals(trajectory: &Trajectory) -> TerminalSignals {
     let (bash_exit_code, stderr_line) = last_run.map_or((None, String::new()), |run| {
         (
             Some(run.exit_code),
-            run.stderr
-                .lines()
-                .rev()
-                .find(|line| !line.trim().is_empty())
-                .unwrap_or_default()
-                .to_owned(),
+            last_non_empty_line(&run.stderr).to_owned(),
         )
     });
     TerminalSignals {
@@ -759,16 +754,13 @@ mod tests {
     }
 
     #[test]
-    fn signature_id_aliases_cluster_id_and_accessors_expose_normalized_fields() {
+    fn accessors_expose_normalized_fields() {
         let sig = FailureSignature::from_parts(
             "model_parse",
             "Parser failed in /tmp/swe/task-101/src/main.py line 33",
             Some(2),
             "SyntaxError: unexpected token 404",
         );
-
-        // signature_id is exactly the cluster_id hash, just a single-instance name.
-        assert_eq!(sig.signature_id(), sig.cluster_id());
 
         // Accessors expose the normalized constituent fields used in the hash.
         assert_eq!(sig.failure_category(), "model_parse");

--- a/tests/bench_failure_digest.rs
+++ b/tests/bench_failure_digest.rs
@@ -397,7 +397,7 @@ fn digest_json_format_is_schema_versioned_and_stable() {
 
     let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
 
-    assert_eq!(json["schema_version"], "1.0", "schema_version must be 1.0");
+    assert_eq!(json["schema_version"], "1.1", "schema_version must be 1.1");
     assert_eq!(json["instance_id"], "error-1");
     assert_eq!(json["outcome"], "error");
     assert_eq!(json["failure_category"], "model_parse");
@@ -492,6 +492,305 @@ fn digest_max_chars_truncation_preserves_headline_and_triage_footer() {
     assert!(
         stdout.contains("aabbccdd") || stdout.contains("Triage") || stdout.contains("triage"),
         "triage section should survive truncation: {stdout}"
+    );
+}
+
+// ── (i) failure signature: JSON shape ─────────────────────────────────────────
+
+#[test]
+fn digest_json_includes_failure_signature_object_with_constituent_fields() {
+    let sweep = fixture_path("sweep-single-errored");
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap(), "--format", "json"]);
+    assert!(out.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let sig = &json["failure_signature"];
+    assert!(
+        sig.is_object(),
+        "failure_signature must be an object: {json}"
+    );
+
+    let signature_id = sig["signature_id"].as_str().unwrap_or("");
+    assert!(
+        !signature_id.is_empty() && signature_id.chars().all(|c| c.is_ascii_hexdigit()),
+        "signature_id must be a non-empty hex string: {signature_id:?}"
+    );
+    assert_eq!(
+        sig["failure_category"], "model_parse",
+        "signature must carry failure_category"
+    );
+    assert!(
+        sig.get("assistant_tail").is_some(),
+        "signature must carry assistant_tail: {sig}"
+    );
+    assert!(
+        sig.get("bash_exit_code").is_some(),
+        "signature must carry bash_exit_code: {sig}"
+    );
+    assert!(
+        sig.get("stderr_line").is_some(),
+        "signature must carry stderr_line: {sig}"
+    );
+    assert!(
+        sig["summary"].as_str().map_or(0, str::len) > 0,
+        "signature must carry a non-empty summary: {sig}"
+    );
+}
+
+// ── (j) determinism: identical inputs → identical signature_id ────────────────
+
+#[test]
+fn digest_signature_id_is_deterministic_across_runs() {
+    let sweep = fixture_path("sweep-single-errored");
+    let run_once = || {
+        let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap(), "--format", "json"]);
+        assert!(out.status.success());
+        let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+        json["failure_signature"]["signature_id"]
+            .as_str()
+            .unwrap()
+            .to_owned()
+    };
+    assert_eq!(
+        run_once(),
+        run_once(),
+        "signature_id must be identical across independent runs"
+    );
+}
+
+// ── (k) discrimination: differing terminal failures → different signature_id ──
+
+#[test]
+fn digest_signature_id_discriminates_distinct_failures() {
+    let signature_of = |fixture: &str| {
+        let sweep = fixture_path(fixture);
+        let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap(), "--format", "json"]);
+        assert!(out.status.success(), "{fixture} should succeed");
+        let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+        json["failure_signature"]["signature_id"]
+            .as_str()
+            .unwrap()
+            .to_owned()
+    };
+
+    let errored = signature_of("sweep-single-errored");
+    let step_limit = signature_of("sweep-step-limit");
+    assert_ne!(
+        errored, step_limit,
+        "distinct terminal failures must produce distinct signature_id"
+    );
+}
+
+// ── (l) markdown greppable failure_signature line ─────────────────────────────
+
+#[test]
+fn digest_markdown_renders_greppable_failure_signature_line() {
+    let sweep = fixture_path("sweep-single-errored");
+    let md_out = run_failure_digest(&["--sweep", sweep.to_str().unwrap()]);
+    assert!(md_out.status.success());
+    let md = String::from_utf8(md_out.stdout).unwrap();
+    assert!(
+        md.contains("failure_signature: "),
+        "markdown must contain a greppable `failure_signature: ` line: {md}"
+    );
+
+    // The id in markdown must match the id in JSON.
+    let json_out = run_failure_digest(&["--sweep", sweep.to_str().unwrap(), "--format", "json"]);
+    let json: serde_json::Value = serde_json::from_slice(&json_out.stdout).unwrap();
+    let id = json["failure_signature"]["signature_id"].as_str().unwrap();
+    assert!(
+        md.contains(id),
+        "markdown failure_signature id must match JSON id `{id}`: {md}"
+    );
+}
+
+// ── (m) baseline recurrence verdict ───────────────────────────────────────────
+
+#[test]
+fn digest_baseline_matching_signature_is_classified_recurring() {
+    let sweep = fixture_path("sweep-single-errored");
+    // First, learn the current signature_id.
+    let first = run_failure_digest(&["--sweep", sweep.to_str().unwrap(), "--format", "json"]);
+    let json: serde_json::Value = serde_json::from_slice(&first.stdout).unwrap();
+    let id = json["failure_signature"]["signature_id"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+
+    // Now classify against that baseline → recurring.
+    let out = run_failure_digest(&[
+        "--sweep",
+        sweep.to_str().unwrap(),
+        "--baseline-signature",
+        &id,
+        "--format",
+        "json",
+    ]);
+    assert!(
+        out.status.success(),
+        "recurrence verdict must not change exit code"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(
+        json["recurrence"]["verdict"], "recurring",
+        "matching baseline must classify as recurring: {json}"
+    );
+    assert_eq!(json["recurrence"]["baseline_signature_id"], id);
+
+    // Markdown surface too.
+    let md_out = run_failure_digest(&[
+        "--sweep",
+        sweep.to_str().unwrap(),
+        "--baseline-signature",
+        &id,
+    ]);
+    assert!(md_out.status.success());
+    let md = String::from_utf8(md_out.stdout).unwrap();
+    assert!(
+        md.contains("recurrence: recurring"),
+        "markdown must surface recurrence verdict: {md}"
+    );
+}
+
+#[test]
+fn digest_baseline_nonmatching_signature_is_classified_new_and_exit_zero() {
+    let sweep = fixture_path("sweep-single-errored");
+    let out = run_failure_digest(&[
+        "--sweep",
+        sweep.to_str().unwrap(),
+        "--baseline-signature",
+        "deadbeefdeadbeef",
+        "--format",
+        "json",
+    ]);
+    assert!(
+        out.status.success(),
+        "recurrence verdict must not change exit code (got {:?})",
+        out.status.code()
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(
+        json["recurrence"]["verdict"], "new",
+        "non-matching baseline must classify as new: {json}"
+    );
+}
+
+#[test]
+fn digest_without_baseline_omits_recurrence() {
+    let sweep = fixture_path("sweep-single-errored");
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap(), "--format", "json"]);
+    assert!(out.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert!(
+        json.get("recurrence").is_none(),
+        "recurrence must be absent when no baseline is supplied: {json}"
+    );
+}
+
+// ── (n) signature is redaction-safe ───────────────────────────────────────────
+
+#[test]
+fn digest_signature_never_leaks_raw_secret() {
+    let sweep = tempfile::tempdir().unwrap();
+    let secret_value = "super-secret-key-value-9999";
+
+    std::fs::write(
+        sweep.path().join("results.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "artifact_kind": "sweep_results",
+            "schema_version": {"major": 1, "minor": 4},
+            "total": 1,
+            "submitted": 0,
+            "skipped": 0,
+            "errored": 1,
+            "total_cost_usd": 1.0,
+            "instances": [{
+                "instance_id": "secret-test",
+                "exit_reason": "error",
+                "outcome": "error",
+                "failure_category": "model_api",
+                "cost_usd": 1.0,
+                "steps": 1,
+                "patch_present": false,
+                "non_empty_patch": false,
+                "attempts": 1,
+                "runs": 1,
+                "resolved_count": 0,
+                "pass_at_1": false,
+                "tests_run_before_submit": false
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    std::fs::write(
+        sweep.path().join("secret-test.traj.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "trajectory_format": "mini-swe-agent-1.1",
+            "artifact_kind": "trajectory",
+            "schema_version": {"major": 1, "minor": 4},
+            "info": {
+                "task": "secret-test",
+                "model_name": "fixture-model",
+                "outcome": "error",
+                "failure_category": "model_api",
+                "total_cost_usd": 1.0,
+                "steps": 1,
+                "test_invocations": [],
+                "tests_run_before_submit": false
+            },
+            "messages": [
+                {"role": "assistant", "content": format!("Calling the API with key={secret_value}")},
+                {
+                    "role": "user",
+                    "content": "observation",
+                    "extra": {
+                        "run_result": {
+                            "stdout": "",
+                            "stderr": format!("API call failed with key={secret_value}"),
+                            "exit_code": 1,
+                            "timed_out": false
+                        }
+                    }
+                }
+            ]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let out = run_failure_digest_with_env(
+        &[
+            "--sweep",
+            sweep.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ],
+        &[("OPENROUTER_API_KEY", secret_value)],
+    );
+    assert!(out.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let sig = &json["failure_signature"];
+    let signature_id = sig["signature_id"].as_str().unwrap_or("");
+    let summary = sig["summary"].as_str().unwrap_or("");
+    let assistant_tail = sig["assistant_tail"].as_str().unwrap_or("");
+    let stderr_line = sig["stderr_line"].as_str().unwrap_or("");
+    assert!(
+        !signature_id.contains(secret_value),
+        "signature_id must not contain raw secret"
+    );
+    assert!(
+        !summary.contains(secret_value),
+        "summary must not contain raw secret: {summary}"
+    );
+    assert!(
+        !assistant_tail.contains(secret_value),
+        "assistant_tail must not contain raw secret: {assistant_tail}"
+    );
+    assert!(
+        !stderr_line.contains(secret_value),
+        "stderr_line must not contain raw secret: {stderr_line}"
     );
 }
 

--- a/tests/bench_failure_digest.rs
+++ b/tests/bench_failure_digest.rs
@@ -704,6 +704,27 @@ fn digest_without_baseline_omits_recurrence() {
     );
 }
 
+#[test]
+fn digest_rejects_malformed_baseline_signature() {
+    let sweep = fixture_path("sweep-single-errored");
+    // 15 chars (too short) — must error rather than silently classify as `new`.
+    let out = run_failure_digest(&[
+        "--sweep",
+        sweep.to_str().unwrap(),
+        "--baseline-signature",
+        "deadbeefdeadbee",
+    ]);
+    assert!(
+        !out.status.success(),
+        "a malformed baseline signature must exit non-zero"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("baseline-signature"),
+        "error must mention the offending flag: {stderr}"
+    );
+}
+
 // ── (n) signature is redaction-safe ───────────────────────────────────────────
 
 #[test]

--- a/tests/bench_failure_digest.rs
+++ b/tests/bench_failure_digest.rs
@@ -451,6 +451,10 @@ fn digest_json_format_is_schema_versioned_and_stable() {
             json["patch_status"], golden["patch_status"],
             "patch_status must be stable"
         );
+        assert_eq!(
+            json["failure_signature"]["signature_id"], golden["failure_signature"]["signature_id"],
+            "signature_id must be stable — if it changed update the golden file and investigate"
+        );
     } else {
         // First run: write golden file
         std::fs::create_dir_all(golden_path.parent().unwrap()).unwrap();
@@ -492,6 +496,19 @@ fn digest_max_chars_truncation_preserves_headline_and_triage_footer() {
     assert!(
         stdout.contains("aabbccdd") || stdout.contains("Triage") || stdout.contains("triage"),
         "triage section should survive truncation: {stdout}"
+    );
+}
+
+#[test]
+fn digest_signature_line_survives_aggressive_max_chars_truncation() {
+    let sweep = fixture_path("sweep-single-errored");
+    // 100 chars: smaller than the headline+sig_line+marker+footer budget
+    let out = run_failure_digest(&["--sweep", sweep.to_str().unwrap(), "--max-chars", "100"]);
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("failure_signature: "),
+        "failure_signature: greppable line must survive --max-chars=100 truncation:\n{stdout}"
     );
 }
 

--- a/tests/fixtures/failure_digest/golden/error-1-digest.json
+++ b/tests/fixtures/failure_digest/golden/error-1-digest.json
@@ -1,15 +1,23 @@
 {
-  "failure_category": "model_parse",
+  "schema_version": "1.1",
   "instance_id": "error-1",
+  "outcome": "error",
+  "failure_category": "model_parse",
+  "total_cost_usd": 2.5,
+  "step_count": 5,
+  "task_duration_secs": 42.0,
   "last_assistant_message": "I tried to parse the model response but failed due to an unexpected format.",
   "last_tool_stderr": "model parse error: unexpected token at position 42",
   "last_tool_stdout": "some output here",
-  "outcome": "error",
   "patch_status": "not_attempted",
+  "triage_cluster_label": null,
   "redacted": false,
-  "schema_version": "1.0",
-  "step_count": 5,
-  "task_duration_secs": 42.0,
-  "total_cost_usd": 2.5,
-  "triage_cluster_label": null
+  "failure_signature": {
+    "signature_id": "36c90d5bc0621642",
+    "failure_category": "model_parse",
+    "assistant_tail": "i tried to parse the model response but failed due to an unexpected format.",
+    "bash_exit_code": 1,
+    "stderr_line": "model parse error: unexpected token at position <num>",
+    "summary": "assistant=\"i tried to parse the model response but failed due to an unexpected format.\" exit=1 stderr=\"model parse error: unexpected token at position <num>\""
+  }
 }


### PR DESCRIPTION
## Summary

This PR adds a stable, redaction-safe **failure signature** to the `bench failure-digest` output, enabling deterministic deduplication of recurring failures across runs. The signature is computed from normalized terminal failure signals (assistant message tail, bash exit code, stderr line, and failure category) and is surfaced as both a greppable markdown line and a JSON object.

## Key Changes

- **Schema version bump**: Updated `FailureDigest` schema from `1.0` to `1.1`
- **Failure signature computation**: Added `FailureSignatureView` struct containing:
  - `signature_id`: 16-char hex hash of normalized terminal signals
  - Constituent fields: `failure_category`, `assistant_tail`, `bash_exit_code`, `stderr_line`
  - Human-readable `summary` for quick visual inspection
- **Redaction safety**: Signature is computed only from already-redacted fields, preventing raw secrets from leaking into the `signature_id`
- **Baseline recurrence matching**: New `--baseline-signature` CLI flag enables classification of failures as `recurring` or `new` against a known baseline
- **Markdown surface**: Added greppable `failure_signature: <id>` and optional `recurrence: <verdict>` lines directly under the headline for CI log matching
- **Truncation protection**: Updated markdown truncation logic to preserve both headline and signature lines during aggressive `--max-chars` truncation
- **Marker normalization**: Signature inputs are normalized through `fingerprint::normalize_redaction_markers()` to strip per-run salts, ensuring identical signatures across record/replay of the same failure

## Implementation Details

- `FailureSignature` primitive (already used by `bench triage`) is reused for single-instance digests
- Signature inputs are normalized identically to multi-instance clustering for consistency
- Recurrence verdict is informational only and never changes process exit code
- Added comprehensive test coverage including determinism, discrimination, redaction safety, and baseline matching
- New specification document `docs/spec-failure-signature.md` documents stability guarantees and cross-tool divergence with `bench triage`
- Golden test fixture updated with new schema version and signature fields

https://claude.ai/code/session_01LLDQyGa9XwW24qG4pJCZHC