### PR TITLE
👺 Havoc: Percent Decoding Destroys Entire Header on Invalid UTF-8

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -534,8 +534,10 @@ mod tests {
             network_pos.is_some(),
             "expected --network flag in args: {args:?}"
         );
+        #[allow(clippy::unwrap_used)]
+        let pos = network_pos.unwrap();
         assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
+            args.get(pos + 1).map(String::as_str),
             Some("none")
         );
     }
@@ -550,6 +552,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network").unwrap();

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -176,7 +176,7 @@ fn percent_decode(s: &str) -> String {
         out.push(bytes[i]);
         i += 1;
     }
-    String::from_utf8(out).unwrap_or_default()
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 /// Parse a comma-separated OTel header env var value into `(name, value)` pairs.
@@ -1133,6 +1133,15 @@ mod tests {
             .get_or_init(Mutex::default)
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    #[test]
+    fn percent_decode_preserves_valid_chars_with_invalid_utf8() {
+        let input = "abc%FFdef";
+        let decoded = percent_decode(input);
+        // %FF is invalid UTF-8, it should be replaced with the replacement char (),
+        // but the valid characters before and after should be preserved.
+        assert_eq!(decoded, "abc\u{FFFD}def");
     }
 
     #[test]


### PR DESCRIPTION
🧨 **The Trigger:** Percent-decoding an HTTP header value containing invalid UTF-8 sequences (e.g., `value%FF`) caused the `String::from_utf8(out).unwrap_or_default()` call to return `""`, destroying the entire header's value rather than just falling back gracefully.

📉 **The Stack Trace:** No panic, but silent data loss at `src/telemetry/mod.rs` `percent_decode` returning `""`.

🧪 **Reproduction:** Run a fuzzer or `cargo test --test fuzz_percent_decode` to see `parse_otlp_header_env("Authorization=Bearer token,key=value%FFafter")` return empty for `key`.

😈 **Comment:** "You assumed all URLs and headers would be perfectly encoded UTF-8. You were wrong. Embrace the chaos, preserve the valid bytes, use lossy decoding."

---
*PR created automatically by Jules for task [12494751162432208436](https://jules.google.com/task/12494751162432208436) started by @madmax983*