### PR TITLE
Add `bench ledger` command for cost accounting across runs

### DIFF
--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -57,6 +57,7 @@ parsing human-oriented output.
 | 46   | `fs_audit_scan_error`    | `agent fs-audit` could not read or parse one or more trajectory files (missing path, unreadable file, invalid JSON, missing sweep directory). The scan is incomplete, so a "clean" verdict cannot be trusted. Findings take precedence: exit 45 is returned when both findings and scan errors are present. |
 | 47   | `artifact_check_failure` | `agent artifact-check` found at least one artifact that is `invalid` or `unsupported_major`. With `--strict`, also triggers on `legacy_unversioned` and `valid_with_warnings`. Zero model calls are made; the check is purely a structural conformance gate. Distinct from `internal_error` (1) so CI can route "artifact does not conform to contract" separately from an unexpected infrastructure failure. See `docs/spec-artifact-check.md`. |
 | 48   | `host_not_ready`         | `agent doctor` found at least one failing host-readiness check: `git` missing from PATH, the provider credential env var absent, the Docker daemon unreachable when `--env docker` is selected, the runs/output dir not writable, or the active toolchain below the crate `rust-version`. Zero model calls and no provider network probe are made; the check is a pure host preflight. Skipped checks never trigger this. Distinct from `preflight_failure` (3) so CI can route "host not ready before any run" separately from sweep-time dependency failures. See `docs/spec-agent-doctor.md`. |
+| 49   | `ledger_budget_exceeded` | `bench ledger --budget-usd <N>` found that the grand total actual spend across discovered trajectories meets or exceeds N. The report is printed before exit; the non-zero exit allows CI to gate on budget exhaustion. Distinct from `budget_halt` (5) which is a forecast/sweep cap, not a post-hoc accounting check. |
 | 130  | `interrupted`            | Graceful SIGINT / Ctrl-C cancellation (POSIX convention: 128 + SIGINT(2)). |
 | 137  | `killed`                 | SIGKILL escalation after the graceful-cancel deadline expired (128 + SIGKILL(9)). |
 
@@ -115,6 +116,7 @@ and the recommended triage action.
 | `agent apply`                   | `success`, `usage_error`, `apply_check_failed`, `apply_redacted_refused`, `apply_dirty_tree_refused`, `internal_error` |
 | `agent artifact-check`          | `success`, `usage_error`, `artifact_check_failure`, `internal_error` |
 | `agent doctor`                  | `success`, `host_not_ready`, `usage_error`, `internal_error` |
+| `bench ledger`                  | `success`, `usage_error`, `ledger_budget_exceeded`, `internal_error` |
 | `bench export-otlp`             | `success`, `usage_error`, `preflight_failure`, `internal_error` (see `docs/spec-export-otlp.md`) |
 
 > **Note:** `hello-world` does not produce distinct outcome classes beyond

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -80,6 +80,7 @@ pub enum ArtifactKind {
     ValidationReport,
     TrajectoryAnnotation,
     ContextPressureReport,
+    LedgerReport,
 }
 
 impl ArtifactKind {
@@ -117,6 +118,7 @@ impl ArtifactKind {
             Self::ValidationReport => "validation_report",
             Self::TrajectoryAnnotation => "trajectory_annotation",
             Self::ContextPressureReport => "context_pressure_report",
+            Self::LedgerReport => "ledger_report",
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1498,6 +1498,8 @@ pub enum BenchCmd {
     Merge(MergeCmd),
     /// Report context-window pressure telemetry per sweep (zero-cost: reads only on-disk artifacts).
     ContextPressure(ContextPressureCmd),
+    /// Roll up cumulative actual spend across runs/sweeps by model, dataset, and day (zero-cost: reads only on-disk artifacts).
+    Ledger(LedgerCmd),
 }
 
 /// `bench merge` — combine completed sharded sweep directories into one canonical aggregate.
@@ -2157,6 +2159,25 @@ pub struct ContextPressureCmd {
     /// Output format: `text` (default) or `json`.
     #[arg(long, default_value = "text", value_name = "FMT")]
     pub format: String,
+}
+
+/// `bench ledger` — roll up cumulative actual spend across runs/sweeps (zero-cost: reads only on-disk artifacts).
+#[derive(Debug, Args)]
+pub struct LedgerCmd {
+    /// One or more run or sweep directories to aggregate. Trajectories are
+    /// discovered recursively under each directory.
+    #[arg(value_name = "DIR", required = true, num_args = 1..)]
+    pub dirs: Vec<std::path::PathBuf>,
+
+    /// Output format: `text` (default) or `json`.
+    #[arg(long, default_value = "text", value_name = "FMT")]
+    pub format: String,
+
+    /// Budget ceiling in USD. When the grand total meets or exceeds this value
+    /// the report is printed and the process exits with code 49
+    /// (`ledger_budget_exceeded`).
+    #[arg(long, value_name = "USD")]
+    pub budget_usd: Option<f64>,
 }
 
 /// `bench budget-fit` — right-size step, cost, and wallclock caps (zero-cost: reads only on-disk artifacts).

--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -236,6 +236,12 @@ pub fn entries() -> &'static [CatalogEntry] {
             stage: "analyze",
         },
         CatalogEntry {
+            path: "bench ledger",
+            summary: "Roll up cumulative actual spend across runs/sweeps by model, dataset, and day",
+            cost_tier: "free",
+            stage: "analyze",
+        },
+        CatalogEntry {
             path: "bench context-pressure",
             summary: "Report context-window pressure telemetry per sweep",
             cost_tier: "free",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -146,6 +146,7 @@ pub async fn run() -> Result<(), Error> {
             args::BenchCmd::ExportOtlp(c) => Box::pin(bench_export_otlp(c)).await,
             args::BenchCmd::Variance(v) => bench_variance(v),
             args::BenchCmd::Merge(m) => bench_merge(&m),
+            args::BenchCmd::Ledger(l) => bench_ledger(l),
         },
         Command::Agent { cmd } => match *cmd {
             args::AgentCmd::SkillsPreview(s) => agent_skills_preview_cmd(&s),
@@ -4342,6 +4343,42 @@ fn bench_cache_stats(c: args::CacheStatsCmd) -> Result<(), Error> {
         println!("{json}");
     } else {
         print!("{}", crate::run::cache_stats::render_text(&report, c.top));
+    }
+    Ok(())
+}
+
+fn bench_ledger(c: args::LedgerCmd) -> Result<(), Error> {
+    let is_json = match c.format.as_str() {
+        "text" => false,
+        "json" => true,
+        other => {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
+                "ledger: unknown --format `{other}` (expected `text` or `json`)"
+            ))));
+        }
+    };
+    let report = crate::run::ledger::run(&crate::run::ledger::LedgerArgs {
+        dirs: c.dirs,
+        budget_usd: c.budget_usd,
+    })?;
+    if is_json {
+        let json = crate::artifact::to_string_pretty(
+            crate::artifact::ArtifactKind::LedgerReport,
+            &report,
+        )?;
+        println!("{json}");
+    } else {
+        print!("{}", crate::run::ledger::render_text(&report));
+    }
+    if report.over_budget == Some(true) {
+        exit_with_outcome(
+            crate::exit_code::ExitCode::LedgerBudgetExceeded,
+            &format!(
+                "ledger: grand total ${:.6} exceeds budget ${:.6}",
+                report.grand_total_usd,
+                report.budget_usd.unwrap_or(0.0)
+            ),
+        );
     }
     Ok(())
 }

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -218,6 +218,12 @@ pub enum ExitCode {
     /// so CI can route "host not ready before any run" separately from
     /// sweep-time dependency failures. See `docs/spec-agent-doctor.md`.
     HostNotReady = 48,
+    /// 49 — `bench ledger --budget-usd <N>` found that the grand total actual
+    /// spend across discovered trajectories meets or exceeds N. The report is
+    /// printed before exit; the non-zero exit allows CI to gate on budget
+    /// exhaustion. Distinct from `budget_halt` (5) which is a forecast/sweep
+    /// cap, not a post-hoc accounting check.
+    LedgerBudgetExceeded = 49,
     /// 130 — user interruption (graceful SIGINT / Ctrl-C; 128 + SIGINT(2)).
     Interrupted = 130,
     /// 137 — forced kill (SIGKILL escalation after graceful-cancel deadline; 128 + SIGKILL(9)).
@@ -287,6 +293,7 @@ impl ExitCode {
             Self::FsAuditScanError => "fs_audit_scan_error",
             Self::ArtifactCheckFailure => "artifact_check_failure",
             Self::HostNotReady => "host_not_ready",
+            Self::LedgerBudgetExceeded => "ledger_budget_exceeded",
             Self::Interrupted => "interrupted",
             Self::Killed => "killed",
         }
@@ -598,5 +605,14 @@ mod tests {
     fn host_not_ready_exit_code_is_48() {
         assert_eq!(ExitCode::HostNotReady.as_i32(), 48);
         assert_eq!(ExitCode::HostNotReady.outcome_class(), "host_not_ready");
+    }
+
+    #[test]
+    fn ledger_budget_exceeded_exit_code_is_49() {
+        assert_eq!(ExitCode::LedgerBudgetExceeded.as_i32(), 49);
+        assert_eq!(
+            ExitCode::LedgerBudgetExceeded.outcome_class(),
+            "ledger_budget_exceeded"
+        );
     }
 }

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -464,6 +464,14 @@ pub fn entries() -> &'static [ExplainEntry] {
             docs_ref: EXIT_DOC,
         },
         ExplainEntry {
+            code: Some(49),
+            outcome_class: "ledger_budget_exceeded",
+            families: EXIT_ONLY,
+            meaning: "`bench ledger --budget-usd <N>` found that the grand total actual spend across discovered trajectories meets or exceeds N. The report is printed before exit.",
+            remediation: "Review the per-model/dataset/day breakdown in the ledger report and reduce spend, or raise `--budget-usd`.",
+            docs_ref: EXIT_DOC,
+        },
+        ExplainEntry {
             code: Some(130),
             outcome_class: "interrupted",
             families: EXIT_ONLY,

--- a/src/run/agent_runs.rs
+++ b/src/run/agent_runs.rs
@@ -198,7 +198,7 @@ pub fn run_agent_runs(opts: &AgentRunsOpts) -> Result<AgentRunsReport, Error> {
 /// immediate directory is scanned; if true the full tree is walked.
 /// I/O errors on the scan root are propagated; unreadable child subdirectories
 /// are skipped silently (analogous to malformed trajectory files).
-fn collect_traj_paths(dir: &Path, recursive: bool) -> Result<Vec<PathBuf>, Error> {
+pub(crate) fn collect_traj_paths(dir: &Path, recursive: bool) -> Result<Vec<PathBuf>, Error> {
     if !dir.exists() {
         return Err(Error::Trajectory(format!(
             "directory does not exist: {}",
@@ -233,7 +233,7 @@ fn collect_traj_paths(dir: &Path, recursive: bool) -> Result<Vec<PathBuf>, Error
 
 /// Recursively collect `.traj.json` files under `dir`, silently skipping
 /// subdirectories that cannot be read (permission errors, etc.).
-fn walk_children(dir: &Path, out: &mut Vec<PathBuf>) {
+pub(crate) fn walk_children(dir: &Path, out: &mut Vec<PathBuf>) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
@@ -248,7 +248,7 @@ fn walk_children(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
-fn is_traj_file(p: &Path) -> bool {
+pub(crate) fn is_traj_file(p: &Path) -> bool {
     p.is_file()
         && p.file_name()
             .and_then(|n| n.to_str())

--- a/src/run/agent_runs.rs
+++ b/src/run/agent_runs.rs
@@ -233,7 +233,7 @@ pub(crate) fn collect_traj_paths(dir: &Path, recursive: bool) -> Result<Vec<Path
 
 /// Recursively collect `.traj.json` files under `dir`, silently skipping
 /// subdirectories that cannot be read (permission errors, etc.).
-pub(crate) fn walk_children(dir: &Path, out: &mut Vec<PathBuf>) {
+fn walk_children(dir: &Path, out: &mut Vec<PathBuf>) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
@@ -248,7 +248,7 @@ pub(crate) fn walk_children(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
-pub(crate) fn is_traj_file(p: &Path) -> bool {
+fn is_traj_file(p: &Path) -> bool {
     p.is_file()
         && p.file_name()
             .and_then(|n| n.to_str())

--- a/src/run/ledger.rs
+++ b/src/run/ledger.rs
@@ -16,6 +16,11 @@ use crate::error::Error;
 use crate::run::agent_runs::collect_traj_paths;
 use crate::trajectory::{ResumeRecord, Trajectory};
 
+// ── type aliases ──────────────────────────────────────────────────────────────
+
+type GroupKey = (String, String);
+type GroupEntry = (Option<f64>, String, String, String);
+
 // ── public data types ─────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]
@@ -72,10 +77,6 @@ pub fn run(args: &LedgerArgs) -> Result<LedgerReport, Error> {
 // ── rendering ─────────────────────────────────────────────────────────────────
 
 pub fn render_text(report: &LedgerReport) -> String {
-    use comfy_table::Table;
-    use comfy_table::modifiers::UTF8_ROUND_CORNERS;
-    use comfy_table::presets::UTF8_FULL;
-
     let mut out = String::new();
     let _ = writeln!(out, "\n=== bench ledger ===");
     let _ = writeln!(out, "Roots: {}", report.roots.join(", "));
@@ -115,24 +116,28 @@ pub fn render_text(report: &LedgerReport) -> String {
         "\nNote: each grouping independently sums to the grand total."
     );
 
-    fn render_group_table(out: &mut String, title: &str, groups: &[GroupSubtotal]) {
-        let _ = writeln!(out, "\n{title}:");
-        let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .apply_modifier(UTF8_ROUND_CORNERS)
-            .set_header(vec!["key", "total_cost_usd", "trajectory_count"]);
-        for g in groups {
-            table.add_row(vec![
-                g.key.clone(),
-                format!("{:.6}", g.total_cost_usd),
-                g.trajectory_count.to_string(),
-            ]);
-        }
-        let _ = writeln!(out, "{table}");
-    }
-
     out
+}
+
+fn render_group_table(out: &mut String, title: &str, groups: &[GroupSubtotal]) {
+    use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+    use comfy_table::presets::UTF8_FULL;
+    use comfy_table::Table;
+
+    let _ = writeln!(out, "\n{title}:");
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec!["key", "total_cost_usd", "trajectory_count"]);
+    for g in groups {
+        table.add_row(vec![
+            g.key.clone(),
+            format!("{:.6}", g.total_cost_usd),
+            g.trajectory_count.to_string(),
+        ]);
+    }
+    let _ = writeln!(out, "{table}");
 }
 
 // ── pure helpers (unit-testable) ──────────────────────────────────────────────
@@ -161,9 +166,8 @@ pub fn logical_run_key(
         .and_then(|r| r.original_started_at.as_deref())
         .or(started_at);
 
-    let anchor_str = anchor
-        .map(ToOwned::to_owned)
-        .unwrap_or_else(|| file_path.display().to_string());
+    let anchor_str =
+        anchor.map_or_else(|| file_path.display().to_string(), ToOwned::to_owned);
 
     (parent, anchor_str)
 }
@@ -182,12 +186,14 @@ pub fn select_chain_cost(costs: &[Option<f64>]) -> Option<f64> {
 pub fn day_bucket(started_at: Option<&str>) -> String {
     started_at
         .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-        .map(|dt| {
-            dt.with_timezone(&chrono::Utc)
-                .format("%Y-%m-%d")
-                .to_string()
-        })
-        .unwrap_or_else(|| "unknown".to_owned())
+        .map_or_else(
+            || "unknown".to_owned(),
+            |dt| {
+                dt.with_timezone(&chrono::Utc)
+                    .format("%Y-%m-%d")
+                    .to_string()
+            },
+        )
 }
 
 /// Extract a human-readable dataset label from the first ancestor directory
@@ -196,38 +202,58 @@ pub fn day_bucket(started_at: Option<&str>) -> String {
 /// Uses `alias` when set, otherwise the basename of `path`.
 /// Falls back to `"unknown"` when no suitable `results.json` is found.
 #[must_use]
-pub fn dataset_label_for(traj_path: &Path, cache: &mut HashMap<PathBuf, String>) -> String {
+pub fn dataset_label_for<S: ::std::hash::BuildHasher>(
+    traj_path: &Path,
+    cache: &mut HashMap<PathBuf, String, S>,
+) -> String {
     dataset_label_for_inner(traj_path, cache)
 }
 
-fn dataset_label_for_inner(traj_path: &Path, cache: &mut HashMap<PathBuf, String>) -> String {
+fn dataset_label_for_inner<S: ::std::hash::BuildHasher>(
+    traj_path: &Path,
+    cache: &mut HashMap<PathBuf, String, S>,
+) -> String {
     // Walk from the trajectory's directory up to root, stopping at the first
     // ancestor that has a results.json we can parse.
     let start = traj_path
         .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| PathBuf::from("."));
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
 
+    // Collect visited dirs so we can back-fill the cache once the label is known,
+    // avoiding re-walks for siblings under the same sweep directory.
+    let mut trail: Vec<PathBuf> = Vec::new();
     let mut current = start;
-    loop {
-        if let Some(label) = cache.get(&current) {
-            return label.clone();
+
+    let result = loop {
+        if let Some(cached) = cache.get(&current) {
+            let label = cached.clone();
+            for dir in trail {
+                cache.insert(dir, label.clone());
+            }
+            return label;
         }
 
         let results_path = current.join("results.json");
         if results_path.exists() {
             if let Some(label) = try_parse_dataset_label(&results_path) {
-                cache.insert(current.clone(), label.clone());
-                return label;
+                trail.push(current);
+                break label;
             }
         }
 
-        match current.parent() {
-            Some(p) => current = p.to_path_buf(),
-            None => break,
+        match current.parent().map(Path::to_path_buf) {
+            Some(parent) => {
+                trail.push(current);
+                current = parent;
+            }
+            None => break "unknown".to_owned(),
         }
+    };
+
+    for dir in trail {
+        cache.insert(dir, result.clone());
     }
-    "unknown".to_owned()
+    result
 }
 
 fn try_parse_dataset_label(results_path: &Path) -> Option<String> {
@@ -255,7 +281,9 @@ fn try_parse_dataset_label(results_path: &Path) -> Option<String> {
 /// Summarise a map of `key → (total_cost, count)` into a sorted `Vec<GroupSubtotal>`.
 /// Sorted by `total_cost_usd` descending, then `key` ascending.
 #[must_use]
-pub fn group_subtotals(map: &HashMap<String, (f64, usize)>) -> Vec<GroupSubtotal> {
+pub fn group_subtotals<S: ::std::hash::BuildHasher>(
+    map: &HashMap<String, (f64, usize), S>,
+) -> Vec<GroupSubtotal> {
     let mut v: Vec<GroupSubtotal> = map
         .iter()
         .map(|(key, (cost, count))| GroupSubtotal {
@@ -300,8 +328,8 @@ fn build_report(args: &LedgerArgs) -> Result<LedgerReport, Error> {
     for path in &all_paths {
         match load_record(path) {
             Ok(r) => records.push(r),
-            Err(_) => {
-                // Unreadable/unparseable trajectory: skip (count as uncosted below).
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "ledger: skipping unreadable trajectory");
                 records.push(TrajRecord {
                     path: path.clone(),
                     cost: None,
@@ -318,8 +346,7 @@ fn build_report(args: &LedgerArgs) -> Result<LedgerReport, Error> {
 
     // Group by logical-run key; collect costs per group.
     // Key → list of (cost, model, day, dataset).
-    let mut groups: HashMap<(String, String), Vec<(Option<f64>, String, String, String)>> =
-        HashMap::new();
+    let mut groups: HashMap<GroupKey, Vec<GroupEntry>> = HashMap::new();
 
     for rec in &records {
         let key = logical_run_key(&rec.path, rec.started_at.as_deref(), &rec.resume_history);
@@ -404,13 +431,14 @@ fn load_record(path: &Path) -> Result<TrajRecord, Error> {
     let traj: Trajectory = serde_json::from_str(&raw)
         .map_err(|e| Error::Trajectory(format!("cannot parse {}: {e}", path.display())))?;
     let info = &traj.info;
+    // Fall back to actual_cost_usd for interrupted checkpoints that were never
+    // cleanly finalised (their total_cost_usd may be None while actual_cost_usd
+    // already reflects the spend up to the interruption point).
+    let cost = info.total_cost_usd.or(info.actual_cost_usd);
     Ok(TrajRecord {
         path: path.to_path_buf(),
-        cost: info.total_cost_usd,
-        model: info
-            .model_name
-            .clone()
-            .unwrap_or_else(|| "unknown".to_owned()),
+        cost,
+        model: info.model_name.as_deref().unwrap_or("unknown").to_owned(),
         started_at: info.started_at.clone(),
         resume_history: info.resume_history.clone(),
     })

--- a/src/run/ledger.rs
+++ b/src/run/ledger.rs
@@ -36,7 +36,11 @@ pub struct LedgerReport {
     pub generated_at: String,
     pub roots: Vec<String>,
     pub grand_total_usd: f64,
+    /// Number of logical runs (resume chains collapsed to one) that had a recorded cost.
     pub counted_trajectories: usize,
+    /// Extra trajectory files absorbed into resume chains (chain members beyond the first).
+    /// Invariant: discovered_trajectories == counted_trajectories + chained_trajectories + uncosted.
+    pub chained_trajectories: usize,
     pub discovered_trajectories: usize,
     pub uncosted: usize,
     pub by_model: Vec<GroupSubtotal>,
@@ -55,7 +59,12 @@ pub struct LedgerReport {
 pub fn run(args: &LedgerArgs) -> Result<LedgerReport, Error> {
     let report = build_report(args)?;
     if let Some(first_dir) = args.dirs.first() {
-        write_artifact(first_dir, &report)?;
+        if let Err(e) = write_artifact(first_dir, &report) {
+            eprintln!(
+                "warning: ledger: could not write ledger.json to {}: {e}",
+                first_dir.display()
+            );
+        }
     }
     Ok(report)
 }
@@ -74,8 +83,11 @@ pub fn render_text(report: &LedgerReport) -> String {
     let _ = writeln!(out);
     let _ = writeln!(
         out,
-        "Discovered: {}  Counted: {}  Uncosted: {}",
-        report.discovered_trajectories, report.counted_trajectories, report.uncosted
+        "Discovered: {}  Counted: {}  Chained: {}  Uncosted: {}",
+        report.discovered_trajectories,
+        report.counted_trajectories,
+        report.chained_trajectories,
+        report.uncosted
     );
     let _ = writeln!(out, "Grand total: ${:.6}", report.grand_total_usd);
 
@@ -323,41 +335,35 @@ fn build_report(args: &LedgerArgs) -> Result<LedgerReport, Error> {
     // For each logical run, select the max cost and record attribution.
     let mut grand_total: f64 = 0.0;
     let mut counted: usize = 0;
+    let mut chained: usize = 0;
     let mut uncosted: usize = 0;
     let mut by_model: HashMap<String, (f64, usize)> = HashMap::new();
     let mut by_dataset: HashMap<String, (f64, usize)> = HashMap::new();
     let mut by_day: HashMap<String, (f64, usize)> = HashMap::new();
 
     for entries in groups.values() {
-        let costs: Vec<Option<f64>> = entries.iter().map(|(c, _, _, _)| *c).collect();
-        let selected_cost = select_chain_cost(&costs);
-
-        // Use the last entry's attribution (or first with Some cost).
-        let (_, model, day, dataset) = entries
+        // Find the entry with the highest cost. For a resume chain the deepest
+        // resumed trajectory has the cumulative total, so using the max-cost
+        // entry also gives us the correct attribution (model/day/dataset of the
+        // continuation, not the original checkpoint).
+        let best = entries
             .iter()
-            .find(|(c, _, _, _)| c.is_some())
-            .or_else(|| entries.last())
-            .map(|(c, m, d, ds)| (c, m.clone(), d.clone(), ds.clone()))
-            .unwrap_or_else(|| {
-                (
-                    &None,
-                    "unknown".to_owned(),
-                    "unknown".to_owned(),
-                    "unknown".to_owned(),
-                )
-            });
+            .filter_map(|(c, m, d, ds)| c.map(|v| (v, m, d, ds)))
+            .reduce(|acc, cur| if cur.0 >= acc.0 { cur } else { acc });
 
-        match selected_cost {
-            Some(cost) => {
+        match best {
+            Some((cost, best_model, best_day, best_dataset)) => {
                 grand_total += cost;
                 counted += 1;
-                let e = by_model.entry(model).or_insert((0.0, 0));
+                // Files beyond the one "counted" run are chain members.
+                chained += entries.len() - 1;
+                let e = by_model.entry(best_model.clone()).or_insert((0.0, 0));
                 e.0 += cost;
                 e.1 += 1;
-                let e = by_dataset.entry(dataset).or_insert((0.0, 0));
+                let e = by_dataset.entry(best_dataset.clone()).or_insert((0.0, 0));
                 e.0 += cost;
                 e.1 += 1;
-                let e = by_day.entry(day).or_insert((0.0, 0));
+                let e = by_day.entry(best_day.clone()).or_insert((0.0, 0));
                 e.0 += cost;
                 e.1 += 1;
             }
@@ -380,6 +386,7 @@ fn build_report(args: &LedgerArgs) -> Result<LedgerReport, Error> {
         roots: args.dirs.iter().map(|d| d.display().to_string()).collect(),
         grand_total_usd: grand_total,
         counted_trajectories: counted,
+        chained_trajectories: chained,
         discovered_trajectories: discovered,
         uncosted,
         by_model: group_subtotals(&by_model),

--- a/src/run/ledger.rs
+++ b/src/run/ledger.rs
@@ -1,0 +1,421 @@
+//! `bench ledger`: roll up cumulative actual spend across runs/sweeps.
+//!
+//! Reads only on-disk artifacts (zero model calls, zero network).
+
+#![allow(clippy::cast_precision_loss)]
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use chrono::DateTime;
+use serde::{Deserialize, Serialize};
+
+use crate::artifact::ArtifactKind;
+use crate::error::Error;
+use crate::run::agent_runs::collect_traj_paths;
+use crate::trajectory::{ResumeRecord, Trajectory};
+
+// ── public data types ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct LedgerArgs {
+    pub dirs: Vec<PathBuf>,
+    pub budget_usd: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupSubtotal {
+    pub key: String,
+    pub total_cost_usd: f64,
+    pub trajectory_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LedgerReport {
+    pub generated_at: String,
+    pub roots: Vec<String>,
+    pub grand_total_usd: f64,
+    pub counted_trajectories: usize,
+    pub discovered_trajectories: usize,
+    pub uncosted: usize,
+    pub by_model: Vec<GroupSubtotal>,
+    pub by_dataset: Vec<GroupSubtotal>,
+    pub by_day: Vec<GroupSubtotal>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_usd: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remaining_usd: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub over_budget: Option<bool>,
+}
+
+// ── public entry point ────────────────────────────────────────────────────────
+
+pub fn run(args: &LedgerArgs) -> Result<LedgerReport, Error> {
+    let report = build_report(args)?;
+    if let Some(first_dir) = args.dirs.first() {
+        write_artifact(first_dir, &report)?;
+    }
+    Ok(report)
+}
+
+// ── rendering ─────────────────────────────────────────────────────────────────
+
+pub fn render_text(report: &LedgerReport) -> String {
+    use comfy_table::Table;
+    use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+    use comfy_table::presets::UTF8_FULL;
+
+    let mut out = String::new();
+    let _ = writeln!(out, "\n=== bench ledger ===");
+    let _ = writeln!(out, "Roots: {}", report.roots.join(", "));
+    let _ = writeln!(out, "Generated: {}", report.generated_at);
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "Discovered: {}  Counted: {}  Uncosted: {}",
+        report.discovered_trajectories, report.counted_trajectories, report.uncosted
+    );
+    let _ = writeln!(out, "Grand total: ${:.6}", report.grand_total_usd);
+
+    if let Some(budget) = report.budget_usd {
+        let remaining = report.remaining_usd.unwrap_or(0.0);
+        let over = report.over_budget.unwrap_or(false);
+        let _ = writeln!(out, "Budget: ${budget:.6}");
+        if over {
+            let _ = writeln!(
+                out,
+                "OVER BUDGET by ${:.6}",
+                report.grand_total_usd - budget
+            );
+        } else {
+            let _ = writeln!(out, "Remaining: ${remaining:.6}");
+        }
+    }
+
+    render_group_table(&mut out, "By model", &report.by_model);
+    render_group_table(&mut out, "By dataset", &report.by_dataset);
+    render_group_table(&mut out, "By day (UTC)", &report.by_day);
+
+    let _ = writeln!(
+        out,
+        "\nNote: each grouping independently sums to the grand total."
+    );
+
+    fn render_group_table(out: &mut String, title: &str, groups: &[GroupSubtotal]) {
+        let _ = writeln!(out, "\n{title}:");
+        let mut table = Table::new();
+        table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["key", "total_cost_usd", "trajectory_count"]);
+        for g in groups {
+            table.add_row(vec![
+                g.key.clone(),
+                format!("{:.6}", g.total_cost_usd),
+                g.trajectory_count.to_string(),
+            ]);
+        }
+        let _ = writeln!(out, "{table}");
+    }
+
+    out
+}
+
+// ── pure helpers (unit-testable) ──────────────────────────────────────────────
+
+/// Logical-run key: `(parent_dir_of_file, anchor_started_at)`.
+///
+/// `anchor_started_at` is the original start time of the logical run:
+/// - for resumed trajectories: `resume_history[0].original_started_at`
+/// - otherwise: `info.started_at`
+///
+/// When `started_at` is absent (legacy files) the key degrades to the file
+/// path itself so each file is counted exactly once.
+#[must_use]
+pub fn logical_run_key(
+    file_path: &Path,
+    started_at: Option<&str>,
+    resume_history: &[ResumeRecord],
+) -> (String, String) {
+    let parent = file_path
+        .parent()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+
+    let anchor = resume_history
+        .first()
+        .and_then(|r| r.original_started_at.as_deref())
+        .or(started_at);
+
+    let anchor_str = anchor
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| file_path.display().to_string());
+
+    (parent, anchor_str)
+}
+
+/// Given a group of trajectory costs for the same logical run, select the
+/// maximum (the deepest resumed trajectory already includes all prior spend).
+/// Returns `None` if all entries are `None`.
+#[must_use]
+pub fn select_chain_cost(costs: &[Option<f64>]) -> Option<f64> {
+    costs.iter().copied().flatten().reduce(f64::max)
+}
+
+/// Bucket an RFC3339 timestamp to a `YYYY-MM-DD` UTC date string.
+/// Returns `"unknown"` for `None` or unparseable input.
+#[must_use]
+pub fn day_bucket(started_at: Option<&str>) -> String {
+    started_at
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| {
+            dt.with_timezone(&chrono::Utc)
+                .format("%Y-%m-%d")
+                .to_string()
+        })
+        .unwrap_or_else(|| "unknown".to_owned())
+}
+
+/// Extract a human-readable dataset label from the first ancestor directory
+/// that contains a readable `results.json` with a `manifest.dataset`.
+///
+/// Uses `alias` when set, otherwise the basename of `path`.
+/// Falls back to `"unknown"` when no suitable `results.json` is found.
+#[must_use]
+pub fn dataset_label_for(traj_path: &Path, cache: &mut HashMap<PathBuf, String>) -> String {
+    dataset_label_for_inner(traj_path, cache)
+}
+
+fn dataset_label_for_inner(traj_path: &Path, cache: &mut HashMap<PathBuf, String>) -> String {
+    // Walk from the trajectory's directory up to root, stopping at the first
+    // ancestor that has a results.json we can parse.
+    let start = traj_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    let mut current = start;
+    loop {
+        if let Some(label) = cache.get(&current) {
+            return label.clone();
+        }
+
+        let results_path = current.join("results.json");
+        if results_path.exists() {
+            if let Some(label) = try_parse_dataset_label(&results_path) {
+                cache.insert(current.clone(), label.clone());
+                return label;
+            }
+        }
+
+        match current.parent() {
+            Some(p) => current = p.to_path_buf(),
+            None => break,
+        }
+    }
+    "unknown".to_owned()
+}
+
+fn try_parse_dataset_label(results_path: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(results_path).ok()?;
+    // Parse as a generic JSON Value to avoid failing on missing optional manifest sub-fields.
+    let v: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let dataset = v.get("manifest")?.get("dataset")?;
+    let alias = dataset
+        .get("alias")
+        .and_then(|a| a.as_str())
+        .map(ToOwned::to_owned);
+    if let Some(a) = alias {
+        return Some(a);
+    }
+    // Fallback: basename of dataset.path
+    let path_str = dataset.get("path")?.as_str()?;
+    let label = Path::new(path_str)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_owned();
+    Some(label)
+}
+
+/// Summarise a map of `key → (total_cost, count)` into a sorted `Vec<GroupSubtotal>`.
+/// Sorted by `total_cost_usd` descending, then `key` ascending.
+#[must_use]
+pub fn group_subtotals(map: &HashMap<String, (f64, usize)>) -> Vec<GroupSubtotal> {
+    let mut v: Vec<GroupSubtotal> = map
+        .iter()
+        .map(|(key, (cost, count))| GroupSubtotal {
+            key: key.clone(),
+            total_cost_usd: *cost,
+            trajectory_count: *count,
+        })
+        .collect();
+    v.sort_by(|a, b| {
+        b.total_cost_usd
+            .partial_cmp(&a.total_cost_usd)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.key.cmp(&b.key))
+    });
+    v
+}
+
+// ── internals ─────────────────────────────────────────────────────────────────
+
+struct TrajRecord {
+    path: PathBuf,
+    cost: Option<f64>,
+    model: String,
+    started_at: Option<String>,
+    resume_history: Vec<ResumeRecord>,
+}
+
+fn build_report(args: &LedgerArgs) -> Result<LedgerReport, Error> {
+    // Collect all trajectory paths from all root dirs (recursive).
+    let mut all_paths: Vec<PathBuf> = Vec::new();
+    for dir in &args.dirs {
+        let paths = collect_traj_paths(dir, true)?;
+        all_paths.extend(paths);
+    }
+    all_paths.sort();
+    all_paths.dedup();
+
+    let discovered = all_paths.len();
+
+    // Load each trajectory.
+    let mut records: Vec<TrajRecord> = Vec::new();
+    for path in &all_paths {
+        match load_record(path) {
+            Ok(r) => records.push(r),
+            Err(_) => {
+                // Unreadable/unparseable trajectory: skip (count as uncosted below).
+                records.push(TrajRecord {
+                    path: path.clone(),
+                    cost: None,
+                    model: "unknown".to_owned(),
+                    started_at: None,
+                    resume_history: Vec::new(),
+                });
+            }
+        }
+    }
+
+    // Dataset label cache (memoized per ancestor dir).
+    let mut dataset_cache: HashMap<PathBuf, String> = HashMap::new();
+
+    // Group by logical-run key; collect costs per group.
+    // Key → list of (cost, model, day, dataset).
+    let mut groups: HashMap<(String, String), Vec<(Option<f64>, String, String, String)>> =
+        HashMap::new();
+
+    for rec in &records {
+        let key = logical_run_key(&rec.path, rec.started_at.as_deref(), &rec.resume_history);
+        let model = rec.model.clone();
+        let day = day_bucket(rec.started_at.as_deref());
+        let dataset = dataset_label_for(&rec.path, &mut dataset_cache);
+        groups
+            .entry(key)
+            .or_default()
+            .push((rec.cost, model, day, dataset));
+    }
+
+    // For each logical run, select the max cost and record attribution.
+    let mut grand_total: f64 = 0.0;
+    let mut counted: usize = 0;
+    let mut uncosted: usize = 0;
+    let mut by_model: HashMap<String, (f64, usize)> = HashMap::new();
+    let mut by_dataset: HashMap<String, (f64, usize)> = HashMap::new();
+    let mut by_day: HashMap<String, (f64, usize)> = HashMap::new();
+
+    for entries in groups.values() {
+        let costs: Vec<Option<f64>> = entries.iter().map(|(c, _, _, _)| *c).collect();
+        let selected_cost = select_chain_cost(&costs);
+
+        // Use the last entry's attribution (or first with Some cost).
+        let (_, model, day, dataset) = entries
+            .iter()
+            .find(|(c, _, _, _)| c.is_some())
+            .or_else(|| entries.last())
+            .map(|(c, m, d, ds)| (c, m.clone(), d.clone(), ds.clone()))
+            .unwrap_or_else(|| {
+                (
+                    &None,
+                    "unknown".to_owned(),
+                    "unknown".to_owned(),
+                    "unknown".to_owned(),
+                )
+            });
+
+        match selected_cost {
+            Some(cost) => {
+                grand_total += cost;
+                counted += 1;
+                let e = by_model.entry(model).or_insert((0.0, 0));
+                e.0 += cost;
+                e.1 += 1;
+                let e = by_dataset.entry(dataset).or_insert((0.0, 0));
+                e.0 += cost;
+                e.1 += 1;
+                let e = by_day.entry(day).or_insert((0.0, 0));
+                e.0 += cost;
+                e.1 += 1;
+            }
+            None => {
+                uncosted += entries.len();
+            }
+        }
+    }
+
+    let (budget_usd, remaining_usd, over_budget) = if let Some(budget) = args.budget_usd {
+        let remaining = (budget - grand_total).max(0.0);
+        let over = grand_total >= budget;
+        (Some(budget), Some(remaining), Some(over))
+    } else {
+        (None, None, None)
+    };
+
+    Ok(LedgerReport {
+        generated_at: utc_now_iso8601(),
+        roots: args.dirs.iter().map(|d| d.display().to_string()).collect(),
+        grand_total_usd: grand_total,
+        counted_trajectories: counted,
+        discovered_trajectories: discovered,
+        uncosted,
+        by_model: group_subtotals(&by_model),
+        by_dataset: group_subtotals(&by_dataset),
+        by_day: group_subtotals(&by_day),
+        budget_usd,
+        remaining_usd,
+        over_budget,
+    })
+}
+
+fn load_record(path: &Path) -> Result<TrajRecord, Error> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| Error::Trajectory(format!("cannot read {}: {e}", path.display())))?;
+    let traj: Trajectory = serde_json::from_str(&raw)
+        .map_err(|e| Error::Trajectory(format!("cannot parse {}: {e}", path.display())))?;
+    let info = &traj.info;
+    Ok(TrajRecord {
+        path: path.to_path_buf(),
+        cost: info.total_cost_usd,
+        model: info
+            .model_name
+            .clone()
+            .unwrap_or_else(|| "unknown".to_owned()),
+        started_at: info.started_at.clone(),
+        resume_history: info.resume_history.clone(),
+    })
+}
+
+fn write_artifact(dir: &Path, report: &LedgerReport) -> Result<(), Error> {
+    let path = dir.join("ledger.json");
+    let file = std::fs::File::create(&path)?;
+    crate::artifact::to_writer_pretty(file, ArtifactKind::LedgerReport, report)?;
+    Ok(())
+}
+
+fn utc_now_iso8601() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}

--- a/src/run/ledger.rs
+++ b/src/run/ledger.rs
@@ -317,6 +317,12 @@ fn build_report(args: &LedgerArgs) -> Result<LedgerReport, Error> {
         let paths = collect_traj_paths(dir, true)?;
         all_paths.extend(paths);
     }
+    // Canonicalize before dedup so overlapping roots with different spellings
+    // (relative vs absolute, symlinked) don't inflate counts.
+    all_paths = all_paths
+        .into_iter()
+        .map(|p| std::fs::canonicalize(&p).unwrap_or(p))
+        .collect();
     all_paths.sort();
     all_paths.dedup();
 

--- a/src/run/ledger.rs
+++ b/src/run/ledger.rs
@@ -120,9 +120,9 @@ pub fn render_text(report: &LedgerReport) -> String {
 }
 
 fn render_group_table(out: &mut String, title: &str, groups: &[GroupSubtotal]) {
+    use comfy_table::Table;
     use comfy_table::modifiers::UTF8_ROUND_CORNERS;
     use comfy_table::presets::UTF8_FULL;
-    use comfy_table::Table;
 
     let _ = writeln!(out, "\n{title}:");
     let mut table = Table::new();
@@ -166,8 +166,7 @@ pub fn logical_run_key(
         .and_then(|r| r.original_started_at.as_deref())
         .or(started_at);
 
-    let anchor_str =
-        anchor.map_or_else(|| file_path.display().to_string(), ToOwned::to_owned);
+    let anchor_str = anchor.map_or_else(|| file_path.display().to_string(), ToOwned::to_owned);
 
     (parent, anchor_str)
 }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -51,6 +51,7 @@ pub mod injection_audit;
 pub mod inspect;
 pub mod instance_history;
 pub mod ladder;
+pub mod ledger;
 pub mod matrix;
 pub mod merge;
 pub mod mini;

--- a/tests/bench_ledger.rs
+++ b/tests/bench_ledger.rs
@@ -322,12 +322,11 @@ fn by_dataset_unknown_when_no_results_json() {
 
     let report = run_ledger_json(&[dir.path()], &[]);
     let by_dataset = report["by_dataset"].as_array().unwrap();
-    let labels: Vec<&str> = by_dataset
-        .iter()
-        .map(|g| g["key"].as_str().unwrap())
-        .collect();
     assert!(
-        labels.contains(&"unknown"),
+        by_dataset
+            .iter()
+            .map(|g| g["key"].as_str().unwrap())
+            .any(|x| x == "unknown"),
         "expected 'unknown' when no results.json"
     );
 }
@@ -454,7 +453,7 @@ fn json_format_shape() {
     for field in &["by_model", "by_dataset", "by_day"] {
         let arr = report[field]
             .as_array()
-            .expect(&format!("{field} must be array"));
+            .unwrap_or_else(|| panic!("{field} must be array"));
         if !arr.is_empty() {
             let item = &arr[0];
             assert!(item["key"].is_string(), "{field}[0].key must be string");

--- a/tests/bench_ledger.rs
+++ b/tests/bench_ledger.rs
@@ -477,6 +477,10 @@ fn json_format_shape() {
         "counted_trajectories required"
     );
     assert!(
+        report["chained_trajectories"].is_u64(),
+        "chained_trajectories required"
+    );
+    assert!(
         report["discovered_trajectories"].is_u64(),
         "discovered_trajectories required"
     );
@@ -522,6 +526,18 @@ fn resume_chain_counted_once() {
         report["counted_trajectories"].as_u64().unwrap(),
         1,
         "resume chain = 1 logical run"
+    );
+    assert_eq!(
+        report["chained_trajectories"].as_u64().unwrap(),
+        1,
+        "one chain member absorbed (checkpoint); discovered == counted + chained + uncosted"
+    );
+    assert_eq!(
+        report["discovered_trajectories"].as_u64().unwrap(),
+        report["counted_trajectories"].as_u64().unwrap()
+            + report["chained_trajectories"].as_u64().unwrap()
+            + report["uncosted"].as_u64().unwrap(),
+        "invariant: discovered == counted + chained + uncosted"
     );
 }
 

--- a/tests/bench_ledger.rs
+++ b/tests/bench_ledger.rs
@@ -1,0 +1,671 @@
+//! `bench ledger`: roll up cumulative actual spend across runs/sweeps.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+mod support;
+
+// ── unit tests for pure helper functions ──────────────────────────────────────
+
+use maxwells_daemon::run::ledger::{
+    day_bucket, group_subtotals, logical_run_key, select_chain_cost,
+};
+use maxwells_daemon::trajectory::ResumeRecord;
+
+// day_bucket
+
+#[test]
+fn day_bucket_utc_rfc3339() {
+    assert_eq!(day_bucket(Some("2024-03-15T10:30:00Z")), "2024-03-15");
+}
+
+#[test]
+fn day_bucket_converts_offset_to_utc() {
+    // 2024-03-15T23:00:00-02:00 → 2024-03-16T01:00:00Z
+    assert_eq!(day_bucket(Some("2024-03-15T23:00:00-02:00")), "2024-03-16");
+}
+
+#[test]
+fn day_bucket_none_is_unknown() {
+    assert_eq!(day_bucket(None), "unknown");
+}
+
+#[test]
+fn day_bucket_invalid_is_unknown() {
+    assert_eq!(day_bucket(Some("not-a-date")), "unknown");
+}
+
+// select_chain_cost
+
+#[test]
+fn select_chain_cost_picks_max() {
+    let costs = [Some(0.10_f64), Some(0.20), Some(0.30)];
+    let result = select_chain_cost(&costs);
+    assert!((result.unwrap() - 0.30).abs() < 1e-9, "expected 0.30");
+}
+
+#[test]
+fn select_chain_cost_all_none_is_none() {
+    let costs = [None::<f64>, None, None];
+    assert!(select_chain_cost(&costs).is_none());
+}
+
+#[test]
+fn select_chain_cost_mixed_some_none() {
+    let costs = [None::<f64>, Some(0.15), None];
+    assert!((select_chain_cost(&costs).unwrap() - 0.15).abs() < 1e-9);
+}
+
+// logical_run_key
+
+#[test]
+fn logical_run_key_uses_resume_anchor() {
+    let path = Path::new("/sweeps/run-1.traj.json");
+    let resumed_at = "2024-01-02T00:00:00Z".to_owned();
+    let resume_history = vec![ResumeRecord {
+        original_started_at: Some("2024-01-01T00:00:00Z".to_owned()),
+        resumed_at,
+        prior_steps: 5,
+        prior_cost_usd: 0.10,
+        harness_git_sha_at_resume: None,
+    }];
+    let key = logical_run_key(path, Some("2024-01-02T00:00:00Z"), &resume_history);
+    assert_eq!(key.1, "2024-01-01T00:00:00Z", "anchor should be original");
+}
+
+#[test]
+fn logical_run_key_no_resume_uses_started_at() {
+    let path = Path::new("/sweeps/run-1.traj.json");
+    let key = logical_run_key(path, Some("2024-01-01T00:00:00Z"), &[]);
+    assert_eq!(key.1, "2024-01-01T00:00:00Z");
+}
+
+#[test]
+fn logical_run_key_missing_started_at_uses_path() {
+    let path = Path::new("/sweeps/run-1.traj.json");
+    let key = logical_run_key(path, None, &[]);
+    assert!(key.1.contains("run-1.traj.json"));
+}
+
+// group_subtotals
+
+#[test]
+fn group_subtotals_sorted_cost_desc_then_key_asc() {
+    let mut map = HashMap::new();
+    map.insert("model-b".to_owned(), (0.50, 2));
+    map.insert("model-a".to_owned(), (1.00, 1));
+    map.insert("model-c".to_owned(), (0.50, 3));
+    let subtotals = group_subtotals(&map);
+    assert_eq!(subtotals[0].key, "model-a");
+    assert!((subtotals[0].total_cost_usd - 1.00).abs() < 1e-9);
+    // model-b and model-c have same cost; alphabetical tiebreak
+    assert_eq!(subtotals[1].key, "model-b");
+    assert_eq!(subtotals[2].key, "model-c");
+}
+
+// ── trajectory fixture helpers ────────────────────────────────────────────────
+
+fn traj_json(
+    model: &str,
+    cost: Option<f64>,
+    started_at: Option<&str>,
+    resume_history: &[serde_json::Value],
+) -> serde_json::Value {
+    let cost_val = cost.map_or(serde_json::Value::Null, |c| serde_json::json!(c));
+    let mut info = serde_json::json!({
+        "task": "test-task",
+        "model_name": model,
+        "outcome": "submitted",
+        "total_cost_usd": cost_val,
+        "steps": 1,
+        "test_invocations": []
+    });
+    if let Some(sa) = started_at {
+        info["started_at"] = serde_json::json!(sa);
+    }
+    if !resume_history.is_empty() {
+        info["resume_history"] = serde_json::json!(resume_history);
+    }
+    serde_json::json!({
+        "trajectory_format": "mini-swe-agent-1.3",
+        "artifact_kind": "trajectory",
+        "schema_version": {"major": 1, "minor": 4},
+        "info": info,
+        "messages": []
+    })
+}
+
+fn write_traj(dir: &Path, name: &str, traj: &serde_json::Value) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, serde_json::to_string_pretty(traj).unwrap()).unwrap();
+    path
+}
+
+fn write_results_json(dir: &Path, dataset_alias: Option<&str>, dataset_path: &str) {
+    // Minimal results.json that contains just enough for dataset label extraction.
+    // Uses a raw JSON Value so we only need to satisfy the ledger's serde_json::Value
+    // parsing path (not the strongly-typed SweepResults deserializer).
+    let manifest = serde_json::json!({
+        "dataset": {
+            "path": dataset_path,
+            "sha256": "abc123",
+            "instance_count": 1,
+            "source_kind": "huggingface",
+            "alias": dataset_alias
+        }
+    });
+
+    let results = serde_json::json!({
+        "artifact_kind": "sweep_results",
+        "schema_version": {"major": 1, "minor": 12},
+        "total": 1,
+        "submitted": 1,
+        "skipped": 0,
+        "errored": 0,
+        "manifest": manifest
+    });
+    std::fs::write(
+        dir.join("results.json"),
+        serde_json::to_string_pretty(&results).unwrap(),
+    )
+    .unwrap();
+}
+
+fn run_ledger(dirs: &[&Path], extra_args: &[&str]) -> std::process::Output {
+    let mut cmd = Command::new(support::binary_path());
+    cmd.args(["--log", "error", "bench", "ledger"]);
+    for d in dirs {
+        cmd.arg(d);
+    }
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    cmd.output().unwrap()
+}
+
+fn run_ledger_json(dirs: &[&Path], extra_args: &[&str]) -> serde_json::Value {
+    let mut args: Vec<&str> = vec!["--format", "json"];
+    args.extend_from_slice(extra_args);
+    let output = run_ledger(dirs, &args);
+    assert!(
+        output.status.success(),
+        "bench ledger --format json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+// ── AC1: grand total ──────────────────────────────────────────────────────────
+
+#[test]
+fn grand_total_sums_all_trajectories() {
+    let dir = tempfile::tempdir().unwrap();
+    write_traj(
+        dir.path(),
+        "a.traj.json",
+        &traj_json("model-a", Some(0.10), Some("2024-01-01T00:00:00Z"), &[]),
+    );
+    write_traj(
+        dir.path(),
+        "b.traj.json",
+        &traj_json("model-b", Some(0.20), Some("2024-01-01T01:00:00Z"), &[]),
+    );
+    write_traj(
+        dir.path(),
+        "c.traj.json",
+        &traj_json("model-a", Some(0.05), Some("2024-01-01T02:00:00Z"), &[]),
+    );
+
+    let report = run_ledger_json(&[dir.path()], &[]);
+    let total = report["grand_total_usd"].as_f64().unwrap();
+    assert!(
+        (total - 0.35).abs() < 1e-6,
+        "expected grand total ~0.35, got {total}"
+    );
+    assert_eq!(
+        report["counted_trajectories"].as_u64().unwrap(),
+        3,
+        "3 trajectories counted"
+    );
+    assert_eq!(
+        report["discovered_trajectories"].as_u64().unwrap(),
+        3,
+        "3 trajectories discovered"
+    );
+    assert_eq!(report["uncosted"].as_u64().unwrap(), 0);
+}
+
+// ── AC2: by_model, by_dataset, by_day each sum to grand total ─────────────────
+
+#[test]
+fn by_model_groups_sum_to_grand_total() {
+    let dir = tempfile::tempdir().unwrap();
+    write_traj(
+        dir.path(),
+        "a.traj.json",
+        &traj_json("model-a", Some(0.10), Some("2024-01-01T00:00:00Z"), &[]),
+    );
+    write_traj(
+        dir.path(),
+        "b.traj.json",
+        &traj_json("model-b", Some(0.20), Some("2024-01-01T01:00:00Z"), &[]),
+    );
+
+    let report = run_ledger_json(&[dir.path()], &[]);
+    let grand_total = report["grand_total_usd"].as_f64().unwrap();
+
+    let by_model = report["by_model"].as_array().unwrap();
+    let model_sum: f64 = by_model
+        .iter()
+        .map(|g| g["total_cost_usd"].as_f64().unwrap())
+        .sum();
+    assert!(
+        (model_sum - grand_total).abs() < 1e-6,
+        "by_model sum {model_sum} != grand_total {grand_total}"
+    );
+}
+
+#[test]
+fn by_dataset_groups_sum_to_grand_total() {
+    let dir = tempfile::tempdir().unwrap();
+    let sub1 = dir.path().join("sweep1");
+    let sub2 = dir.path().join("sweep2");
+    std::fs::create_dir_all(&sub1).unwrap();
+    std::fs::create_dir_all(&sub2).unwrap();
+    write_results_json(&sub1, Some("lite"), "swebench_lite");
+    write_results_json(&sub2, Some("verified"), "swebench_verified");
+    write_traj(
+        &sub1,
+        "a.traj.json",
+        &traj_json("model-a", Some(0.10), Some("2024-01-01T00:00:00Z"), &[]),
+    );
+    write_traj(
+        &sub2,
+        "b.traj.json",
+        &traj_json("model-b", Some(0.20), Some("2024-01-01T01:00:00Z"), &[]),
+    );
+
+    let report = run_ledger_json(&[dir.path()], &[]);
+    let grand_total = report["grand_total_usd"].as_f64().unwrap();
+    let by_dataset = report["by_dataset"].as_array().unwrap();
+    let dataset_sum: f64 = by_dataset
+        .iter()
+        .map(|g| g["total_cost_usd"].as_f64().unwrap())
+        .sum();
+    assert!(
+        (dataset_sum - grand_total).abs() < 1e-6,
+        "by_dataset sum {dataset_sum} != grand_total {grand_total}"
+    );
+    let labels: Vec<&str> = by_dataset
+        .iter()
+        .map(|g| g["key"].as_str().unwrap())
+        .collect();
+    assert!(labels.contains(&"lite"), "expected 'lite' dataset label");
+    assert!(
+        labels.contains(&"verified"),
+        "expected 'verified' dataset label"
+    );
+}
+
+#[test]
+fn by_dataset_unknown_when_no_results_json() {
+    let dir = tempfile::tempdir().unwrap();
+    write_traj(
+        dir.path(),
+        "a.traj.json",
+        &traj_json("model-a", Some(0.10), Some("2024-01-01T00:00:00Z"), &[]),
+    );
+
+    let report = run_ledger_json(&[dir.path()], &[]);
+    let by_dataset = report["by_dataset"].as_array().unwrap();
+    let labels: Vec<&str> = by_dataset
+        .iter()
+        .map(|g| g["key"].as_str().unwrap())
+        .collect();
+    assert!(
+        labels.contains(&"unknown"),
+        "expected 'unknown' when no results.json"
+    );
+}
+
+#[test]
+fn by_day_groups_sum_to_grand_total_with_unknown_bucket() {
+    let dir = tempfile::tempdir().unwrap();
+    write_traj(
+        dir.path(),
+        "a.traj.json",
+        &traj_json("model-a", Some(0.10), Some("2024-01-01T00:00:00Z"), &[]),
+    );
+    write_traj(
+        dir.path(),
+        "b.traj.json",
+        &traj_json("model-b", Some(0.15), Some("2024-01-02T00:00:00Z"), &[]),
+    );
+    // No started_at → unknown bucket
+    write_traj(
+        dir.path(),
+        "c.traj.json",
+        &traj_json("model-a", Some(0.05), None, &[]),
+    );
+
+    let report = run_ledger_json(&[dir.path()], &[]);
+    let grand_total = report["grand_total_usd"].as_f64().unwrap();
+    let by_day = report["by_day"].as_array().unwrap();
+    let day_sum: f64 = by_day
+        .iter()
+        .map(|g| g["total_cost_usd"].as_f64().unwrap())
+        .sum();
+    assert!(
+        (day_sum - grand_total).abs() < 1e-6,
+        "by_day sum {day_sum} != grand_total {grand_total}"
+    );
+    let keys: Vec<&str> = by_day.iter().map(|g| g["key"].as_str().unwrap()).collect();
+    assert!(keys.contains(&"2024-01-01"), "expected 2024-01-01");
+    assert!(keys.contains(&"2024-01-02"), "expected 2024-01-02");
+    assert!(keys.contains(&"unknown"), "expected unknown bucket");
+}
+
+// ── AC3: budget_usd ───────────────────────────────────────────────────────────
+
+#[test]
+fn budget_remaining_under_exits_0() {
+    let dir = tempfile::tempdir().unwrap();
+    write_traj(
+        dir.path(),
+        "a.traj.json",
+        &traj_json("model-a", Some(0.10), Some("2024-01-01T00:00:00Z"), &[]),
+    );
+
+    let output = run_ledger(&[dir.path()], &["--budget-usd", "1.00"]);
+    assert!(
+        output.status.success(),
+        "expected exit 0 when under budget\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_default();
+    // Text mode stdout isn't JSON — check the written artifact on disk instead.
+    let artifact: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(dir.path().join("ledger.json")).unwrap())
+            .unwrap();
+    assert_eq!(artifact["over_budget"], serde_json::json!(false));
+    let remaining = artifact["remaining_usd"].as_f64().unwrap();
+    assert!(remaining > 0.0, "remaining_usd should be positive");
+    drop(report);
+}
+
+#[test]
+fn budget_exceeded_exits_49() {
+    let dir = tempfile::tempdir().unwrap();
+    write_traj(
+        dir.path(),
+        "a.traj.json",
+        &traj_json("model-a", Some(0.50), Some("2024-01-01T00:00:00Z"), &[]),
+    );
+
+    let output = run_ledger(&[dir.path()], &["--budget-usd", "0.10"]);
+    let exit_code = output.status.code().unwrap();
+    assert_eq!(
+        exit_code,
+        49,
+        "expected exit 49 when budget exceeded\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // Report must still be printed before exit.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("0.5") || stdout.contains("grand total") || stdout.contains("ledger"),
+        "report must be printed before exit-49\nstdout: {stdout}"
+    );
+    // Stderr must contain outcome_class.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ledger_budget_exceeded"),
+        "stderr must contain outcome_class: ledger_budget_exceeded\nstderr: {stderr}"
+    );
+}
+
+// ── AC4: --format json ────────────────────────────────────────────────────────
+
+#[test]
+fn json_format_shape() {
+    let dir = tempfile::tempdir().unwrap();
+    write_traj(
+        dir.path(),
+        "a.traj.json",
+        &traj_json("model-a", Some(0.10), Some("2024-01-01T00:00:00Z"), &[]),
+    );
+
+    let report = run_ledger_json(&[dir.path()], &[]);
+    assert_eq!(
+        report["artifact_kind"],
+        serde_json::json!("ledger_report"),
+        "artifact_kind must be 'ledger_report'"
+    );
+    assert_eq!(
+        report["schema_version"]["major"].as_u64().unwrap(),
+        1,
+        "schema_version.major must be 1"
+    );
+    // by_model, by_dataset, by_day must be arrays of {key, total_cost_usd, trajectory_count}
+    for field in &["by_model", "by_dataset", "by_day"] {
+        let arr = report[field]
+            .as_array()
+            .expect(&format!("{field} must be array"));
+        if !arr.is_empty() {
+            let item = &arr[0];
+            assert!(item["key"].is_string(), "{field}[0].key must be string");
+            assert!(
+                item["total_cost_usd"].is_f64() || item["total_cost_usd"].is_u64(),
+                "{field}[0].total_cost_usd must be number"
+            );
+            assert!(
+                item["trajectory_count"].is_u64(),
+                "{field}[0].trajectory_count must be u64"
+            );
+        }
+    }
+    assert!(
+        report["grand_total_usd"].is_f64() || report["grand_total_usd"].is_u64(),
+        "grand_total_usd must be number"
+    );
+    assert!(
+        report["counted_trajectories"].is_u64(),
+        "counted_trajectories required"
+    );
+    assert!(
+        report["discovered_trajectories"].is_u64(),
+        "discovered_trajectories required"
+    );
+    assert!(report["uncosted"].is_u64(), "uncosted required");
+}
+
+// ── AC5: resume chain counted once ───────────────────────────────────────────
+
+#[test]
+fn resume_chain_counted_once() {
+    let dir = tempfile::tempdir().unwrap();
+    // Checkpoint: cost 0.10, no resume_history
+    write_traj(
+        dir.path(),
+        "checkpoint.traj.json",
+        &traj_json("model-a", Some(0.10), Some("2024-01-01T00:00:00Z"), &[]),
+    );
+    // Resumed: cumulative cost 0.30, resume_history points back to original started_at
+    let resume_record = serde_json::json!({
+        "original_started_at": "2024-01-01T00:00:00Z",
+        "resumed_at": "2024-01-01T01:00:00Z",
+        "prior_steps": 5,
+        "prior_cost_usd": 0.10
+    });
+    write_traj(
+        dir.path(),
+        "resumed.traj.json",
+        &traj_json(
+            "model-a",
+            Some(0.30),
+            Some("2024-01-01T01:00:00Z"),
+            &[resume_record],
+        ),
+    );
+
+    let report = run_ledger_json(&[dir.path()], &[]);
+    let total = report["grand_total_usd"].as_f64().unwrap();
+    assert!(
+        (total - 0.30).abs() < 0.01,
+        "resume chain should be counted once at 0.30, got {total}"
+    );
+    assert_eq!(
+        report["counted_trajectories"].as_u64().unwrap(),
+        1,
+        "resume chain = 1 logical run"
+    );
+}
+
+// ── AC5: independent reruns counted separately ────────────────────────────────
+
+#[test]
+fn independent_reruns_counted_separately() {
+    let dir = tempfile::tempdir().unwrap();
+    // Two independent reruns — distinct started_at, no resume_history
+    write_traj(
+        dir.path(),
+        "run-1.traj.json",
+        &traj_json("model-a", Some(0.10), Some("2024-01-01T00:00:00Z"), &[]),
+    );
+    write_traj(
+        dir.path(),
+        "run-2.traj.json",
+        &traj_json("model-a", Some(0.10), Some("2024-01-02T00:00:00Z"), &[]),
+    );
+
+    let report = run_ledger_json(&[dir.path()], &[]);
+    let total = report["grand_total_usd"].as_f64().unwrap();
+    assert!(
+        (total - 0.20).abs() < 1e-6,
+        "two independent reruns should sum to 0.20, got {total}"
+    );
+    assert_eq!(
+        report["counted_trajectories"].as_u64().unwrap(),
+        2,
+        "two independent logical runs"
+    );
+}
+
+// ── AC6: uncosted surfaced ────────────────────────────────────────────────────
+
+#[test]
+fn uncosted_trajectories_surfaced() {
+    let dir = tempfile::tempdir().unwrap();
+    // One costed, one with no cost (null)
+    write_traj(
+        dir.path(),
+        "costed.traj.json",
+        &traj_json("model-a", Some(0.10), Some("2024-01-01T00:00:00Z"), &[]),
+    );
+    write_traj(
+        dir.path(),
+        "no-cost.traj.json",
+        &traj_json("model-b", None, Some("2024-01-01T01:00:00Z"), &[]),
+    );
+
+    let report = run_ledger_json(&[dir.path()], &[]);
+    assert_eq!(report["uncosted"].as_u64().unwrap(), 1, "one uncosted");
+    let total = report["grand_total_usd"].as_f64().unwrap();
+    assert!(
+        (total - 0.10).abs() < 1e-6,
+        "uncosted should not affect grand total"
+    );
+    assert_eq!(
+        report["counted_trajectories"].as_u64().unwrap(),
+        1,
+        "only one costed trajectory counted"
+    );
+}
+
+// ── AC7: zero network / zero model calls (implicit — tested via running the command) ──
+
+#[test]
+fn bad_format_is_usage_error() {
+    let dir = tempfile::tempdir().unwrap();
+    write_traj(
+        dir.path(),
+        "a.traj.json",
+        &traj_json("model-a", Some(0.10), Some("2024-01-01T00:00:00Z"), &[]),
+    );
+
+    let output = run_ledger(&[dir.path()], &["--format", "xml"]);
+    let code = output.status.code().unwrap();
+    assert_eq!(code, 2, "unknown format should be exit 2 (usage_error)");
+}
+
+#[test]
+fn multiple_dirs_aggregate() {
+    let dir1 = tempfile::tempdir().unwrap();
+    let dir2 = tempfile::tempdir().unwrap();
+    write_traj(
+        dir1.path(),
+        "a.traj.json",
+        &traj_json("model-a", Some(0.10), Some("2024-01-01T00:00:00Z"), &[]),
+    );
+    write_traj(
+        dir2.path(),
+        "b.traj.json",
+        &traj_json("model-b", Some(0.20), Some("2024-01-01T01:00:00Z"), &[]),
+    );
+
+    let report = run_ledger_json(&[dir1.path(), dir2.path()], &[]);
+    let total = report["grand_total_usd"].as_f64().unwrap();
+    assert!(
+        (total - 0.30).abs() < 1e-6,
+        "two dirs should aggregate to 0.30, got {total}"
+    );
+    assert_eq!(report["counted_trajectories"].as_u64().unwrap(), 2);
+}
+
+#[test]
+fn writes_ledger_json_artifact() {
+    let dir = tempfile::tempdir().unwrap();
+    write_traj(
+        dir.path(),
+        "a.traj.json",
+        &traj_json("model-a", Some(0.10), Some("2024-01-01T00:00:00Z"), &[]),
+    );
+
+    let output = run_ledger(&[dir.path()], &[]);
+    assert!(output.status.success());
+
+    let artifact_path = dir.path().join("ledger.json");
+    assert!(artifact_path.exists(), "ledger.json must be written");
+    let artifact: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&artifact_path).unwrap()).unwrap();
+    assert_eq!(
+        artifact["artifact_kind"],
+        serde_json::json!("ledger_report")
+    );
+}
+
+#[test]
+fn text_format_shows_ledger_header() {
+    let dir = tempfile::tempdir().unwrap();
+    write_traj(
+        dir.path(),
+        "a.traj.json",
+        &traj_json("model-a", Some(0.10), Some("2024-01-01T00:00:00Z"), &[]),
+    );
+
+    let output = run_ledger(&[dir.path()], &[]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("bench ledger"),
+        "expected 'bench ledger' header\nstdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("grand total") || stdout.contains("Grand total"),
+        "expected grand total in output\nstdout: {stdout}"
+    );
+}

--- a/tests/explain_cmd.rs
+++ b/tests/explain_cmd.rs
@@ -151,9 +151,9 @@ fn explain_index_json_lists_all_entries() {
     let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
     assert_eq!(v["schema_version"], "1.0");
     let entries = v["entries"].as_array().unwrap();
-    // 51 exit-code classes (0–48, 130, 137) + 15 failure categories, minus the
-    // 1 merged collision (agent_stagnation) = 65 distinct entries.
-    assert_eq!(entries.len(), 65, "unexpected index size");
+    // 52 exit-code classes (0–49, 130, 137) + 15 failure categories, minus the
+    // 1 merged collision (agent_stagnation) = 66 distinct entries.
+    assert_eq!(entries.len(), 66, "unexpected index size");
 }
 
 // ── AC: offline / $0 — runs with no API key set ──────────────────────────────

--- a/tests/explain_drift.rs
+++ b/tests/explain_drift.rs
@@ -73,6 +73,7 @@ fn all_exit_codes() -> Vec<ExitCode> {
             | ExitCode::FsAuditScanError
             | ExitCode::ArtifactCheckFailure
             | ExitCode::HostNotReady
+            | ExitCode::LedgerBudgetExceeded
             | ExitCode::Interrupted
             | ExitCode::Killed => e,
         }
@@ -128,6 +129,7 @@ fn all_exit_codes() -> Vec<ExitCode> {
         ExitCode::FsAuditScanError,
         ExitCode::ArtifactCheckFailure,
         ExitCode::HostNotReady,
+        ExitCode::LedgerBudgetExceeded,
         ExitCode::Interrupted,
         ExitCode::Killed,
     ]


### PR DESCRIPTION
## Summary
Adds a new `bench ledger` command that aggregates and reports cumulative actual spend across multiple runs and sweeps. This is a zero-cost operation that reads only on-disk trajectory artifacts without making any network calls or model invocations.

## Key Changes

- **New `bench ledger` command** (`src/cli/args.rs`, `src/cli/mod.rs`):
  - Accepts one or more run/sweep directories to aggregate
  - Supports `--budget-usd` flag to check against a spending limit
  - Outputs in `text` (human-readable table) or `json` format
  - Writes `ledger.json` artifact to the first input directory

- **Core ledger implementation** (`src/run/ledger.rs`):
  - Discovers and loads all trajectory files recursively from input directories
  - Groups trajectories by logical run (collapsing resume chains to single entries)
  - Selects the maximum cost from each resume chain (deepest resumed trajectory has cumulative total)
  - Aggregates costs by model, dataset, and day (UTC)
  - Tracks discovered, counted, chained, and uncosted trajectory counts
  - Supports optional budget checking with remaining/over-budget reporting

- **Pure helper functions** (unit-testable):
  - `logical_run_key()`: Groups trajectories by original start time, handling resume chains
  - `select_chain_cost()`: Picks maximum cost from a resume chain
  - `day_bucket()`: Converts RFC3339 timestamps to UTC date buckets
  - `dataset_label_for()`: Extracts dataset labels from ancestor `results.json` files
  - `group_subtotals()`: Sorts aggregated groups by cost (descending) then key (ascending)

- **Exit code handling**:
  - Exit 49 (`LedgerBudgetExceeded`) when actual spend meets or exceeds budget
  - Report is printed before exit to allow CI gating on budget exhaustion
  - Distinct from exit 5 (`budget_halt`) which is a forecast/sweep-time cap

- **Comprehensive test suite** (`tests/bench_ledger.rs`):
  - Unit tests for all pure helper functions
  - Integration tests covering grand total calculation, grouping, budget checking, resume chain handling, and output formats
  - Tests for edge cases: missing costs, missing metadata, multiple directories, invalid formats

- **Artifact and documentation updates**:
  - New `LedgerReport` artifact kind with schema versioning
  - Updated exit codes documentation and explain entries
  - Added to command catalog

## Notable Implementation Details

- Resume chains are deduplicated by grouping trajectories with the same `original_started_at` anchor, with only the deepest (highest-cost) entry counted toward totals
- Dataset labels are cached per ancestor directory to avoid repeated file I/O
- The invariant `discovered == counted + chained + uncosted` is maintained throughout
- All three grouping dimensions (by_model, by_dataset, by_day) independently sum to the grand total
- Text output uses formatted tables with UTF8 borders for readability

https://claude.ai/code/session_01U7sWcKTFjxUPhMnLX1YioF