### PR TITLE
⚒️ Forge: Fix clippy::unwrap_used in docker.rs

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected my-image in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"


### PR DESCRIPTION
🚮 Smell: Several tests in `src/env/docker.rs` were using `.unwrap()` on `Option` types, which triggers `clippy::unwrap_used` warnings and makes test failure messages opaque.

✨ Solution: Replaced the `.unwrap()` calls with idiomatic guard clauses (`let Some(...) = ... else { panic!(...) }`).

🧼 Benefit: Improves test readability, removes warnings, and provides better context on test failures since the guard clauses explicitly panic with the underlying `args` printed rather than just failing the unwrap.

🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [479873100234489637](https://jules.google.com/task/479873100234489637) started by @madmax983*