### PR TITLE
🛡️ Sentry: Fix unwrap panics in docker env tests

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,11 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let network_pos = args
+            .iter()
+            .position(|a| a == "--network")
+            .unwrap_or_else(|| panic!("expected --network flag in args: {args:?}"));
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +548,14 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let network_pos = args
+            .iter()
+            .position(|a| a == "--network")
+            .unwrap_or_else(|| panic!("missing --network flag"));
+        let image_pos = args
+            .iter()
+            .position(|a| a == "my-image")
+            .unwrap_or_else(|| panic!("missing image arg"));
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"


### PR DESCRIPTION
🎯 Target: `src/env/docker.rs`

💣 Risk: Prevents potential panic backtraces without context in tests by explicitly defining expectations on `Option::unwrap()`.

🧪 Strategy: Refactored `unwrap()` calls into `unwrap_or_else(|| panic!(...))` with explicit failure states for test conditions.

🔬 Verification: Verified locally with `cargo check` and `cargo clippy --all-targets --all-features -- -D warnings`.

---
*PR created automatically by Jules for task [10727610218773335086](https://jules.google.com/task/10727610218773335086) started by @madmax983*