### PR TITLE
⚡ Bolt: Lazy cloning in hook/tool env generation

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -2883,18 +2883,65 @@ fn json_str(value: &serde_json::Value) -> String {
     }
 }
 
-fn capped_env_context(value: &serde_json::Value) -> serde_json::Value {
+/// Optimizes serialization of hook and tool environment payloads by lazily cloning the JSON tree.
+/// Reduces heavy `Vec` and `String` allocations across large megabyte-sized task histories.
+fn capped_env_context(value: &serde_json::Value) -> std::borrow::Cow<'_, serde_json::Value> {
     match value {
-        serde_json::Value::String(s) => serde_json::Value::String(truncate_for_hook_env(s)),
-        serde_json::Value::Array(values) => {
-            serde_json::Value::Array(values.iter().map(capped_env_context).collect())
+        serde_json::Value::String(s) => {
+            let truncated = truncate_for_hook_env(s);
+            if truncated.len() == s.len() {
+                std::borrow::Cow::Borrowed(value)
+            } else {
+                std::borrow::Cow::Owned(serde_json::Value::String(truncated))
+            }
         }
-        serde_json::Value::Object(map) => serde_json::Value::Object(
-            map.iter()
-                .map(|(key, value)| (key.clone(), capped_env_context(value)))
-                .collect(),
-        ),
-        other => other.clone(),
+        serde_json::Value::Array(values) => {
+            let mut new_values: Option<Vec<serde_json::Value>> = None;
+            for (i, v) in values.iter().enumerate() {
+                let capped = capped_env_context(v);
+                if let std::borrow::Cow::Owned(owned_v) = capped {
+                    if new_values.is_none() {
+                        let mut vec = Vec::with_capacity(values.len());
+                        vec.extend(values[..i].iter().cloned());
+                        new_values = Some(vec);
+                    }
+                    if let Some(vec) = new_values.as_mut() {
+                        vec.push(owned_v);
+                    }
+                } else if let Some(vec) = new_values.as_mut() {
+                    vec.push(v.clone());
+                }
+            }
+            if let Some(vec) = new_values {
+                std::borrow::Cow::Owned(serde_json::Value::Array(vec))
+            } else {
+                std::borrow::Cow::Borrowed(value)
+            }
+        }
+        serde_json::Value::Object(map) => {
+            let mut new_map: Option<Vec<(String, serde_json::Value)>> = None;
+            for (i, (k, v)) in map.iter().enumerate() {
+                let capped = capped_env_context(v);
+                if let std::borrow::Cow::Owned(owned_v) = capped {
+                    if new_map.is_none() {
+                        let mut vec = Vec::with_capacity(map.len());
+                        vec.extend(map.iter().take(i).map(|(k, v)| (k.clone(), v.clone())));
+                        new_map = Some(vec);
+                    }
+                    if let Some(vec) = new_map.as_mut() {
+                        vec.push((k.clone(), owned_v));
+                    }
+                } else if let Some(vec) = new_map.as_mut() {
+                    vec.push((k.clone(), v.clone()));
+                }
+            }
+            if let Some(vec) = new_map {
+                std::borrow::Cow::Owned(serde_json::Value::Object(vec.into_iter().collect()))
+            } else {
+                std::borrow::Cow::Borrowed(value)
+            }
+        }
+        _ => std::borrow::Cow::Borrowed(value),
     }
 }
 

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -534,10 +534,10 @@ mod tests {
             network_pos.is_some(),
             "expected --network flag in args: {args:?}"
         );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(pos) = network_pos else {
+            panic!("expected --network flag")
+        };
+        assert_eq!(args.get(pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +552,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag")
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected image name")
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"


### PR DESCRIPTION
💡 What: Refactored `capped_env_context` in `src/agent/default.rs` to return `std::borrow::Cow<'_, serde_json::Value>` instead of cloning the full tree into a new `serde_json::Value`.

🎯 Why: Deep cloning `serde_json::Value` allocates significantly on the heap for every key and element. Given this context contains massive histories (often megabytes), traversing and cloning everything just to enforce a string truncation hook limit was an unnecessary performance drag.

📊 Impact: Substantially reduces redundant heap allocations per turn (avoiding deep `Vec` and `String` allocations for unmodified values).

🔬 Measurement: Run bench tests simulating deep context nesting and tracing allocations, or observe reduced runtime allocations on LLM iteration calls.

---
*PR created automatically by Jules for task [16258907551800524863](https://jules.google.com/task/16258907551800524863) started by @madmax983*