### PR TITLE
🛡️ Sentry: [test coverage improvement] Fix `unwrap()` usage in docker test suite

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected image name in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement] Fix `unwrap()` usage in docker test suite

🎯 Target: `src/env/docker.rs` tests (`build_run_args_*`).
💣 Risk: `unwrap()` calls on `Option` variants mask actual assertions with unhelpful `NoneError` panics, obscuring exactly what state failed.
🧪 Strategy: Replaced `.unwrap()` with `let Some(..) = .. else { panic!("...") }` guard clauses, preserving test behavior while ensuring clear errors with context if arguments ever change unexpectedly.
🔭 Verification: `cargo test` and `cargo clippy` passed.

---
*PR created automatically by Jules for task [3557573098148176433](https://jules.google.com/task/3557573098148176433) started by @madmax983*