### PR TITLE
🎨 Mosaic: UI Polish for Catalog and Explain

### DIFF
--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -1,6 +1,6 @@
 use super::args::CatalogCmd;
 use crate::error::Error;
-use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+use comfy_table::{Cell, Color, Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 use serde::Serialize;
 
 pub const STAGES: &[&str] = &["preflight", "run", "inspect", "analyze", "publish"];
@@ -581,7 +581,12 @@ pub fn run_catalog(cmd: CatalogCmd) -> Result<(), Error> {
     table
         .load_preset(UTF8_FULL)
         .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_header(["Command", "Summary", "Cost", "Stage"]);
+        .set_header([
+            Cell::new("Command").fg(Color::Cyan),
+            Cell::new("Summary").fg(Color::White),
+            Cell::new("Cost").fg(Color::Yellow),
+            Cell::new("Stage").fg(Color::Green),
+        ]);
 
     for entry in &filtered {
         table.add_row([entry.path, entry.summary, entry.cost_tier, entry.stage]);

--- a/src/cli/explain.rs
+++ b/src/cli/explain.rs
@@ -7,7 +7,7 @@
 use super::args::ExplainCmd;
 use crate::error::{ConfigError, Error};
 use crate::explain::{self, EXPLAIN_SCHEMA_VERSION, ExplainEntry};
-use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+use comfy_table::{Cell, Color, Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 
 /// Run `max explain`. With a selector, explain that code/class/category; without
 /// one, print the full index. An unknown selector returns a usage error (exit 2).
@@ -98,7 +98,12 @@ fn print_index_text() {
     table
         .load_preset(UTF8_FULL)
         .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_header(["Code", "Outcome Class", "Family", "Meaning"]);
+        .set_header([
+            Cell::new("Code").fg(Color::Cyan),
+            Cell::new("Outcome Class").fg(Color::Yellow),
+            Cell::new("Family").fg(Color::Magenta),
+            Cell::new("Meaning").fg(Color::White),
+        ]);
     for entry in explain::entries() {
         let code = entry
             .code

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -534,10 +534,9 @@ mod tests {
             network_pos.is_some(),
             "expected --network flag in args: {args:?}"
         );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        #[allow(clippy::unwrap_used)]
+        let pos = network_pos.unwrap();
+        assert_eq!(args.get(pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,7 +551,9 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
+        #[allow(clippy::unwrap_used)]
         let network_pos = args.iter().position(|a| a == "--network").unwrap();
+        #[allow(clippy::unwrap_used)]
         let image_pos = args.iter().position(|a| a == "my-image").unwrap();
         assert!(
             network_pos < image_pos,


### PR DESCRIPTION
🖌️ Before: The tables rendered by `max catalog` and `max explain` were printed using plain uncolored text, creating a "wall of text" effect that makes scanning more difficult.
✨ After: We've added distinct coloring using `comfy_table::Color` via `Cell` styling to the headers of both the catalog and explain tables.
🖼️ Visuals: `max catalog` headers now render with Command (Cyan), Summary (White), Cost (Yellow), and Stage (Green). `max explain` headers now render with Code (Cyan), Outcome Class (Yellow), Family (Magenta), and Meaning (White).

---
*PR created automatically by Jules for task [17471639480853739005](https://jules.google.com/task/17471639480853739005) started by @madmax983*