### PR TITLE
⚡ Bolt: Pre-allocate collections in merge module to reduce heap allocations

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -535,7 +535,9 @@ mod tests {
             "expected --network flag in args: {args:?}"
         );
         assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
+            network_pos
+                .and_then(|p| args.get(p + 1))
+                .map(String::as_str),
             Some("none")
         );
     }
@@ -552,8 +554,16 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        #[allow(clippy::expect_used)]
+        let network_pos = args
+            .iter()
+            .position(|a| a == "--network")
+            .expect("Missing --network");
+        #[allow(clippy::expect_used)]
+        let image_pos = args
+            .iter()
+            .position(|a| a == "my-image")
+            .expect("Missing my-image");
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -449,7 +449,10 @@ fn build_union_instances(
     loaded: &[(String, PathBuf, SweepResults)],
     policy: MergeCollisionPolicy,
 ) -> UnionResult {
-    let mut seen: HashMap<String, usize> = HashMap::new(); // id → shard index
+    // ⚡ Pre-allocate collections based on total instances across all shards to prevent
+    // repeated heap allocations during the initial detection and ordered union passes.
+    let total_instances = loaded.iter().map(|(_, _, r)| r.instances.len()).sum();
+    let mut seen: HashMap<String, usize> = HashMap::with_capacity(total_instances); // id → shard index
     let mut collisions: Vec<(String, usize, usize)> = Vec::new(); // (id, first_shard, second_shard)
     let mut duplicates = 0;
 
@@ -501,8 +504,8 @@ fn build_union_instances(
     }
 
     // Build ordered union (shard order, then instance order within shard)
-    let mut included: HashSet<String> = HashSet::new();
-    let mut union: Vec<crate::run::swebench::InstanceResult> = Vec::new();
+    let mut included: HashSet<String> = HashSet::with_capacity(seen.len());
+    let mut union: Vec<crate::run::swebench::InstanceResult> = Vec::with_capacity(seen.len());
 
     for (shard_idx, (_, _, results)) in loaded.iter().enumerate() {
         for inst in &results.instances {
@@ -675,7 +678,7 @@ fn merge_evaluation_json(
         return Ok(None);
     }
 
-    let mut eval_entries: Vec<Value> = Vec::new();
+    let mut eval_entries: Vec<Value> = Vec::with_capacity(owner_shard.len());
     let mut merged_provenance: Option<(String, Value)> = None; // (shard label, provenance)
     let mut shards_with_provenance = 0usize;
 


### PR DESCRIPTION
💡 What: Pre-allocated `seen`, `union`, `included`, and `eval_entries` collections in `src/run/merge.rs` using `::with_capacity()`. Also fixed `unwrap()` warnings in `docker.rs` by allowing `expect_used`.

🎯 Why: To reduce redundant heap allocations, dynamic resizing, and element moving while merging thousands of trajectory artifacts into a union sweep.

📊 Impact: Reduces O(N log N) reallocation steps in the hot path of merge initialization down to O(1) single large capacity allocations.

🔬 Measurement: Run `cargo check`, `cargo fmt`, and `cargo test --lib run::` to verify the logic and metrics remain consistent without regressions.

---
*PR created automatically by Jules for task [4256682197102630076](https://jules.google.com/task/4256682197102630076) started by @madmax983*