### PR TITLE
🎨 Mosaic: UI Polish for Agent CLI Commands

### DIFF
--- a/src/run/agent_profile.rs
+++ b/src/run/agent_profile.rs
@@ -8,6 +8,7 @@ use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 
 use crate::artifact::{ArtifactKind, ArtifactSchemaVersion};
 use crate::error::Error;
@@ -278,44 +279,34 @@ pub fn format_text(report: &AgentProfileReport) -> String {
         "\n── Stage Breakdown ──────────────────────────────────────"
     );
     let sb = &report.stage_breakdown;
-    let _ = writeln!(out, "  {:<10} {:>10}   {:>5}", "stage", "ms", "share");
-    let _ = writeln!(out, "  {}", "─".repeat(30));
-    let _ = writeln!(
-        out,
-        "  {:<10} {:>10}   {:>5}",
-        "model",
-        fmt_ms(sb.model_ms),
-        fmt_pct(sb.model_pct)
-    );
-    let _ = writeln!(
-        out,
-        "  {:<10} {:>10}   {:>5}",
-        "tool",
-        fmt_ms(sb.tool_ms),
-        fmt_pct(sb.tool_pct)
-    );
-    let _ = writeln!(
-        out,
-        "  {:<10} {:>10}   {:>5}",
-        "harness",
-        fmt_ms(sb.harness_ms),
-        fmt_pct(sb.harness_pct)
-    );
+    let mut table_sb = Table::new();
+    table_sb
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec!["stage", "ms", "share"]);
+    table_sb.add_row(vec!["model".to_string(), fmt_ms(sb.model_ms), fmt_pct(sb.model_pct)]);
+    table_sb.add_row(vec!["tool".to_string(), fmt_ms(sb.tool_ms), fmt_pct(sb.tool_pct)]);
+    table_sb.add_row(vec!["harness".to_string(), fmt_ms(sb.harness_ms), fmt_pct(sb.harness_pct)]);
+    let _ = write!(out, "{table_sb}\n");
 
     // Action mix
     let _ = writeln!(
         out,
         "\n── Action Mix ───────────────────────────────────────────"
     );
-    let _ = writeln!(out, "  {:<10} {:>6}   {:>6}", "class", "count", "share");
-    let _ = writeln!(out, "  {}", "─".repeat(28));
+    let mut table_mix = Table::new();
+    table_mix
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec!["class", "count", "share"]);
     for (name, entry) in &report.action_mix {
-        let _ = writeln!(
-            out,
-            "  {:<10} {:>6}   {:>5.1}%",
-            name, entry.count, entry.share_pct
-        );
+        table_mix.add_row(vec![
+            name.to_owned(),
+            entry.count.to_string(),
+            format!("{:.1}%", entry.share_pct)
+        ]);
     }
+    let _ = write!(out, "{table_mix}\n");
 
     out
 }

--- a/src/run/agent_runs.rs
+++ b/src/run/agent_runs.rs
@@ -9,6 +9,7 @@ use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 
 use crate::artifact::{ArtifactKind, ArtifactSchemaVersion};
 use crate::error::Error;
@@ -371,13 +372,19 @@ pub fn format_text(report: &AgentRunsReport) -> String {
         return out;
     }
 
-    // Header row — outcome needs ≥20 chars (step_limit_reached=18), failure_category ≥26 (history_compaction_failed=25)
-    let _ = writeln!(
-        out,
-        "{:<42} {:<20} {:<26} {:>6} {:>10} {:>9} model",
-        "task", "outcome", "failure_category", "steps", "duration", "cost_usd"
-    );
-    let _ = writeln!(out, "{}", "─".repeat(126));
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec![
+            "task",
+            "outcome",
+            "failure_category",
+            "steps",
+            "duration",
+            "cost_usd",
+            "model",
+        ]);
 
     for row in &report.rows {
         let task_raw = row
@@ -399,15 +406,20 @@ pub fn format_text(report: &AgentRunsReport) -> String {
             .map_or_else(|| "-".to_owned(), |c| format!("${c:.4}"));
         let model = row.model.as_deref().unwrap_or("");
 
-        let _ = writeln!(
-            out,
-            "{task:<42} {outcome:<20} {failure:<26} {steps:>6} {dur:>10} {cost:>9} {model}"
-        );
+        table.add_row(vec![
+            task,
+            outcome.to_owned(),
+            failure.to_owned(),
+            steps,
+            dur,
+            cost,
+            model.to_owned(),
+        ]);
     }
 
-    // Footer
-    let _ = writeln!(out, "{}", "─".repeat(126));
+    let _ = writeln!(out, "{table}");
 
+    // Footer
     // Outcome breakdown
     let outcome_parts: Vec<String> = report
         .footer

--- a/src/run/policy_check.rs
+++ b/src/run/policy_check.rs
@@ -8,6 +8,7 @@ use std::io::Read as _;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 
 use crate::artifact::ArtifactSchemaVersion;
 use crate::config::Config;
@@ -260,53 +261,22 @@ pub fn format_text(output: &PolicyCheckOutput) -> String {
         return out;
     }
 
-    let cmd_width = output
-        .verdicts
-        .iter()
-        .map(|v| v.command.len())
-        .max()
-        .unwrap_or(7)
-        .max(7); // min width: "command"
-    let rule_width = output
-        .verdicts
-        .iter()
-        .map(|v| v.matching_rule.len())
-        .max()
-        .unwrap_or(12)
-        .max(12); // min width: "matching_rule"
-
     let mut out = String::new();
-    let _ = writeln!(
-        out,
-        "{:<width$}  {:<8}  {:<rule_w$}  profile",
-        "command",
-        "verdict",
-        "matching_rule",
-        width = cmd_width,
-        rule_w = rule_width,
-    );
-    let _ = writeln!(
-        out,
-        "{:-<width$}  {:-<8}  {:-<rule_w$}  -------",
-        "",
-        "",
-        "",
-        width = cmd_width,
-        rule_w = rule_width,
-    );
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec!["command", "verdict", "matching_rule", "profile"]);
 
     for v in &output.verdicts {
-        let _ = writeln!(
-            out,
-            "{:<width$}  {:<8}  {:<rule_w$}  {}",
-            v.command,
-            v.verdict.as_str(),
-            v.matching_rule,
-            v.profile,
-            width = cmd_width,
-            rule_w = rule_width,
-        );
+        table.add_row(vec![
+            v.command.clone(),
+            v.verdict.as_str().to_owned(),
+            v.matching_rule.clone(),
+            v.profile.clone(),
+        ]);
     }
+    let _ = write!(out, "{table}\n");
 
     if !output.mismatches.is_empty() {
         out.push('\n');


### PR DESCRIPTION
🖌️ **Before**: The CLI text output for commands like `max agent runs`, `max agent profile`, and `max agent policy-check` printed raw string lines aligned using string paddings and manual dividers. Although functional, it lacked semantic structure, rounded borders, and did not align with a visual dashboard philosophy.

✨ **After**: Those commands now utilize the `comfy-table` crate using `presets::UTF8_FULL` and `modifiers::UTF8_ROUND_CORNERS`. The output matches the beautiful, fully structured interface patterns demonstrated by commands like `max explain` and `max catalog`, offering true tables with borders and cell boundaries.

🖼️ **Visuals**:
* `max agent profile`: Output now renders two clear tables ("Stage Breakdown" and "Action Mix") bordered with rounded edges, replacing the simple space-aligned lines.
* `max agent runs`: Replaces the dash-padded list view with an explicit seven-column table layout, keeping the final stats block underneath.
* `max agent policy-check`: Employs a table for the `command | verdict | matching_rule | profile` headers. Rejects simple padding for robust table cell bounds.

---
*PR created automatically by Jules for task [9503500568215059353](https://jules.google.com/task/9503500568215059353) started by @madmax983*