### PR TITLE
🎨 Mosaic: UI Polish for skills-preview

### DIFF
--- a/src/run/skills_preview.rs
+++ b/src/run/skills_preview.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeSet;
 use std::fmt::Write as _;
 use std::path::PathBuf;
 
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
@@ -257,18 +258,27 @@ pub fn format_text(report: &SkillsPreviewReport, redactor: &Redactor) -> String 
         if task.active_skills.is_empty() {
             out.push_str("  (no skills activated)\n");
         } else {
+            let mut table = Table::new();
+            table
+                .load_preset(UTF8_FULL)
+                .apply_modifier(UTF8_ROUND_CORNERS)
+                .set_header(vec!["Skill Name", "Reason", "Prefix", "Bytes", "Path"]);
+
             for skill in &task.active_skills {
                 let reason_str = match skill.reason {
                     SkillActivationReason::ExplicitMention => "explicit",
                     SkillActivationReason::AutoMatch => "auto",
                 };
                 let path_str = skill.path.display().to_string();
-                let _ = writeln!(
-                    out,
-                    "  {} | {} | {} | {} bytes | {}",
-                    skill.name, reason_str, skill.sha256_prefix, skill.bytes, path_str,
-                );
+                table.add_row(vec![
+                    skill.name.clone(),
+                    reason_str.to_string(),
+                    skill.sha256_prefix.clone(),
+                    skill.bytes.to_string(),
+                    path_str,
+                ]);
             }
+            let _ = writeln!(out, "{table}");
         }
         let _ = writeln!(out, "  total_bytes_injected: {}", task.total_bytes_injected);
         let _ = writeln!(
@@ -283,20 +293,35 @@ pub fn format_text(report: &SkillsPreviewReport, redactor: &Redactor) -> String 
         );
     }
 
-    let _ = writeln!(
-        out,
-        "\n--- summary ---\n\
-         task_count: {}\n\
-         unique_skills_activated: {}\n\
-         p50_bytes_per_task: {}\n\
-         p95_bytes_per_task: {}\n\
-         tasks_hitting_max_active: {}",
-        report.summary.task_count,
-        report.summary.unique_skills_activated,
-        report.summary.p50_bytes_per_task,
-        report.summary.p95_bytes_per_task,
-        report.summary.tasks_hitting_max_active,
-    );
+    let mut summary_table = Table::new();
+    summary_table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec!["Metric", "Value"]);
+
+    summary_table.add_row(vec![
+        "task_count".to_string(),
+        report.summary.task_count.to_string(),
+    ]);
+    summary_table.add_row(vec![
+        "unique_skills_activated".to_string(),
+        report.summary.unique_skills_activated.to_string(),
+    ]);
+    summary_table.add_row(vec![
+        "p50_bytes_per_task".to_string(),
+        report.summary.p50_bytes_per_task.to_string(),
+    ]);
+    summary_table.add_row(vec![
+        "p95_bytes_per_task".to_string(),
+        report.summary.p95_bytes_per_task.to_string(),
+    ]);
+    summary_table.add_row(vec![
+        "tasks_hitting_max_active".to_string(),
+        report.summary.tasks_hitting_max_active.to_string(),
+    ]);
+
+    let _ = writeln!(out, "\n--- summary ---");
+    let _ = writeln!(out, "{summary_table}");
 
     redactor.redact_text(&out, surface::TRAJECTORY).text
 }


### PR DESCRIPTION
Upgraded the output of `agent skills-preview` from unformatted strings to structured UTF-8 tables with rounded corners for readability.

🖌️ **Before:** The output of `agent skills-preview` printed flat rows of skills and plain text metrics which were hard to read for humans.
✨ **After:** The skills and summary metrics are now rendered inside structured tables with clear headers and rounded corners.
🖼️ **Visuals:** The skill listing now features columns for "Skill Name", "Reason", "Prefix", "Bytes", and "Path". The summary now features columns for "Metric" and "Value". Both tables use UTF8 rendering.

---
*PR created automatically by Jules for task [6920757232955263249](https://jules.google.com/task/6920757232955263249) started by @madmax983*