### PR TITLE
⚡ Bolt: Optimize vector allocations in dataset_stats

### DIFF
--- a/src/run/dataset_stats.rs
+++ b/src/run/dataset_stats.rs
@@ -81,7 +81,7 @@ pub fn compute_stats(
         let repo = inst.repo.clone().unwrap_or_else(|| "unknown".to_owned());
         *repo_counts.entry(repo).or_insert(0) += 1;
     }
-    let mut repos = Vec::new();
+    let mut repos = Vec::with_capacity(repo_counts.len());
     for (repo, count) in repo_counts {
         #[allow(clippy::cast_precision_loss)]
         let percent_share = if total_instances > 0 {
@@ -100,7 +100,7 @@ pub fn compute_stats(
 
     // 2. Count tokens in problem statement using TokenCounter
     let counter = TokenCounter::new();
-    let mut slice_tokens = Vec::new();
+    let mut slice_tokens = Vec::with_capacity(slice_instances.len());
     for inst in slice_instances {
         let text = inst.problem_statement.as_deref().unwrap_or("");
         let count = match counter.count_completion_tokens(model, text) {
@@ -119,7 +119,7 @@ pub fn compute_stats(
     };
 
     // Calculate full dataset median for token length skew checking
-    let mut full_tokens = Vec::new();
+    let mut full_tokens = Vec::with_capacity(full_instances.len());
     for inst in full_instances {
         let text = inst.problem_statement.as_deref().unwrap_or("");
         let count = match counter.count_completion_tokens(model, text) {
@@ -132,7 +132,7 @@ pub fn compute_stats(
     let full_median = median(&full_tokens);
 
     // 3. Count expected tests from FAIL_TO_PASS and PASS_TO_PASS
-    let mut expected_tests_list = Vec::new();
+    let mut expected_tests_list = Vec::with_capacity(slice_instances.len());
     for inst in slice_instances {
         expected_tests_list.push(get_expected_tests_count(inst));
     }
@@ -394,7 +394,7 @@ fn analyze_historical_resolved_rates(
         }
     }
 
-    let mut rates = Vec::new();
+    let mut rates = Vec::with_capacity(instances.len());
     for inst in instances {
         if let Some(&(resolved, runs)) = hist_map.get(&inst.instance_id) {
             if runs > 0 {


### PR DESCRIPTION
💡 What: Replaced 5 instances of `Vec::new()` with `Vec::with_capacity(...)` in `src/run/dataset_stats.rs`.
🎯 Why: The size of these vectors is known exactly or has a hard upper bound based on the iteration count (`repo_counts.len()`, `slice_instances.len()`, `full_instances.len()`, `instances.len()`). Pre-allocating prevents unnecessary memory reallocations and memory fragmentation as the loops push items.
📊 Impact: Completely eliminates multiple heap reallocations during offline dataset stat generation, specifically during loops that iterate over thousands of instances.
🔬 Measurement: Run `cargo bench` (if available) or `cargo test dataset_stats` to verify correct behavior remains unchanged.

---
*PR created automatically by Jules for task [1151450649697677453](https://jules.google.com/task/1151450649697677453) started by @madmax983*