### PR TITLE
⚒️ Forge: Use guard clauses instead of unwrap in docker tests

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected my-image in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"


### PR DESCRIPTION
🚰 Smell: Using `.unwrap()` directly on `Option`s in tests creates a clippy warning (`clippy::unwrap_used`) and can obscure the exact failure location if a test panics unexpectedly.
✨ Solution: Replaced `let x = opt.unwrap()` with `let Some(x) = opt else { panic!("custom message") }` guard clauses in `src/env/docker.rs`.
🧼 Benefit: Resolves clippy warnings and provides clearer, customizable panic messages when tests fail, adhering to idiomatic Rust error handling.
🛡️ Verification: Ran `cargo check`, `cargo fmt`, `cargo clippy`, and `cargo test` successfully. No logic changed.

---
*PR created automatically by Jules for task [16997503536591156076](https://jules.google.com/task/16997503536591156076) started by @madmax983*