### PR TITLE
⚡ Bolt: Use BTreeMap to avoid hashing overhead in evaluate

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,63 @@
+1. **Optimize hashing overhead in `src/run/evaluate.rs`**.
+   - Use `replace_with_git_merge_diff` to replace `HashMap<u32, Vec<String>>` with `BTreeMap<u32, Vec<String>>` for `ids_by_run` in `build_source_reports`. `HashMap` uses `SipHash`, which is slow for small integer keys. `BTreeMap` avoids this overhead entirely.
+
+```rust
+<<<<<<< SEARCH
+fn build_source_reports(
+    resolved_by_run: &HashMap<RunSlotKey, bool>,
+    args: &EvaluateArgs,
+    run_id_str: &str,
+) -> Vec<SourceReportEntry> {
+=======
+/// Switched HashMap to BTreeMap for `ids_by_run` to avoid hashing overhead on small integer keys.
+fn build_source_reports(
+    resolved_by_run: &HashMap<RunSlotKey, bool>,
+    args: &EvaluateArgs,
+    run_id_str: &str,
+) -> Vec<SourceReportEntry> {
+>>>>>>> REPLACE
+```
+
+```rust
+<<<<<<< SEARCH
+    if max_run_index <= 1 {
+        return vec![];
+    }
+    let mut ids_by_run: HashMap<u32, Vec<String>> = HashMap::new();
+    for key in resolved_by_run.keys() {
+        ids_by_run
+            .entry(key.run_index)
+            .or_default()
+            .push(key.instance_id.clone());
+    }
+=======
+    if max_run_index <= 1 {
+        return vec![];
+    }
+    let mut ids_by_run: BTreeMap<u32, Vec<String>> = BTreeMap::new();
+    for key in resolved_by_run.keys() {
+        ids_by_run
+            .entry(key.run_index)
+            .or_default()
+            .push(key.instance_id.clone());
+    }
+>>>>>>> REPLACE
+```
+
+2. **Verify syntax**.
+   - Use `run_in_bash_session` to execute `cargo check`.
+3. **Format code**.
+   - Use `run_in_bash_session` to execute `cargo fmt --all`.
+4. **Run Clippy**.
+   - Use `run_in_bash_session` to execute `cargo clippy --all-targets --all-features -- -D warnings`.
+5. **Run core module tests**.
+   - Use `run_in_bash_session` to execute `cargo test --lib run::`.
+6. **Complete pre-commit steps**.
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+7. **Submit**.
+   - Use the `submit` tool with branch `bolt-evaluate-btreemap`, and a title `⚡ Bolt: Use BTreeMap to avoid hashing overhead in evaluate`.
+   - The PR description will be:
+     💡 What: Switched `HashMap` to `BTreeMap` for mapping run indices to instance IDs in `build_source_reports`.
+     🎯 Why: The default `HashMap` uses SipHash, which is a cryptographically secure hash function that incurs significant overhead for small integer keys like `u32`.
+     📊 Impact: Reduces CPU cycles spent on hash calculation, making evaluation report generation marginally faster without sacrificing safety or correctness.
+     🔬 Measurement: Verify tests run smoothly using `cargo test --lib run::`.

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -757,6 +757,7 @@ fn collect_report_paths(report_dir: &Path, run_id: &str, args: &EvaluateArgs) ->
     }
 }
 
+/// Switched HashMap to BTreeMap for `ids_by_run` to avoid hashing overhead on small integer keys.
 fn build_source_reports(
     resolved_by_run: &HashMap<RunSlotKey, bool>,
     args: &EvaluateArgs,
@@ -773,7 +774,7 @@ fn build_source_reports(
     if max_run_index <= 1 {
         return vec![];
     }
-    let mut ids_by_run: HashMap<u32, Vec<String>> = HashMap::new();
+    let mut ids_by_run: BTreeMap<u32, Vec<String>> = BTreeMap::new();
     for key in resolved_by_run.keys() {
         ids_by_run
             .entry(key.run_index)


### PR DESCRIPTION
💡 What: Switched `HashMap` to `BTreeMap` for mapping run indices to instance IDs in `build_source_reports`.
🎯 Why: The default `HashMap` uses SipHash, which is a cryptographically secure hash function that incurs significant overhead for small integer keys like `u32`.
📊 Impact: Reduces CPU cycles spent on hash calculation, making evaluation report generation marginally faster without sacrificing safety or correctness.
🔬 Measurement: Verified with `cargo test --lib run::`.

---
*PR created automatically by Jules for task [5373400714912546293](https://jules.google.com/task/5373400714912546293) started by @madmax983*