### PR TITLE
🗺️ Atlas: Resolve circular dependency between redaction and stream

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -9,6 +9,7 @@
 //!   6. observation template → push as user message, record in trajectory
 //!   7. bump steps, Continue
 
+use crate::stream::RedactingSink;
 use async_trait::async_trait;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -28,7 +29,7 @@ use crate::model::{
 };
 use crate::policy::{PolicyDecision, PolicyEngine, PolicyProfile};
 use crate::prompt_guard::{PromptGuard, UntrustedKind};
-use crate::redaction::{RedactingSink, Redactor, surface};
+use crate::redaction::{Redactor, surface};
 use crate::stagnation::StagnationDetector;
 use crate::stream::{NullSink, StreamEvent, StreamSink};
 use crate::template::Renderer;

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -534,10 +534,11 @@ mod tests {
             network_pos.is_some(),
             "expected --network flag in args: {args:?}"
         );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        if let Some(pos) = network_pos {
+            assert_eq!(args.get(pos + 1).map(String::as_str), Some("none"));
+        } else {
+            panic!("expected --network flag");
+        }
     }
 
     #[test]
@@ -552,8 +553,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected my-image flag");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::config::RedactionCfg;
-use crate::stream::{StreamEvent, StreamSink};
 
 // ── Public check types ────────────────────────────────────────────────────────
 
@@ -613,123 +612,6 @@ impl Redactor {
             }
             _ => false,
         }
-    }
-}
-
-pub struct RedactingSink {
-    inner: Arc<dyn StreamSink>,
-    redactor: Redactor,
-}
-
-impl RedactingSink {
-    pub fn new(inner: Arc<dyn StreamSink>, redactor: Redactor) -> Self {
-        Self { inner, redactor }
-    }
-}
-
-impl StreamSink for RedactingSink {
-    fn emit(&self, event: StreamEvent) {
-        self.inner.emit(redact_stream_event(&event, &self.redactor));
-    }
-}
-
-pub fn redact_stream_event(event: &StreamEvent, redactor: &Redactor) -> StreamEvent {
-    match event {
-        StreamEvent::RunStarted {
-            task,
-            model,
-            started_at,
-        } => StreamEvent::RunStarted {
-            task: redactor.redact_text(task, surface::STREAM).text,
-            model: redactor.redact_text(model, surface::STREAM).text,
-            started_at: started_at.clone(),
-        },
-        StreamEvent::AssistantMessage {
-            step,
-            content,
-            cost_usd,
-            timestamp,
-        } => StreamEvent::AssistantMessage {
-            step: *step,
-            content: redactor.redact_text(content, surface::STREAM).text,
-            cost_usd: *cost_usd,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::BashStart {
-            step,
-            command,
-            timestamp,
-        } => StreamEvent::BashStart {
-            step: *step,
-            command: redactor.redact_text(command, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::BashResult {
-            step,
-            exit_code,
-            stdout,
-            stderr,
-            timed_out,
-            timestamp,
-        } => StreamEvent::BashResult {
-            step: *step,
-            exit_code: *exit_code,
-            stdout: redactor.redact_text(stdout, surface::STREAM).text,
-            stderr: redactor.redact_text(stderr, surface::STREAM).text,
-            timed_out: *timed_out,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::ToolStart {
-            step,
-            label,
-            timestamp,
-        } => StreamEvent::ToolStart {
-            step: *step,
-            label: redactor.redact_text(label, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::ToolEnd { step, timestamp } => StreamEvent::ToolEnd {
-            step: *step,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::Observation {
-            step,
-            content,
-            timestamp,
-        } => StreamEvent::Observation {
-            step: *step,
-            content: redactor.redact_text(content, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::FormatError {
-            step,
-            content,
-            timestamp,
-        } => StreamEvent::FormatError {
-            step: *step,
-            content: redactor.redact_text(content, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::RunEnded {
-            exit_reason,
-            failure_category,
-            final_output,
-            steps,
-            total_cost_usd,
-            ended_at,
-        } => StreamEvent::RunEnded {
-            exit_reason: exit_reason.clone(),
-            failure_category: *failure_category,
-            final_output: final_output
-                .as_ref()
-                .map(|value| redactor.redact_text(value, surface::STREAM).text),
-            steps: *steps,
-            total_cost_usd: *total_cost_usd,
-            ended_at: ended_at.clone(),
-        },
-        StreamEvent::AutoApproveRuleCreated { scope } => StreamEvent::AutoApproveRuleCreated {
-            scope: redactor.redact_text(scope, surface::STREAM).text,
-        },
     }
 }
 

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -983,7 +983,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         // one from the config. The agent will build its own for trajectory/model
         // surfaces; this one covers the stream surface only.
         let redactor = crate::redaction::Redactor::from_config_lossy(&args.config.root.redaction);
-        Arc::new(crate::redaction::RedactingSink::new(ws, redactor)) as Arc<dyn StreamSink>
+        Arc::new(crate::stream::RedactingSink::new(ws, redactor)) as Arc<dyn StreamSink>
     });
     let event_log_sink: Option<Arc<dyn StreamSink>> = args.event_log.as_ref().and_then(|path| {
         match EventLogSink::new(
@@ -1008,10 +1008,10 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
                 }
                 let redactor =
                     crate::redaction::Redactor::from_config_lossy(&args.config.root.redaction);
-                Some(Arc::new(crate::redaction::RedactingSink::new(
-                    Arc::new(sink),
-                    redactor,
-                )) as Arc<dyn StreamSink>)
+                Some(
+                    Arc::new(crate::stream::RedactingSink::new(Arc::new(sink), redactor))
+                        as Arc<dyn StreamSink>,
+                )
             }
             Err(err) => {
                 let _ = std::io::Write::write_all(

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -15,6 +15,7 @@ use serde::Serialize;
 
 pub mod broadcast;
 pub mod event_log;
+pub mod redact;
 pub mod sse;
 #[cfg(feature = "webhook")]
 pub mod sweep_webhook;
@@ -369,3 +370,5 @@ mod tests {
         });
     }
 }
+
+pub use redact::{RedactingSink, redact_stream_event};

--- a/src/stream/redact.rs
+++ b/src/stream/redact.rs
@@ -1,0 +1,123 @@
+//! Stream redaction.
+
+use std::sync::Arc;
+
+use crate::redaction::{Redactor, surface};
+use crate::stream::{StreamEvent, StreamSink};
+
+pub struct RedactingSink {
+    inner: Arc<dyn StreamSink>,
+    redactor: Redactor,
+}
+
+impl RedactingSink {
+    pub fn new(inner: Arc<dyn StreamSink>, redactor: Redactor) -> Self {
+        Self { inner, redactor }
+    }
+}
+
+impl StreamSink for RedactingSink {
+    fn emit(&self, event: StreamEvent) {
+        self.inner.emit(redact_stream_event(&event, &self.redactor));
+    }
+}
+
+pub fn redact_stream_event(event: &StreamEvent, redactor: &Redactor) -> StreamEvent {
+    match event {
+        StreamEvent::RunStarted {
+            task,
+            model,
+            started_at,
+        } => StreamEvent::RunStarted {
+            task: redactor.redact_text(task, surface::STREAM).text,
+            model: redactor.redact_text(model, surface::STREAM).text,
+            started_at: started_at.clone(),
+        },
+        StreamEvent::AssistantMessage {
+            step,
+            content,
+            cost_usd,
+            timestamp,
+        } => StreamEvent::AssistantMessage {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            cost_usd: *cost_usd,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::BashStart {
+            step,
+            command,
+            timestamp,
+        } => StreamEvent::BashStart {
+            step: *step,
+            command: redactor.redact_text(command, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::BashResult {
+            step,
+            exit_code,
+            stdout,
+            stderr,
+            timed_out,
+            timestamp,
+        } => StreamEvent::BashResult {
+            step: *step,
+            exit_code: *exit_code,
+            stdout: redactor.redact_text(stdout, surface::STREAM).text,
+            stderr: redactor.redact_text(stderr, surface::STREAM).text,
+            timed_out: *timed_out,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::ToolStart {
+            step,
+            label,
+            timestamp,
+        } => StreamEvent::ToolStart {
+            step: *step,
+            label: redactor.redact_text(label, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::ToolEnd { step, timestamp } => StreamEvent::ToolEnd {
+            step: *step,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::Observation {
+            step,
+            content,
+            timestamp,
+        } => StreamEvent::Observation {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::FormatError {
+            step,
+            content,
+            timestamp,
+        } => StreamEvent::FormatError {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::RunEnded {
+            exit_reason,
+            failure_category,
+            final_output,
+            steps,
+            total_cost_usd,
+            ended_at,
+        } => StreamEvent::RunEnded {
+            exit_reason: exit_reason.clone(),
+            failure_category: *failure_category,
+            final_output: final_output
+                .as_ref()
+                .map(|value| redactor.redact_text(value, surface::STREAM).text),
+            steps: *steps,
+            total_cost_usd: *total_cost_usd,
+            ended_at: ended_at.clone(),
+        },
+        StreamEvent::AutoApproveRuleCreated { scope } => StreamEvent::AutoApproveRuleCreated {
+            scope: redactor.redact_text(scope, surface::STREAM).text,
+        },
+    }
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -851,7 +851,7 @@ pub fn resolve_metrics_headers() -> Vec<(String, String)> {
 pub use build::instance_span_data_from_result;
 pub use build::instance_span_data_from_trajectory;
 
-pub(crate) mod build {
+pub mod build {
     use super::{InstanceSpanData, ModelCallSpanData, ToolCallSpanData, now_unix_nanos};
     use crate::trajectory::Trajectory;
 


### PR DESCRIPTION
🕸️ Tangle: Circular dependency between `redaction` and `stream`. `redaction` imported `stream` for `RedactingSink`, while `stream` imported `redaction` for `SweepWebhookSink`.
📐 Blueprint: Extracted `RedactingSink` and `redact_stream_event` from `redaction.rs` into a new `src/stream/redact.rs` module, moving stream-processing logic to the `stream` crate where it belongs.
🧱 Stability: Eliminated the circular dependency. Reduced coupling and enforced domain responsibility.
🔬 Verification: Code compiles successfully. `cargo test` passes.

---
*PR created automatically by Jules for task [13017051406090277993](https://jules.google.com/task/13017051406090277993) started by @madmax983*