### PR TITLE
Add `max explain` command for offline exit code and failure category lookup

### DIFF
--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -26,6 +26,9 @@ parsing human-oriented output.
 | 15   | `resume_already_terminal` | `mini --resume` target trajectory already has a terminal outcome (`submitted`, `error`, `step_limit_reached`, `budget_exhausted`, `cancelled`, `wallclock_timeout`). Cannot continue a run that already completed. |
 | 16   | `resume_manifest_missing` | `mini --resume` target trajectory is missing required fields (`task` and/or `model_name`). The file may pre-date the run-manifest schema; create a fresh run instead. |
 | 17   | `resume_invalid_prefix` | `mini --resume` target trajectory is structurally invalid for resume: message sequence is empty, too short (fewer than 2 messages), or ends in a partial assistant turn. |
+| 18   | `bisect_budget_exhausted` | `bench bisect` exhausted its budget before identifying the regressing commit. |
+| 19   | `bisect_schema_break` | `bench bisect` found only trajectory-schema breaks in the remaining search space. |
+| 20   | `audit_failure` | `bench audit` detected a divergence exceeding tolerance or a bijection/evaluator contradiction. |
 | 21   | `eval_gaming_gate_failure` | `bench compare --max-test-only-resolved-rate` threshold was exceeded by the candidate sweep. |
 | 22   | `artifact_integrity_violation` | `bench export-ci` detected that JUnit XML aggregate attributes do not match `results.json` counts. The export wrote whatever it had; the mismatch signals a corrupt or incomplete sweep artifact. |
 | 23   | `scriptability_check_failure` | `bench scriptability-check` found at least one misconfigured MCP server or hook. Zero model calls were made; this is a wiring preflight. Distinct from `preflight_failure` (3) so CI can route scriptability misconfig separately from infrastructure failures. |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -4024,6 +4024,20 @@ pub struct CatalogCmd {
     pub format: String,
 }
 
+/// `explain` — offline lookup of an exit code, outcome class, or failure
+/// category to its documented meaning and remediation (issue #535).
+#[derive(Debug, Args, Clone)]
+pub struct ExplainCmd {
+    /// Selector to explain: an exit code (`7`), an outcome class
+    /// (`verification_failure`), or a failure category (`step_limit` /
+    /// `StepLimit`). Omit to list every addressable code/class/category.
+    pub selector: Option<String>,
+
+    /// Output format: `text` or `json`.
+    #[arg(long, default_value = "text", value_parser = ["text", "json"])]
+    pub format: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -30,6 +30,12 @@ pub fn entries() -> &'static [CatalogEntry] {
             stage: "preflight",
         },
         CatalogEntry {
+            path: "explain",
+            summary: "Explain an exit code, outcome class, or failure category offline",
+            cost_tier: "free",
+            stage: "inspect",
+        },
+        CatalogEntry {
             path: "cleanup",
             summary: "Reap leftover Maxwell's Daemon containers, including legacy labels",
             cost_tier: "free",

--- a/src/cli/explain.rs
+++ b/src/cli/explain.rs
@@ -104,10 +104,10 @@ fn print_index_text() {
             .code
             .map_or_else(|| "-".to_string(), |c| c.to_string());
         table.add_row([
-            code,
-            entry.outcome_class.to_string(),
-            families_label(entry),
-            entry.meaning.to_string(),
+            comfy_table::Cell::from(code),
+            comfy_table::Cell::from(entry.outcome_class),
+            comfy_table::Cell::from(families_label(entry)),
+            comfy_table::Cell::from(entry.meaning),
         ]);
     }
     println!("{table}");

--- a/src/cli/explain.rs
+++ b/src/cli/explain.rs
@@ -1,0 +1,129 @@
+//! `max explain` — offline lookup over the exit-code and failure-category
+//! contracts (issue #535).
+//!
+//! Read-only, $0, zero network: every answer comes from the compiled-in
+//! [`crate::explain`] registry. Mirrors `rustc --explain E0382`.
+
+use super::args::ExplainCmd;
+use crate::error::{ConfigError, Error};
+use crate::explain::{self, EXPLAIN_SCHEMA_VERSION, ExplainEntry};
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+
+/// Run `max explain`. With a selector, explain that code/class/category; without
+/// one, print the full index. An unknown selector returns a usage error (exit 2).
+pub fn run_explain(cmd: &ExplainCmd) -> Result<(), Error> {
+    let json = cmd.format == "json";
+    if let Some(selector) = cmd.selector.as_deref() {
+        let entry = explain::resolve(selector).ok_or_else(|| unknown_selector_error(selector))?;
+        if json {
+            print_entry_json(entry)?;
+        } else {
+            print_entry_text(entry);
+        }
+    } else if json {
+        print_index_json()?;
+    } else {
+        print_index_text();
+    }
+    Ok(())
+}
+
+/// Comma-joined family wire names, e.g. `exit_code` or `exit_code, failure_category`.
+fn families_label(entry: &ExplainEntry) -> String {
+    entry
+        .families
+        .iter()
+        .map(|f| f.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn entry_json(entry: &ExplainEntry) -> serde_json::Value {
+    serde_json::json!({
+        "code": entry.code,
+        "outcome_class": entry.outcome_class,
+        "family": entry.families.iter().map(|f| f.as_str()).collect::<Vec<_>>(),
+        "meaning": entry.meaning,
+        "remediation": entry.remediation,
+        "docs_ref": entry.docs_ref,
+    })
+}
+
+fn print_entry_json(entry: &ExplainEntry) -> Result<(), Error> {
+    let mut obj = entry_json(entry);
+    if let Some(map) = obj.as_object_mut() {
+        map.insert(
+            "schema_version".to_string(),
+            serde_json::Value::from(EXPLAIN_SCHEMA_VERSION),
+        );
+    }
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&obj).map_err(Error::Json)?
+    );
+    Ok(())
+}
+
+fn print_entry_text(entry: &ExplainEntry) {
+    if let Some(code) = entry.code {
+        println!("Exit code:     {code}");
+    }
+    println!("Outcome class: {}", entry.outcome_class);
+    println!("Family:        {}", families_label(entry));
+    println!();
+    println!("Meaning:");
+    println!("  {}", entry.meaning);
+    println!();
+    println!("Remediation:");
+    println!("  {}", entry.remediation);
+    println!();
+    println!("Docs: {}", entry.docs_ref);
+}
+
+fn print_index_json() -> Result<(), Error> {
+    let entries: Vec<serde_json::Value> = explain::entries().iter().map(entry_json).collect();
+    let doc = serde_json::json!({
+        "schema_version": EXPLAIN_SCHEMA_VERSION,
+        "entries": entries,
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&doc).map_err(Error::Json)?
+    );
+    Ok(())
+}
+
+fn print_index_text() {
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(["Code", "Outcome Class", "Family", "Meaning"]);
+    for entry in explain::entries() {
+        let code = entry
+            .code
+            .map_or_else(|| "-".to_string(), |c| c.to_string());
+        table.add_row([
+            code,
+            entry.outcome_class.to_string(),
+            families_label(entry),
+            entry.meaning.to_string(),
+        ]);
+    }
+    println!("{table}");
+    println!(
+        "\nRun `max explain <selector>` to explain one entry by exit code, \
+         outcome class, or failure category."
+    );
+}
+
+/// Usage error (exit 2) for an unknown selector; lists the valid selector
+/// families so an operator can correct the invocation.
+fn unknown_selector_error(selector: &str) -> Error {
+    Error::Config(ConfigError::Invalid(format!(
+        "unknown explain selector '{selector}'. Valid selectors are: an exit code \
+         integer (e.g. 7), an outcome class name (e.g. verification_failure), or a \
+         failure category (e.g. step_limit / StepLimit). Run `max explain` with no \
+         argument to list every addressable selector."
+    )))
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -17,6 +17,7 @@ use crate::exit_code::ExitCode;
 
 pub mod args;
 pub mod catalog;
+pub mod explain;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -56,6 +57,8 @@ pub enum Command {
     Ui(args::UiCmd),
     /// Self-describing command catalog for operator discoverability.
     Catalog(args::CatalogCmd),
+    /// Explain an exit code, outcome class, or failure category offline.
+    Explain(args::ExplainCmd),
     /// Reap leftover Maxwell's Daemon containers, including legacy labels.
     Cleanup,
 }
@@ -167,6 +170,7 @@ pub async fn run() -> Result<(), Error> {
             args::AgentCmd::Annotate(a) => agent_annotate_cmd(&a),
         },
         Command::Catalog(c) => catalog::run_catalog(c),
+        Command::Explain(c) => explain::run_explain(&c),
         Command::Ui(u) => ui_cmd(u).await,
         #[cfg(feature = "docker")]
         Command::Cleanup => cleanup_cmd().await,

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -1,0 +1,673 @@
+//! Offline `explain` registry: a compiled-in read surface over the two stable
+//! taxonomies operators react to — the [`crate::exit_code::ExitCode`] contract
+//! (documented in `docs/exit-codes.md`) and the
+//! [`crate::trajectory::FailureCategory`] enum (documented in
+//! `docs/failure-categories.md`).
+//!
+//! `max explain <selector>` turns an exit code (`7`), an outcome-class name
+//! (`verification_failure`), or a failure-category value (`step_limit` /
+//! `StepLimit`) into its documented meaning plus a remediation hint, with **no**
+//! network or model call. This mirrors `rustc --explain E0382`.
+//!
+//! This module is the single source of truth for the explanation text. The
+//! `tests/explain_drift.rs` suite cross-checks it against `ExitCode`,
+//! `docs/exit-codes.md`, and `FailureCategory` in both directions, so a new code
+//! or category cannot be added without a matching explanation — contract drift
+//! fails the build rather than shipping silently.
+
+/// Stable schema version for the `--format json` output of `max explain`.
+pub const EXPLAIN_SCHEMA_VERSION: &str = "1.0";
+
+/// Which taxonomy (or taxonomies) a selector name belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Family {
+    /// A process exit-code outcome class from `docs/exit-codes.md`.
+    ExitCode,
+    /// A trajectory `failure_category` value from `docs/failure-categories.md`.
+    FailureCategory,
+}
+
+impl Family {
+    /// Stable lowercase wire string for JSON output.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ExitCode => "exit_code",
+            Self::FailureCategory => "failure_category",
+        }
+    }
+}
+
+/// One addressable explanation: a code/class/category, its meaning, a
+/// remediation hint, and a documentation reference.
+#[derive(Debug, Clone, Copy)]
+pub struct ExplainEntry {
+    /// Process exit code, present only when this entry is an exit-code class.
+    pub code: Option<i32>,
+    /// Canonical snake_case selector name (outcome class and/or failure-category
+    /// wire name).
+    pub outcome_class: &'static str,
+    /// Taxonomy(ies) this name belongs to.
+    pub families: &'static [Family],
+    /// One-line documented meaning.
+    pub meaning: &'static str,
+    /// What to do about it.
+    pub remediation: &'static str,
+    /// Documentation reference (path, optionally with an anchor).
+    pub docs_ref: &'static str,
+}
+
+const EXIT_ONLY: &[Family] = &[Family::ExitCode];
+const CATEGORY_ONLY: &[Family] = &[Family::FailureCategory];
+const BOTH: &[Family] = &[Family::ExitCode, Family::FailureCategory];
+
+const EXIT_DOC: &str = "docs/exit-codes.md";
+
+/// The full registry: every `ExitCode` outcome class and every
+/// `FailureCategory` variant. The single cross-taxonomy collision —
+/// `agent_stagnation`, which is both exit code 12 and a failure category — is a
+/// single merged entry tagged with both families.
+#[allow(clippy::too_many_lines)]
+pub fn entries() -> &'static [ExplainEntry] {
+    &[
+        // ── Exit-code outcome classes (docs/exit-codes.md) ──────────────────
+        ExplainEntry {
+            code: Some(0),
+            outcome_class: "success",
+            families: EXIT_ONLY,
+            meaning: "Command completed with no errors; all checks passed (also covers no-op success).",
+            remediation: "No action needed.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(1),
+            outcome_class: "internal_error",
+            families: EXIT_ONLY,
+            meaning: "Unexpected failure: I/O error, JSON parse failure, or unclassified panic. Treat as infrastructure broken, not a domain result.",
+            remediation: "Re-run; if it persists capture the stderr message and file a bug. Do not treat as a task or gate result.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(2),
+            outcome_class: "usage_error",
+            families: EXIT_ONLY,
+            meaning: "Bad flag, missing required argument, unknown enum value, or invalid config file.",
+            remediation: "Fix the invocation or config and retry; see `max <command> --help`.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(3),
+            outcome_class: "preflight_failure",
+            families: EXIT_ONLY,
+            meaning: "A dependency was unavailable at sweep start: Docker not installed, daemon unreachable, container failed to start, or model endpoint probe failed.",
+            remediation: "Verify Docker is running and the model endpoint is reachable, then retry. `max agent doctor` checks host readiness.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(4),
+            outcome_class: "task_unsuccessful",
+            families: EXIT_ONLY,
+            meaning: "The agent ran but produced no usable result: step limit reached, environment command failed, wallclock timeout, or repeated model API errors.",
+            remediation: "Inspect the trajectory's `failure_category` for the precise cause, then raise the relevant limit or fix the environment.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(5),
+            outcome_class: "budget_halt",
+            families: EXIT_ONLY,
+            meaning: "Cost ceiling triggered: a forecast projected an over-cap run, or the sweep stopped because `--sweep-cost-limit-usd` was reached.",
+            remediation: "Increase the cost cap or reduce the dataset/scope, then retry.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(6),
+            outcome_class: "regression_gate_failure",
+            families: EXIT_ONLY,
+            meaning: "`bench compare` exceeded `--max-regressions` or `--max-patch-size-regression`.",
+            remediation: "Review the regressions in `bench compare` output; fix the candidate or adjust the threshold deliberately.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(7),
+            outcome_class: "verification_failure",
+            families: EXIT_ONLY,
+            meaning: "One or more `--verify NAME:COMMAND` checks did not pass after a `mini` run, or `bench bundle` detected a redaction/archive mismatch.",
+            remediation: "Read the failing check output and fix the change so the verify command passes.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(8),
+            outcome_class: "calibration_optimistic",
+            families: EXIT_ONLY,
+            meaning: "`bench calibrate --fail-on-optimistic` found actual sweep metrics above the forecast interval.",
+            remediation: "Recalibrate the forecast or widen the budget before the next run.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(9),
+            outcome_class: "replay_prompt_drift",
+            families: EXIT_ONLY,
+            meaning: "`bench replay` detected at least one input fingerprint that does not match the cassette.",
+            remediation: "Re-record the cassette, or align the inputs with the recorded trajectory.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(10),
+            outcome_class: "replay_response_exhausted",
+            families: EXIT_ONLY,
+            meaning: "`bench replay` ran out of scripted responses before the agent finished (structural drift).",
+            remediation: "Re-record the cassette so it covers the full run.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(11),
+            outcome_class: "systemic_halt",
+            families: EXIT_ONLY,
+            meaning: "The mid-sweep circuit breaker tripped: at least N completed instances share the same operator-actionable failure category at or above the share threshold.",
+            remediation: "Fix the systemic cause (often `env_setup` or `model_api`) — e.g. check credentials and Docker — then resume the sweep.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(12),
+            outcome_class: "agent_stagnation",
+            families: BOTH,
+            meaning: "The agent repeated the same action at least K times within a trailing window of W steps without progress, so the harness halted it. Surfaces both as process exit 12 and as the `agent_stagnation` failure_category on the trajectory.",
+            remediation: "Inspect the repeated action; adjust the task, the available tools, or the K/W stagnation thresholds.",
+            docs_ref: "docs/exit-codes.md (see also docs/failure-categories.md#agent_stagnation)",
+        },
+        ExplainEntry {
+            code: Some(13),
+            outcome_class: "env_preview_warning",
+            families: EXIT_ONLY,
+            meaning: "`agent env preview` found at least one risky finding (wide host path, sensitive env var forwarded, MCP server outside workdir, etc.).",
+            remediation: "Review the printed findings and tighten the environment before running a sweep.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(14),
+            outcome_class: "skills_preview_warning",
+            families: EXIT_ONLY,
+            meaning: "`agent skills-preview` found a warning: a task hit `max_active`, an activated manifest has no `version`, or `auto_load` matched a skill implicitly.",
+            remediation: "Review the preview warnings and adjust the skills configuration.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(15),
+            outcome_class: "resume_already_terminal",
+            families: EXIT_ONLY,
+            meaning: "`mini --resume` target trajectory already has a terminal outcome; the run already completed, was cancelled, or hit a cap.",
+            remediation: "Start a fresh run; `--resume` only continues an in-progress run.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(16),
+            outcome_class: "resume_manifest_missing",
+            families: EXIT_ONLY,
+            meaning: "`mini --resume` target is missing required `task`/`model_name` fields (it pre-dates the run-manifest schema).",
+            remediation: "Create a fresh run instead of resuming.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(17),
+            outcome_class: "resume_invalid_prefix",
+            families: EXIT_ONLY,
+            meaning: "`mini --resume` target is structurally invalid: the message sequence is empty, too short, or ends in a partial assistant turn.",
+            remediation: "Create a fresh run; the trajectory cannot be resumed.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(18),
+            outcome_class: "bisect_budget_exhausted",
+            families: EXIT_ONLY,
+            meaning: "`bench bisect` exhausted its budget before identifying the regressing commit.",
+            remediation: "Increase the bisect budget or narrow the commit range.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(19),
+            outcome_class: "bisect_schema_break",
+            families: EXIT_ONLY,
+            meaning: "`bench bisect` found only trajectory-schema breaks in the remaining search space.",
+            remediation: "Re-record the affected trajectories or exclude schema-broken commits from the range.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(20),
+            outcome_class: "audit_failure",
+            families: EXIT_ONLY,
+            meaning: "`bench audit` detected a divergence exceeding tolerance or a bijection/evaluator contradiction.",
+            remediation: "Investigate the divergence reported by `bench audit` and reconcile the evaluator.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(21),
+            outcome_class: "eval_gaming_gate_failure",
+            families: EXIT_ONLY,
+            meaning: "`bench compare --max-test-only-resolved-rate` was exceeded by the candidate sweep.",
+            remediation: "Investigate test-only resolutions (possible eval gaming) before accepting the candidate.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(22),
+            outcome_class: "artifact_integrity_violation",
+            families: EXIT_ONLY,
+            meaning: "`bench export-ci` found JUnit XML aggregate attributes that disagree with the counts in `results.json`.",
+            remediation: "Re-run the export on a complete sweep; the artifact is corrupt or incomplete.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(23),
+            outcome_class: "scriptability_check_failure",
+            families: EXIT_ONLY,
+            meaning: "`bench scriptability-check` found at least one misconfigured MCP server or hook. Zero model calls were made; this is a wiring preflight.",
+            remediation: "Fix the MCP/hook wiring; distinct from `preflight_failure` so CI can route it separately.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(24),
+            outcome_class: "feature_unavailable",
+            families: EXIT_ONLY,
+            meaning: "The subcommand requires a Cargo feature that was not compiled in.",
+            remediation: "Rebuild with the named feature enabled (see the docs link in the error message).",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(25),
+            outcome_class: "redact_check_stale_literals",
+            families: EXIT_ONLY,
+            meaning: "`agent redact-check` found a `secret_literals` entry that produced zero matches against the sample input — likely stale.",
+            remediation: "Update or remove the stale literal so redaction keeps protecting something.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(26),
+            outcome_class: "redact_check_strict_fail",
+            families: EXIT_ONLY,
+            meaning: "`agent redact-check --strict` found a `custom_patterns` regex that compiled but produced zero matches.",
+            remediation: "Fix the regex typo or update it for the renamed token format.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(27),
+            outcome_class: "slo_rule_failure",
+            families: EXIT_ONLY,
+            meaning: "`bench assert` evaluated all rules and at least one rule (or a missing artifact in fail-closed mode) did not pass.",
+            remediation: "Review `assertions.json`; the sweep did not meet the declared SLO. Distinct from `usage_error`.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(28),
+            outcome_class: "continue_non_terminal",
+            families: EXIT_ONLY,
+            meaning: "`mini --continue` target trajectory is non-terminal (still partial/in-progress).",
+            remediation: "Use `--resume` to continue an in-progress run; `--continue` only accepts a terminal trajectory.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(29),
+            outcome_class: "apply_check_failed",
+            families: EXIT_ONLY,
+            meaning: "`agent apply` ran `git apply --check` and the patch cannot apply cleanly to the current tree. The working tree is unchanged.",
+            remediation: "Rebase the patch onto the current tree or regenerate it.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(30),
+            outcome_class: "apply_redacted_refused",
+            families: EXIT_ONLY,
+            meaning: "`agent apply` detected `[REDACTED:…]` markers in the patch, or the source trajectory recorded patch-submission redaction.",
+            remediation: "Use an unredacted patch, or pass `--allow-redacted` to override.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(31),
+            outcome_class: "apply_dirty_tree_refused",
+            families: EXIT_ONLY,
+            meaning: "`agent apply` found uncommitted changes in the target working tree.",
+            remediation: "Commit or stash your changes, or pass `--allow-dirty` to override.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(32),
+            outcome_class: "redact_audit_findings",
+            families: EXIT_ONLY,
+            meaning: "`agent redact-audit` found at least one new finding at `medium` or higher severity in the scanned artifacts.",
+            remediation: "Treat as a leak: scrub the artifact before publishing.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(33),
+            outcome_class: "redact_audit_scan_error",
+            families: EXIT_ONLY,
+            meaning: "`agent redact-audit` could not read or extract one or more artifacts, so the scan is incomplete.",
+            remediation: "Fix the unreadable/corrupt artifact and re-run; a clean verdict cannot be trusted yet.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(34),
+            outcome_class: "github_issue_missing_token",
+            families: EXIT_ONLY,
+            meaning: "The `GITHUB_TOKEN` environment variable was empty or missing during issue ingestion.",
+            remediation: "Export a valid `GITHUB_TOKEN` and retry.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(35),
+            outcome_class: "github_issue_not_found",
+            families: EXIT_ONLY,
+            meaning: "The GitHub API returned 404 Not Found (or a 403 for a private/unauthorized repository).",
+            remediation: "Check the issue/repo reference and the token's scope.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(36),
+            outcome_class: "github_issue_rate_limited",
+            families: EXIT_ONLY,
+            meaning: "The GitHub API returned 403 Rate Limit Exceeded during issue ingestion.",
+            remediation: "Wait for the rate-limit window to reset, or use a token with a higher limit.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(37),
+            outcome_class: "injection_audit_hits",
+            families: EXIT_ONLY,
+            meaning: "`agent injection-audit` found at least one hit at or above the configured `--fail-on` severity threshold.",
+            remediation: "Review the flagged content for prompt injection before publishing.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(38),
+            outcome_class: "injection_audit_scan_error",
+            families: EXIT_ONLY,
+            meaning: "`agent injection-audit` could not read the sweep directory or a trajectory file, so the scan is incomplete.",
+            remediation: "Fix the unreadable path and re-run; a clean verdict cannot be trusted yet.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(39),
+            outcome_class: "stability_gate_failure",
+            families: EXIT_ONLY,
+            meaning: "`agent stability --fail-under <F>` found `pass_at_k < F`. All runs completed; the measured pass rate missed the threshold.",
+            remediation: "Improve run stability, or lower the threshold deliberately.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(40),
+            outcome_class: "dataset_verify_mismatch",
+            families: EXIT_ONLY,
+            meaning: "`bench dataset-verify` detected a mismatch between the candidate dataset and the canonical reference.",
+            remediation: "Re-sync the dataset to the canonical reference.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(41),
+            outcome_class: "best_of_all_failed",
+            families: EXIT_ONLY,
+            meaning: "`agent best-of` completed all runs and none passed every verify check. The best-scoring run was still selected and its patch emitted.",
+            remediation: "Improve the task or model, or pass `--allow-no-pass` to accept the best run while keeping `all_failed: true`.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(42),
+            outcome_class: "config_override_warning",
+            families: EXIT_ONLY,
+            meaning: "`agent config resolve` found a clap-default override hazard: a `--config` field (`model.name` or `agent.step_limit`) will be silently overwritten unless its flag is also passed.",
+            remediation: "Pass the corresponding flag explicitly, or accept the resolved config (exit 0 means no hazards).",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(43),
+            outcome_class: "eval_parity_gate_failure",
+            families: EXIT_ONLY,
+            meaning: "`bench eval-parity --min-agreement <F>` measured an offline-vs-canonical agreement rate below the declared threshold.",
+            remediation: "Investigate evaluator divergence; distinct from `slo_rule_failure`.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(44),
+            outcome_class: "utilization_gate_failure",
+            families: EXIT_ONLY,
+            meaning: "`bench utilization --min-utilization <PCT>` measured a concurrency utilization below the declared floor.",
+            remediation: "Increase concurrency or investigate under-utilization; distinct from `slo_rule_failure`.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(45),
+            outcome_class: "fs_audit_findings",
+            families: EXIT_ONLY,
+            meaning: "`agent fs-audit` found at least one bash command that accessed a path outside the configured workdir.",
+            remediation: "Review the filesystem-boundary violation before publishing.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(46),
+            outcome_class: "fs_audit_scan_error",
+            families: EXIT_ONLY,
+            meaning: "`agent fs-audit` could not read or parse one or more trajectory files, so the scan is incomplete.",
+            remediation: "Fix the unreadable/invalid trajectory and re-run; a clean verdict cannot be trusted yet.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(47),
+            outcome_class: "artifact_check_failure",
+            families: EXIT_ONLY,
+            meaning: "`agent artifact-check` found an `invalid` or `unsupported_major` artifact (with `--strict`, also legacy/with-warnings). Zero model calls; a structural conformance gate.",
+            remediation: "Regenerate the artifact so it conforms to the contract.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(48),
+            outcome_class: "host_not_ready",
+            families: EXIT_ONLY,
+            meaning: "`agent doctor` found a failing host-readiness check: git missing, provider credential absent, Docker daemon unreachable, runs/output dir not writable, or toolchain below the crate `rust-version`.",
+            remediation: "Fix the failing host check reported by `agent doctor`, then retry.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(130),
+            outcome_class: "interrupted",
+            families: EXIT_ONLY,
+            meaning: "Graceful SIGINT / Ctrl-C cancellation (POSIX convention: 128 + SIGINT(2)).",
+            remediation: "Re-run if the interruption was unintended; partial results may be on disk.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
+            code: Some(137),
+            outcome_class: "killed",
+            families: EXIT_ONLY,
+            meaning: "SIGKILL escalation after the graceful-cancel deadline expired (128 + SIGKILL(9)).",
+            remediation: "Re-run; if cancellation routinely escalates to a kill, increase the graceful-cancel deadline.",
+            docs_ref: EXIT_DOC,
+        },
+        // ── Failure categories (docs/failure-categories.md) ─────────────────
+        // (agent_stagnation is the merged exit/category entry above.)
+        ExplainEntry {
+            code: None,
+            outcome_class: "env_setup",
+            families: CATEGORY_ONLY,
+            meaning: "An environment or infrastructure failure prevented a successful run: setup failed before any agent turns (Docker down, image pull/clone failed) or patch capture failed after the agent ran.",
+            remediation: "Check Docker, image availability, and the workspace. Operator-actionable: can trip the systemic-halt circuit breaker.",
+            docs_ref: "docs/failure-categories.md#env_setup",
+        },
+        ExplainEntry {
+            code: None,
+            outcome_class: "model_api",
+            families: CATEGORY_ONLY,
+            meaning: "Repeated errors calling the model API (invalid key, exhausted quota, or persistent provider errors).",
+            remediation: "Verify the API key, quota, and provider status. Operator-actionable: can trip the systemic-halt circuit breaker.",
+            docs_ref: "docs/failure-categories.md#model_api",
+        },
+        ExplainEntry {
+            code: None,
+            outcome_class: "model_parse",
+            families: CATEGORY_ONLY,
+            meaning: "Repeated failures to parse the model's response format.",
+            remediation: "Check the prompt/format contract and the model's compatibility with the expected output shape.",
+            docs_ref: "docs/failure-categories.md#model_parse",
+        },
+        ExplainEntry {
+            code: None,
+            outcome_class: "step_limit",
+            families: CATEGORY_ONLY,
+            meaning: "The agent exhausted its maximum step budget before submitting.",
+            remediation: "Raise `--step-limit` if the task genuinely needs more steps, or investigate why the agent looped.",
+            docs_ref: "docs/failure-categories.md#step_limit",
+        },
+        ExplainEntry {
+            code: None,
+            outcome_class: "cost_limit",
+            families: CATEGORY_ONLY,
+            meaning: "The per-task USD cost ceiling was reached.",
+            remediation: "Raise the per-task cost limit or reduce task scope.",
+            docs_ref: "docs/failure-categories.md#cost_limit",
+        },
+        ExplainEntry {
+            code: None,
+            outcome_class: "budget_exhausted",
+            families: CATEGORY_ONLY,
+            meaning: "The per-task USD budget was reached mid-loop; any patch accumulated before the cap fired is preserved.",
+            remediation: "Raise the budget or reduce scope; inspect the preserved partial patch.",
+            docs_ref: "docs/failure-categories.md#budget_exhausted",
+        },
+        ExplainEntry {
+            code: None,
+            outcome_class: "wallclock_timeout",
+            families: CATEGORY_ONLY,
+            meaning: "The maximum real-time execution duration was reached.",
+            remediation: "Raise the wallclock limit or reduce task scope.",
+            docs_ref: "docs/failure-categories.md#wallclock_timeout",
+        },
+        ExplainEntry {
+            code: None,
+            outcome_class: "agent_internal",
+            families: CATEGORY_ONLY,
+            meaning: "An internal logic error within the agent harness.",
+            remediation: "Capture the trajectory and file a bug; this is not an expected per-task outcome.",
+            docs_ref: "docs/failure-categories.md#agent_internal",
+        },
+        ExplainEntry {
+            code: None,
+            outcome_class: "patch_apply_invalid",
+            families: CATEGORY_ONLY,
+            meaning: "A patch was captured but `git apply --check` rejected it at capture time.",
+            remediation: "Inspect the diff; the agent produced a malformed or conflicting patch.",
+            docs_ref: "docs/failure-categories.md#patch_apply_invalid",
+        },
+        ExplainEntry {
+            code: None,
+            outcome_class: "patch_empty",
+            families: CATEGORY_ONLY,
+            meaning: "The agent submitted but the captured diff was empty (zero bytes).",
+            remediation: "Check whether the agent actually edited files; the submission produced no change.",
+            docs_ref: "docs/failure-categories.md#patch_empty",
+        },
+        ExplainEntry {
+            code: None,
+            outcome_class: "secret_leak_detected",
+            families: CATEGORY_ONLY,
+            meaning: "A configured secret literal was found in a submission artifact.",
+            remediation: "Rotate the exposed secret, scrub the artifact, and review the redaction config.",
+            docs_ref: "docs/failure-categories.md#secret_leak_detected",
+        },
+        ExplainEntry {
+            code: None,
+            outcome_class: "history_compaction_failed",
+            families: CATEGORY_ONLY,
+            meaning: "Trajectory history could not be compacted within `history_max_input_tokens` even after eliding all older observations.",
+            remediation: "Reduce context usage or raise `history_max_input_tokens`. Operator-actionable: can trip the systemic-halt circuit breaker.",
+            docs_ref: "docs/failure-categories.md#history_compaction_failed",
+        },
+        ExplainEntry {
+            code: None,
+            outcome_class: "read_only_violation",
+            families: CATEGORY_ONLY,
+            meaning: "Read-only mode blocked a tool invocation that attempted a write.",
+            remediation: "Remove `--read-only` for write tasks, or constrain the agent to read-only actions.",
+            docs_ref: "docs/failure-categories.md#read_only_violation",
+        },
+        ExplainEntry {
+            code: None,
+            outcome_class: "unknown",
+            families: CATEGORY_ONLY,
+            meaning: "An unknown or unclassified failure, or a value produced by a newer harness version this reader does not recognise. Reserved for forward-compatible parsing.",
+            remediation: "Update to a matching harness version, or inspect the raw trajectory for details.",
+            docs_ref: "docs/failure-categories.md#unknown",
+        },
+    ]
+}
+
+/// Normalize a selector for case-insensitive matching across snake_case and the
+/// enum's PascalCase display form: lowercase and drop underscores so
+/// `step_limit`, `StepLimit`, and `STEP_LIMIT` all collapse to `steplimit`.
+fn normalize(selector: &str) -> String {
+    selector
+        .chars()
+        .filter(|c| *c != '_')
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+/// Resolve a selector — an exit-code integer, an outcome-class name, or a
+/// failure-category value — to its explanation. Returns `None` if unknown.
+#[must_use]
+pub fn resolve(selector: &str) -> Option<&'static ExplainEntry> {
+    let trimmed = selector.trim();
+    if let Ok(code) = trimmed.parse::<i32>() {
+        return entries().iter().find(|e| e.code == Some(code));
+    }
+    let needle = normalize(trimmed);
+    entries()
+        .iter()
+        .find(|e| normalize(e.outcome_class) == needle)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_by_integer_code() {
+        let e = resolve("7").unwrap();
+        assert_eq!(e.outcome_class, "verification_failure");
+        assert_eq!(e.code, Some(7));
+    }
+
+    #[test]
+    fn resolves_outcome_class_case_insensitively() {
+        assert_eq!(resolve("verification_failure").unwrap().code, Some(7));
+        assert_eq!(resolve("VERIFICATION_FAILURE").unwrap().code, Some(7));
+        assert_eq!(resolve("Verification_Failure").unwrap().code, Some(7));
+    }
+
+    #[test]
+    fn resolves_failure_category_snake_and_pascal() {
+        let snake = resolve("step_limit").unwrap();
+        let pascal = resolve("StepLimit").unwrap();
+        assert_eq!(snake.outcome_class, "step_limit");
+        assert_eq!(snake.outcome_class, pascal.outcome_class);
+        assert!(snake.code.is_none());
+    }
+
+    #[test]
+    fn unknown_selector_resolves_to_none() {
+        assert!(resolve("definitely_not_real").is_none());
+        assert!(resolve("9999").is_none());
+    }
+
+    #[test]
+    fn agent_stagnation_carries_both_families() {
+        let e = resolve("agent_stagnation").unwrap();
+        assert_eq!(e.code, Some(12));
+        assert!(e.families.contains(&Family::ExitCode));
+        assert!(e.families.contains(&Family::FailureCategory));
+    }
+
+    #[test]
+    fn no_duplicate_outcome_classes() {
+        let mut seen = std::collections::HashSet::new();
+        for e in entries() {
+            assert!(seen.insert(e.outcome_class), "dup: {}", e.outcome_class);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod cost;
 pub mod env;
 pub mod error;
 pub mod exit_code;
+pub mod explain;
 pub mod fingerprint;
 pub mod ids;
 pub mod model;

--- a/tests/explain_cmd.rs
+++ b/tests/explain_cmd.rs
@@ -1,0 +1,175 @@
+//! Integration tests for `max explain` (issue #535).
+//!
+//! Spawns the `max` binary and asserts the read-only, offline, $0 contract:
+//! resolving exit codes / outcome classes / failure categories to a documented
+//! meaning + remediation, the stable JSON schema, the usage-error (exit 2) on an
+//! unknown selector, and the built-in index when no selector is given.
+
+#![allow(clippy::unwrap_used)]
+
+use std::process::Command;
+
+mod support;
+use support::binary_path;
+
+/// A fresh `max explain …` command with all provider keys removed, proving the
+/// command needs no API key (read-only, offline, $0).
+fn explain() -> Command {
+    let mut cmd = Command::new(binary_path());
+    cmd.arg("explain");
+    cmd.env_remove("ANTHROPIC_API_KEY");
+    cmd.env_remove("OPENAI_API_KEY");
+    cmd
+}
+
+// ── AC: resolve an exit code integer ─────────────────────────────────────────
+
+#[test]
+fn explain_exit_code_integer_exits_zero() {
+    let out = explain().arg("7").output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("verification_failure"),
+        "expected verification_failure in:\n{stdout}"
+    );
+}
+
+// ── AC: resolve an outcome class name, case-insensitively ────────────────────
+
+#[test]
+fn explain_outcome_class_case_insensitive() {
+    let lower = explain().arg("verification_failure").output().unwrap();
+    let upper = explain().arg("VERIFICATION_FAILURE").output().unwrap();
+    assert_eq!(lower.status.code(), Some(0));
+    assert_eq!(upper.status.code(), Some(0));
+    assert_eq!(lower.stdout, upper.stdout, "case must not change output");
+}
+
+// ── AC: resolve a failure category by snake_case and PascalCase ──────────────
+
+#[test]
+fn explain_failure_category_snake_and_pascal() {
+    let snake = explain().arg("step_limit").output().unwrap();
+    let pascal = explain().arg("StepLimit").output().unwrap();
+    assert_eq!(
+        snake.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&snake.stderr)
+    );
+    assert_eq!(pascal.status.code(), Some(0));
+    let s = String::from_utf8_lossy(&snake.stdout);
+    assert!(s.contains("step_limit"), "expected step_limit in:\n{s}");
+    assert_eq!(snake.stdout, pascal.stdout, "snake and Pascal must agree");
+}
+
+// ── AC: --format json emits the stable schema-versioned object ───────────────
+
+#[test]
+fn explain_json_has_stable_schema() {
+    let out = explain().args(["--format", "json", "7"]).output().unwrap();
+    assert_eq!(out.status.code(), Some(0));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["schema_version"], "1.0");
+    assert_eq!(v["code"], 7);
+    assert_eq!(v["outcome_class"], "verification_failure");
+    assert!(v["meaning"].is_string() && !v["meaning"].as_str().unwrap().is_empty());
+    assert!(v["remediation"].is_string() && !v["remediation"].as_str().unwrap().is_empty());
+    assert!(v["docs_ref"].is_string() && !v["docs_ref"].as_str().unwrap().is_empty());
+}
+
+#[test]
+fn explain_json_failure_category_has_null_code() {
+    let out = explain()
+        .args(["--format", "json", "step_limit"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(0));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["outcome_class"], "step_limit");
+    assert!(v["code"].is_null(), "failure category has no exit code");
+}
+
+// ── AC: unknown selector → usage error (exit 2), lists selector families ──────
+
+#[test]
+fn explain_unknown_selector_is_usage_error() {
+    let out = explain()
+        .arg("definitely_not_a_real_selector")
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "unknown selector must exit 2 (usage_error)"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("usage_error"),
+        "stderr should carry outcome_class: usage_error:\n{stderr}"
+    );
+    // Must list the valid selector families to guide the operator.
+    assert!(
+        stderr.contains("exit code")
+            && stderr.contains("outcome class")
+            && stderr.contains("failure category"),
+        "usage error must list valid selector families:\n{stderr}"
+    );
+}
+
+// ── AC: no selector → built-in index, exit 0 ─────────────────────────────────
+
+#[test]
+fn explain_no_selector_lists_index() {
+    let out = explain().output().unwrap();
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // A sampling from each taxonomy must appear in the index.
+    for needle in [
+        "verification_failure",
+        "step_limit",
+        "host_not_ready",
+        "unknown",
+    ] {
+        assert!(
+            stdout.contains(needle),
+            "index missing '{needle}':\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn explain_index_json_lists_all_entries() {
+    let out = explain().args(["--format", "json"]).output().unwrap();
+    assert_eq!(out.status.code(), Some(0));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["schema_version"], "1.0");
+    let entries = v["entries"].as_array().unwrap();
+    // 51 exit-code classes (0–48, 130, 137) + 15 failure categories, minus the
+    // 1 merged collision (agent_stagnation) = 65 distinct entries.
+    assert_eq!(entries.len(), 65, "unexpected index size");
+}
+
+// ── AC: offline / $0 — runs with no API key set ──────────────────────────────
+
+#[test]
+fn explain_runs_offline_with_no_api_key() {
+    // env_clear removes *everything*; the command must still succeed because it
+    // reads only compiled-in data — no network, no model, no key.
+    let mut cmd = Command::new(binary_path());
+    cmd.env_clear();
+    cmd.args(["explain", "verification_failure"]);
+    let out = cmd.output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "explain must work with a cleared environment; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/tests/explain_drift.rs
+++ b/tests/explain_drift.rs
@@ -1,0 +1,345 @@
+//! Anti-rot drift test for `max explain` (issue #535).
+//!
+//! This is the core acceptance guarantee: the compiled-in `explain` registry,
+//! the `ExitCode` enum, `docs/exit-codes.md`, and the `FailureCategory` enum
+//! must all stay in sync. The test is bidirectional — a code/class/category
+//! present in one source but missing from another fails the build, so contract
+//! drift is structurally impossible rather than merely discouraged.
+//!
+//! The exhaustive `match` arms below (`exit_code_identity` / `failure_serde`)
+//! turn *adding a variant without an `explain` entry* into a compile error; the
+//! runtime assertions turn *adding a variant without a doc row* into a test
+//! failure.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use maxwells_daemon::exit_code::ExitCode;
+use maxwells_daemon::explain::{self, Family};
+use maxwells_daemon::trajectory::FailureCategory;
+
+/// Every `ExitCode` variant, with a compile-time-exhaustive match so a new
+/// variant cannot be added without updating this list.
+#[allow(clippy::too_many_lines)]
+fn all_exit_codes() -> Vec<ExitCode> {
+    // The exhaustive match forces a compile error if a variant is added/removed.
+    fn exit_code_identity(e: ExitCode) -> ExitCode {
+        match e {
+            ExitCode::Success
+            | ExitCode::InternalError
+            | ExitCode::UsageError
+            | ExitCode::PreflightFailure
+            | ExitCode::TaskUnsuccessful
+            | ExitCode::BudgetHalt
+            | ExitCode::RegressionGateFailure
+            | ExitCode::VerificationFailure
+            | ExitCode::CalibrationOptimistic
+            | ExitCode::ReplayPromptDrift
+            | ExitCode::ReplayResponseExhausted
+            | ExitCode::SystemicHalt
+            | ExitCode::AgentStagnation
+            | ExitCode::EnvPreviewWarning
+            | ExitCode::SkillsPreviewWarning
+            | ExitCode::ResumeAlreadyTerminal
+            | ExitCode::ResumeManifestMissing
+            | ExitCode::ResumeInvalidPrefix
+            | ExitCode::BisectBudgetExhausted
+            | ExitCode::BisectSchemaBreak
+            | ExitCode::AuditFailure
+            | ExitCode::EvalGamingGateFailure
+            | ExitCode::ArtifactIntegrityViolation
+            | ExitCode::ScriptabilityCheckFailure
+            | ExitCode::FeatureUnavailable
+            | ExitCode::RedactCheckStaleLiterals
+            | ExitCode::RedactCheckStrictFail
+            | ExitCode::SloRuleFailure
+            | ExitCode::ContinueNonTerminal
+            | ExitCode::ApplyCheckFailed
+            | ExitCode::ApplyRedactedRefused
+            | ExitCode::ApplyDirtyTreeRefused
+            | ExitCode::RedactAuditFindings
+            | ExitCode::RedactAuditScanError
+            | ExitCode::GithubIssueMissingToken
+            | ExitCode::GithubIssueNotFound
+            | ExitCode::GithubIssueRateLimited
+            | ExitCode::InjectionAuditHits
+            | ExitCode::InjectionAuditScanError
+            | ExitCode::StabilityGateFailure
+            | ExitCode::DatasetVerifyMismatch
+            | ExitCode::BestOfAllFailed
+            | ExitCode::ConfigOverrideWarning
+            | ExitCode::EvalParityGateFailure
+            | ExitCode::UtilizationGateFailure
+            | ExitCode::FsAuditFindings
+            | ExitCode::FsAuditScanError
+            | ExitCode::ArtifactCheckFailure
+            | ExitCode::HostNotReady
+            | ExitCode::Interrupted
+            | ExitCode::Killed => e,
+        }
+    }
+
+    [
+        ExitCode::Success,
+        ExitCode::InternalError,
+        ExitCode::UsageError,
+        ExitCode::PreflightFailure,
+        ExitCode::TaskUnsuccessful,
+        ExitCode::BudgetHalt,
+        ExitCode::RegressionGateFailure,
+        ExitCode::VerificationFailure,
+        ExitCode::CalibrationOptimistic,
+        ExitCode::ReplayPromptDrift,
+        ExitCode::ReplayResponseExhausted,
+        ExitCode::SystemicHalt,
+        ExitCode::AgentStagnation,
+        ExitCode::EnvPreviewWarning,
+        ExitCode::SkillsPreviewWarning,
+        ExitCode::ResumeAlreadyTerminal,
+        ExitCode::ResumeManifestMissing,
+        ExitCode::ResumeInvalidPrefix,
+        ExitCode::BisectBudgetExhausted,
+        ExitCode::BisectSchemaBreak,
+        ExitCode::AuditFailure,
+        ExitCode::EvalGamingGateFailure,
+        ExitCode::ArtifactIntegrityViolation,
+        ExitCode::ScriptabilityCheckFailure,
+        ExitCode::FeatureUnavailable,
+        ExitCode::RedactCheckStaleLiterals,
+        ExitCode::RedactCheckStrictFail,
+        ExitCode::SloRuleFailure,
+        ExitCode::ContinueNonTerminal,
+        ExitCode::ApplyCheckFailed,
+        ExitCode::ApplyRedactedRefused,
+        ExitCode::ApplyDirtyTreeRefused,
+        ExitCode::RedactAuditFindings,
+        ExitCode::RedactAuditScanError,
+        ExitCode::GithubIssueMissingToken,
+        ExitCode::GithubIssueNotFound,
+        ExitCode::GithubIssueRateLimited,
+        ExitCode::InjectionAuditHits,
+        ExitCode::InjectionAuditScanError,
+        ExitCode::StabilityGateFailure,
+        ExitCode::DatasetVerifyMismatch,
+        ExitCode::BestOfAllFailed,
+        ExitCode::ConfigOverrideWarning,
+        ExitCode::EvalParityGateFailure,
+        ExitCode::UtilizationGateFailure,
+        ExitCode::FsAuditFindings,
+        ExitCode::FsAuditScanError,
+        ExitCode::ArtifactCheckFailure,
+        ExitCode::HostNotReady,
+        ExitCode::Interrupted,
+        ExitCode::Killed,
+    ]
+    .into_iter()
+    .map(exit_code_identity)
+    .collect()
+}
+
+/// Every `FailureCategory` variant with its serde snake_case wire name; the
+/// exhaustive match forces a compile error if a variant is added/removed.
+fn all_failure_categories() -> Vec<(FailureCategory, &'static str)> {
+    fn failure_serde(c: FailureCategory) -> &'static str {
+        match c {
+            FailureCategory::EnvSetup => "env_setup",
+            FailureCategory::ModelApi => "model_api",
+            FailureCategory::ModelParse => "model_parse",
+            FailureCategory::StepLimit => "step_limit",
+            FailureCategory::CostLimit => "cost_limit",
+            FailureCategory::BudgetExhausted => "budget_exhausted",
+            FailureCategory::WallclockTimeout => "wallclock_timeout",
+            FailureCategory::AgentInternal => "agent_internal",
+            FailureCategory::PatchApplyInvalid => "patch_apply_invalid",
+            FailureCategory::PatchEmpty => "patch_empty",
+            FailureCategory::SecretLeakDetected => "secret_leak_detected",
+            FailureCategory::AgentStagnation => "agent_stagnation",
+            FailureCategory::HistoryCompactionFailed => "history_compaction_failed",
+            FailureCategory::ReadOnlyViolation => "read_only_violation",
+            FailureCategory::Unknown => "unknown",
+        }
+    }
+
+    [
+        FailureCategory::EnvSetup,
+        FailureCategory::ModelApi,
+        FailureCategory::ModelParse,
+        FailureCategory::StepLimit,
+        FailureCategory::CostLimit,
+        FailureCategory::BudgetExhausted,
+        FailureCategory::WallclockTimeout,
+        FailureCategory::AgentInternal,
+        FailureCategory::PatchApplyInvalid,
+        FailureCategory::PatchEmpty,
+        FailureCategory::SecretLeakDetected,
+        FailureCategory::AgentStagnation,
+        FailureCategory::HistoryCompactionFailed,
+        FailureCategory::ReadOnlyViolation,
+        FailureCategory::Unknown,
+    ]
+    .into_iter()
+    .map(|c| (c, failure_serde(c)))
+    .collect()
+}
+
+/// Parse `(code, outcome_class)` rows from the markdown table in
+/// `docs/exit-codes.md` (lines shaped like `| 7 | \`verification_failure\` | … |`).
+fn parse_exit_code_doc_rows() -> Vec<(i32, String)> {
+    let doc = std::fs::read_to_string("docs/exit-codes.md").unwrap();
+    let mut rows = Vec::new();
+    for line in doc.lines() {
+        let line = line.trim();
+        if !line.starts_with('|') {
+            continue;
+        }
+        let cells: Vec<&str> = line.trim_matches('|').split('|').map(str::trim).collect();
+        if cells.len() < 3 {
+            continue;
+        }
+        // First cell must be a bare integer (skips the header and separator rows).
+        let Ok(code) = cells[0].parse::<i32>() else {
+            continue;
+        };
+        let class = cells[1].trim_matches('`').to_string();
+        rows.push((code, class));
+    }
+    rows
+}
+
+// ── AC: every ExitCode variant is resolvable by code and by class ────────────
+
+#[test]
+fn every_exit_code_variant_is_resolvable() {
+    for ec in all_exit_codes() {
+        let code = ec.as_i32();
+        let class = ec.outcome_class();
+
+        let by_int = explain::resolve(&code.to_string()).unwrap_or_else(|| {
+            panic!("explain cannot resolve exit code {code} ({class}); add a registry entry")
+        });
+        assert_eq!(by_int.code, Some(code), "code mismatch for {class}");
+        assert_eq!(
+            by_int.outcome_class, class,
+            "class mismatch for code {code}"
+        );
+        assert!(
+            by_int.families.contains(&Family::ExitCode),
+            "{class} must be tagged Family::ExitCode"
+        );
+
+        let by_name = explain::resolve(class)
+            .unwrap_or_else(|| panic!("explain cannot resolve outcome class '{class}'"));
+        assert_eq!(
+            by_name.code,
+            Some(code),
+            "name lookup code mismatch for {class}"
+        );
+    }
+}
+
+// ── AC: docs/exit-codes.md ⇄ registry are bidirectionally in sync ────────────
+
+#[test]
+fn every_doc_exit_code_row_is_resolvable() {
+    for (code, class) in parse_exit_code_doc_rows() {
+        let entry = explain::resolve(&code.to_string())
+            .unwrap_or_else(|| panic!("docs/exit-codes.md row {code} ({class}) not in explain"));
+        assert_eq!(entry.outcome_class, class, "class drift for code {code}");
+    }
+}
+
+#[test]
+fn every_registry_exit_code_appears_in_docs() {
+    let doc_rows = parse_exit_code_doc_rows();
+    for entry in explain::entries() {
+        if !entry.families.contains(&Family::ExitCode) {
+            continue;
+        }
+        let code = entry
+            .code
+            .expect("exit-code entry must carry an integer code");
+        let found = doc_rows
+            .iter()
+            .any(|(c, class)| *c == code && class == entry.outcome_class);
+        assert!(
+            found,
+            "explain entry {code} ({}) has no matching row in docs/exit-codes.md",
+            entry.outcome_class
+        );
+    }
+}
+
+// ── AC: every FailureCategory variant is resolvable (snake + Pascal, ci) ─────
+
+#[test]
+fn every_failure_category_variant_is_resolvable() {
+    for (cat, wire) in all_failure_categories() {
+        let by_snake = explain::resolve(wire)
+            .unwrap_or_else(|| panic!("explain cannot resolve failure category '{wire}'"));
+        assert!(
+            by_snake.families.contains(&Family::FailureCategory),
+            "{wire} must be tagged Family::FailureCategory"
+        );
+        assert_eq!(by_snake.outcome_class, wire);
+
+        // PascalCase form (the enum's display form), case-insensitively.
+        let pascal = format!("{cat:?}");
+        let by_pascal = explain::resolve(&pascal)
+            .unwrap_or_else(|| panic!("explain cannot resolve '{pascal}' (Pascal form of {wire})"));
+        assert_eq!(by_pascal.outcome_class, wire);
+
+        // Upper-case snake form must also resolve (case-insensitive).
+        let by_upper = explain::resolve(&wire.to_uppercase())
+            .unwrap_or_else(|| panic!("explain cannot resolve '{}' ", wire.to_uppercase()));
+        assert_eq!(by_upper.outcome_class, wire);
+    }
+}
+
+#[test]
+fn every_registry_failure_category_is_a_real_variant() {
+    let wire_names: Vec<&'static str> = all_failure_categories().iter().map(|(_, w)| *w).collect();
+    for entry in explain::entries() {
+        if !entry.families.contains(&Family::FailureCategory) {
+            continue;
+        }
+        assert!(
+            wire_names.contains(&entry.outcome_class),
+            "explain failure-category entry '{}' is not a FailureCategory variant",
+            entry.outcome_class
+        );
+    }
+}
+
+// ── AC: every entry carries meaning + remediation + docs_ref ─────────────────
+
+#[test]
+fn every_entry_has_meaning_remediation_and_docs_ref() {
+    for entry in explain::entries() {
+        assert!(
+            !entry.meaning.trim().is_empty(),
+            "{} has empty meaning",
+            entry.outcome_class
+        );
+        assert!(
+            !entry.remediation.trim().is_empty(),
+            "{} has empty remediation",
+            entry.outcome_class
+        );
+        assert!(
+            !entry.docs_ref.trim().is_empty(),
+            "{} has empty docs_ref",
+            entry.outcome_class
+        );
+    }
+}
+
+#[test]
+fn registry_has_no_duplicate_outcome_classes() {
+    let mut seen = std::collections::HashSet::new();
+    for entry in explain::entries() {
+        assert!(
+            seen.insert(entry.outcome_class),
+            "duplicate explain entry for '{}'",
+            entry.outcome_class
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements a new `max explain` subcommand that provides offline, zero-cost lookup of exit codes, outcome classes, and failure categories to their documented meanings and remediation hints. This mirrors the behavior of `rustc --explain E0382` and addresses issue #535.

## Key Changes

- **New `explain` module** (`src/explain.rs`): Compiled-in registry containing 65 entries (51 exit-code classes + 15 failure categories, with 1 merged collision for `agent_stagnation`). Each entry includes:
  - Exit code (if applicable)
  - Outcome class name (snake_case wire format)
  - Taxonomy family(ies) (ExitCode, FailureCategory, or both)
  - One-line meaning
  - Remediation guidance
  - Documentation reference

- **CLI integration** (`src/cli/explain.rs`): Command handler supporting:
  - Selector resolution by exit code integer, outcome class name, or failure category (case-insensitive)
  - Text output with formatted entry details
  - JSON output with stable `1.0` schema version
  - Built-in index when no selector provided
  - Usage error (exit 2) for unknown selectors

- **Argument parsing** (`src/cli/args.rs`): New `ExplainCmd` struct with optional selector and `--format` flag

- **Command registration** (`src/cli/mod.rs`, `src/cli/catalog.rs`): Registered `explain` as a free, preflight-stage command

- **Comprehensive drift tests** (`tests/explain_drift.rs`): Bidirectional validation ensuring:
  - Every `ExitCode` variant has a matching registry entry
  - Every `FailureCategory` variant has a matching registry entry
  - All entries in `docs/exit-codes.md` are resolvable
  - All registry entries appear in documentation
  - Every entry carries meaning, remediation, and docs reference
  - Compile-time exhaustive matches prevent adding variants without updating the registry

- **Integration tests** (`tests/explain_cmd.rs`): Validates:
  - Exit code and outcome class resolution
  - Case-insensitive matching
  - Failure category resolution (snake_case and PascalCase)
  - JSON schema stability
  - Unknown selector handling
  - Offline operation (no API keys required)

## Notable Implementation Details

- The registry is the single source of truth; `explain_drift.rs` enforces bidirectional sync with `ExitCode`, `FailureCategory`, and `docs/exit-codes.md` at compile/test time, making contract drift structurally impossible
- The `agent_stagnation` entry is tagged with both `Family::ExitCode` and `Family::FailureCategory` to represent the cross-taxonomy collision (exit code 12 and failure category)
- Selector resolution is case-insensitive and supports multiple formats (integer codes, snake_case names, PascalCase enum forms)
- The command requires no environment variables, API keys, or network access—purely offline lookup

https://claude.ai/code/session_01XCvnRWNBG5V7PU7QqHxFxB