### PR TITLE
🎨 Mosaic: UI Polish for CLI Catalog and Explain

### DIFF
--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -1,6 +1,6 @@
 use super::args::CatalogCmd;
 use crate::error::Error;
-use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+use comfy_table::{Attribute, Cell, Color, Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 use serde::Serialize;
 
 pub const STAGES: &[&str] = &["preflight", "run", "inspect", "analyze", "publish"];
@@ -569,10 +569,35 @@ pub fn run_catalog(cmd: CatalogCmd) -> Result<(), Error> {
     table
         .load_preset(UTF8_FULL)
         .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_header(["Command", "Summary", "Cost", "Stage"]);
+        .set_header([
+            Cell::new("Command").add_attribute(Attribute::Bold),
+            Cell::new("Summary").add_attribute(Attribute::Bold),
+            Cell::new("Cost").add_attribute(Attribute::Bold),
+            Cell::new("Stage").add_attribute(Attribute::Bold),
+        ]);
 
     for entry in &filtered {
-        table.add_row([entry.path, entry.summary, entry.cost_tier, entry.stage]);
+        let cost_cell = if entry.cost_tier == "free" {
+            Cell::new(entry.cost_tier).fg(Color::Green)
+        } else {
+            Cell::new(entry.cost_tier).fg(Color::Yellow)
+        };
+
+        let stage_cell = match entry.stage {
+            "preflight" => Cell::new(entry.stage).fg(Color::Cyan),
+            "run" => Cell::new(entry.stage).fg(Color::Magenta),
+            "inspect" => Cell::new(entry.stage).fg(Color::Blue),
+            "analyze" => Cell::new(entry.stage).fg(Color::DarkYellow),
+            "publish" => Cell::new(entry.stage).fg(Color::Green),
+            _ => Cell::new(entry.stage),
+        };
+
+        table.add_row([
+            Cell::new(entry.path).fg(Color::Cyan),
+            Cell::new(entry.summary),
+            cost_cell,
+            stage_cell,
+        ]);
     }
 
     println!("{table}");

--- a/src/cli/explain.rs
+++ b/src/cli/explain.rs
@@ -7,7 +7,8 @@
 use super::args::ExplainCmd;
 use crate::error::{ConfigError, Error};
 use crate::explain::{self, EXPLAIN_SCHEMA_VERSION, ExplainEntry};
-use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+use comfy_table::{Attribute, Cell, Color, Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+use crossterm::style::Stylize;
 
 /// Run `max explain`. With a selector, explain that code/class/category; without
 /// one, print the full index. An unknown selector returns a usage error (exit 2).
@@ -66,18 +67,18 @@ fn print_entry_json(entry: &ExplainEntry) -> Result<(), Error> {
 
 fn print_entry_text(entry: &ExplainEntry) {
     if let Some(code) = entry.code {
-        println!("Exit code:     {code}");
+        println!("{} {}", "Exit code:    ".bold(), code.to_string().cyan());
     }
-    println!("Outcome class: {}", entry.outcome_class);
-    println!("Family:        {}", families_label(entry));
+    println!("{} {}", "Outcome class:".bold(), entry.outcome_class.yellow());
+    println!("{} {}", "Family:       ".bold(), families_label(entry));
     println!();
-    println!("Meaning:");
+    println!("{}", "Meaning:".bold());
     println!("  {}", entry.meaning);
     println!();
-    println!("Remediation:");
+    println!("{}", "Remediation:".bold());
     println!("  {}", entry.remediation);
     println!();
-    println!("Docs: {}", entry.docs_ref);
+    println!("{} {}", "Docs:".bold(), entry.docs_ref);
 }
 
 fn print_index_json() -> Result<(), Error> {
@@ -98,16 +99,21 @@ fn print_index_text() {
     table
         .load_preset(UTF8_FULL)
         .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_header(["Code", "Outcome Class", "Family", "Meaning"]);
+        .set_header([
+            Cell::new("Code").add_attribute(Attribute::Bold),
+            Cell::new("Outcome Class").add_attribute(Attribute::Bold),
+            Cell::new("Family").add_attribute(Attribute::Bold),
+            Cell::new("Meaning").add_attribute(Attribute::Bold),
+        ]);
     for entry in explain::entries() {
         let code = entry
             .code
             .map_or_else(|| "-".to_string(), |c| c.to_string());
         table.add_row([
-            comfy_table::Cell::from(code),
-            comfy_table::Cell::from(entry.outcome_class),
-            comfy_table::Cell::from(families_label(entry)),
-            comfy_table::Cell::from(entry.meaning),
+            Cell::new(code).fg(Color::Cyan),
+            Cell::new(entry.outcome_class).fg(Color::Yellow),
+            Cell::new(families_label(entry)),
+            Cell::new(entry.meaning),
         ]);
     }
     println!("{table}");


### PR DESCRIPTION
🖌️ **Before:**
The output of `max catalog` and `max explain` printed raw plaintext tables. They lacked visual hierarchy; categories, types, and stage strings did not pop. It required the user to read lines of text wall manually to figure out what was "paid" vs "free".

✨ **After:**
The output of both commands are now beautifully formatted with `comfy-table` attributes and `crossterm::style` styling.
- `max catalog`: The header is bold. The "Command" column is Cyan. The "Cost" column uses Green for "free" and Yellow for "paid". The "Stage" column uses matching distinct colors (Cyan, Magenta, Blue, DarkYellow, Green).
- `max explain`: The index table headers are bold. The Code column is Cyan and the Outcome Class is Yellow. The detailed output of `max explain <selector>` has bold headers ("Exit code:", "Outcome class:", "Meaning:", "Remediation:", "Docs:") and corresponding values colored for easy skimming.

🖼️ **Visuals:**
The CLI now acts more like a colorful UI dashboard instead of a dull log file, enforcing proper visual hierarchy and immediate feedback.

---
*PR created automatically by Jules for task [2272764594794484249](https://jules.google.com/task/2272764594794484249) started by @madmax983*