### PR TITLE
⚒️ Forge: Replace unwrap with safe guard clauses in docker tests

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected image name in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"


### PR DESCRIPTION
🚮 Smell: `unwrap()` calls on `Option` types in `src/env/docker.rs` tests which triggered `clippy::unwrap_used` lint warnings and lacked explicit panic messages.
✨ Solution: Replaced the `unwrap()` calls with explicit `let Some(x) = y else { panic!(...) }` guard clauses.
🧼 Benefit: Improves readability and robustness. The tests now explicitly declare what they are waiting for, and fail with descriptive messages instead of silent unwrap panics, fully satisfying Clippy rules without suppressing them.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [15937516918778464575](https://jules.google.com/task/15937516918778464575) started by @madmax983*