### PR TITLE
🛡️ Sentry: Fix docker unwrap and add chaos test

### DIFF
--- a/src/env/chaos.rs
+++ b/src/env/chaos.rs
@@ -114,4 +114,21 @@ mod tests {
         assert!(res3.timed_out);
         assert_eq!(res3.exit_code, -1);
     }
+
+    #[tokio::test]
+    async fn test_chaos_environment_never_injects_failures_when_fail_every_is_zero()
+    -> Result<(), crate::error::EnvError> {
+        let inner = Box::new(LocalEnvironment::new());
+        let env = ChaosEnvironment::new(inner, 0); // Never fail
+
+        let req = RunRequest::new("echo hello");
+
+        for _ in 0..5 {
+            let res = env.run(req.clone()).await?;
+            assert_eq!(res.exit_code, 0);
+            assert!(!res.timed_out);
+        }
+
+        Ok(())
+    }
 }

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -530,14 +530,10 @@ mod tests {
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = network_pos else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +548,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected my-image in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"


### PR DESCRIPTION
🛡️ Sentry: Fix docker unwrap and add chaos test

🎯 Target: src/env/docker.rs, src/env/chaos.rs
💣 Risk: Untested edge case where fail_every is 0 in ChaosEnvironment, and ticking time-bomb unwraps in docker.rs tests
🧪 Strategy: Added a new test test_chaos_environment_never_injects_failures_when_fail_every_is_zero and refactored unwraps using let Some(...) = ... else { panic!(...) }
🔬 Verification: Commands: cargo test --lib env::docker and cargo test --lib env::chaos

---
*PR created automatically by Jules for task [1142490354876667169](https://jules.google.com/task/1142490354876667169) started by @madmax983*