### PR TITLE
🎻 Bard: Fix intra-doc links and redundant targets

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -527,6 +527,7 @@ mod tests {
     // ── Network mode RED-phase tests ─────────────────────────────────────────
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
@@ -550,6 +551,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network").unwrap();

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -471,7 +471,7 @@ impl Redactor {
 
     /// Run redaction and return per-match annotations for operator verification.
     ///
-    /// Unlike [`redact_text`], this method does not update surface-level telemetry
+    /// Unlike [`Self::redact_text`], this method does not update surface-level telemetry
     /// counts and does not require a surface label. It is designed for the
     /// `agent redact-check` preflight command.
     #[must_use]

--- a/src/run/claude_driver.rs
+++ b/src/run/claude_driver.rs
@@ -405,10 +405,10 @@ fn record_claude_config(agent: &mut DefaultAgent, cwd: &Path, isolated: bool) {
 ///   OAuth/keychain auth, ambient `.claude` discovery (hooks, skills, plugins,
 ///   MCP, memory, `CLAUDE.md`), native session persistence, and the team's own
 ///   permission settings. The harness *records* the discovered config (see
-///   [`discover_claude_config`]) into the trajectory so the run is auditable
+///   `discover_claude_config`) into the trajectory so the run is auditable
 ///   without being sterilized. This is the enterprise-auditing case.
 /// - `true` (*isolation*): pass `--bare` (skip ambient discovery), `--tools`
-///   (restrict to [`ALLOWED_TOOLS`]), and `--no-session-persistence` for a
+///   (restrict to `ALLOWED_TOOLS`), and `--no-session-persistence` for a
 ///   reproducible measurement run. Note: `--bare` forces API-key-only auth, so
 ///   OAuth/keychain logins do not apply in this mode.
 #[allow(clippy::too_many_lines)]

--- a/src/run/codex_driver.rs
+++ b/src/run/codex_driver.rs
@@ -3,7 +3,7 @@
 //! Similar to `claude_driver.rs`, this module lets an operator point the *same*
 //! run machinery at the OpenAI Codex CLI instead of the built-in bash-first loop.
 //! `codex` runs in `--full-auto --json` mode; we read its newline-delimited JSON
-//! stream and translate each event into the harness [`Trajectory`] format so that
+//! stream and translate each event into the harness [`Trajectory`](crate::trajectory::Trajectory) format so that
 //! patch capture, verification, `bench inspect`, and evaluation all keep working
 //! unchanged.
 //!

--- a/src/run/contamination_check.rs
+++ b/src/run/contamination_check.rs
@@ -6,9 +6,9 @@
 //!
 //! | Signal | Description | Range |
 //! |--------|-------------|-------|
-//! | `edit_before_read_ratio` | Fraction of edited files never read before patching | [0,1] |
-//! | `patch_similarity_to_gold` | Normalised similarity between agent patch and gold patch | [0,1] |
-//! | `time_to_first_edit` | Suspicion from early first edit (step 0 → 1.0, last step → 0.0) | [0,1] |
+//! | `edit_before_read_ratio` | Fraction of edited files never read before patching | \[0,1\] |
+//! | `patch_similarity_to_gold` | Normalised similarity between agent patch and gold patch | \[0,1\] |
+//! | `time_to_first_edit` | Suspicion from early first edit (step 0 → 1.0, last step → 0.0) | \[0,1\] |
 //! | `verbatim_recall` | Whether agent message contains ≥ N tokens from gold patch surface | {0,1} |
 //!
 //! # Risk tiers

--- a/src/run/redact_audit.rs
+++ b/src/run/redact_audit.rs
@@ -1,6 +1,6 @@
 //! `agent redact-audit <dir>` — post-hoc secret-leak detection for sweep artifacts.
 //!
-//! Issue #342. The runtime [`Redactor`](crate::redaction::Redactor) masks secrets
+//! Issue #342. The runtime [`Redactor`] masks secrets
 //! *at write-time* and explicitly does not retroactively rewrite stored
 //! artifacts. Trajectories and sweep outputs are routinely shared (PRs, HTML
 //! exports, bundles), so a redaction-config bug or an unanticipated secret shape

--- a/src/run/ui.rs
+++ b/src/run/ui.rs
@@ -39,7 +39,7 @@ pub struct InstanceEntry {
     pub traj_path: PathBuf,
 }
 
-/// Arguments forwarded from the CLI to [`run`].
+/// Arguments forwarded from the CLI to `run`.
 pub struct UiArgs {
     pub sweep: PathBuf,
     pub port: u16,

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -6,7 +6,7 @@
 //! narrative document, complete with headers and code blocks.
 //!
 //! You can extend this module with new formats by implementing the [`crate::trajectory::export::TrajectoryExporter`] trait.
-//! Every new exporter MUST register in [`registry`] and MUST apply redaction via
+//! Every new exporter MUST register in `registry` and MUST apply redaction via
 //! [`crate::redaction::Redactor::default_enabled`] on [`crate::redaction::surface::EXPORT`] before emitting any output.
 //! See `docs/spec-export.md` for the full governing contract.
 


### PR DESCRIPTION
📖 Chapter: Fixed unresolved and broken links in `redaction`, `run`, and `trajectory`.
🔦 Insight: Replaced private and redundant links with valid backticks and escaped brackets in markdown tables. Fixed rustdoc warnings `unresolved link to redact_text`, `public documentation links to private item`, `redundant explicit link target`, etc. Fixed clippy `unwrap_used` warning in tests.
🧪 Example: Replaced `[`discover_claude_config`]` with `` `discover_claude_config` `` and `[0,1]` with `\[0,1\]`.
🖼️ Preview: Documentation is now clean of rustdoc warnings.

---
*PR created automatically by Jules for task [2567808919258064687](https://jules.google.com/task/2567808919258064687) started by @madmax983*