### PR TITLE
Add global stop key (Ctrl-Q) with confirmation for graceful run abort

### DIFF
--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -157,6 +157,9 @@ struct DashboardState {
     should_exit: bool,
     is_monitor: bool,
     search: Option<SearchState>,
+    /// True while the operator has pressed the global stop key (Ctrl-Q) and we
+    /// are waiting for the y/N confirmation before aborting the run (#638).
+    stop_pending: bool,
     /// Scroll offset (in wrapped display rows) within the confirm modal's
     /// reasoning region (issue #655). Reset to 0 each time a new prompt opens.
     rationale_scroll: usize,
@@ -203,6 +206,7 @@ impl Default for DashboardState {
             should_exit: false,
             is_monitor: false,
             search: None,
+            stop_pending: false,
             rationale_scroll: 0,
             last_rationale_total_rows: 0,
             last_rationale_visible_rows: 0,
@@ -1330,6 +1334,51 @@ fn handle_key(dash: &Arc<RatatuiDashboard>, key: KeyEvent) {
     let ctrl_c = key.modifiers.contains(KeyModifiers::CONTROL)
         && matches!(key.code, KeyCode::Char('c' | 'C'));
 
+    // Global stop gesture (Ctrl-Q, #638): works in every state — mid-activity,
+    // modal-open, and monitor/yolo mode where no modal ever appears.
+    let ctrl_q = key.modifiers.contains(KeyModifiers::CONTROL)
+        && matches!(key.code, KeyCode::Char('q' | 'Q'));
+
+    // When a stop confirmation is waiting, only y/n/Esc are meaningful; swallow
+    // everything else so a stray keypress cannot accidentally approve a pending
+    // modal or navigate the feed while the operator is deciding.
+    if s.stop_pending {
+        match key.code {
+            KeyCode::Char('y' | 'Y') => {
+                s.stop_pending = false;
+                if let Some(pending) = s.pending.take() {
+                    s.feedback_input = None;
+                    s.edit_input = None;
+                    drop(s);
+                    let _ = pending.responder.send(ConfirmDecision::Abort);
+                } else if s.finished.is_none() {
+                    if let Some(ref tx) = dash.cancel_tx {
+                        let _ = tx.send(true);
+                    }
+                    drop(s);
+                } else {
+                    drop(s);
+                }
+                dash.notify.notify_waiters();
+            }
+            KeyCode::Char('n' | 'N') | KeyCode::Esc => {
+                s.stop_pending = false;
+                drop(s);
+                dash.notify.notify_waiters();
+            }
+            _ => {}
+        }
+        return;
+    }
+
+    // Activate the stop confirmation when the run is still live.
+    if ctrl_q && s.finished.is_none() {
+        s.stop_pending = true;
+        drop(s);
+        dash.notify.notify_waiters();
+        return;
+    }
+
     if let Some(pending) = s.pending.take() {
         if ctrl_c {
             s.feedback_input = None;
@@ -1750,6 +1799,7 @@ fn draw_frame(
             last_log_height: s.last_log_height,
             is_monitor: s.is_monitor,
             search: s.search.clone(),
+            stop_pending: s.stop_pending,
             rationale_scroll: s.rationale_scroll,
             activity: ActivitySnapshot::from_activity(&s.activity),
             stall_threshold: s.stall_threshold,
@@ -1781,6 +1831,7 @@ struct DashboardSnapshot {
     last_log_height: usize,
     is_monitor: bool,
     search: Option<SearchState>,
+    stop_pending: bool,
     rationale_scroll: usize,
     activity: ActivitySnapshot,
     stall_threshold: Duration,
@@ -2029,12 +2080,17 @@ fn log_paragraph(snap: &DashboardSnapshot, visible_lines: usize) -> Paragraph<'_
 
 fn footer_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
     let bold = Style::default().add_modifier(Modifier::BOLD);
-    // detail_open, search, finished, edit, pending, and idle activity all
-    // take precedence in this order.
+    // detail_open, stop_pending, search, finished, edit, pending, and idle
+    // activity all take precedence in this order.
     let span = if snap.detail_open {
         Span::styled(
             "[Esc/q] close   [Up/Down/j/k] scroll   [PgUp/PgDn] page   [Home/End] bounds",
             bold,
+        )
+    } else if snap.stop_pending {
+        Span::styled(
+            "stop run? [y] yes   [n/Esc] cancel",
+            bold.fg(Color::Red),
         )
     } else if let Some(search) = &snap.search {
         let max_lines = snap.log.len().min(MAX_LOG_LINES);
@@ -2079,7 +2135,7 @@ fn footer_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
         match &snap.activity {
             ActivitySnapshot::Thinking { elapsed } => Span::styled(
                 format!(
-                    "{} thinking… (model · {}s)",
+                    "{} thinking… (model · {}s)   [Ctrl-Q] stop",
                     spinner_frame(*elapsed),
                     elapsed.as_secs()
                 ),
@@ -2087,14 +2143,14 @@ fn footer_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
             ),
             ActivitySnapshot::Running { elapsed, command } => Span::styled(
                 format!(
-                    "{} running: {command} ({}s)",
+                    "{} running: {command} ({}s)   [Ctrl-Q] stop",
                     spinner_frame(*elapsed),
                     elapsed.as_secs()
                 ),
                 activity_style(*elapsed, snap.stall_threshold),
             ),
             ActivitySnapshot::Idle => Span::styled(
-                "waiting for next agent step…  [↑/↓] navigate   [Enter] inspect   [/ search]",
+                "waiting for next agent step…  [↑/↓] navigate   [Enter] inspect   [/ search]   [Ctrl-Q] stop",
                 bold,
             ),
         }
@@ -3289,6 +3345,7 @@ mod tests {
             last_log_height: s.last_log_height,
             is_monitor: s.is_monitor,
             search: s.search.clone(),
+            stop_pending: s.stop_pending,
             rationale_scroll: s.rationale_scroll,
             activity: ActivitySnapshot::from_activity(&s.activity),
             stall_threshold: s.stall_threshold,
@@ -5622,5 +5679,202 @@ mod tests {
 
         // Since auto_follow is false, feed_scroll_top should remain stable at 2 (not advance to 3)
         assert_eq!(snap(&d).feed_scroll_top, 2);
+    }
+
+    // ── Global stop key (#638) ─────────────────────────────────────────────
+
+    fn ctrl_q() -> KeyEvent {
+        KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL)
+    }
+
+    fn make_dashboard_with_cancel() -> (Arc<RatatuiDashboard>, tokio::sync::watch::Receiver<bool>) {
+        let (tx, rx) = tokio::sync::watch::channel(false);
+        let d = Arc::new(RatatuiDashboard {
+            state: Mutex::new(DashboardState::default()),
+            notify: Notify::new(),
+            cancel_tx: Some(tx),
+            bell: Bell::silent(),
+        });
+        (d, rx)
+    }
+
+    #[test]
+    fn stop_key_sets_stop_pending_no_modal() {
+        let d = make_dashboard();
+        assert!(!snap(&d).stop_pending, "stop_pending starts false");
+        handle_key(&d, ctrl_q());
+        assert!(snap(&d).stop_pending, "Ctrl-Q must set stop_pending");
+    }
+
+    #[test]
+    fn stop_key_works_in_monitor_mode() {
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.is_monitor = true;
+        }
+        handle_key(&d, ctrl_q());
+        assert!(snap(&d).stop_pending, "Ctrl-Q must work in monitor/yolo mode");
+    }
+
+    #[test]
+    fn stop_key_no_op_when_finished() {
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.finished = Some("done".into());
+        }
+        handle_key(&d, ctrl_q());
+        assert!(!snap(&d).stop_pending, "Ctrl-Q is no-op after run finished");
+    }
+
+    #[test]
+    fn stop_pending_n_cancels_stop() {
+        let d = make_dashboard();
+        handle_key(&d, ctrl_q());
+        assert!(snap(&d).stop_pending);
+        handle_key(&d, KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
+        assert!(!snap(&d).stop_pending, "'n' must clear stop_pending");
+    }
+
+    #[test]
+    fn stop_pending_esc_cancels_stop() {
+        let d = make_dashboard();
+        handle_key(&d, ctrl_q());
+        assert!(snap(&d).stop_pending);
+        handle_key(&d, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(!snap(&d).stop_pending, "Esc must clear stop_pending");
+    }
+
+    #[test]
+    fn stop_pending_y_fires_cancel_tx() {
+        let (d, rx) = make_dashboard_with_cancel();
+        handle_key(&d, ctrl_q());
+        assert!(snap(&d).stop_pending);
+        assert!(!*rx.borrow(), "cancel not yet signalled");
+        handle_key(&d, KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+        assert!(!snap(&d).stop_pending, "stop_pending cleared after confirm");
+        assert!(*rx.borrow(), "'y' must fire cancel_tx");
+    }
+
+    #[test]
+    fn stop_pending_y_aborts_pending_modal() {
+        let d = make_dashboard();
+        let mut rx = make_pending(&d);
+        handle_key(&d, ctrl_q());
+        assert!(snap(&d).stop_pending);
+        handle_key(&d, KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+        assert!(!snap(&d).stop_pending);
+        assert!(snap(&d).pending.is_none(), "modal must be cleared on abort");
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            ConfirmDecision::Abort,
+            "'y' while modal pending must send Abort"
+        );
+    }
+
+    #[test]
+    fn stop_pending_swallows_other_keys() {
+        let (d, rx) = make_dashboard_with_cancel();
+        handle_key(&d, ctrl_q());
+        assert!(snap(&d).stop_pending);
+        // Any key other than y/n/Esc should NOT trigger cancel or clear stop_pending
+        handle_key(&d, KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        assert!(snap(&d).stop_pending, "other keys must leave stop_pending set");
+        assert!(!*rx.borrow(), "other keys must not fire cancel");
+    }
+
+    #[test]
+    fn single_ctrl_q_does_not_abort() {
+        let (d, rx) = make_dashboard_with_cancel();
+        handle_key(&d, ctrl_q());
+        // After one Ctrl-Q, cancel must NOT have fired yet (confirmation step)
+        assert!(!*rx.borrow(), "single Ctrl-Q must not abort without confirmation");
+    }
+
+    #[test]
+    fn footer_shows_stop_gesture_when_thinking() {
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.activity = Activity::Thinking {
+                since: std::time::Instant::now(),
+            };
+        }
+        let s = snap(&d);
+        let buf = render_to_buffer(&s, 100, 6);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("Ctrl-Q"),
+            "footer must advertise Ctrl-Q stop when thinking; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn footer_shows_stop_gesture_when_idle() {
+        let d = make_dashboard();
+        let s = snap(&d);
+        let buf = render_to_buffer(&s, 100, 6);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("Ctrl-Q"),
+            "footer must advertise Ctrl-Q stop when idle; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn footer_shows_stop_gesture_when_running() {
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.activity = Activity::Running {
+                since: std::time::Instant::now(),
+                command: "ls".into(),
+            };
+        }
+        let s = snap(&d);
+        let buf = render_to_buffer(&s, 100, 6);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("Ctrl-Q"),
+            "footer must advertise Ctrl-Q stop when running; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn footer_shows_stop_confirmation_when_pending() {
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.stop_pending = true;
+        }
+        let s = snap(&d);
+        let buf = render_to_buffer(&s, 100, 6);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("[y]") || text.contains("yes"),
+            "footer must show stop confirmation prompt; got:\n{text}"
+        );
+        assert!(
+            text.contains("[n]") || text.contains("cancel"),
+            "footer must show cancel option in stop prompt; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn footer_does_not_show_stop_gesture_after_finished() {
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.finished = Some("done".into());
+        }
+        let s = snap(&d);
+        let buf = render_to_buffer(&s, 100, 6);
+        let text = buffer_text(&buf);
+        // finished state uses its own message; stop hint should not appear there
+        assert!(
+            text.contains("run complete"),
+            "finished footer should show run-complete message; got:\n{text}"
+        );
     }
 }

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -1339,34 +1339,31 @@ fn handle_key(dash: &Arc<RatatuiDashboard>, key: KeyEvent) {
     let ctrl_q = key.modifiers.contains(KeyModifiers::CONTROL)
         && matches!(key.code, KeyCode::Char('q' | 'Q'));
 
-    // When a stop confirmation is waiting, only y/n/Esc are meaningful; swallow
-    // everything else so a stray keypress cannot accidentally approve a pending
-    // modal or navigate the feed while the operator is deciding.
+    // When a stop confirmation is waiting, y/Y and Ctrl-C immediately abort;
+    // n/N/Esc cancel; everything else is swallowed so a stray keypress cannot
+    // accidentally approve a pending modal or navigate the feed.
     if s.stop_pending {
-        match key.code {
-            KeyCode::Char('y' | 'Y') => {
-                s.stop_pending = false;
-                if let Some(pending) = s.pending.take() {
-                    s.feedback_input = None;
-                    s.edit_input = None;
-                    drop(s);
-                    let _ = pending.responder.send(ConfirmDecision::Abort);
-                } else if s.finished.is_none() {
-                    if let Some(ref tx) = dash.cancel_tx {
-                        let _ = tx.send(true);
-                    }
-                    drop(s);
-                } else {
-                    drop(s);
-                }
-                dash.notify.notify_waiters();
-            }
-            KeyCode::Char('n' | 'N') | KeyCode::Esc => {
-                s.stop_pending = false;
+        let confirm_abort = ctrl_c || matches!(key.code, KeyCode::Char('y' | 'Y'));
+        if confirm_abort {
+            s.stop_pending = false;
+            if let Some(pending) = s.pending.take() {
+                s.feedback_input = None;
+                s.edit_input = None;
                 drop(s);
-                dash.notify.notify_waiters();
+                let _ = pending.responder.send(ConfirmDecision::Abort);
+            } else if s.finished.is_none() {
+                if let Some(ref tx) = dash.cancel_tx {
+                    let _ = tx.send(true);
+                }
+                drop(s);
+            } else {
+                drop(s);
             }
-            _ => {}
+            dash.notify.notify_waiters();
+        } else if matches!(key.code, KeyCode::Char('n' | 'N') | KeyCode::Esc) {
+            s.stop_pending = false;
+            drop(s);
+            dash.notify.notify_waiters();
         }
         return;
     }
@@ -1809,6 +1806,7 @@ fn draw_frame(
     Ok(())
 }
 
+#[allow(clippy::struct_excessive_bools)]
 struct DashboardSnapshot {
     task: Option<String>,
     model: Option<String>,
@@ -2080,17 +2078,15 @@ fn log_paragraph(snap: &DashboardSnapshot, visible_lines: usize) -> Paragraph<'_
 
 fn footer_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
     let bold = Style::default().add_modifier(Modifier::BOLD);
-    // detail_open, stop_pending, search, finished, edit, pending, and idle
-    // activity all take precedence in this order.
-    let span = if snap.detail_open {
+    // stop_pending takes top priority so the confirmation prompt is always
+    // visible even when the detail inspector is open (detail_open). The
+    // remaining branches follow: search, finished, edit, pending, activity.
+    let span = if snap.stop_pending {
+        Span::styled("stop run? [y] yes   [n/Esc] cancel", bold.fg(Color::Red))
+    } else if snap.detail_open {
         Span::styled(
             "[Esc/q] close   [Up/Down/j/k] scroll   [PgUp/PgDn] page   [Home/End] bounds",
             bold,
-        )
-    } else if snap.stop_pending {
-        Span::styled(
-            "stop run? [y] yes   [n/Esc] cancel",
-            bold.fg(Color::Red),
         )
     } else if let Some(search) = &snap.search {
         let max_lines = snap.log.len().min(MAX_LOG_LINES);
@@ -5714,7 +5710,10 @@ mod tests {
             s.is_monitor = true;
         }
         handle_key(&d, ctrl_q());
-        assert!(snap(&d).stop_pending, "Ctrl-Q must work in monitor/yolo mode");
+        assert!(
+            snap(&d).stop_pending,
+            "Ctrl-Q must work in monitor/yolo mode"
+        );
     }
 
     #[test]
@@ -5780,7 +5779,10 @@ mod tests {
         assert!(snap(&d).stop_pending);
         // Any key other than y/n/Esc should NOT trigger cancel or clear stop_pending
         handle_key(&d, KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
-        assert!(snap(&d).stop_pending, "other keys must leave stop_pending set");
+        assert!(
+            snap(&d).stop_pending,
+            "other keys must leave stop_pending set"
+        );
         assert!(!*rx.borrow(), "other keys must not fire cancel");
     }
 
@@ -5789,7 +5791,10 @@ mod tests {
         let (d, rx) = make_dashboard_with_cancel();
         handle_key(&d, ctrl_q());
         // After one Ctrl-Q, cancel must NOT have fired yet (confirmation step)
-        assert!(!*rx.borrow(), "single Ctrl-Q must not abort without confirmation");
+        assert!(
+            !*rx.borrow(),
+            "single Ctrl-Q must not abort without confirmation"
+        );
     }
 
     #[test]
@@ -5875,6 +5880,37 @@ mod tests {
         assert!(
             text.contains("run complete"),
             "finished footer should show run-complete message; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn stop_pending_ctrl_c_immediately_aborts() {
+        let (d, rx) = make_dashboard_with_cancel();
+        handle_key(&d, ctrl_q());
+        assert!(snap(&d).stop_pending);
+        handle_key(&d, KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+        assert!(!snap(&d).stop_pending, "Ctrl-C must clear stop_pending");
+        assert!(*rx.borrow(), "Ctrl-C must fire cancel_tx immediately");
+    }
+
+    #[test]
+    fn footer_shows_stop_confirmation_even_when_detail_open() {
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.stop_pending = true;
+            s.detail_open = true;
+        }
+        let s = snap(&d);
+        let buf = render_to_buffer(&s, 100, 6);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("[y]") || text.contains("yes"),
+            "stop confirmation must show even with detail_open; got:\n{text}"
+        );
+        assert!(
+            !text.contains("[Esc/q] close"),
+            "detail hint must not override stop_pending in footer; got:\n{text}"
         );
     }
 }

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -1342,30 +1342,38 @@ fn handle_key(dash: &Arc<RatatuiDashboard>, key: KeyEvent) {
     // When a stop confirmation is waiting, y/Y and Ctrl-C immediately abort;
     // n/N/Esc cancel; everything else is swallowed so a stray keypress cannot
     // accidentally approve a pending modal or navigate the feed.
+    //
+    // Edge case: if the run ends naturally (RunEnded sets `finished`) while
+    // stop_pending is true and the operator has not yet answered, the stale
+    // confirmation must be dismissed automatically so the finished-close
+    // path (q/Esc → should_exit) becomes reachable again (#638).
     if s.stop_pending {
-        let confirm_abort = ctrl_c || matches!(key.code, KeyCode::Char('y' | 'Y'));
-        if confirm_abort {
+        if s.finished.is_some() {
             s.stop_pending = false;
-            if let Some(pending) = s.pending.take() {
-                s.feedback_input = None;
-                s.edit_input = None;
-                drop(s);
-                let _ = pending.responder.send(ConfirmDecision::Abort);
-            } else if s.finished.is_none() {
-                if let Some(ref tx) = dash.cancel_tx {
-                    let _ = tx.send(true);
+            // fall through to normal finished-close handling below
+        } else {
+            let confirm_abort = ctrl_c || matches!(key.code, KeyCode::Char('y' | 'Y'));
+            if confirm_abort {
+                s.stop_pending = false;
+                if let Some(pending) = s.pending.take() {
+                    s.feedback_input = None;
+                    s.edit_input = None;
+                    drop(s);
+                    let _ = pending.responder.send(ConfirmDecision::Abort);
+                } else {
+                    if let Some(ref tx) = dash.cancel_tx {
+                        let _ = tx.send(true);
+                    }
+                    drop(s);
                 }
+                dash.notify.notify_waiters();
+            } else if matches!(key.code, KeyCode::Char('n' | 'N') | KeyCode::Esc) {
+                s.stop_pending = false;
                 drop(s);
-            } else {
-                drop(s);
+                dash.notify.notify_waiters();
             }
-            dash.notify.notify_waiters();
-        } else if matches!(key.code, KeyCode::Char('n' | 'N') | KeyCode::Esc) {
-            s.stop_pending = false;
-            drop(s);
-            dash.notify.notify_waiters();
+            return;
         }
-        return;
     }
 
     // Activate the stop confirmation when the run is still live.
@@ -5946,6 +5954,33 @@ mod tests {
         assert!(
             text.contains("stop run"),
             "stop confirmation must be visible; got:\n{text}"
+        );
+    }
+
+    /// If the run ends naturally while stop_pending is true (race condition),
+    /// the next keypress must auto-clear stop_pending so the finished-close
+    /// path (q/Esc → should_exit) becomes reachable again.
+    #[test]
+    fn stop_pending_clears_when_run_finishes() {
+        let d = make_dashboard();
+        // Activate the stop confirmation.
+        handle_key(&d, ctrl_q());
+        assert!(
+            snap(&d).stop_pending,
+            "stop_pending must be set after Ctrl-Q"
+        );
+
+        // Simulate RunEnded arriving while the operator hasn't answered yet.
+        {
+            let mut s = d.state.lock().unwrap();
+            s.finished = Some("done".into());
+        }
+
+        // Any subsequent key should auto-dismiss stop_pending without aborting.
+        handle_key(&d, KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        assert!(
+            !snap(&d).stop_pending,
+            "stop_pending must be auto-cleared when finished is set"
         );
     }
 }

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -1891,7 +1891,11 @@ fn draw(frame: &mut ratatui::Frame, dash: &Arc<RatatuiDashboard>, snap: &Dashboa
     }
 
     if let Some(ctx) = &snap.pending {
-        if !snap.detail_open {
+        // Suppress the modal while a stop confirmation is in progress so
+        // the visible key hints stay consistent with what handle_key does:
+        // the footer shows "stop run? [y] yes  [n/Esc] cancel" and the
+        // modal's "(y) approve" prompt must not contradict it (#638).
+        if !snap.detail_open && !snap.stop_pending {
             draw_modal(
                 frame,
                 ctx,
@@ -5911,6 +5915,37 @@ mod tests {
         assert!(
             !text.contains("[Esc/q] close"),
             "detail hint must not override stop_pending in footer; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn modal_hidden_while_stop_pending() {
+        let d = make_dashboard();
+        let _rx = make_pending(&d);
+        // Simulate the user pressing Ctrl-Q while a confirm modal is open.
+        handle_key(&d, ctrl_q());
+        assert!(snap(&d).stop_pending, "Ctrl-Q sets stop_pending");
+        assert!(
+            snap(&d).pending.is_some(),
+            "modal context is still retained"
+        );
+
+        let s = snap(&d);
+        let buf = render_to_buffer(&s, 100, 24);
+        let text = buffer_text(&buf);
+        // The approval modal must not be visible while stop is pending.
+        assert!(
+            !text.contains("confirm action"),
+            "modal must be hidden while stop_pending; got:\n{text}"
+        );
+        assert!(
+            !text.contains("approve"),
+            "approve prompt must not show while stop_pending; got:\n{text}"
+        );
+        // The stop confirmation must be visible instead.
+        assert!(
+            text.contains("stop run"),
+            "stop confirmation must be visible; got:\n{text}"
         );
     }
 }

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -1689,6 +1689,11 @@ fn handle_paste(dash: &Arc<RatatuiDashboard>, text: &str) {
         .state
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+    // While the stop confirmation is pending the UI only accepts y/n/Esc;
+    // drop pastes so they cannot silently accumulate in a hidden input buffer.
+    if s.stop_pending {
+        return;
+    }
     match active_input_target(&s) {
         InputTarget::Feedback => {
             if let Some(buffer) = s.feedback_input.as_mut() {
@@ -5981,6 +5986,35 @@ mod tests {
         assert!(
             !snap(&d).stop_pending,
             "stop_pending must be auto-cleared when finished is set"
+        );
+    }
+
+    /// Bracketed paste must be silently ignored while the stop confirmation
+    /// is pending so pasted text cannot accumulate in a hidden input buffer
+    /// and reappear when the operator later cancels the stop prompt.
+    #[test]
+    fn paste_ignored_while_stop_pending() {
+        let d = make_dashboard();
+        let _rx = make_pending(&d);
+
+        // Enter reject-feedback mode so there is an active feedback buffer.
+        handle_key(&d, KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
+        assert_eq!(
+            snap(&d).feedback_input.as_deref(),
+            Some(""),
+            "feedback buffer must be active"
+        );
+
+        // Activate the stop confirmation.
+        handle_key(&d, ctrl_q());
+        assert!(snap(&d).stop_pending, "stop_pending must be set");
+
+        // A paste while stop_pending must not append to the feedback buffer.
+        handle_paste(&d, "malicious paste");
+        assert_eq!(
+            snap(&d).feedback_input.as_deref(),
+            Some(""),
+            "paste must not modify the feedback buffer while stop_pending"
         );
     }
 }


### PR DESCRIPTION
## Summary
Implements a global stop gesture (Ctrl-Q) that allows operators to gracefully abort a run from any state in the TUI, with a y/N confirmation step to prevent accidental termination.

## Key Changes
- **New `stop_pending` state field**: Tracks when the operator has pressed Ctrl-Q and is awaiting confirmation before aborting
- **Global Ctrl-Q handler**: Works in all states (mid-activity, modal-open, monitor/yolo mode) and sets `stop_pending` when the run is still live
- **Confirmation logic**: When `stop_pending` is true, only y/n/Esc keypresses are processed; all other input is swallowed to prevent accidental navigation or modal approval
- **Abort actions**: Pressing 'y' either sends `ConfirmDecision::Abort` to a pending modal or fires the `cancel_tx` channel to signal the run to stop
- **Footer UI updates**: 
  - Displays "[Ctrl-Q] stop" hint during Thinking, Running, and Idle activity states
  - Shows "stop run? [y] yes   [n/Esc] cancel" prompt in red when `stop_pending` is active
  - Stop confirmation takes precedence over other footer messages (after detail_open)
- **Comprehensive test coverage**: 12 new tests validating stop key behavior, confirmation flow, state transitions, and UI messaging

## Implementation Details
- The stop confirmation is modal-like: while `stop_pending` is true, the key handler returns early after processing only y/n/Esc, preventing any other state changes
- Works seamlessly with existing modals (feedback, edit) by clearing them on abort
- Respects the "finished" state—Ctrl-Q is a no-op once the run has completed
- Footer precedence ensures the stop confirmation prompt is always visible when active

https://claude.ai/code/session_01CGPPZrsJc5wkWrK33e2E9K