### PR TITLE
Add `agent suite --check` zero-spend preflight validator (issue #821)

### DIFF
--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -11,7 +11,7 @@ parsing human-oriented output.
 | 0    | `success`                | Command completed with no errors; all checks passed. Also covers no-op success (e.g. `bench doctor` with every preflight check green). |
 | 1    | `internal_error`         | Unexpected failure: I/O error, JSON parse failure, unclassified panic. Treat as infrastructure broken, not a domain result. |
 | 2    | `usage_error`            | Bad flag, missing required argument, unknown enum value, or invalid config file. Fix the invocation before retrying. |
-| 3    | `preflight_failure`      | Dependency unavailable at sweep start: Docker not installed, Docker daemon unreachable, container failed to start, or model endpoint probe failed. |
+| 3    | `preflight_failure`      | Dependency unavailable at sweep start: Docker not installed, Docker daemon unreachable, container failed to start, or model endpoint probe failed. Also emitted by `agent suite --check` when any fatal pack-validation, verify-launchability, MCP/hook, or (with `--strict`) config-hazard check fails — zero model calls are made. See `docs/spec-agent-suite.md`. |
 | 4    | `task_unsuccessful`      | The agent ran but did not produce a usable result: step limit reached, environment command failed, wallclock timeout, or repeated model API errors. |
 | 5    | `budget_halt`            | Cost ceiling triggered: `bench forecast --fail-over-cap` projected an over-cap run, or the sweep stopped because `--sweep-cost-limit-usd` was reached and no new tasks were dispatched. |
 | 6    | `regression_gate_failure`| `bench compare --max-regressions` or `--max-patch-size-regression` threshold was exceeded. |
@@ -110,6 +110,7 @@ and the recommended triage action.
 | `agent env preview`             | `success`, `usage_error`, `env_preview_warning`, `internal_error` |
 | `agent skills-preview`          | `success`, `usage_error`, `skills_preview_warning`, `internal_error` |
 | `bench scriptability-check`     | `success`, `usage_error`, `scriptability_check_failure`, `internal_error` |
+| `agent suite --check`           | `success`, `usage_error`, `preflight_failure`, `internal_error` (see `docs/spec-agent-suite.md`) |
 | `agent redact-check`            | `success`, `usage_error`, `redact_check_stale_literals`, `redact_check_strict_fail`, `internal_error` |
 | `agent redact-audit`            | `success`, `usage_error`, `redact_audit_findings`, `redact_audit_scan_error`, `internal_error` |
 | `bench assert`                  | `success`, `usage_error`, `slo_rule_failure`, `internal_error` |

--- a/docs/spec-agent-suite.md
+++ b/docs/spec-agent-suite.md
@@ -103,6 +103,9 @@ verify = ["lint:cargo clippy --quiet"]
 | `--history-keep-last-observations N` | (unset)  | Keep only last N observations                      |
 | `--config PATH`           | (none)               | TOML config overlay                                |
 | `--resume`                | false                | Skip tasks with existing terminal trajectories     |
+| `--check`                 | false                | Preflight-only: validate the pack and exit with **zero model calls** (see below) |
+| `--check-format text\|json` | `text`             | Output format for `--check`'s report (requires `--check`) |
+| `--strict`                | false                | With `--check`, escalate config hazards from warnings to fatal (requires `--check`) |
 
 ---
 
@@ -264,6 +267,77 @@ max agent suite \
 # 3. Inspect results
 cat regression-runs/my-regression-pack/suite-results.json | jq '.tasks[] | {id, outcome, attempt_count, unchanged_failure_count, verifier_delta}'
 ```
+
+---
+
+## `agent suite --check` — Zero-Spend Preflight (issue #821)
+
+The dataset path has `bench swebench --dry-run` and `bench scriptability-check`
+to validate inputs before a paid sweep. `agent suite --check` is the
+equivalent for the operator personal-eval path: it validates a task pack —
+parsing, task fields, verify-check launchability, MCP/hook startup, and
+config-provenance hazards — **without making any model call or starting an
+agent loop**, so a typo'd verify command or missing test binary is caught
+before dozens of paid trajectories are burned.
+
+```sh
+max agent suite --tasks-file my-tasks.yaml --check
+max agent suite --tasks-file my-tasks.yaml --check --check-format json
+max agent suite --tasks-file my-tasks.yaml --check --strict   # hazards become fatal
+```
+
+### What it validates
+
+| # | Check                | Fatal?                  | Notes                                                     |
+|---|-----------------------|--------------------------|------------------------------------------------------------|
+| a | Pack parses for the detected/declared format | yes | `format_detect`, `pack_readable`, `pack_parse` |
+| b | Every task has non-empty `id` and `task`     | yes | `task_fields_and_ids` |
+| c | Task ids are unique                          | yes | `task_fields_and_ids` (reuses the same validation `agent suite` runs) |
+| d | Every `--verify`/per-task `verify` is well-formed `NAME:COMMAND` and its command is **statically launchable** | yes | `verify:<name>` — resolves the first program token against `PATH` / shell builtins; never executes the command |
+| e | Configured MCP servers and hooks start       | yes | `mcp_server`, `hook:<phase>` — reuses the `bench scriptability-check` probe (the same transient, non-model subprocess spawn) |
+| — | Config-provenance hazards (e.g. a silently overridden `model.name`) | only with `--strict` | `hazard:<field>` — reuses the `agent config resolve` hazard detector |
+| — | Worst-case cost vs `--suite-cost-limit-usd`  | never (informational)   | `cost_ceiling` — `--per-task-budget-usd × task_count`, no model call |
+
+Launchability is a *static* check only: the out-of-scope verify-execution
+semantics from issue #821 mean `--check` confirms a command's program token
+resolves to something runnable, not that the command would actually pass.
+Complex shell constructs (subshells, command substitution) are not specially
+parsed — keep verify commands to a simple `program args...` or
+`VAR=val program args...` shape.
+
+### Output
+
+On success: exit `0` and a one-line summary —
+
+```
+agent suite --check [PASS]  tasks-file=my-tasks.yaml  (4 ms)
+5 task(s), 6 verify check(s), 0 MCP server(s), 0 hook(s), worst-case $0.5000 (limit $1.0000)
+```
+
+On any fatal check failing: exit `3` (`preflight_failure`) and every failure
+is listed with its check id and offending task id / target:
+
+```
+agent suite --check [FAIL]  tasks-file=my-tasks.yaml  (6 ms)
+5 task(s), 6 verify check(s), 0 MCP server(s), 0 hook(s), worst-case cost unknown (no --per-task-budget-usd set)
+
+Failures:
+  [FAIL] task_fields_and_ids       id=task-47               task id 'task-47' must not contain path separators or '..'
+  [FAIL] verify:tests              id=task-12               'pytset' was not found on PATH
+```
+
+`--check-format json` emits a schema-versioned report (`schema_version: 1`)
+listing every check performed — including passes — each with
+`status: "pass" | "fail" | "warn"`, suitable for CI parsing.
+
+### Guarantees
+
+- **Zero spend**: no model call, no agent loop. Asserted in tests by running
+  with no credential env vars set.
+- **Read-only**: `--check` takes no `--output` directory and never writes
+  `suite-results.json` or per-task artifacts — only the transient MCP-server
+  and hook probe subprocesses are spawned (same as `scriptability-check`).
+- **< 1s** for a 50-task pack with no MCP servers configured.
 
 ---
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -343,6 +343,22 @@ pub struct SuiteCmd {
     /// re-run only missing or non-terminal tasks.
     #[arg(long, default_value_t = false)]
     pub resume: bool,
+
+    /// Preflight-only mode (issue #821): validate the pack, verify-check
+    /// launchability, MCP/hook startup, and config-provenance hazards, then
+    /// exit *without making any model call or starting an agent loop*.
+    /// Zero spend; makes no writes to `--output`.
+    #[arg(long, default_value_t = false)]
+    pub check: bool,
+
+    /// Output format for `--check`'s report: `text` (default) or `json`.
+    #[arg(long = "check-format", default_value = "text", value_parser = ["text", "json"], requires = "check")]
+    pub check_format: String,
+
+    /// With `--check`, escalate config-provenance hazards (e.g. a silently
+    /// overridden `model.name`) from warnings to fatal preflight failures.
+    #[arg(long, default_value_t = false, requires = "check")]
+    pub strict: bool,
 }
 
 /// `agent artifact-check` — zero-cost structural conformance gate for artifact files (issue #534).

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -277,9 +277,12 @@ pub struct SuiteCmd {
     #[arg(long = "suite-name", value_name = "NAME")]
     pub suite_name: Option<String>,
 
-    /// Model name (e.g. `claude-haiku-4-5-20251001`).
-    #[arg(long, default_value = "claude-opus-4-7")]
-    pub model: String,
+    /// Model name (e.g. `claude-haiku-4-5-20251001`). Defaults to
+    /// `claude-opus-4-7` when omitted. Left as `Option` (rather than a clap
+    /// default) so `--check` can distinguish "not passed" from "explicitly
+    /// passed the default value" when detecting config-provenance hazards.
+    #[arg(long)]
+    pub model: Option<String>,
 
     /// Optional path to a TOML config file (overlays defaults).
     #[arg(long)]

--- a/src/cli/catalog.rs
+++ b/src/cli/catalog.rs
@@ -170,7 +170,7 @@ pub fn entries() -> &'static [CatalogEntry] {
         },
         CatalogEntry {
             path: "agent suite",
-            summary: "Run an operator-defined personal eval task pack",
+            summary: "Run an operator-defined personal eval task pack ($0 preflight via --check)",
             cost_tier: "paid",
             stage: "run",
         },

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7656,6 +7656,7 @@ async fn agent_suite_cmd(s: args::SuiteCmd) -> Result<(), Error> {
             per_task_budget_usd: s.per_task_budget_usd,
             step_limit_flag: s.step_limit,
             model_flag: s.model.clone(),
+            detect_stagnation_flag: s.detect_stagnation,
             strict: s.strict,
         };
         let report = crate::run::suite_check::run(&check_args).await?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7639,6 +7639,12 @@ async fn agent_suite_cmd(s: args::SuiteCmd) -> Result<(), Error> {
     });
 
     if s.check {
+        // `--model` always carries a clap default, so only forward it to the
+        // hazard detector when the operator passed something other than that
+        // default — otherwise every config file that sets model.name would
+        // be treated as "explicitly acknowledged" even when it wasn't.
+        let model_flag =
+            (s.model != crate::run::config_resolve::CLAP_DEFAULT_MODEL).then(|| s.model.clone());
         let check_args = crate::run::suite_check::SuiteCheckArgs {
             tasks_file: s.tasks_file,
             format_override: s.format,
@@ -7649,6 +7655,7 @@ async fn agent_suite_cmd(s: args::SuiteCmd) -> Result<(), Error> {
             suite_cost_limit_usd: s.suite_cost_limit_usd,
             per_task_budget_usd: s.per_task_budget_usd,
             step_limit_flag: s.step_limit,
+            model_flag,
             strict: s.strict,
         };
         let report = crate::run::suite_check::run(&check_args).await?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7638,6 +7638,39 @@ async fn agent_suite_cmd(s: args::SuiteCmd) -> Result<(), Error> {
             .to_owned()
     });
 
+    if s.check {
+        let check_args = crate::run::suite_check::SuiteCheckArgs {
+            tasks_file: s.tasks_file,
+            format_override: s.format,
+            suite_name,
+            config: cfg,
+            config_path: s.config,
+            verify: s.verify,
+            suite_cost_limit_usd: s.suite_cost_limit_usd,
+            per_task_budget_usd: s.per_task_budget_usd,
+            step_limit_flag: s.step_limit,
+            strict: s.strict,
+        };
+        let report = crate::run::suite_check::run(&check_args).await?;
+        match s.check_format.as_str() {
+            "json" => {
+                let wrapped = serde_json::json!({ "suite_check": &report });
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&wrapped).map_err(Error::Json)?
+                );
+            }
+            _ => print!("{}", crate::run::suite_check::render_text(&report)),
+        }
+        if !report.ok {
+            exit_with_outcome(
+                ExitCode::PreflightFailure,
+                "agent suite --check found at least one fatal preflight failure",
+            );
+        }
+        return Ok(());
+    }
+
     let suite_args = crate::run::suite::SuiteArgs {
         tasks_file: s.tasks_file,
         format_override: s.format,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7605,7 +7605,13 @@ async fn agent_suite_cmd(s: args::SuiteCmd) -> Result<(), Error> {
         None => Config::defaults()?,
     };
 
-    cfg.root.model.name.clone_from(&s.model);
+    // `--model` has no clap default (it's an `Option`) so `--check` can tell
+    // "not passed" apart from "explicitly passed the default value"; the
+    // live run path still always resolves to a concrete model name here.
+    cfg.root.model.name = s
+        .model
+        .clone()
+        .unwrap_or_else(|| crate::run::config_resolve::CLAP_DEFAULT_MODEL.to_owned());
 
     if let Some(v) = s.step_limit {
         cfg.root.agent.step_limit = v;
@@ -7639,12 +7645,6 @@ async fn agent_suite_cmd(s: args::SuiteCmd) -> Result<(), Error> {
     });
 
     if s.check {
-        // `--model` always carries a clap default, so only forward it to the
-        // hazard detector when the operator passed something other than that
-        // default — otherwise every config file that sets model.name would
-        // be treated as "explicitly acknowledged" even when it wasn't.
-        let model_flag =
-            (s.model != crate::run::config_resolve::CLAP_DEFAULT_MODEL).then(|| s.model.clone());
         let check_args = crate::run::suite_check::SuiteCheckArgs {
             tasks_file: s.tasks_file,
             format_override: s.format,
@@ -7655,7 +7655,7 @@ async fn agent_suite_cmd(s: args::SuiteCmd) -> Result<(), Error> {
             suite_cost_limit_usd: s.suite_cost_limit_usd,
             per_task_budget_usd: s.per_task_budget_usd,
             step_limit_flag: s.step_limit,
-            model_flag,
+            model_flag: s.model.clone(),
             strict: s.strict,
         };
         let report = crate::run::suite_check::run(&check_args).await?;

--- a/src/run/agent_doctor.rs
+++ b/src/run/agent_doctor.rs
@@ -350,7 +350,10 @@ fn check_toolchain() -> DoctorCheck {
 /// must additionally carry an executable permission bit, so a non-executable
 /// file of the same name in a higher-priority `PATH` directory is not a false
 /// positive.
-fn resolve_on_path(name: &str) -> Option<PathBuf> {
+///
+/// Shared with `agent suite --check`'s verify-command launchability check
+/// (issue #821) so both preflights resolve executables identically.
+pub(crate) fn resolve_on_path(name: &str) -> Option<PathBuf> {
     let path_var = std::env::var_os("PATH")?;
     for dir in std::env::split_paths(&path_var) {
         if dir.as_os_str().is_empty() {
@@ -372,13 +375,13 @@ fn resolve_on_path(name: &str) -> Option<PathBuf> {
 /// Whether `path` is a regular file that is runnable as a command. On Unix this
 /// requires an executable permission bit; elsewhere being a file is sufficient.
 #[cfg(unix)]
-fn is_executable(path: &Path) -> bool {
+pub(crate) fn is_executable(path: &Path) -> bool {
     use std::os::unix::fs::PermissionsExt as _;
     std::fs::metadata(path).is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
 }
 
 #[cfg(not(unix))]
-fn is_executable(path: &Path) -> bool {
+pub(crate) fn is_executable(path: &Path) -> bool {
     path.is_file()
 }
 

--- a/src/run/config_resolve.rs
+++ b/src/run/config_resolve.rs
@@ -97,7 +97,7 @@ pub struct ConfigResolveReport {
 // ── Clap-default constants ────────────────────────────────────────────────────
 
 /// Clap default for `--model` in `mini` and `bench swebench`.
-const CLAP_DEFAULT_MODEL: &str = "claude-opus-4-7";
+pub(crate) const CLAP_DEFAULT_MODEL: &str = "claude-opus-4-7";
 /// Clap default for `--step-limit` in `bench swebench`.
 const CLAP_DEFAULT_STEP_LIMIT: u64 = 50;
 

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -78,6 +78,7 @@ pub mod stability;
 pub mod stagnation_report;
 pub mod subset;
 pub mod suite;
+pub mod suite_check;
 pub mod swebench;
 pub mod tail;
 pub mod test_progress;

--- a/src/run/suite.rs
+++ b/src/run/suite.rs
@@ -370,33 +370,10 @@ pub async fn run(args: SuiteArgs) -> Result<ExitCode, Error> {
     }
 
     // ── Validate task IDs ─────────────────────────────────────────────────
-    {
-        let mut seen = std::collections::HashSet::new();
-        for task in &tasks {
-            if task.id.is_empty() {
-                return Err(Error::Config(crate::error::ConfigError::Invalid(
-                    "task id must not be empty".into(),
-                )));
-            }
-            if task.task.trim().is_empty() {
-                return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                    "task '{}': task description must not be empty",
-                    task.id
-                ))));
-            }
-            if task.id.contains('/') || task.id.contains('\\') || task.id.contains("..") {
-                return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                    "task id '{}' must not contain path separators or '..'",
-                    task.id
-                ))));
-            }
-            if !seen.insert(task.id.as_str()) {
-                return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                    "duplicate task id '{}'",
-                    task.id
-                ))));
-            }
-        }
+    if let Some(issue) = collect_task_validation_issues(&tasks).into_iter().next() {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(
+            issue.message,
+        )));
     }
 
     // ── Prepare output directory ──────────────────────────────────────────
@@ -754,8 +731,58 @@ fn write_suite_results(
     Ok(())
 }
 
+/// One task-pack validation problem found by [`collect_task_validation_issues`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TaskIssue {
+    /// The offending task id, when known (absent for an empty-id violation).
+    pub task_id: Option<String>,
+    /// Human-readable description, matching the historical `agent suite`
+    /// error-message wording for each violation kind.
+    pub message: String,
+}
+
+/// Validate every task's `id`/`task` fields and cross-task id uniqueness,
+/// returning *all* violations found rather than stopping at the first
+/// (unlike the `agent suite` run path, which bails on the first issue via
+/// [`run`]). Used by both `agent suite` (which reports only the first issue)
+/// and `agent suite --check` (which reports every issue it can find).
+pub(crate) fn collect_task_validation_issues(tasks: &[SuiteTaskSpec]) -> Vec<TaskIssue> {
+    let mut issues = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for task in tasks {
+        if task.id.is_empty() {
+            issues.push(TaskIssue {
+                task_id: None,
+                message: "task id must not be empty".to_owned(),
+            });
+        }
+        if task.task.trim().is_empty() {
+            issues.push(TaskIssue {
+                task_id: Some(task.id.clone()),
+                message: format!("task '{}': task description must not be empty", task.id),
+            });
+        }
+        if task.id.contains('/') || task.id.contains('\\') || task.id.contains("..") {
+            issues.push(TaskIssue {
+                task_id: Some(task.id.clone()),
+                message: format!(
+                    "task id '{}' must not contain path separators or '..'",
+                    task.id
+                ),
+            });
+        }
+        if !task.id.is_empty() && !seen.insert(task.id.as_str()) {
+            issues.push(TaskIssue {
+                task_id: Some(task.id.clone()),
+                message: format!("duplicate task id '{}'", task.id),
+            });
+        }
+    }
+    issues
+}
+
 /// Parse `NAME:COMMAND` verify check specs.
-fn parse_verify_checks(specs: &[String]) -> Result<Vec<VerificationCheck>, Error> {
+pub(crate) fn parse_verify_checks(specs: &[String]) -> Result<Vec<VerificationCheck>, Error> {
     specs
         .iter()
         .map(|s| {
@@ -866,6 +893,77 @@ mod tests {
     fn parse_bad_jsonl_returns_error() {
         let input = "not json\n";
         assert!(parse_task_file(input, TaskFileFormat::Jsonl).is_err());
+    }
+
+    // ── RED: collect_task_validation_issues (issue #821) ───────────────────
+
+    fn spec(id: &str, task: &str) -> SuiteTaskSpec {
+        SuiteTaskSpec {
+            id: id.to_owned(),
+            task: task.to_owned(),
+            extra_context: None,
+            verify: vec![],
+        }
+    }
+
+    #[test]
+    fn collect_task_validation_issues_empty_for_valid_pack() {
+        let tasks = vec![spec("t1", "do a thing"), spec("t2", "do another")];
+        assert!(collect_task_validation_issues(&tasks).is_empty());
+    }
+
+    #[test]
+    fn collect_task_validation_issues_flags_empty_id() {
+        let tasks = vec![spec("", "do a thing")];
+        let issues = collect_task_validation_issues(&tasks);
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.message == "task id must not be empty")
+        );
+    }
+
+    #[test]
+    fn collect_task_validation_issues_flags_empty_task_description() {
+        let tasks = vec![spec("t1", "   ")];
+        let issues = collect_task_validation_issues(&tasks);
+        assert!(issues.iter().any(|i| i.task_id.as_deref() == Some("t1")
+            && i.message.contains("task description must not be empty")));
+    }
+
+    #[test]
+    fn collect_task_validation_issues_flags_unsafe_id() {
+        let tasks = vec![spec("../escape", "do a thing")];
+        let issues = collect_task_validation_issues(&tasks);
+        assert!(issues.iter().any(|i| i.message.contains("path separators")));
+    }
+
+    #[test]
+    fn collect_task_validation_issues_flags_duplicate_id() {
+        let tasks = vec![spec("dup", "first"), spec("dup", "second")];
+        let issues = collect_task_validation_issues(&tasks);
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.message == "duplicate task id 'dup'")
+        );
+    }
+
+    #[test]
+    fn collect_task_validation_issues_reports_every_violation_not_just_first() {
+        // Three independently-broken tasks: all issues should surface, not
+        // just the first one encountered (the whole point of --check).
+        let tasks = vec![
+            spec("", "ok task"),
+            spec("t2", "  "),
+            spec("dup", "ok"),
+            spec("dup", "ok again"),
+        ];
+        let issues = collect_task_validation_issues(&tasks);
+        assert!(
+            issues.len() >= 3,
+            "expected multiple issues, got {issues:?}"
+        );
     }
 
     // ── RED: TaskFileFormat detection ─────────────────────────────────────

--- a/src/run/suite.rs
+++ b/src/run/suite.rs
@@ -378,14 +378,8 @@ pub async fn run(args: SuiteArgs) -> Result<ExitCode, Error> {
 
     // ── Prepare output directory ──────────────────────────────────────────
     let suite_dir = args.output_dir.join(&args.suite_name);
-    if args.suite_name.contains('/')
-        || args.suite_name.contains('\\')
-        || args.suite_name.contains("..")
-    {
-        return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "suite name '{}' must not contain path separators or '..'",
-            args.suite_name
-        ))));
+    if let Err(msg) = validate_suite_name(&args.suite_name) {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(msg)));
     }
     std::fs::create_dir_all(&suite_dir).map_err(Error::Io)?;
 
@@ -781,6 +775,19 @@ pub(crate) fn collect_task_validation_issues(tasks: &[SuiteTaskSpec]) -> Vec<Tas
     issues
 }
 
+/// Validate a suite name for safe use as an `--output` subdirectory path
+/// segment. Shared by `agent suite` (fails fast on the first violation via
+/// [`run`]) and `agent suite --check` (reports it as a preflight check).
+pub(crate) fn validate_suite_name(name: &str) -> Result<(), String> {
+    if name.contains('/') || name.contains('\\') || name.contains("..") {
+        Err(format!(
+            "suite name '{name}' must not contain path separators or '..'"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 /// Parse `NAME:COMMAND` verify check specs.
 pub(crate) fn parse_verify_checks(specs: &[String]) -> Result<Vec<VerificationCheck>, Error> {
     specs
@@ -964,6 +971,20 @@ mod tests {
             issues.len() >= 3,
             "expected multiple issues, got {issues:?}"
         );
+    }
+
+    // ── RED: validate_suite_name ────────────────────────────────────────
+
+    #[test]
+    fn validate_suite_name_accepts_plain_name() {
+        assert!(validate_suite_name("my-suite").is_ok());
+    }
+
+    #[test]
+    fn validate_suite_name_rejects_path_separators_and_dotdot() {
+        assert!(validate_suite_name("../escape").is_err());
+        assert!(validate_suite_name("a/b").is_err());
+        assert!(validate_suite_name("a\\b").is_err());
     }
 
     // ── RED: TaskFileFormat detection ─────────────────────────────────────

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -23,7 +23,7 @@ use crate::run::config_resolve::{ConfigResolveArgs, OverrideHazard, run_config_r
 use crate::run::scriptability_check;
 use crate::run::suite::{
     SuiteTaskSpec, TaskFileFormat, collect_task_validation_issues, parse_task_file,
-    parse_verify_checks,
+    parse_verify_checks, validate_suite_name,
 };
 
 /// Schema version for [`SuiteCheckReport`]'s machine-readable form.
@@ -134,10 +134,11 @@ pub struct SuiteCheckArgs {
     pub suite_cost_limit_usd: Option<f64>,
     pub per_task_budget_usd: Option<f64>,
     pub step_limit_flag: Option<u32>,
-    /// The explicit `--model` value, when the caller passed one that differs
-    /// from the clap default. Forwarded to the hazard detector so a
-    /// deliberately-acknowledged `--model` override doesn't get flagged as a
-    /// silent config-file override hazard.
+    /// The `--model` value, `Some(_)` iff the caller explicitly passed the
+    /// flag (regardless of whether the value matches the clap default).
+    /// Forwarded to the hazard detector so a deliberately-acknowledged
+    /// `--model` override doesn't get flagged as a silent config-file
+    /// override hazard.
     pub model_flag: Option<String>,
     pub strict: bool,
 }
@@ -199,13 +200,24 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
         _ => None,
     };
 
-    // Verify commands run inside the configured environment, not on this
-    // host: with `--env docker` the real check runs in the container image,
-    // so a host-PATH lookup can't validate it (a docker-only binary would
-    // false-fail; a host-only same-named binary would false-pass). Skip the
-    // static launchability probe in that case and only validate
-    // `NAME:COMMAND` well-formedness.
-    let skip_launchability = matches!(args.config.root.environment.kind, EnvKind::Docker);
+    // ── Suite name (output-directory path segment) ─────────────────────
+    // The live run rejects an unsafe suite name before creating the output
+    // directory; --check must catch the same problem so it can't report
+    // PASS for a pack whose real run would immediately fail on invocation.
+    match validate_suite_name(&args.suite_name) {
+        Ok(()) => checks.push(CheckItem::pass("suite_name_safe", None)),
+        Err(msg) => checks.push(CheckItem::fail("suite_name_safe", None, msg)),
+    }
+
+    // With `--env docker`, verify commands, MCP servers, and hooks all run
+    // inside the container image in a live run — not on this host. A
+    // host-side probe/PATH lookup can't authoritatively validate them (a
+    // docker-only binary would false-fail; a host-only same-named binary
+    // would false-pass). Verify-command launchability is skipped entirely
+    // in that case (format is still validated); MCP/hook probe failures are
+    // downgraded to warnings instead of fatal (see below).
+    let is_docker = matches!(args.config.root.environment.kind, EnvKind::Docker);
+    let skip_launchability = is_docker;
 
     // ── Non-empty pack + per-task field/id validation ──────────────────
     let mut task_count = 0usize;
@@ -254,30 +266,30 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
     let verify_check_count = args.verify.len() + per_task_verify_count;
 
     // ── MCP servers + hooks (reuse scriptability-check, no artifact write) ─
+    // NOTE: `scriptability_check` always probes via a `LocalEnvironment`
+    // regardless of `environment.kind` (a pre-existing limitation shared by
+    // `bench scriptability-check` itself). Under `--env docker`, a live run
+    // launches MCP servers/hooks inside the container instead, so a host
+    // probe failure here may not reflect the real environment — downgrade
+    // it to a warning rather than a fatal preflight failure.
     let scriptability_report = scriptability_check::run_with_config(&args.config, None).await?;
     for server in &scriptability_report.servers {
-        checks.push(CheckItem {
-            check: "mcp_server".to_owned(),
-            target: Some(server.name.clone()),
-            status: if server.ok {
-                CheckStatus::Pass
-            } else {
-                CheckStatus::Fail
-            },
-            message: server.error.clone(),
-        });
+        checks.push(scriptability_check_item(
+            "mcp_server".to_owned(),
+            server.name.clone(),
+            server.ok,
+            server.error.clone(),
+            is_docker,
+        ));
     }
     for hook in &scriptability_report.hooks {
-        checks.push(CheckItem {
-            check: format!("hook:{}", hook.phase),
-            target: Some(hook.name.clone()),
-            status: if hook.ok {
-                CheckStatus::Pass
-            } else {
-                CheckStatus::Fail
-            },
-            message: hook.error.clone(),
-        });
+        checks.push(scriptability_check_item(
+            format!("hook:{}", hook.phase),
+            hook.name.clone(),
+            hook.ok,
+            hook.error.clone(),
+            is_docker,
+        ));
     }
     let mcp_server_count = scriptability_report.servers.len();
     let hook_count = scriptability_report.hooks.len();
@@ -383,6 +395,36 @@ fn resolve_format(path: &Path, format_override: Option<&str>) -> Result<TaskFile
             path.display()
         )
     })
+}
+
+// ── MCP/hook probe result → CheckItem ────────────────────────────────────────
+
+/// Build a [`CheckItem`] from a `scriptability_check` server/hook result.
+/// A failure is downgraded from `Fail` to `Warn` under `--env docker`,
+/// since the probe ran on the host, not inside the configured container.
+fn scriptability_check_item(
+    check: String,
+    target: String,
+    ok: bool,
+    error: Option<String>,
+    is_docker: bool,
+) -> CheckItem {
+    if ok {
+        return CheckItem::pass(check, Some(target));
+    }
+    let message = error.unwrap_or_else(|| "probe failed".to_owned());
+    if is_docker {
+        CheckItem::warn(
+            check,
+            Some(target),
+            format!(
+                "{message} (probed on the host; --env docker runs MCP servers/hooks inside \
+                 the container image, so this may not reflect the real environment)"
+            ),
+        )
+    } else {
+        CheckItem::fail(check, Some(target), message)
+    }
 }
 
 // ── verify-check format + launchability ─────────────────────────────────────────
@@ -690,6 +732,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unsafe_suite_name_fails_preflight() {
+        // The live `agent suite` run rejects a suite name containing path
+        // separators or '..' before creating the output directory; --check
+        // must catch this too instead of reporting PASS for a pack whose
+        // real run would fail on invocation (regression test for a gap
+        // found in review, issue #821).
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let mut args = base_args(path);
+        args.suite_name = "../escape".to_owned();
+        let report = run(&args).await.unwrap();
+        assert!(!report.ok);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "suite_name_safe" && c.status == CheckStatus::Fail)
+        );
+    }
+
+    #[tokio::test]
+    async fn safe_suite_name_passes_preflight() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "suite_name_safe" && c.status == CheckStatus::Pass)
+        );
+    }
+
+    #[tokio::test]
     async fn empty_pack_fails_non_empty_check() {
         let dir = tempfile::tempdir().unwrap();
         let path = write_tasks(&dir, "tasks.jsonl", "");
@@ -807,6 +883,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn docker_env_downgrades_mcp_failure_to_warning() {
+        // `scriptability_check` always probes on the host; under --env
+        // docker a live run launches MCP servers inside the container
+        // instead, so a host-side probe failure can't be trusted as fatal.
+        // Regression test for a false-fail found in review (issue #821).
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let mut config = Config::defaults().unwrap();
+        config.root.environment.kind = EnvKind::Docker;
+        config
+            .root
+            .agent
+            .mcp_servers
+            .push(crate::config::McpServerCfg {
+                command: "__no_such_binary_xyz_suite_check_mcp__".to_owned(),
+                timeout_secs: Some(1),
+            });
+        let mut args = base_args(path);
+        args.config = config;
+        let report = run(&args).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
+        let checked = report
+            .checks
+            .iter()
+            .find(|c| c.check == "mcp_server")
+            .unwrap();
+        assert_eq!(checked.status, CheckStatus::Warn);
+    }
+
+    #[tokio::test]
+    async fn local_env_mcp_failure_stays_fatal() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let mut config = Config::defaults().unwrap();
+        config
+            .root
+            .agent
+            .mcp_servers
+            .push(crate::config::McpServerCfg {
+                command: "__no_such_binary_xyz_suite_check_mcp__".to_owned(),
+                timeout_secs: Some(1),
+            });
+        let mut args = base_args(path);
+        args.config = config;
+        let report = run(&args).await.unwrap();
+        assert!(!report.ok);
+        let checked = report
+            .checks
+            .iter()
+            .find(|c| c.check == "mcp_server")
+            .unwrap();
+        assert_eq!(checked.status, CheckStatus::Fail);
+    }
+
+    #[tokio::test]
     async fn malformed_verify_spec_without_colon_fails() {
         let dir = tempfile::tempdir().unwrap();
         let path = write_tasks(
@@ -895,6 +1026,32 @@ mod tests {
         let mut args = base_args(path);
         args.config_path = Some(config_path);
         args.model_flag = Some("claude-sonnet-4-6".to_owned());
+        args.strict = true;
+        let report = run(&args).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
+        assert!(
+            !report.checks.iter().any(|c| c.check == "hazard:model.name"),
+            "checks: {:?}",
+            report.checks
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_model_flag_matching_clap_default_still_suppresses_hazard() {
+        // The operator explicitly chose the clap-default model name on
+        // purpose (e.g. `--model claude-opus-4-7`) to override a config
+        // file that sets a different model.name. Because `model_flag` is
+        // `Some(_)` regardless of which value was passed, this must count
+        // as an acknowledged override, not a silent one — regression test
+        // for the "explicitness vs. value" gap found in review (issue #821).
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "[model]\nname = \"claude-sonnet-4-6\"\n").unwrap();
+
+        let mut args = base_args(path);
+        args.config_path = Some(config_path);
+        args.model_flag = Some(crate::run::config_resolve::CLAP_DEFAULT_MODEL.to_owned());
         args.strict = true;
         let report = run(&args).await.unwrap();
         assert!(report.ok, "checks: {:?}", report.checks);

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -602,6 +602,32 @@ fn check_command_launchable(command: &str) -> Result<(), String> {
 /// wrapper shape: `env [OPTION]... [NAME=VALUE]... [COMMAND [ARG]...]`.
 const WRAPPER_COMMANDS: &[&str] = &["time", "exec", "command", "eval", "builtin", "env"];
 
+/// Shell binaries whose `-c`/`-lc`/etc. option hands an entire nested
+/// command line to the shell as a single string argument.
+const SHELL_BINARIES: &[&str] = &["bash", "sh", "zsh", "ksh", "dash"];
+
+/// Whether `token` (already extracted as the program name, with `remainder`
+/// the rest of the command line) is a known shell binary invoked with a
+/// `-c`-style option — i.e. `bash -c '...'`, `sh -lc '...'`. Matches by
+/// basename so `/bin/bash -c ...` is caught too.
+fn is_shell_dash_c_invocation(token: &str, remainder: &str) -> bool {
+    let base_name = token.rsplit('/').next().unwrap_or(token);
+    if !SHELL_BINARIES.contains(&base_name) {
+        return false;
+    }
+    let mut rest = remainder;
+    while let Some((word, next_remainder)) = next_shell_word(rest) {
+        let Some(flags) = word.strip_prefix('-') else {
+            return false;
+        };
+        if flags.contains('c') {
+            return true;
+        }
+        rest = next_remainder;
+    }
+    false
+}
+
 /// Reasons `check_command_launchable` can't be trusted to resolve `command`
 /// statically, checked at every layer as [`WRAPPER_COMMANDS`] are unwrapped
 /// — not just the outermost command string. A `PATH=` assignment or an
@@ -625,6 +651,20 @@ fn verify_command_inconclusive_reason(command: &str) -> Option<&'static str> {
             );
         }
         let (token, remainder) = split_off_program_token(rest)?;
+        if is_shell_dash_c_invocation(&token, remainder) {
+            // `bash -c '...'`, `sh -lc '...'` etc. hand an entire nested
+            // command line to the shell as a single string argument —
+            // safely inspecting it would mean recursively re-parsing an
+            // arbitrary shell string (which could itself contain further
+            // wrappers, PATH assignments, pipes...). Resolving just the
+            // outer shell binary (which almost always exists) and calling
+            // it Pass would hide a typo'd/missing binary inside the
+            // payload until after a paid task ran.
+            return Some(
+                "verify command delegates to a nested shell invocation (a `-c`-style option), \
+                 whose payload this static check does not parse",
+            );
+        }
         if !WRAPPER_COMMANDS.contains(&token.as_str()) {
             return None;
         }
@@ -1819,6 +1859,51 @@ mod tests {
         assert!(verify_command_inconclusive_reason("time cargo test").is_none());
         assert!(verify_command_inconclusive_reason("cargo -v test").is_none());
         assert!(verify_command_inconclusive_reason("env PYTHONPATH=. cargo test").is_none());
+    }
+
+    #[test]
+    fn verify_command_inconclusive_reason_detects_shell_dash_c() {
+        // `bash -c '...'` / `sh -lc '...'` hand an entire nested command
+        // line to the shell as one string argument — resolving just the
+        // outer shell binary (which almost always exists) would hide a
+        // typo'd/missing binary inside that payload until after a paid
+        // task ran. Regression test for a gap found in review (issue
+        // #821).
+        assert!(verify_command_inconclusive_reason("bash -lc __no_such_binary_xyz__").is_some());
+        assert!(verify_command_inconclusive_reason("sh -c 'pytest -q'").is_some());
+        assert!(verify_command_inconclusive_reason("/bin/bash -c cargo").is_some());
+        // Nested inside another wrapper too.
+        assert!(verify_command_inconclusive_reason("time bash -c cargo").is_some());
+    }
+
+    #[test]
+    fn verify_command_inconclusive_reason_none_for_shell_without_dash_c() {
+        // Running a script file (no -c) is an ordinary case this checker
+        // doesn't specially model — it just resolves the shell binary
+        // itself, same as before this fix.
+        assert!(verify_command_inconclusive_reason("bash script.sh").is_none());
+        assert!(verify_command_inconclusive_reason("bash -l script.sh").is_none());
+    }
+
+    #[tokio::test]
+    async fn verify_command_with_shell_dash_c_is_inconclusive_not_fatal() {
+        // Exact scenario from review (issue #821): `bash -lc
+        // __no_such_binary__` previously resolved only the outer `bash`
+        // and reported PASS.
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(
+            &dir,
+            "tasks.yaml",
+            "- id: t1\n  task: fix it\n  verify:\n    - tests:bash -lc __no_such_binary_xyz_suite_check__\n",
+        );
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
+        let checked = report
+            .checks
+            .iter()
+            .find(|c| c.check == "verify:tests")
+            .unwrap();
+        assert_eq!(checked.status, CheckStatus::Warn);
     }
 
     #[tokio::test]

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -610,22 +610,38 @@ const SHELL_BINARIES: &[&str] = &["bash", "sh", "zsh", "ksh", "dash"];
 /// the rest of the command line) is a known shell binary invoked with a
 /// `-c`-style option — i.e. `bash -c '...'`, `sh -lc '...'`. Matches by
 /// basename so `/bin/bash -c ...` is caught too.
+/// Short options for [`SHELL_BINARIES`] that consume the *following* word
+/// as their own operand (e.g. `bash -O extglob`, `bash -o pipefail`)
+/// rather than being boolean toggles. That operand must be skipped rather
+/// than treated as "the first non-flag word" — otherwise a later `-c`
+/// (e.g. `bash -O extglob -c foo`) would never be reached.
+const SHELL_OPTIONS_WITH_OPERAND: &[&str] = &["-o", "-O", "+o", "+O"];
+
 fn is_shell_dash_c_invocation(token: &str, remainder: &str) -> bool {
     let base_name = token.rsplit('/').next().unwrap_or(token);
     if !SHELL_BINARIES.contains(&base_name) {
         return false;
     }
     let mut rest = remainder;
-    while let Some((word, next_remainder)) = next_shell_word(rest) {
-        let Some(flags) = word.strip_prefix('-') else {
+    loop {
+        let Some((word, next_remainder)) = next_shell_word(rest) else {
             return false;
         };
-        if flags.contains('c') {
+        if SHELL_OPTIONS_WITH_OPERAND.contains(&word.as_str()) {
+            let Some((_, after_operand)) = next_shell_word(next_remainder) else {
+                return false;
+            };
+            rest = after_operand;
+            continue;
+        }
+        if !(word.starts_with('-') || word.starts_with('+')) {
+            return false;
+        }
+        if word[1..].contains('c') {
             return true;
         }
         rest = next_remainder;
     }
-    false
 }
 
 /// Reasons `check_command_launchable` can't be trusted to resolve `command`
@@ -1883,6 +1899,35 @@ mod tests {
         // itself, same as before this fix.
         assert!(verify_command_inconclusive_reason("bash script.sh").is_none());
         assert!(verify_command_inconclusive_reason("bash -l script.sh").is_none());
+    }
+
+    #[test]
+    fn verify_command_inconclusive_reason_detects_dash_c_behind_operand_taking_flag() {
+        // `-o`/`-O` (and `+o`/`+O`) consume the *next* word as their own
+        // operand (e.g. "extglob", "pipefail"), not a flag — a naive scan
+        // that stops at the first non-flag word would treat that operand
+        // as "not a flag" and give up before reaching a later -c.
+        // Regression test for a gap found in review (issue #821):
+        // `bash -O extglob -c __no_such_binary__` previously wasn't
+        // recognized as a -c invocation at all.
+        assert!(
+            verify_command_inconclusive_reason("bash -O extglob -c __no_such_binary__").is_some()
+        );
+        assert!(
+            verify_command_inconclusive_reason("bash -o pipefail -c __no_such_binary__").is_some()
+        );
+        // Multiple operand-taking flags before -c.
+        assert!(
+            verify_command_inconclusive_reason("bash -O extglob -o pipefail -c __no_such_binary__")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn verify_command_inconclusive_reason_none_for_operand_taking_flag_without_dash_c() {
+        // `-O extglob` alone (no later -c) is an ordinary shopt toggle —
+        // still just resolves the shell binary itself, not ambiguous.
+        assert!(verify_command_inconclusive_reason("bash -O extglob script.sh").is_none());
     }
 
     #[tokio::test]

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -568,29 +568,46 @@ fn check_verify_spec(target: Option<String>, spec: &str, skip_launchability: boo
 /// are not specially parsed; operators should keep verify commands to a
 /// simple `program args...` or `VAR=val program args...` shape.
 fn check_command_launchable(command: &str) -> Result<(), String> {
-    let Some(token) = extract_program_token(command) else {
-        return Err("verify command has no resolvable program token".to_owned());
-    };
-    if is_shell_builtin_or_keyword(&token) {
-        return Ok(());
-    }
-    if token.contains('/') || token.contains(std::path::MAIN_SEPARATOR) {
-        let path = Path::new(&token);
-        return if path.is_file() && is_executable(path) {
+    let mut rest = command;
+    loop {
+        let Some((token, remainder)) = split_off_program_token(rest) else {
+            return Err("verify command has no resolvable program token".to_owned());
+        };
+        // `time foo`, `exec foo`, `command foo`, `eval foo`, and `builtin foo`
+        // don't launch anything themselves — the real payload is whatever
+        // follows. Unwrap the wrapper and check that instead, rather than
+        // asserting Ok on the wrapper's own name.
+        if WRAPPER_BUILTINS.contains(&token.as_str()) {
+            rest = remainder;
+            continue;
+        }
+        if is_shell_builtin_or_keyword(&token) {
+            return Ok(());
+        }
+        if token.contains('/') || token.contains(std::path::MAIN_SEPARATOR) {
+            let path = Path::new(&token);
+            return if path.is_file() && is_executable(path) {
+                Ok(())
+            } else {
+                Err(format!("'{token}' does not resolve to an executable file"))
+            };
+        }
+        return if resolve_on_path(&token).is_some() {
             Ok(())
         } else {
-            Err(format!("'{token}' does not resolve to an executable file"))
+            Err(format!("'{token}' was not found on PATH"))
         };
-    }
-    if resolve_on_path(&token).is_some() {
-        Ok(())
-    } else {
-        Err(format!("'{token}' was not found on PATH"))
     }
 }
 
-/// Extract the first non-`VAR=value` token from a shell command string.
-fn extract_program_token(command: &str) -> Option<String> {
+/// Builtins/keywords whose own name is not the thing being launched — the
+/// command that follows them is. Checked before [`SHELL_BUILTINS_AND_KEYWORDS`]
+/// so `time __no_such_binary__` doesn't short-circuit on `time` alone.
+const WRAPPER_BUILTINS: &[&str] = &["time", "exec", "command", "eval", "builtin"];
+
+/// Extract the first non-`VAR=value` token from a shell command string,
+/// along with the unconsumed remainder of the command after it.
+fn split_off_program_token(command: &str) -> Option<(String, &str)> {
     let mut rest = command;
     loop {
         let (word, remainder) = next_shell_word(rest)?;
@@ -598,7 +615,7 @@ fn extract_program_token(command: &str) -> Option<String> {
         if is_env_assignment(&word) {
             continue;
         }
-        return Some(word);
+        return Some((word, rest));
     }
 }
 
@@ -672,11 +689,14 @@ fn has_leading_path_assignment(command: &str) -> bool {
 
 const SHELL_BUILTINS_AND_KEYWORDS: &[&str] = &[
     "cd", "pushd", "popd", "echo", "printf", "export", "unset", "set", "source", ".", ":", "true",
-    "false", "test", "[", "[[", "exit", "return", "eval", "exec", "read", "type", "command",
-    "builtin", "pwd", "alias", "unalias", "local", "declare", "typeset", "readonly", "shift",
-    "trap", "wait", "jobs", "ulimit", "umask", "hash", "let", "time", "if", "then", "elif", "else",
-    "fi", "for", "while", "until", "do", "done", "case", "esac", "function", "select", "in", "not",
-    "{", "}",
+    "false", "test", "[", "[[", "exit", "return", "read", "type", "pwd", "alias", "unalias",
+    "local", "declare", "typeset", "readonly", "shift", "trap", "wait", "jobs", "ulimit", "umask",
+    "hash", "let", "if", "then", "elif", "else", "fi", "for", "while", "until", "do", "done",
+    "case", "esac", "function", "select", "in", "not", "{",
+    "}",
+    // NOTE: "time", "exec", "command", "eval", "builtin" are intentionally
+    // absent — they're wrapper builtins handled by WRAPPER_BUILTINS above,
+    // which unwraps them and checks the command that actually follows.
 ];
 
 fn is_shell_builtin_or_keyword(token: &str) -> bool {
@@ -1627,7 +1647,11 @@ mod tests {
         assert!(text.contains("dup"));
     }
 
-    // ── extract_program_token / launchability unit tests ────────────────
+    // ── split_off_program_token / launchability unit tests ────────────────
+
+    fn extract_program_token(command: &str) -> Option<String> {
+        split_off_program_token(command).map(|(token, _)| token)
+    }
 
     #[test]
     fn extract_program_token_skips_env_assignments() {
@@ -1687,5 +1711,26 @@ mod tests {
     fn path_resolvable_binary_is_launchable() {
         // `cargo` must exist on PATH for the test harness itself to have run.
         assert!(check_command_launchable("cargo --version").is_ok());
+    }
+
+    #[test]
+    fn wrapper_builtin_does_not_hide_unresolvable_wrapped_command() {
+        // `time`/`exec`/`command`/`eval`/`builtin` launch whatever follows
+        // them, not themselves — a missing wrapped binary must still be
+        // caught rather than short-circuiting as launchable on the wrapper
+        // alone. Regression test for a gap found in review (issue #821).
+        assert!(check_command_launchable("time __no_such_binary_xyz_suite_check__").is_err());
+        assert!(check_command_launchable("exec __no_such_binary_xyz_suite_check__").is_err());
+        assert!(check_command_launchable("command __no_such_binary_xyz_suite_check__").is_err());
+        assert!(check_command_launchable("eval __no_such_binary_xyz_suite_check__").is_err());
+        assert!(check_command_launchable("builtin __no_such_binary_xyz_suite_check__").is_err());
+    }
+
+    #[test]
+    fn wrapper_builtin_resolves_a_real_wrapped_command() {
+        assert!(check_command_launchable("time cargo --version").is_ok());
+        assert!(check_command_launchable("exec true").is_ok());
+        // Nested wrappers unwrap one at a time.
+        assert!(check_command_launchable("time exec cargo --version").is_ok());
     }
 }

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -5,9 +5,11 @@
 //! paid agent loop: the pack parses, every task has a non-empty `id`/`task`
 //! and unique id, every `--verify`/per-task `verify` entry is well-formed and
 //! its command is statically launchable, configured MCP servers and hooks
-//! start (reusing the `scriptability-check` probe), the `[policy]` config
-//! builds a valid `PolicyEngine`, every task's configured skills resolve
-//! cleanly, and the resolved suite config carries no silent clap-default
+//! start (reusing the `scriptability-check` probe), discovered MCP tool
+//! names don't collide with `bash` or a configured tool, the `[policy]`
+//! config builds a valid `PolicyEngine`, every task's configured skills
+//! resolve cleanly, `[prompts].system`/`[prompts].instance` render for every
+//! task, and the resolved suite config carries no silent clap-default
 //! override hazard (reusing the `agent config resolve` hazard detector). No
 //! model calls and no agent loop are ever started; no files are written
 //! (this module takes no output directory).
@@ -351,6 +353,7 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
     let mcp_server_count = args.config.root.agent.mcp_servers.len();
     let hook_count = args.config.root.agent.hooks.pre_tool_use.len()
         + args.config.root.agent.hooks.post_tool_use.len();
+    let mut scriptability_report: Option<scriptability_check::ScriptabilityCheckReport> = None;
     if is_docker {
         for (i, _) in args.config.root.agent.mcp_servers.iter().enumerate() {
             checks.push(CheckItem::warn(
@@ -387,8 +390,8 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
             ));
         }
     } else {
-        let scriptability_report = scriptability_check::run_with_config(&args.config, None).await?;
-        for server in &scriptability_report.servers {
+        let report = scriptability_check::run_with_config(&args.config, None).await?;
+        for server in &report.servers {
             checks.push(scriptability_check_item(
                 "mcp_server".to_owned(),
                 server.name.clone(),
@@ -396,13 +399,118 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
                 server.error.clone(),
             ));
         }
-        for hook in &scriptability_report.hooks {
+        for hook in &report.hooks {
             checks.push(scriptability_check_item(
                 format!("hook:{}", hook.phase),
                 hook.name.clone(),
                 hook.ok,
                 hook.error.clone(),
             ));
+        }
+        scriptability_report = Some(report);
+    }
+
+    // ── MCP tool-name validation (mirrors `ToolRegistry::index_provider_tools`) ─
+    // `ToolRegistry::from_config_and_providers` rejects a discovered MCP
+    // tool name that fails `validate_tool_name`, collides with the
+    // built-in `bash` tool, or duplicates a configured command tool /
+    // another provider's tool name — before the first task starts. Reuse
+    // the tool names the scriptability probe above already discovered
+    // (skipped for docker, same as that probe) rather than reconnecting.
+    if let Some(report) = &scriptability_report {
+        if !report.servers.is_empty() {
+            let mut seen_names: std::collections::BTreeSet<String> = args
+                .config
+                .root
+                .agent
+                .tools
+                .iter()
+                .map(|t| t.name.clone())
+                .collect();
+            let mut issues: Vec<(String, String)> = Vec::new();
+            for server in &report.servers {
+                for tool in &server.tools {
+                    if let Err(reason) = crate::tool::validate_tool_name(&tool.name) {
+                        issues.push((
+                            tool.name.clone(),
+                            format!("invalid tool provider name {:?}: {reason}", tool.name),
+                        ));
+                    } else if tool.name == crate::tool::BASH_TOOL_NAME
+                        || !seen_names.insert(tool.name.clone())
+                    {
+                        issues.push((
+                            tool.name.clone(),
+                            format!("duplicate runtime tool name {:?}", tool.name),
+                        ));
+                    }
+                }
+            }
+            if issues.is_empty() {
+                checks.push(CheckItem::pass("mcp_tool_names", None));
+            } else {
+                for (name, message) in issues {
+                    checks.push(CheckItem::fail("mcp_tool_names", Some(name), message));
+                }
+            }
+        }
+    }
+
+    // ── Prompt template rendering (reuses the exact render call
+    // `DefaultAgentBuilder::build_with_tool_providers` makes before the
+    // first model request) ──────────────────────────────────────────────
+    // A MiniJinja syntax error in `[prompts].system`/`[prompts].instance`
+    // fails there, before any task runs. Rendering is pure string
+    // templating (no subprocess, no model call), so it's safe to run for
+    // every parsed task regardless of --env.
+    if let Some(tasks) = &tasks {
+        let renderer = crate::template::Renderer::new();
+        let mut prompt_tools =
+            crate::tool::ToolRegistry::from_config(&args.config.root.agent.tools).prompt_tools();
+        if let Some(report) = &scriptability_report {
+            for server in &report.servers {
+                for tool in &server.tools {
+                    prompt_tools.push(crate::tool::ToolPromptInfo {
+                        name: tool.name.clone(),
+                        description: String::new(),
+                        input_schema: None,
+                    });
+                }
+            }
+        }
+        for task in tasks {
+            let wrapped_task = crate::prompt_guard::PromptGuard::wrap(
+                crate::prompt_guard::UntrustedKind::TaskText,
+                &task.task,
+            );
+            let wrapped_extra_context = task.extra_context.as_deref().map(|ctx| {
+                crate::prompt_guard::PromptGuard::wrap(
+                    crate::prompt_guard::UntrustedKind::ExtraContext,
+                    ctx,
+                )
+            });
+            let ctx = serde_json::json!({
+                "task": wrapped_task,
+                "extra_context": wrapped_extra_context,
+                "tools": &prompt_tools,
+            });
+            match (
+                renderer.render_str(&args.config.root.prompts.system, &ctx),
+                renderer.render_str(&args.config.root.prompts.instance, &ctx),
+            ) {
+                (Ok(_), Ok(_)) => {
+                    checks.push(CheckItem::pass("prompts_render", Some(task.id.clone())));
+                }
+                (Err(e), _) => checks.push(CheckItem::fail(
+                    "prompts_render",
+                    Some(task.id.clone()),
+                    format!("[prompts].system: {e}"),
+                )),
+                (_, Err(e)) => checks.push(CheckItem::fail(
+                    "prompts_render",
+                    Some(task.id.clone()),
+                    format!("[prompts].instance: {e}"),
+                )),
+            }
         }
     }
 
@@ -1422,6 +1530,143 @@ mod tests {
             .find(|c| c.check == "mcp_server")
             .unwrap();
         assert_eq!(checked.status, CheckStatus::Fail);
+    }
+
+    /// Writes a minimal Python-based mock MCP stdio server that answers
+    /// `initialize` and `tools/list` with a single tool of `tool_name`, then
+    /// returns the `--mcp-server`-style shell command to launch it.
+    fn mock_mcp_server_command(dir: &tempfile::TempDir, tool_name: &str) -> String {
+        let script_path = dir.path().join("mock_mcp.py");
+        std::fs::write(
+            &script_path,
+            format!(
+                "import sys\n\
+                 sys.stdin.readline()\n\
+                 sys.stdin.readline()\n\
+                 print('{{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{{}},\"serverInfo\":{{\"name\":\"mock\",\"version\":\"1.0\"}}}}}}')\n\
+                 print('{{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{{\"tools\":[{{\"name\":\"{tool_name}\"}}]}}}}')\n"
+            ),
+        )
+        .unwrap();
+        format!("python3 {}", script_path.display())
+    }
+
+    #[tokio::test]
+    async fn mcp_tool_named_bash_fails_preflight() {
+        // `ToolRegistry::index_provider_tools` rejects a discovered MCP tool
+        // named `bash` — it collides with the built-in tool — before the
+        // first task starts. Regression test for a gap found in review
+        // (issue #821): --check probed MCP servers for launchability but
+        // never validated the tool names they advertised.
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let mut config = Config::defaults().unwrap();
+        config
+            .root
+            .agent
+            .mcp_servers
+            .push(crate::config::McpServerCfg {
+                command: mock_mcp_server_command(&dir, "bash"),
+                timeout_secs: Some(5),
+            });
+        let mut args = base_args(path);
+        args.config = config;
+        let report = run(&args).await.unwrap();
+        assert!(!report.ok, "checks: {:?}", report.checks);
+        let checked = report
+            .checks
+            .iter()
+            .find(|c| c.check == "mcp_tool_names")
+            .unwrap();
+        assert_eq!(checked.status, CheckStatus::Fail);
+    }
+
+    #[tokio::test]
+    async fn mcp_tool_with_invalid_name_fails_preflight() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let mut config = Config::defaults().unwrap();
+        config
+            .root
+            .agent
+            .mcp_servers
+            .push(crate::config::McpServerCfg {
+                command: mock_mcp_server_command(&dir, "1invalid"),
+                timeout_secs: Some(5),
+            });
+        let mut args = base_args(path);
+        args.config = config;
+        let report = run(&args).await.unwrap();
+        assert!(!report.ok, "checks: {:?}", report.checks);
+        let checked = report
+            .checks
+            .iter()
+            .find(|c| c.check == "mcp_tool_names")
+            .unwrap();
+        assert_eq!(checked.status, CheckStatus::Fail);
+    }
+
+    #[tokio::test]
+    async fn mcp_tool_names_pass_without_collision() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let mut config = Config::defaults().unwrap();
+        config
+            .root
+            .agent
+            .mcp_servers
+            .push(crate::config::McpServerCfg {
+                command: mock_mcp_server_command(&dir, "diagnose"),
+                timeout_secs: Some(5),
+            });
+        let mut args = base_args(path);
+        args.config = config;
+        let report = run(&args).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "mcp_tool_names" && c.status == CheckStatus::Pass)
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_prompt_template_fails_preflight() {
+        // `DefaultAgentBuilder::build_with_tool_providers` renders
+        // `[prompts].system`/`[prompts].instance` before the first model
+        // request — a MiniJinja syntax error fails there. Regression test
+        // for a gap found in review (issue #821): --check never exercised
+        // the prompt-render path and would report PASS.
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let mut config = Config::defaults().unwrap();
+        config.root.prompts.system = "{{ unterminated".to_owned();
+        let mut args = base_args(path);
+        args.config = config;
+        let report = run(&args).await.unwrap();
+        assert!(!report.ok, "checks: {:?}", report.checks);
+        let checked = report
+            .checks
+            .iter()
+            .find(|c| c.check == "prompts_render")
+            .unwrap();
+        assert_eq!(checked.status, CheckStatus::Fail);
+        assert_eq!(checked.target.as_deref(), Some("t1"));
+    }
+
+    #[tokio::test]
+    async fn valid_prompt_templates_pass_preflight() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "prompts_render" && c.status == CheckStatus::Pass)
+        );
     }
 
     #[tokio::test]

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -140,6 +140,13 @@ pub struct SuiteCheckArgs {
     /// `--model` override doesn't get flagged as a silent config-file
     /// override hazard.
     pub model_flag: Option<String>,
+    /// Mirrors `agent suite --detect-stagnation`. Forwarded to the hazard
+    /// detector's stagnation-bounds validation so `--check` sees the same
+    /// effective `detect_stagnation` the live run resolves — otherwise a
+    /// config file that disables stagnation (masking invalid thresholds)
+    /// could pass preflight while an explicit `--detect-stagnation` on the
+    /// live invocation re-enables it and `DefaultAgent` rejects the task.
+    pub detect_stagnation_flag: Option<bool>,
     pub strict: bool,
 }
 
@@ -217,6 +224,23 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
     // in that case (format is still validated); MCP/hook probe failures are
     // downgraded to warnings instead of fatal (see below).
     let is_docker = matches!(args.config.root.environment.kind, EnvKind::Docker);
+
+    // `mini::build_docker_env` unconditionally requires `docker_image` and
+    // errors before any task runs; catch that statically here rather than
+    // reporting PASS for a suite that cannot start. This does not probe the
+    // Docker daemon itself or pull the image — run `agent doctor` for full
+    // host readiness.
+    if is_docker {
+        match &args.config.root.environment.docker_image {
+            Some(_) => checks.push(CheckItem::pass("docker_image_configured", None)),
+            None => checks.push(CheckItem::fail(
+                "docker_image_configured",
+                None,
+                "environment.kind=docker requires environment.docker_image; run `agent doctor` \
+                 to also verify the Docker daemon is reachable",
+            )),
+        }
+    }
     let skip_launchability = is_docker;
 
     // ── Non-empty pack + per-task field/id validation ──────────────────
@@ -305,7 +329,11 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
         hide_budget_from_agent_flag: false,
         env_flag: None,
         workdir_flag: None,
-        detect_stagnation_flag: None,
+        // `agent suite` has no `--stagnation-repeat-threshold`/`--stagnation-window`
+        // flags of its own (only `--detect-stagnation`), so those two mirror
+        // that same gap in the live run path — not something --check can
+        // close on its own.
+        detect_stagnation_flag: args.detect_stagnation_flag,
         stagnation_repeat_threshold_flag: None,
         stagnation_window_flag: None,
     };
@@ -314,12 +342,22 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
     // `forecast`/`doctor`, not `agent suite`, which honors a config-file
     // step_limit when `--step-limit` is absent). Only surface hazards that
     // actually affect `agent suite`.
-    let hazards: Vec<OverrideHazard> = run_config_resolve(&hazard_args)
-        .map_err(Error::Config)?
-        .hazards
-        .into_iter()
-        .filter(|h| h.commands_affected.iter().any(|c| c == "agent suite"))
-        .collect();
+    //
+    // `run_config_resolve` can itself return `Err` (e.g. invalid stagnation
+    // bounds when detection is effectively enabled) — report that as a
+    // fatal check rather than aborting `run` with an unstructured error, so
+    // `--check` always produces a full report with the documented exit code.
+    let hazards: Vec<OverrideHazard> = match run_config_resolve(&hazard_args) {
+        Ok(resolved) => resolved
+            .hazards
+            .into_iter()
+            .filter(|h| h.commands_affected.iter().any(|c| c == "agent suite"))
+            .collect(),
+        Err(e) => {
+            checks.push(CheckItem::fail("config_resolve", None, e.to_string()));
+            Vec::new()
+        }
+    };
     for hazard in &hazards {
         let target = Some(hazard.field.clone());
         if args.strict {
@@ -659,6 +697,7 @@ mod tests {
             per_task_budget_usd: None,
             step_limit_flag: None,
             model_flag: None,
+            detect_stagnation_flag: None,
             strict: false,
         }
     }
@@ -762,6 +801,60 @@ mod tests {
                 .checks
                 .iter()
                 .any(|c| c.check == "suite_name_safe" && c.status == CheckStatus::Pass)
+        );
+    }
+
+    #[tokio::test]
+    async fn docker_env_without_image_fails_preflight() {
+        // `mini::build_docker_env` unconditionally requires
+        // `environment.docker_image` and errors before any task can run;
+        // --check must catch this instead of reporting PASS for a suite
+        // that cannot start. Regression test for a gap found in review
+        // (issue #821).
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let mut config = Config::defaults().unwrap();
+        config.root.environment.kind = EnvKind::Docker;
+        let mut args = base_args(path);
+        args.config = config;
+        let report = run(&args).await.unwrap();
+        assert!(!report.ok, "checks: {:?}", report.checks);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "docker_image_configured" && c.status == CheckStatus::Fail)
+        );
+    }
+
+    #[tokio::test]
+    async fn docker_env_with_image_passes_that_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let mut config = Config::defaults().unwrap();
+        config.root.environment.kind = EnvKind::Docker;
+        config.root.environment.docker_image = Some("my-image:latest".to_owned());
+        let mut args = base_args(path);
+        args.config = config;
+        let report = run(&args).await.unwrap();
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "docker_image_configured" && c.status == CheckStatus::Pass)
+        );
+    }
+
+    #[tokio::test]
+    async fn local_env_has_no_docker_image_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(
+            !report
+                .checks
+                .iter()
+                .any(|c| c.check == "docker_image_configured")
         );
     }
 
@@ -870,6 +963,7 @@ mod tests {
         );
         let mut config = Config::defaults().unwrap();
         config.root.environment.kind = EnvKind::Docker;
+        config.root.environment.docker_image = Some("my-image:latest".to_owned());
         let mut args = base_args(path);
         args.config = config;
         let report = run(&args).await.unwrap();
@@ -892,6 +986,7 @@ mod tests {
         let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
         let mut config = Config::defaults().unwrap();
         config.root.environment.kind = EnvKind::Docker;
+        config.root.environment.docker_image = Some("my-image:latest".to_owned());
         config
             .root
             .agent
@@ -1086,6 +1181,58 @@ mod tests {
             "checks: {:?}",
             report.checks
         );
+    }
+
+    #[tokio::test]
+    async fn explicit_detect_stagnation_flag_surfaces_invalid_config_bounds() {
+        // The config file disables stagnation detection, which masks an
+        // otherwise-invalid `stagnation_window < stagnation_repeat_threshold`.
+        // An explicit `--detect-stagnation` on the live `agent suite`
+        // invocation re-enables it, and `DefaultAgent` would reject the
+        // task before running. --check must forward the flag and surface
+        // this instead of reporting PASS — regression test for a gap found
+        // in review (issue #821).
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            "[agent]\ndetect_stagnation = false\nstagnation_repeat_threshold = 5\nstagnation_window = 1\n",
+        )
+        .unwrap();
+
+        let mut args = base_args(path);
+        args.config_path = Some(config_path);
+        args.detect_stagnation_flag = Some(true);
+        let report = run(&args).await.unwrap();
+        assert!(!report.ok, "checks: {:?}", report.checks);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "config_resolve" && c.status == CheckStatus::Fail)
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_stagnation_bounds_do_not_block_when_detection_stays_disabled() {
+        // Same broken bounds as above, but nothing re-enables detection
+        // (neither the config file nor a --detect-stagnation flag), so the
+        // live run never hits the bounds check either — --check must not
+        // false-fail here.
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            "[agent]\ndetect_stagnation = false\nstagnation_repeat_threshold = 5\nstagnation_window = 1\n",
+        )
+        .unwrap();
+
+        let mut args = base_args(path);
+        args.config_path = Some(config_path);
+        let report = run(&args).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
     }
 
     // ── RED: worst-case cost summary ────────────────────────────────────

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -133,6 +133,11 @@ pub struct SuiteCheckArgs {
     pub suite_cost_limit_usd: Option<f64>,
     pub per_task_budget_usd: Option<f64>,
     pub step_limit_flag: Option<u32>,
+    /// The explicit `--model` value, when the caller passed one that differs
+    /// from the clap default. Forwarded to the hazard detector so a
+    /// deliberately-acknowledged `--model` override doesn't get flagged as a
+    /// silent config-file override hazard.
+    pub model_flag: Option<String>,
     pub strict: bool,
 }
 
@@ -261,14 +266,13 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
             message: hook.error.clone(),
         });
     }
-    let mcp_server_count = args.config.root.agent.mcp_servers.len();
-    let hook_count = args.config.root.agent.hooks.pre_tool_use.len()
-        + args.config.root.agent.hooks.post_tool_use.len();
+    let mcp_server_count = scriptability_report.servers.len();
+    let hook_count = scriptability_report.hooks.len();
 
     // ── Config-provenance hazards (reuse `agent config resolve`) ───────────
     let hazard_args = ConfigResolveArgs {
         config: args.config_path.clone(),
-        model_flag: None,
+        model_flag: args.model_flag.clone(),
         step_limit_flag: args.step_limit_flag,
         observation_max_bytes_flag: None,
         observation_head_ratio_flag: None,
@@ -280,9 +284,17 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
         stagnation_repeat_threshold_flag: None,
         stagnation_window_flag: None,
     };
-    let hazards = run_config_resolve(&hazard_args)
+    // `agent config resolve` reports hazards for several commands (e.g. the
+    // `agent.step_limit` hazard only affects `bench swebench`/`rehearsal`/
+    // `forecast`/`doctor`, not `agent suite`, which honors a config-file
+    // step_limit when `--step-limit` is absent). Only surface hazards that
+    // actually affect `agent suite`.
+    let hazards: Vec<OverrideHazard> = run_config_resolve(&hazard_args)
         .map_err(Error::Config)?
-        .hazards;
+        .hazards
+        .into_iter()
+        .filter(|h| h.commands_affected.iter().any(|c| c == "agent suite"))
+        .collect();
     for hazard in &hazards {
         let target = Some(hazard.field.clone());
         if args.strict {
@@ -358,7 +370,8 @@ fn resolve_format(path: &Path, format_override: Option<&str>) -> Result<TaskFile
 // ── verify-check format + launchability ─────────────────────────────────────────
 
 fn check_verify_spec(target: Option<String>, spec: &str) -> CheckItem {
-    match parse_verify_checks(std::slice::from_ref(&spec.to_owned())) {
+    let specs = [spec.to_owned()];
+    match parse_verify_checks(&specs) {
         Ok(parsed) => {
             let Some(check) = parsed.first() else {
                 return CheckItem::fail("verify", target, "empty --verify entry");
@@ -465,7 +478,7 @@ fn is_env_assignment(word: &str) -> bool {
 }
 
 const SHELL_BUILTINS_AND_KEYWORDS: &[&str] = &[
-    "cd", "pushd", "popd", "echo", "printf", "export", "unset", "set", "source", ".", "true",
+    "cd", "pushd", "popd", "echo", "printf", "export", "unset", "set", "source", ".", ":", "true",
     "false", "test", "[", "[[", "exit", "return", "eval", "exec", "read", "type", "command",
     "builtin", "pwd", "alias", "unalias", "local", "declare", "typeset", "readonly", "shift",
     "trap", "wait", "jobs", "ulimit", "umask", "hash", "let", "time", "if", "then", "elif", "else",
@@ -573,6 +586,7 @@ mod tests {
             suite_cost_limit_usd: None,
             per_task_budget_usd: None,
             step_limit_flag: None,
+            model_flag: None,
             strict: false,
         }
     }
@@ -811,6 +825,56 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn explicit_model_flag_suppresses_model_hazard_even_under_strict() {
+        // The config file's model.name matches the operator's explicit
+        // --model, so this is not a *silent* override and must not be
+        // flagged as a hazard — regression test for a false-positive found
+        // in review (issue #821).
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "[model]\nname = \"claude-sonnet-4-6\"\n").unwrap();
+
+        let mut args = base_args(path);
+        args.config_path = Some(config_path);
+        args.model_flag = Some("claude-sonnet-4-6".to_owned());
+        args.strict = true;
+        let report = run(&args).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
+        assert!(
+            !report.checks.iter().any(|c| c.check == "hazard:model.name"),
+            "checks: {:?}",
+            report.checks
+        );
+    }
+
+    #[tokio::test]
+    async fn step_limit_hazard_does_not_affect_agent_suite_even_under_strict() {
+        // `agent.step_limit`'s hazard only applies to `bench swebench` /
+        // `rehearsal` / `forecast` / `doctor` — `agent suite` honors a
+        // config-file step_limit when `--step-limit` is absent, so this
+        // hazard must never surface for `agent suite --check`, even under
+        // --strict. Regression test for a false-positive found in review
+        // (issue #821).
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "[agent]\nstep_limit = 100\n").unwrap();
+
+        let mut args = base_args(path);
+        args.config_path = Some(config_path);
+        args.strict = true;
+        let report = run(&args).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
+        assert!(report.hazards.is_empty(), "hazards: {:?}", report.hazards);
+        assert!(
+            !report.checks.iter().any(|c| c.check.starts_with("hazard:")),
+            "checks: {:?}",
+            report.checks
+        );
+    }
+
     // ── RED: worst-case cost summary ────────────────────────────────────
 
     #[tokio::test]
@@ -931,6 +995,13 @@ mod tests {
     #[test]
     fn shell_builtin_true_is_launchable() {
         assert!(check_command_launchable("true").is_ok());
+    }
+
+    #[test]
+    fn null_command_builtin_is_launchable() {
+        // `:` is the shell no-op builtin, commonly used as a dummy
+        // always-pass verify command (`verify: ":"`).
+        assert!(check_command_launchable(":").is_ok());
     }
 
     #[test]

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -5,11 +5,12 @@
 //! paid agent loop: the pack parses, every task has a non-empty `id`/`task`
 //! and unique id, every `--verify`/per-task `verify` entry is well-formed and
 //! its command is statically launchable, configured MCP servers and hooks
-//! start (reusing the `scriptability-check` probe), and the resolved suite
-//! config carries no silent clap-default override hazard (reusing the
-//! `agent config resolve` hazard detector). No model calls and no agent loop
-//! are ever started; no files are written (this module takes no output
-//! directory).
+//! start (reusing the `scriptability-check` probe), the `[policy]` config
+//! builds a valid `PolicyEngine`, every task's configured skills resolve
+//! cleanly, and the resolved suite config carries no silent clap-default
+//! override hazard (reusing the `agent config resolve` hazard detector). No
+//! model calls and no agent loop are ever started; no files are written
+//! (this module takes no output directory).
 
 use std::path::{Path, PathBuf};
 
@@ -18,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use crate::config::Config;
 use crate::config::schema::EnvKind;
 use crate::error::Error;
+use crate::policy::PolicyEngine;
 use crate::run::agent_doctor::{is_executable, resolve_on_path};
 use crate::run::config_resolve::{ConfigResolveArgs, OverrideHazard, run_config_resolve};
 use crate::run::scriptability_check;
@@ -25,6 +27,7 @@ use crate::run::suite::{
     SuiteTaskSpec, TaskFileFormat, collect_task_validation_issues, parse_task_file,
     parse_verify_checks, validate_suite_name,
 };
+use crate::skills;
 
 /// Schema version for [`SuiteCheckReport`]'s machine-readable form.
 pub const SUITE_CHECK_SCHEMA_VERSION: u32 = 1;
@@ -219,6 +222,16 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
         Err(msg) => checks.push(CheckItem::fail("suite_name_safe", None, msg)),
     }
 
+    // `DefaultAgent` builds `PolicyEngine::from_cfg(&config.root.policy)`
+    // before running the first task; an unknown `[policy] profile` or an
+    // invalid extra allow/deny regex fails there, after this preflight
+    // would otherwise have reported PASS. `from_cfg` is pure config
+    // validation (no I/O), so it's safe and cheap to run here too.
+    match PolicyEngine::from_cfg(&args.config.root.policy) {
+        Ok(_) => checks.push(CheckItem::pass("policy_config", None)),
+        Err(e) => checks.push(CheckItem::fail("policy_config", None, e.to_string())),
+    }
+
     // With `--env docker`, verify commands, MCP servers, and hooks all run
     // inside the container image in a live run — not on this host. A
     // host-side probe/PATH lookup can't authoritatively validate them (a
@@ -297,6 +310,25 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
                     spec,
                     skip_launchability,
                 ));
+            }
+
+            // `mini::run` resolves skills for the task before building the
+            // agent — a malformed `SKILL.md` or a duplicate skill name in a
+            // configured registry fails there, before any model call. Run
+            // the same (pure filesystem read, no model call) resolution
+            // here so that failure surfaces as a preflight check instead of
+            // reporting PASS for a suite that halts on its first task.
+            match skills::resolve_for_task(
+                &args.config.root.skills,
+                &task.task,
+                task.extra_context.clone(),
+            ) {
+                Ok(_) => checks.push(CheckItem::pass("skills_resolve", Some(task.id.clone()))),
+                Err(e) => checks.push(CheckItem::fail(
+                    "skills_resolve",
+                    Some(task.id.clone()),
+                    e.to_string(),
+                )),
             }
         }
     }
@@ -1488,6 +1520,97 @@ mod tests {
                 .checks
                 .iter()
                 .any(|c| c.check == "hazard:model.name" && c.status == CheckStatus::Fail)
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_policy_profile_fails_preflight() {
+        // `DefaultAgent` builds `PolicyEngine::from_cfg` before running the
+        // first task; an unknown `[policy] profile` fails there, after a
+        // live run has already spent on task setup. Regression test for a
+        // gap found in review (issue #821): --check never validated the
+        // policy config and would report PASS.
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let mut args = base_args(path);
+        args.config.root.policy.profile = "bogus".to_owned();
+        let report = run(&args).await.unwrap();
+        assert!(!report.ok, "checks: {:?}", report.checks);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "policy_config" && c.status == CheckStatus::Fail)
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_policy_regex_fails_preflight() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let mut args = base_args(path);
+        args.config.root.policy.extra_deny_patterns = vec!["[unterminated".to_owned()];
+        let report = run(&args).await.unwrap();
+        assert!(!report.ok, "checks: {:?}", report.checks);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "policy_config" && c.status == CheckStatus::Fail)
+        );
+    }
+
+    #[tokio::test]
+    async fn valid_policy_config_passes_preflight() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "policy_config" && c.status == CheckStatus::Pass)
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_skill_file_fails_preflight() {
+        // `mini::run` resolves skills for the task before building the
+        // agent — a `SKILL.md` missing its YAML frontmatter fails there,
+        // after a live run has already spent on task setup. Regression
+        // test for a gap found in review (issue #821): --check never
+        // resolved configured skills and would report PASS.
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let skills_dir = dir.path().join("skills");
+        std::fs::create_dir_all(&skills_dir).unwrap();
+        std::fs::write(skills_dir.join("SKILL.md"), "not frontmatter\n").unwrap();
+
+        let mut args = base_args(path);
+        args.config.root.skills.enabled = true;
+        args.config.root.skills.paths = vec![skills_dir.to_string_lossy().into_owned()];
+        let report = run(&args).await.unwrap();
+        assert!(!report.ok, "checks: {:?}", report.checks);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "skills_resolve" && c.status == CheckStatus::Fail)
+        );
+    }
+
+    #[tokio::test]
+    async fn skills_disabled_by_default_passes_preflight() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "skills_resolve" && c.status == CheckStatus::Pass)
         );
     }
 

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -507,6 +507,22 @@ fn check_verify_spec(target: Option<String>, spec: &str, skip_launchability: boo
                      the container image, not on this host",
                 );
             }
+            if has_leading_path_assignment(&check.command) {
+                // A command that sets its own PATH (e.g. `PATH=./venv/bin:$PATH
+                // pytest`) is resolved by the shell against that assigned
+                // value, not this process's PATH — resolving the program
+                // token against our own PATH could produce either a
+                // false-fail (only reachable via the assignment) or a
+                // false-pass (the assignment would actually hide it).
+                // Emulating shell variable expansion is out of scope; be
+                // honest that this can't be statically determined.
+                return CheckItem::warn(
+                    check_id,
+                    target,
+                    "launchability not checked: verify command sets PATH itself, which this \
+                     static check does not emulate",
+                );
+            }
             match check_command_launchable(&check.command) {
                 Ok(()) => CheckItem::pass(check_id, target),
                 Err(reason) => CheckItem::fail(check_id, target, reason),
@@ -605,6 +621,24 @@ fn is_env_assignment(word: &str) -> bool {
                 c.is_ascii_alphanumeric() || c == '_'
             }
         })
+}
+
+/// Whether `command` begins with one or more `VAR=value` assignments that
+/// include a `PATH=` override. `resolve_on_path` only ever consults this
+/// process's own `PATH`, so a command that assigns its own can't be
+/// statically resolved against it without emulating shell expansion.
+fn has_leading_path_assignment(command: &str) -> bool {
+    let mut rest = command;
+    while let Some((word, remainder)) = next_shell_word(rest) {
+        if !is_env_assignment(&word) {
+            return false;
+        }
+        if word.split('=').next() == Some("PATH") {
+            return true;
+        }
+        rest = remainder;
+    }
+    false
 }
 
 const SHELL_BUILTINS_AND_KEYWORDS: &[&str] = &[
@@ -1163,6 +1197,30 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn verify_command_with_path_override_is_inconclusive_not_pass_or_fail() {
+        // `resolve_on_path` only ever consults this process's own PATH, so
+        // a verify command that assigns its own PATH (e.g. a venv prefix)
+        // can't be statically resolved against it — asserting Pass could
+        // hide a binary that only the assigned PATH would find, and
+        // asserting Fail could reject one that's genuinely reachable
+        // there. Regression test for a gap found in review (issue #821).
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(
+            &dir,
+            "tasks.yaml",
+            "- id: t1\n  task: fix it\n  verify:\n    - tests:PATH=./venv/bin:$PATH pytest -q\n",
+        );
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
+        let checked = report
+            .checks
+            .iter()
+            .find(|c| c.check == "verify:tests")
+            .unwrap();
+        assert_eq!(checked.status, CheckStatus::Warn);
+    }
+
     // ── RED: hazards ─────────────────────────────────────────────────────
 
     #[tokio::test]
@@ -1492,6 +1550,21 @@ mod tests {
     fn extract_program_token_none_for_empty() {
         assert_eq!(extract_program_token(""), None);
         assert_eq!(extract_program_token("   "), None);
+    }
+
+    #[test]
+    fn has_leading_path_assignment_detects_path_override() {
+        assert!(has_leading_path_assignment("PATH=./venv/bin:$PATH pytest"));
+        assert!(has_leading_path_assignment("PATH=/custom/bin pytest -q"));
+    }
+
+    #[test]
+    fn has_leading_path_assignment_ignores_other_assignments() {
+        assert!(!has_leading_path_assignment("FOO=bar pytest -q"));
+        assert!(!has_leading_path_assignment("cargo test"));
+        // A non-PATH assignment before a PATH assignment doesn't matter for
+        // this check — only that the command as a whole doesn't set PATH.
+        assert!(has_leading_path_assignment("FOO=bar PATH=/x pytest"));
     }
 
     #[test]

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -457,20 +457,30 @@ fn scriptability_check_item(
     error: Option<String>,
     is_docker: bool,
 ) -> CheckItem {
-    if ok {
-        return CheckItem::pass(check, Some(target));
-    }
-    let message = error.unwrap_or_else(|| "probe failed".to_owned());
     if is_docker {
-        CheckItem::warn(
-            check,
-            Some(target),
+        // A host probe result is inconclusive either way under --env
+        // docker: MCP servers/hooks run inside the container image in a
+        // live run, so a passing host probe doesn't confirm the command
+        // exists in the image, and a failing one doesn't confirm it
+        // doesn't. Report both as a warning rather than asserting a
+        // verdict the host can't actually back up.
+        let message = if ok {
+            "host probe succeeded, but --env docker runs MCP servers/hooks inside the \
+             container image — this does not confirm the command is present there"
+                .to_owned()
+        } else {
+            let base = error.unwrap_or_else(|| "probe failed".to_owned());
             format!(
-                "{message} (probed on the host; --env docker runs MCP servers/hooks inside \
+                "{base} (probed on the host; --env docker runs MCP servers/hooks inside \
                  the container image, so this may not reflect the real environment)"
-            ),
-        )
+            )
+        };
+        return CheckItem::warn(check, Some(target), message);
+    }
+    if ok {
+        CheckItem::pass(check, Some(target))
     } else {
+        let message = error.unwrap_or_else(|| "probe failed".to_owned());
         CheckItem::fail(check, Some(target), message)
     }
 }
@@ -1056,6 +1066,44 @@ mod tests {
             .find(|c| c.check == "mcp_server")
             .unwrap();
         assert_eq!(checked.status, CheckStatus::Warn);
+    }
+
+    #[test]
+    fn scriptability_check_item_local_env_reflects_probe_result() {
+        let ok = scriptability_check_item("mcp_server".into(), "s".into(), true, None, false);
+        assert_eq!(ok.status, CheckStatus::Pass);
+
+        let fail = scriptability_check_item(
+            "mcp_server".into(),
+            "s".into(),
+            false,
+            Some("boom".into()),
+            false,
+        );
+        assert_eq!(fail.status, CheckStatus::Fail);
+        assert_eq!(fail.message.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn scriptability_check_item_docker_env_is_inconclusive_either_way() {
+        // A host probe result is never a verdict under --env docker: a
+        // passing host probe doesn't confirm the command exists inside the
+        // container image (the actual execution target), just as a failing
+        // one doesn't confirm it's absent. Regression test for a
+        // pass-side false-positive found in review (issue #821): a host-only
+        // MCP server/hook that doesn't exist in the image previously
+        // reported PASS.
+        let ok = scriptability_check_item("mcp_server".into(), "s".into(), true, None, true);
+        assert_eq!(ok.status, CheckStatus::Warn);
+
+        let fail = scriptability_check_item(
+            "mcp_server".into(),
+            "s".into(),
+            false,
+            Some("boom".into()),
+            true,
+        );
+        assert_eq!(fail.status, CheckStatus::Warn);
     }
 
     #[tokio::test]

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -496,16 +496,16 @@ fn check_verify_spec(target: Option<String>, spec: &str, skip_launchability: boo
             };
             let check_id = format!("verify:{}", check.name);
             if skip_launchability {
-                return CheckItem {
-                    check: check_id,
+                // Inconclusive, not a pass: a typo'd or missing binary
+                // inside the container image would still be undetectable
+                // from here, so asserting Pass would hide it from `ok` and
+                // from a `--format text` reader skimming for failures.
+                return CheckItem::warn(
+                    check_id,
                     target,
-                    status: CheckStatus::Pass,
-                    message: Some(
-                        "launchability not checked: --env docker runs verify commands inside \
-                         the container image, not on this host"
-                            .to_owned(),
-                    ),
-                };
+                    "launchability not checked: --env docker runs verify commands inside \
+                     the container image, not on this host",
+                );
             }
             match check_command_launchable(&check.command) {
                 Ok(()) => CheckItem::pass(check_id, target),
@@ -1006,11 +1006,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn docker_env_skips_host_path_launchability_check() {
+    async fn docker_env_marks_verify_launchability_inconclusive_not_fatal() {
         // A binary that only exists inside the configured Docker image (not
         // on this host) must not fail preflight — the real verify command
-        // runs inside the container, not on the host PATH. Regression test
-        // for a false-fail found in review (issue #821).
+        // runs inside the container, not on the host PATH. It also must not
+        // be asserted as a definite Pass: a typo'd/missing binary inside
+        // the image would be just as undetectable from here. Warn is the
+        // honest status. Regression test for a false-fail (and later a
+        // false-pass) found in review (issue #821).
         let dir = tempfile::tempdir().unwrap();
         let path = write_tasks(
             &dir,
@@ -1025,14 +1028,14 @@ mod tests {
         let report = run(&args).await.unwrap();
         // Not asserting report.ok: this test binary may or may not be built
         // with --features docker, which independently gates `ok` (see
-        // docker_env_fails_when_docker_feature_not_compiled below). Only
-        // the launchability-skip behavior under test is asserted here.
+        // docker_feature_gate_matches_this_build). Only the
+        // launchability-skip behavior under test is asserted here.
         let checked = report
             .checks
             .iter()
             .find(|c| c.check == "verify:tests")
             .unwrap();
-        assert_eq!(checked.status, CheckStatus::Pass);
+        assert_eq!(checked.status, CheckStatus::Warn);
     }
 
     #[tokio::test]

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -153,8 +153,11 @@ pub struct SuiteCheckArgs {
 // ── main entry point ──────────────────────────────────────────────────────────
 
 /// Run the preflight and return a [`SuiteCheckReport`]. Performs zero model
-/// calls and starts no agent loop; the only subprocesses spawned are the
-/// transient MCP-server/hook probes already used by `bench scriptability-check`.
+/// calls and starts no agent loop. For `environment.kind = local`, the only
+/// subprocesses spawned are the transient MCP-server/hook probes already
+/// used by `bench scriptability-check`; for `environment.kind = docker`
+/// those probes are skipped entirely (nothing configured is executed on
+/// the host — see the `is_docker` branch below).
 #[allow(clippy::too_many_lines)]
 pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
     let started = std::time::Instant::now();
@@ -241,13 +244,18 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
                 "docker support not compiled in — rebuild with --features docker",
             ));
         }
-        match &args.config.root.environment.docker_image {
-            Some(_) => checks.push(CheckItem::pass("docker_image_configured", None)),
-            None => checks.push(CheckItem::fail(
+        // `Some("")`/whitespace-only is accepted by the `Option` check but
+        // still passes an unusable image straight to `docker run`, which
+        // fails with a confusing error instead of the clear one above.
+        match args.config.root.environment.docker_image.as_deref() {
+            Some(image) if !image.trim().is_empty() => {
+                checks.push(CheckItem::pass("docker_image_configured", None));
+            }
+            _ => checks.push(CheckItem::fail(
                 "docker_image_configured",
                 None,
-                "environment.kind=docker requires environment.docker_image; run `agent doctor` \
-                 to also verify the Docker daemon is reachable",
+                "environment.kind=docker requires a non-empty environment.docker_image; run \
+                 `agent doctor` to also verify the Docker daemon is reachable",
             )),
         }
     }
@@ -300,33 +308,71 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
     let verify_check_count = args.verify.len() + per_task_verify_count;
 
     // ── MCP servers + hooks (reuse scriptability-check, no artifact write) ─
-    // NOTE: `scriptability_check` always probes via a `LocalEnvironment`
-    // regardless of `environment.kind` (a pre-existing limitation shared by
-    // `bench scriptability-check` itself). Under `--env docker`, a live run
-    // launches MCP servers/hooks inside the container instead, so a host
-    // probe failure here may not reflect the real environment — downgrade
-    // it to a warning rather than a fatal preflight failure.
-    let scriptability_report = scriptability_check::run_with_config(&args.config, None).await?;
-    for server in &scriptability_report.servers {
-        checks.push(scriptability_check_item(
-            "mcp_server".to_owned(),
-            server.name.clone(),
-            server.ok,
-            server.error.clone(),
-            is_docker,
-        ));
+    // `scriptability_check` probes via a `LocalEnvironment` — it actually
+    // spawns each configured MCP server and executes each configured hook
+    // command. Under `--env docker` a live run never does that on the host
+    // (MCP servers/hooks launch inside the container), so doing it here
+    // would both misrepresent the container and — for a destructive or
+    // container-only command — cause real side effects on the host outside
+    // the sandbox the operator chose. Skip the probe entirely for docker;
+    // report each configured server/hook as unprobed instead.
+    let mcp_server_count = args.config.root.agent.mcp_servers.len();
+    let hook_count = args.config.root.agent.hooks.pre_tool_use.len()
+        + args.config.root.agent.hooks.post_tool_use.len();
+    if is_docker {
+        for (i, _) in args.config.root.agent.mcp_servers.iter().enumerate() {
+            checks.push(CheckItem::warn(
+                "mcp_server",
+                Some(format!("mcp-{i}")),
+                "not probed: --env docker is configured; running configured commands on the \
+                 host would bypass the sandbox the operator chose",
+            ));
+        }
+        for hook_cfg in args
+            .config
+            .root
+            .agent
+            .hooks
+            .pre_tool_use
+            .iter()
+            .map(|h| (h, "pre_tool_use"))
+            .chain(
+                args.config
+                    .root
+                    .agent
+                    .hooks
+                    .post_tool_use
+                    .iter()
+                    .map(|h| (h, "post_tool_use")),
+            )
+        {
+            let (hook, phase) = hook_cfg;
+            checks.push(CheckItem::warn(
+                format!("hook:{phase}"),
+                Some(hook.name.clone()),
+                "not probed: --env docker is configured; running configured commands on the \
+                 host would bypass the sandbox the operator chose",
+            ));
+        }
+    } else {
+        let scriptability_report = scriptability_check::run_with_config(&args.config, None).await?;
+        for server in &scriptability_report.servers {
+            checks.push(scriptability_check_item(
+                "mcp_server".to_owned(),
+                server.name.clone(),
+                server.ok,
+                server.error.clone(),
+            ));
+        }
+        for hook in &scriptability_report.hooks {
+            checks.push(scriptability_check_item(
+                format!("hook:{}", hook.phase),
+                hook.name.clone(),
+                hook.ok,
+                hook.error.clone(),
+            ));
+        }
     }
-    for hook in &scriptability_report.hooks {
-        checks.push(scriptability_check_item(
-            format!("hook:{}", hook.phase),
-            hook.name.clone(),
-            hook.ok,
-            hook.error.clone(),
-            is_docker,
-        ));
-    }
-    let mcp_server_count = scriptability_report.servers.len();
-    let hook_count = scriptability_report.hooks.len();
 
     // ── Config-provenance hazards (reuse `agent config resolve`) ───────────
     let hazard_args = ConfigResolveArgs {
@@ -450,33 +496,16 @@ fn resolve_format(path: &Path, format_override: Option<&str>) -> Result<TaskFile
 /// Build a [`CheckItem`] from a `scriptability_check` server/hook result.
 /// A failure is downgraded from `Fail` to `Warn` under `--env docker`,
 /// since the probe ran on the host, not inside the configured container.
+/// Build a [`CheckItem`] from a `scriptability_check` server/hook result.
+/// Only ever called for `environment.kind = local` — under `--env docker`
+/// the probe itself is skipped rather than run and downgraded (see the
+/// `is_docker` branch in [`run`]).
 fn scriptability_check_item(
     check: String,
     target: String,
     ok: bool,
     error: Option<String>,
-    is_docker: bool,
 ) -> CheckItem {
-    if is_docker {
-        // A host probe result is inconclusive either way under --env
-        // docker: MCP servers/hooks run inside the container image in a
-        // live run, so a passing host probe doesn't confirm the command
-        // exists in the image, and a failing one doesn't confirm it
-        // doesn't. Report both as a warning rather than asserting a
-        // verdict the host can't actually back up.
-        let message = if ok {
-            "host probe succeeded, but --env docker runs MCP servers/hooks inside the \
-             container image — this does not confirm the command is present there"
-                .to_owned()
-        } else {
-            let base = error.unwrap_or_else(|| "probe failed".to_owned());
-            format!(
-                "{base} (probed on the host; --env docker runs MCP servers/hooks inside \
-                 the container image, so this may not reflect the real environment)"
-            )
-        };
-        return CheckItem::warn(check, Some(target), message);
-    }
     if ok {
         CheckItem::pass(check, Some(target))
     } else {
@@ -882,6 +911,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn docker_env_with_blank_image_fails_preflight() {
+        // `docker_image = Some("")` (or whitespace) passes the `Option`
+        // check but is still an unusable image string passed straight to
+        // `docker run`, which fails with a confusing error rather than the
+        // clear one above. Regression test for a gap found in review
+        // (issue #821).
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let mut config = Config::defaults().unwrap();
+        config.root.environment.kind = EnvKind::Docker;
+        config.root.environment.docker_image = Some("   ".to_owned());
+        let mut args = base_args(path);
+        args.config = config;
+        let report = run(&args).await.unwrap();
+        assert!(!report.ok, "checks: {:?}", report.checks);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "docker_image_configured" && c.status == CheckStatus::Fail)
+        );
+    }
+
+    #[tokio::test]
     async fn docker_env_with_image_passes_that_check() {
         let dir = tempfile::tempdir().unwrap();
         let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
@@ -1073,11 +1126,81 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn docker_env_downgrades_mcp_failure_to_warning() {
-        // `scriptability_check` always probes on the host; under --env
-        // docker a live run launches MCP servers inside the container
-        // instead, so a host-side probe failure can't be trusted as fatal.
-        // Regression test for a false-fail found in review (issue #821).
+    async fn docker_env_does_not_execute_mcp_servers_on_host() {
+        // The live run never launches MCP servers on the host under --env
+        // docker (they run inside the container), and running a configured
+        // command here anyway could have real side effects outside the
+        // sandbox the operator chose. Prove no execution happens at all —
+        // not just that a failure is downgraded — by using a command whose
+        // side effect (writing a marker file) would be observable if run.
+        // Regression test for a host-execution safety gap found in review
+        // (issue #821).
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let marker = dir.path().join("marker.txt");
+        let mut config = Config::defaults().unwrap();
+        config.root.environment.kind = EnvKind::Docker;
+        config.root.environment.docker_image = Some("my-image:latest".to_owned());
+        config
+            .root
+            .agent
+            .mcp_servers
+            .push(crate::config::McpServerCfg {
+                command: format!("touch {}", marker.display()),
+                timeout_secs: Some(1),
+            });
+        let mut args = base_args(path);
+        args.config = config;
+        let report = run(&args).await.unwrap();
+        assert!(
+            !marker.exists(),
+            "MCP server command must not execute on the host under --env docker"
+        );
+        let checked = report
+            .checks
+            .iter()
+            .find(|c| c.check == "mcp_server")
+            .unwrap();
+        assert_eq!(checked.status, CheckStatus::Warn);
+        assert!(checked.message.as_deref().unwrap().contains("not probed"));
+    }
+
+    #[tokio::test]
+    async fn docker_env_does_not_execute_hooks_on_host() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let marker = dir.path().join("marker.txt");
+        let mut config = Config::defaults().unwrap();
+        config.root.environment.kind = EnvKind::Docker;
+        config.root.environment.docker_image = Some("my-image:latest".to_owned());
+        config
+            .root
+            .agent
+            .hooks
+            .pre_tool_use
+            .push(crate::config::ToolHookCfg {
+                name: "guard".to_owned(),
+                command: format!("touch {}", marker.display()),
+                timeout_secs: Some(1),
+            });
+        let mut args = base_args(path);
+        args.config = config;
+        let report = run(&args).await.unwrap();
+        assert!(
+            !marker.exists(),
+            "hook command must not execute on the host under --env docker"
+        );
+        let checked = report
+            .checks
+            .iter()
+            .find(|c| c.check == "hook:pre_tool_use")
+            .unwrap();
+        assert_eq!(checked.status, CheckStatus::Warn);
+        assert_eq!(checked.target.as_deref(), Some("guard"));
+    }
+
+    #[tokio::test]
+    async fn docker_env_mcp_and_hook_counts_still_reflect_config() {
         let dir = tempfile::tempdir().unwrap();
         let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
         let mut config = Config::defaults().unwrap();
@@ -1088,59 +1211,35 @@ mod tests {
             .agent
             .mcp_servers
             .push(crate::config::McpServerCfg {
-                command: "__no_such_binary_xyz_suite_check_mcp__".to_owned(),
+                command: "true".to_owned(),
+                timeout_secs: Some(1),
+            });
+        config
+            .root
+            .agent
+            .hooks
+            .post_tool_use
+            .push(crate::config::ToolHookCfg {
+                name: "note".to_owned(),
+                command: "true".to_owned(),
                 timeout_secs: Some(1),
             });
         let mut args = base_args(path);
         args.config = config;
         let report = run(&args).await.unwrap();
-        // Not asserting report.ok here — see docker_env_skips_host_path_
-        // launchability_check for why (the docker-feature gate is tested
-        // separately below).
-        let checked = report
-            .checks
-            .iter()
-            .find(|c| c.check == "mcp_server")
-            .unwrap();
-        assert_eq!(checked.status, CheckStatus::Warn);
+        assert_eq!(report.mcp_server_count, 1);
+        assert_eq!(report.hook_count, 1);
     }
 
     #[test]
-    fn scriptability_check_item_local_env_reflects_probe_result() {
-        let ok = scriptability_check_item("mcp_server".into(), "s".into(), true, None, false);
+    fn scriptability_check_item_reflects_probe_result() {
+        let ok = scriptability_check_item("mcp_server".into(), "s".into(), true, None);
         assert_eq!(ok.status, CheckStatus::Pass);
 
-        let fail = scriptability_check_item(
-            "mcp_server".into(),
-            "s".into(),
-            false,
-            Some("boom".into()),
-            false,
-        );
+        let fail =
+            scriptability_check_item("mcp_server".into(), "s".into(), false, Some("boom".into()));
         assert_eq!(fail.status, CheckStatus::Fail);
         assert_eq!(fail.message.as_deref(), Some("boom"));
-    }
-
-    #[test]
-    fn scriptability_check_item_docker_env_is_inconclusive_either_way() {
-        // A host probe result is never a verdict under --env docker: a
-        // passing host probe doesn't confirm the command exists inside the
-        // container image (the actual execution target), just as a failing
-        // one doesn't confirm it's absent. Regression test for a
-        // pass-side false-positive found in review (issue #821): a host-only
-        // MCP server/hook that doesn't exist in the image previously
-        // reported PASS.
-        let ok = scriptability_check_item("mcp_server".into(), "s".into(), true, None, true);
-        assert_eq!(ok.status, CheckStatus::Warn);
-
-        let fail = scriptability_check_item(
-            "mcp_server".into(),
-            "s".into(),
-            false,
-            Some("boom".into()),
-            true,
-        );
-        assert_eq!(fail.status, CheckStatus::Warn);
     }
 
     #[tokio::test]

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::config::Config;
+use crate::config::schema::EnvKind;
 use crate::error::Error;
 use crate::run::agent_doctor::{is_executable, resolve_on_path};
 use crate::run::config_resolve::{ConfigResolveArgs, OverrideHazard, run_config_resolve};
@@ -198,6 +199,14 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
         _ => None,
     };
 
+    // Verify commands run inside the configured environment, not on this
+    // host: with `--env docker` the real check runs in the container image,
+    // so a host-PATH lookup can't validate it (a docker-only binary would
+    // false-fail; a host-only same-named binary would false-pass). Skip the
+    // static launchability probe in that case and only validate
+    // `NAME:COMMAND` well-formedness.
+    let skip_launchability = matches!(args.config.root.environment.kind, EnvKind::Docker);
+
     // ── Non-empty pack + per-task field/id validation ──────────────────
     let mut task_count = 0usize;
     let mut per_task_verify_count = 0usize;
@@ -229,14 +238,18 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
         for task in tasks {
             per_task_verify_count += task.verify.len();
             for spec in &task.verify {
-                checks.push(check_verify_spec(Some(task.id.clone()), spec));
+                checks.push(check_verify_spec(
+                    Some(task.id.clone()),
+                    spec,
+                    skip_launchability,
+                ));
             }
         }
     }
 
     // ── Suite-level verify entries ───────────────────────────────────────
     for spec in &args.verify {
-        checks.push(check_verify_spec(None, spec));
+        checks.push(check_verify_spec(None, spec, skip_launchability));
     }
     let verify_check_count = args.verify.len() + per_task_verify_count;
 
@@ -313,10 +326,15 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
     }
 
     // ── Worst-case cost (arithmetic only — no model call) ──────────────────
+    // The `--per-task-budget-usd` flag always wins when passed; otherwise
+    // fall back to a config-file `[agent] per_task_budget_usd`, which the
+    // live suite run also honors per-task when no flag override is given.
+    let effective_per_task_budget_usd =
+        args.per_task_budget_usd
+            .or(args.config.root.agent.per_task_budget_usd);
     #[allow(clippy::cast_precision_loss)]
-    let estimated_worst_case_cost_usd = args
-        .per_task_budget_usd
-        .map(|budget| budget * task_count as f64);
+    let estimated_worst_case_cost_usd =
+        effective_per_task_budget_usd.map(|budget| budget * task_count as f64);
     if let (Some(cost), Some(limit)) = (estimated_worst_case_cost_usd, args.suite_cost_limit_usd) {
         if cost > limit {
             checks.push(CheckItem::warn(
@@ -369,7 +387,7 @@ fn resolve_format(path: &Path, format_override: Option<&str>) -> Result<TaskFile
 
 // ── verify-check format + launchability ─────────────────────────────────────────
 
-fn check_verify_spec(target: Option<String>, spec: &str) -> CheckItem {
+fn check_verify_spec(target: Option<String>, spec: &str, skip_launchability: bool) -> CheckItem {
     let specs = [spec.to_owned()];
     match parse_verify_checks(&specs) {
         Ok(parsed) => {
@@ -377,6 +395,18 @@ fn check_verify_spec(target: Option<String>, spec: &str) -> CheckItem {
                 return CheckItem::fail("verify", target, "empty --verify entry");
             };
             let check_id = format!("verify:{}", check.name);
+            if skip_launchability {
+                return CheckItem {
+                    check: check_id,
+                    target,
+                    status: CheckStatus::Pass,
+                    message: Some(
+                        "launchability not checked: --env docker runs verify commands inside \
+                         the container image, not on this host"
+                            .to_owned(),
+                    ),
+                };
+            }
             match check_command_launchable(&check.command) {
                 Ok(()) => CheckItem::pass(check_id, target),
                 Err(reason) => CheckItem::fail(check_id, target, reason),
@@ -751,6 +781,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn docker_env_skips_host_path_launchability_check() {
+        // A binary that only exists inside the configured Docker image (not
+        // on this host) must not fail preflight — the real verify command
+        // runs inside the container, not on the host PATH. Regression test
+        // for a false-fail found in review (issue #821).
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(
+            &dir,
+            "tasks.yaml",
+            "- id: t1\n  task: fix it\n  verify:\n    - tests:__no_such_binary_xyz_suite_check__ -q\n",
+        );
+        let mut config = Config::defaults().unwrap();
+        config.root.environment.kind = EnvKind::Docker;
+        let mut args = base_args(path);
+        args.config = config;
+        let report = run(&args).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
+        let checked = report
+            .checks
+            .iter()
+            .find(|c| c.check == "verify:tests")
+            .unwrap();
+        assert_eq!(checked.status, CheckStatus::Pass);
+    }
+
+    #[tokio::test]
     async fn malformed_verify_spec_without_colon_fails() {
         let dir = tempfile::tempdir().unwrap();
         let path = write_tasks(
@@ -897,6 +953,46 @@ mod tests {
         let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: a\n");
         let report = run(&base_args(path)).await.unwrap();
         assert!(report.estimated_worst_case_cost_usd.is_none());
+    }
+
+    #[tokio::test]
+    async fn worst_case_cost_uses_config_file_budget_when_no_cli_flag() {
+        // The live `agent suite` run path honors a config-file
+        // `[agent] per_task_budget_usd` per task when `--per-task-budget-usd`
+        // isn't passed on the CLI — `--check` must estimate cost the same
+        // way instead of reporting "unknown" (regression test for a gap
+        // found in review, issue #821).
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(
+            &dir,
+            "tasks.yaml",
+            "- id: t1\n  task: a\n- id: t2\n  task: b\n",
+        );
+        let mut config = Config::defaults().unwrap();
+        config.root.agent.per_task_budget_usd = Some(0.25);
+        let mut args = base_args(path);
+        args.config = config;
+        let report = run(&args).await.unwrap();
+        assert!(
+            (report.estimated_worst_case_cost_usd.unwrap() - 0.50).abs() < 1e-9,
+            "report: {report:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn worst_case_cost_cli_flag_wins_over_config_file_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: a\n");
+        let mut config = Config::defaults().unwrap();
+        config.root.agent.per_task_budget_usd = Some(0.25);
+        let mut args = base_args(path);
+        args.config = config;
+        args.per_task_budget_usd = Some(1.0);
+        let report = run(&args).await.unwrap();
+        assert!(
+            (report.estimated_worst_case_cost_usd.unwrap() - 1.0).abs() < 1e-9,
+            "report: {report:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -536,36 +536,14 @@ fn check_verify_spec(target: Option<String>, spec: &str, skip_launchability: boo
                      the container image, not on this host",
                 );
             }
-            if has_leading_path_assignment(&check.command) {
-                // A command that sets its own PATH (e.g. `PATH=./venv/bin:$PATH
-                // pytest`) is resolved by the shell against that assigned
-                // value, not this process's PATH — resolving the program
-                // token against our own PATH could produce either a
-                // false-fail (only reachable via the assignment) or a
-                // false-pass (the assignment would actually hide it).
-                // Emulating shell variable expansion is out of scope; be
-                // honest that this can't be statically determined.
-                return CheckItem::warn(
-                    check_id,
-                    target,
-                    "launchability not checked: verify command sets PATH itself, which this \
-                     static check does not emulate",
-                );
-            }
-            if has_ambiguous_wrapper_option(&check.command) {
-                // A wrapper (time/exec/command/env/...) followed by what
-                // looks like an option flag (`time -p`, `command -v`,
-                // `env -i`) may take that flag's own argument before the
-                // real payload (e.g. `exec -a name cmd`), which this
-                // checker doesn't model per-wrapper. Guessing wrong in
-                // either direction is worse than admitting uncertainty.
-                return CheckItem::warn(
-                    check_id,
-                    target,
-                    "launchability not checked: a wrapper command (time/exec/command/eval/\
-                     builtin/env) is followed by what looks like an option flag, which this \
-                     static check does not parse",
-                );
+            if let Some(reason) = verify_command_inconclusive_reason(&check.command) {
+                // A PATH override or an ambiguous wrapper option could sit
+                // behind any number of unwrapped layers (e.g. `env
+                // PATH=/tmp/empty cargo` — the outermost token is `env`,
+                // not `PATH=...`), so this is checked at every layer as
+                // wrapper commands are unwrapped, not just the outermost
+                // command string.
+                return CheckItem::warn(check_id, target, reason);
             }
             match check_command_launchable(&check.command) {
                 Ok(()) => CheckItem::pass(check_id, target),
@@ -624,23 +602,42 @@ fn check_command_launchable(command: &str) -> Result<(), String> {
 /// wrapper shape: `env [OPTION]... [NAME=VALUE]... [COMMAND [ARG]...]`.
 const WRAPPER_COMMANDS: &[&str] = &["time", "exec", "command", "eval", "builtin", "env"];
 
-/// Whether `command`, after unwrapping any [`WRAPPER_COMMANDS`] prefixes, is
-/// followed by a token that looks like an option flag (`-...`) for that
-/// wrapper. Each wrapper has its own option grammar — some flags take their
-/// own argument (e.g. `exec -a name`) — which this checker doesn't model,
-/// so treat the launchability as inconclusive rather than misresolving the
-/// flag (or its argument) as the payload.
-fn has_ambiguous_wrapper_option(command: &str) -> bool {
+/// Reasons `check_command_launchable` can't be trusted to resolve `command`
+/// statically, checked at every layer as [`WRAPPER_COMMANDS`] are unwrapped
+/// — not just the outermost command string. A `PATH=` assignment or an
+/// ambiguous option can appear behind any number of wrapper layers (e.g.
+/// `env PATH=/tmp/empty cargo` — the outermost token is `env`, not
+/// `PATH=...`), so checking only the original string would miss it.
+fn verify_command_inconclusive_reason(command: &str) -> Option<&'static str> {
     let mut rest = command;
     loop {
-        let Some((token, remainder)) = split_off_program_token(rest) else {
-            return false;
-        };
+        if has_leading_path_assignment(rest) {
+            // A command that sets its own PATH (e.g. `PATH=./venv/bin:$PATH
+            // pytest`, or `env PATH=/tmp/empty cargo`) is resolved by the
+            // shell against that assigned value, not this process's PATH —
+            // resolving the program token against our own PATH could
+            // produce either a false-fail (only reachable via the
+            // assignment) or a false-pass (the assignment would actually
+            // hide it). Emulating shell variable expansion is out of scope;
+            // be honest that this can't be statically determined.
+            return Some(
+                "verify command sets PATH itself, which this static check does not emulate",
+            );
+        }
+        let (token, remainder) = split_off_program_token(rest)?;
         if !WRAPPER_COMMANDS.contains(&token.as_str()) {
-            return false;
+            return None;
         }
         if matches!(next_shell_word(remainder), Some((next, _)) if next.starts_with('-')) {
-            return true;
+            // A wrapper followed by what looks like an option flag (`time
+            // -p`, `command -v`, `env -i`) may take that flag's own
+            // argument before the real payload (e.g. `exec -a name cmd`),
+            // which this checker doesn't model per-wrapper. Guessing wrong
+            // in either direction is worse than admitting uncertainty.
+            return Some(
+                "a wrapper command (time/exec/command/eval/builtin/env) is followed by what \
+                 looks like an option flag, which this static check does not parse",
+            );
         }
         rest = remainder;
     }
@@ -1791,7 +1788,7 @@ mod tests {
     }
 
     #[test]
-    fn has_ambiguous_wrapper_option_detects_option_after_wrapper() {
+    fn verify_command_inconclusive_reason_detects_option_after_wrapper() {
         // `time -p`, `command -v`, `env -i` etc. are valid shell/coreutils
         // invocations, but this checker doesn't model each wrapper's own
         // option grammar (some flags take an argument, e.g. `exec -a
@@ -1799,17 +1796,29 @@ mod tests {
         // would misresolve either way. Regression test for a false-fail
         // found in review (issue #821): `time -p cargo test` previously
         // tried (and failed) to resolve "-p" as an executable.
-        assert!(has_ambiguous_wrapper_option("time -p cargo test"));
-        assert!(has_ambiguous_wrapper_option("command -v cargo"));
-        assert!(has_ambiguous_wrapper_option("env -i FOO=bar cargo test"));
-        assert!(has_ambiguous_wrapper_option("time exec -a name cargo"));
+        assert!(verify_command_inconclusive_reason("time -p cargo test").is_some());
+        assert!(verify_command_inconclusive_reason("command -v cargo").is_some());
+        assert!(verify_command_inconclusive_reason("env -i FOO=bar cargo test").is_some());
+        assert!(verify_command_inconclusive_reason("time exec -a name cargo").is_some());
     }
 
     #[test]
-    fn has_ambiguous_wrapper_option_false_for_ordinary_commands() {
-        assert!(!has_ambiguous_wrapper_option("time cargo test"));
-        assert!(!has_ambiguous_wrapper_option("cargo -v test"));
-        assert!(!has_ambiguous_wrapper_option("env PYTHONPATH=. cargo test"));
+    fn verify_command_inconclusive_reason_detects_path_behind_env_wrapper() {
+        // `env PATH=/tmp/empty cargo` sets its own PATH from *behind* the
+        // `env` wrapper layer, not at the very start of the command string
+        // — checking only the outermost command for a leading PATH=
+        // assignment misses it. Regression test for a gap found in review
+        // (issue #821).
+        assert!(
+            verify_command_inconclusive_reason("env PATH=/tmp/empty cargo --version").is_some()
+        );
+    }
+
+    #[test]
+    fn verify_command_inconclusive_reason_none_for_ordinary_commands() {
+        assert!(verify_command_inconclusive_reason("time cargo test").is_none());
+        assert!(verify_command_inconclusive_reason("cargo -v test").is_none());
+        assert!(verify_command_inconclusive_reason("env PYTHONPATH=. cargo test").is_none());
     }
 
     #[tokio::test]
@@ -1819,6 +1828,28 @@ mod tests {
             &dir,
             "tasks.yaml",
             "- id: t1\n  task: fix it\n  verify:\n    - tests:time -p cargo --version\n",
+        );
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
+        let checked = report
+            .checks
+            .iter()
+            .find(|c| c.check == "verify:tests")
+            .unwrap();
+        assert_eq!(checked.status, CheckStatus::Warn);
+    }
+
+    #[tokio::test]
+    async fn verify_command_with_path_behind_env_wrapper_is_inconclusive() {
+        // Exact scenario from review (issue #821): `env PATH=/tmp/empty
+        // cargo --version` sets PATH from behind the `env` wrapper, so a
+        // host-PATH resolution of `cargo` could false-pass even though the
+        // live verifier (restricted to /tmp/empty) would fail to find it.
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(
+            &dir,
+            "tasks.yaml",
+            "- id: t1\n  task: fix it\n  verify:\n    - tests:env PATH=/tmp/empty cargo --version\n",
         );
         let report = run(&base_args(path)).await.unwrap();
         assert!(report.ok, "checks: {:?}", report.checks);

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -572,7 +572,9 @@ fn check_command_launchable(command: &str) -> Result<(), String> {
         // rather than asserting Ok on the wrapper's own name. (Any leading
         // `NAME=VALUE` assignments after `env` are skipped automatically by
         // `split_off_program_token`'s own inner loop on the next iteration.)
-        if WRAPPER_COMMANDS.contains(&token.as_str()) {
+        // Matched by basename so path-qualified forms like `/usr/bin/env`
+        // or `/usr/bin/time` are unwrapped too, not just the bare name.
+        if is_wrapper_command(&token) {
             rest = remainder;
             continue;
         }
@@ -601,6 +603,15 @@ fn check_command_launchable(command: &str) -> Result<(), String> {
 /// is a real external program (not a shell builtin) but has the same
 /// wrapper shape: `env [OPTION]... [NAME=VALUE]... [COMMAND [ARG]...]`.
 const WRAPPER_COMMANDS: &[&str] = &["time", "exec", "command", "eval", "builtin", "env"];
+
+/// Whether `token` — the already-extracted program name — names a
+/// [`WRAPPER_COMMANDS`] entry, matched by basename so path-qualified forms
+/// like `/usr/bin/env` or `/usr/bin/time` are recognized as wrappers too,
+/// not just the bare name.
+fn is_wrapper_command(token: &str) -> bool {
+    let base_name = token.rsplit('/').next().unwrap_or(token);
+    WRAPPER_COMMANDS.contains(&base_name)
+}
 
 /// Shell binaries whose `-c`/`-lc`/etc. option hands an entire nested
 /// command line to the shell as a single string argument.
@@ -681,7 +692,7 @@ fn verify_command_inconclusive_reason(command: &str) -> Option<&'static str> {
                  whose payload this static check does not parse",
             );
         }
-        if !WRAPPER_COMMANDS.contains(&token.as_str()) {
+        if !is_wrapper_command(&token) {
             return None;
         }
         if matches!(next_shell_word(remainder), Some((next, _)) if next.starts_with('-')) {
@@ -1841,6 +1852,35 @@ mod tests {
             check_command_launchable("env PYTHONPATH=. __no_such_binary_xyz_suite_check__")
                 .is_err()
         );
+    }
+
+    #[test]
+    fn path_qualified_wrapper_still_unwraps_to_the_payload() {
+        // `/usr/bin/env foo` and `/usr/bin/time foo` are path-qualified
+        // forms of the same wrapper commands — they don't launch anything
+        // themselves either. Regression test for a gap found in review
+        // (issue #821): matching WRAPPER_COMMANDS by exact string meant
+        // `/usr/bin/env __no_such_binary__` resolved (and passed) `env`
+        // itself instead of unwrapping to check the missing payload.
+        assert!(check_command_launchable("/usr/bin/env PYTHONPATH=. cargo --version").is_ok());
+        assert!(
+            check_command_launchable(
+                "/usr/bin/env PYTHONPATH=. __no_such_binary_xyz_suite_check__"
+            )
+            .is_err()
+        );
+        assert!(check_command_launchable("/usr/bin/time cargo --version").is_ok());
+        assert!(
+            check_command_launchable("/usr/bin/time __no_such_binary_xyz_suite_check__").is_err()
+        );
+    }
+
+    #[test]
+    fn verify_command_inconclusive_reason_detects_option_after_path_qualified_wrapper() {
+        // Same basename-matching gap as `path_qualified_wrapper_still_unwraps_to_the_payload`,
+        // but for the "wrapper followed by an option flag" inconclusive
+        // path rather than plain launchability.
+        assert!(verify_command_inconclusive_reason("/usr/bin/env -i FOO=bar cargo test").is_some());
     }
 
     #[test]

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -835,6 +835,24 @@ fn verify_command_inconclusive_reason(command: &str) -> Option<&'static str> {
         if !is_wrapper_command(&token) {
             return None;
         }
+        // `builtin NAME` is stricter than the other wrappers: bash's
+        // `builtin` skips command/PATH lookup entirely and fails if NAME
+        // isn't in its builtin table — unlike `time`/`exec`/`command`/`eval`/
+        // `env`, an external command is never a valid payload.
+        // `SHELL_BUILTINS_AND_KEYWORDS` is a best-effort subset of bash's
+        // actual builtins (not exhaustive), so a payload we don't recognize
+        // could be a real builtin we're missing (false Fail) or a genuinely
+        // invalid one (false Pass) — admit uncertainty instead of guessing
+        // either way.
+        if token.rsplit('/').next().unwrap_or(&token) == "builtin"
+            && matches!(next_shell_word(remainder), Some((next, _)) if !next.starts_with('-') && !is_shell_builtin_or_keyword(&next))
+        {
+            return Some(
+                "`builtin NAME` requires NAME to be a real shell builtin (bash skips \
+                 command/PATH lookup entirely), which this static check cannot fully verify \
+                 against its own builtins list",
+            );
+        }
         if matches!(next_shell_word(remainder), Some((next, _)) if next.starts_with('-')) {
             // A wrapper followed by what looks like an option flag (`time
             // -p`, `command -v`, `env -i`) may take that flag's own
@@ -2264,6 +2282,29 @@ mod tests {
         assert!(verify_command_inconclusive_reason("command -v cargo").is_some());
         assert!(verify_command_inconclusive_reason("env -i FOO=bar cargo test").is_some());
         assert!(verify_command_inconclusive_reason("time exec -a name cargo").is_some());
+    }
+
+    #[test]
+    fn verify_command_inconclusive_reason_detects_builtin_with_external_payload() {
+        // Unlike `time`/`exec`/`command`/`eval`/`env`, bash's `builtin`
+        // skips command/PATH lookup entirely and fails if its payload isn't
+        // a real shell builtin — `builtin cargo --version` resolves
+        // `cargo` on PATH here but fails live because `cargo` is an
+        // external command, not a builtin. Regression test for a gap found
+        // in review (issue #821): the generic wrapper-unwrap treated
+        // `builtin` the same as the other wrappers and reported PASS.
+        assert!(verify_command_inconclusive_reason("builtin cargo --version").is_some());
+        assert!(verify_command_inconclusive_reason("builtin __no_such_builtin__").is_some());
+        // Nested behind another wrapper too.
+        assert!(verify_command_inconclusive_reason("time builtin cargo --version").is_some());
+    }
+
+    #[test]
+    fn verify_command_inconclusive_reason_none_for_builtin_with_real_builtin_payload() {
+        // A real shell builtin as the payload is unambiguous — `builtin`
+        // will find it without touching PATH, same result either way.
+        assert!(verify_command_inconclusive_reason("builtin cd /tmp").is_none());
+        assert!(verify_command_inconclusive_reason("builtin true").is_none());
     }
 
     #[test]

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -225,12 +225,22 @@ pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
     // downgraded to warnings instead of fatal (see below).
     let is_docker = matches!(args.config.root.environment.kind, EnvKind::Docker);
 
-    // `mini::build_docker_env` unconditionally requires `docker_image` and
-    // errors before any task runs; catch that statically here rather than
-    // reporting PASS for a suite that cannot start. This does not probe the
-    // Docker daemon itself or pull the image — run `agent doctor` for full
-    // host readiness.
+    // `mini::build_docker_env` unconditionally requires `docker_image`, and
+    // a binary built without the (non-default) `docker` cargo feature
+    // refuses `--env docker` entirely — both fail before any task runs.
+    // Catch both statically here rather than reporting PASS for a suite
+    // that cannot start. This does not probe the Docker daemon itself or
+    // pull the image — run `agent doctor` for full host readiness.
     if is_docker {
+        if cfg!(feature = "docker") {
+            checks.push(CheckItem::pass("docker_feature_compiled", None));
+        } else {
+            checks.push(CheckItem::fail(
+                "docker_feature_compiled",
+                None,
+                "docker support not compiled in — rebuild with --features docker",
+            ));
+        }
         match &args.config.root.environment.docker_image {
             Some(_) => checks.push(CheckItem::pass("docker_image_configured", None)),
             None => checks.push(CheckItem::fail(
@@ -856,6 +866,42 @@ mod tests {
                 .iter()
                 .any(|c| c.check == "docker_image_configured")
         );
+        assert!(
+            !report
+                .checks
+                .iter()
+                .any(|c| c.check == "docker_feature_compiled")
+        );
+    }
+
+    #[tokio::test]
+    async fn docker_feature_gate_matches_this_build() {
+        // A binary built without --features docker refuses --env docker
+        // entirely at `mini::build_docker_env`, even with a valid
+        // docker_image configured — --check must catch that too instead of
+        // reporting PASS for a build that cannot start a docker suite.
+        // Self-adapts to whether *this* test binary was built with the
+        // feature, rather than assuming either way. Regression test for a
+        // gap found in review (issue #821).
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let mut config = Config::defaults().unwrap();
+        config.root.environment.kind = EnvKind::Docker;
+        config.root.environment.docker_image = Some("my-image:latest".to_owned());
+        let mut args = base_args(path);
+        args.config = config;
+        let report = run(&args).await.unwrap();
+        let feature_check = report
+            .checks
+            .iter()
+            .find(|c| c.check == "docker_feature_compiled")
+            .unwrap();
+        if cfg!(feature = "docker") {
+            assert_eq!(feature_check.status, CheckStatus::Pass);
+        } else {
+            assert_eq!(feature_check.status, CheckStatus::Fail);
+            assert!(!report.ok, "checks: {:?}", report.checks);
+        }
     }
 
     #[tokio::test]
@@ -967,7 +1013,10 @@ mod tests {
         let mut args = base_args(path);
         args.config = config;
         let report = run(&args).await.unwrap();
-        assert!(report.ok, "checks: {:?}", report.checks);
+        // Not asserting report.ok: this test binary may or may not be built
+        // with --features docker, which independently gates `ok` (see
+        // docker_env_fails_when_docker_feature_not_compiled below). Only
+        // the launchability-skip behavior under test is asserted here.
         let checked = report
             .checks
             .iter()
@@ -998,7 +1047,9 @@ mod tests {
         let mut args = base_args(path);
         args.config = config;
         let report = run(&args).await.unwrap();
-        assert!(report.ok, "checks: {:?}", report.checks);
+        // Not asserting report.ok here — see docker_env_skips_host_path_
+        // launchability_check for why (the docker-feature gate is tested
+        // separately below).
         let checked = report
             .checks
             .iter()

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -1,0 +1,946 @@
+//! `agent suite --check` — zero-spend preflight for a personal-eval task pack
+//! (issue #821).
+//!
+//! Validates everything `agent suite` would need before launching a single
+//! paid agent loop: the pack parses, every task has a non-empty `id`/`task`
+//! and unique id, every `--verify`/per-task `verify` entry is well-formed and
+//! its command is statically launchable, configured MCP servers and hooks
+//! start (reusing the `scriptability-check` probe), and the resolved suite
+//! config carries no silent clap-default override hazard (reusing the
+//! `agent config resolve` hazard detector). No model calls and no agent loop
+//! are ever started; no files are written (this module takes no output
+//! directory).
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::Config;
+use crate::error::Error;
+use crate::run::agent_doctor::{is_executable, resolve_on_path};
+use crate::run::config_resolve::{ConfigResolveArgs, OverrideHazard, run_config_resolve};
+use crate::run::scriptability_check;
+use crate::run::suite::{
+    SuiteTaskSpec, TaskFileFormat, collect_task_validation_issues, parse_task_file,
+    parse_verify_checks,
+};
+
+/// Schema version for [`SuiteCheckReport`]'s machine-readable form.
+pub const SUITE_CHECK_SCHEMA_VERSION: u32 = 1;
+
+// ── report types ──────────────────────────────────────────────────────────────
+
+/// Outcome of a single preflight check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckStatus {
+    Pass,
+    Fail,
+    /// Non-fatal unless `--strict` was requested.
+    Warn,
+}
+
+/// One row of the preflight checklist.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckItem {
+    /// Stable check id, e.g. `pack_parse`, `unique_task_ids`,
+    /// `verify:lint`, `mcp_server`, `hook:pre_tool_use`, `hazard:model.name`.
+    pub check: String,
+    /// Task id / MCP server name / hook name / hazard field this check is
+    /// scoped to. `None` for suite-wide checks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    pub status: CheckStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+impl CheckItem {
+    fn pass(check: impl Into<String>, target: Option<String>) -> Self {
+        Self {
+            check: check.into(),
+            target,
+            status: CheckStatus::Pass,
+            message: None,
+        }
+    }
+
+    fn fail(check: impl Into<String>, target: Option<String>, message: impl Into<String>) -> Self {
+        Self {
+            check: check.into(),
+            target,
+            status: CheckStatus::Fail,
+            message: Some(message.into()),
+        }
+    }
+
+    fn warn(check: impl Into<String>, target: Option<String>, message: impl Into<String>) -> Self {
+        Self {
+            check: check.into(),
+            target,
+            status: CheckStatus::Warn,
+            message: Some(message.into()),
+        }
+    }
+}
+
+/// Full report returned by [`run`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuiteCheckReport {
+    pub schema_version: u32,
+    pub tasks_file: String,
+    pub suite_name: String,
+    /// `0` when the pack failed to parse.
+    pub task_count: usize,
+    /// Suite-level `--verify` entries plus every per-task `verify` entry.
+    pub verify_check_count: usize,
+    pub mcp_server_count: usize,
+    pub hook_count: usize,
+    /// `--per-task-budget-usd * task_count`; `None` when no per-task budget
+    /// was given (worst-case cost cannot be bounded arithmetically).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub estimated_worst_case_cost_usd: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suite_cost_limit_usd: Option<f64>,
+    /// Every check performed, in execution order, including passes.
+    pub checks: Vec<CheckItem>,
+    /// Config-provenance hazards (also folded into `checks` as `hazard:<field>`).
+    pub hazards: Vec<OverrideHazard>,
+    /// Whether hazards were escalated to fatal (`--strict`).
+    pub strict: bool,
+    pub duration_ms: u64,
+    /// `true` iff no check has `status: fail`.
+    pub ok: bool,
+}
+
+// ── arguments ──────────────────────────────────────────────────────────────────
+
+/// Arguments for [`run`]. Deliberately has no output-directory field: a
+/// preflight check makes no writes (AC: read-only except transient MCP/hook
+/// probe processes).
+pub struct SuiteCheckArgs {
+    pub tasks_file: PathBuf,
+    pub format_override: Option<String>,
+    pub suite_name: String,
+    /// Fully-resolved suite config (after `--mcp-server`, `--step-limit`,
+    /// etc. overrides have been applied) — used for the MCP/hook probe.
+    pub config: Config,
+    /// The raw `--config` path, used only for the hazard detector (mirrors
+    /// what a standalone `agent config resolve --config <path>` would see).
+    pub config_path: Option<PathBuf>,
+    /// Suite-level `--verify NAME:COMMAND` entries.
+    pub verify: Vec<String>,
+    pub suite_cost_limit_usd: Option<f64>,
+    pub per_task_budget_usd: Option<f64>,
+    pub step_limit_flag: Option<u32>,
+    pub strict: bool,
+}
+
+// ── main entry point ──────────────────────────────────────────────────────────
+
+/// Run the preflight and return a [`SuiteCheckReport`]. Performs zero model
+/// calls and starts no agent loop; the only subprocesses spawned are the
+/// transient MCP-server/hook probes already used by `bench scriptability-check`.
+#[allow(clippy::too_many_lines)]
+pub async fn run(args: &SuiteCheckArgs) -> Result<SuiteCheckReport, Error> {
+    let started = std::time::Instant::now();
+    let mut checks: Vec<CheckItem> = Vec::new();
+
+    // ── Format detection + parse ────────────────────────────────────────
+    let format = match resolve_format(&args.tasks_file, args.format_override.as_deref()) {
+        Ok(f) => {
+            checks.push(CheckItem::pass("format_detect", None));
+            Some(f)
+        }
+        Err(msg) => {
+            checks.push(CheckItem::fail("format_detect", None, msg));
+            None
+        }
+    };
+
+    let content = match format {
+        Some(_) => match std::fs::read_to_string(&args.tasks_file) {
+            Ok(c) => {
+                checks.push(CheckItem::pass("pack_readable", None));
+                Some(c)
+            }
+            Err(e) => {
+                checks.push(CheckItem::fail(
+                    "pack_readable",
+                    None,
+                    format!(
+                        "cannot read tasks file '{}': {e}",
+                        args.tasks_file.display()
+                    ),
+                ));
+                None
+            }
+        },
+        None => None,
+    };
+
+    let tasks: Option<Vec<SuiteTaskSpec>> = match (format, content) {
+        (Some(fmt), Some(content)) => match parse_task_file(&content, fmt) {
+            Ok(t) => {
+                checks.push(CheckItem::pass("pack_parse", None));
+                Some(t)
+            }
+            Err(e) => {
+                checks.push(CheckItem::fail("pack_parse", None, e.to_string()));
+                None
+            }
+        },
+        _ => None,
+    };
+
+    // ── Non-empty pack + per-task field/id validation ──────────────────
+    let mut task_count = 0usize;
+    let mut per_task_verify_count = 0usize;
+    if let Some(tasks) = &tasks {
+        if tasks.is_empty() {
+            checks.push(CheckItem::fail(
+                "pack_non_empty",
+                None,
+                "task pack contains no tasks",
+            ));
+        } else {
+            checks.push(CheckItem::pass("pack_non_empty", None));
+        }
+        task_count = tasks.len();
+
+        let issues = collect_task_validation_issues(tasks);
+        if issues.is_empty() {
+            checks.push(CheckItem::pass("task_fields_and_ids", None));
+        } else {
+            for issue in issues {
+                checks.push(CheckItem::fail(
+                    "task_fields_and_ids",
+                    issue.task_id,
+                    issue.message,
+                ));
+            }
+        }
+
+        for task in tasks {
+            per_task_verify_count += task.verify.len();
+            for spec in &task.verify {
+                checks.push(check_verify_spec(Some(task.id.clone()), spec));
+            }
+        }
+    }
+
+    // ── Suite-level verify entries ───────────────────────────────────────
+    for spec in &args.verify {
+        checks.push(check_verify_spec(None, spec));
+    }
+    let verify_check_count = args.verify.len() + per_task_verify_count;
+
+    // ── MCP servers + hooks (reuse scriptability-check, no artifact write) ─
+    let scriptability_report = scriptability_check::run_with_config(&args.config, None).await?;
+    for server in &scriptability_report.servers {
+        checks.push(CheckItem {
+            check: "mcp_server".to_owned(),
+            target: Some(server.name.clone()),
+            status: if server.ok {
+                CheckStatus::Pass
+            } else {
+                CheckStatus::Fail
+            },
+            message: server.error.clone(),
+        });
+    }
+    for hook in &scriptability_report.hooks {
+        checks.push(CheckItem {
+            check: format!("hook:{}", hook.phase),
+            target: Some(hook.name.clone()),
+            status: if hook.ok {
+                CheckStatus::Pass
+            } else {
+                CheckStatus::Fail
+            },
+            message: hook.error.clone(),
+        });
+    }
+    let mcp_server_count = args.config.root.agent.mcp_servers.len();
+    let hook_count = args.config.root.agent.hooks.pre_tool_use.len()
+        + args.config.root.agent.hooks.post_tool_use.len();
+
+    // ── Config-provenance hazards (reuse `agent config resolve`) ───────────
+    let hazard_args = ConfigResolveArgs {
+        config: args.config_path.clone(),
+        model_flag: None,
+        step_limit_flag: args.step_limit_flag,
+        observation_max_bytes_flag: None,
+        observation_head_ratio_flag: None,
+        per_task_budget_usd_flag: None,
+        hide_budget_from_agent_flag: false,
+        env_flag: None,
+        workdir_flag: None,
+        detect_stagnation_flag: None,
+        stagnation_repeat_threshold_flag: None,
+        stagnation_window_flag: None,
+    };
+    let hazards = run_config_resolve(&hazard_args)
+        .map_err(Error::Config)?
+        .hazards;
+    for hazard in &hazards {
+        let target = Some(hazard.field.clone());
+        if args.strict {
+            checks.push(CheckItem::fail(
+                format!("hazard:{}", hazard.field),
+                target,
+                hazard.message.clone(),
+            ));
+        } else {
+            checks.push(CheckItem::warn(
+                format!("hazard:{}", hazard.field),
+                target,
+                hazard.message.clone(),
+            ));
+        }
+    }
+
+    // ── Worst-case cost (arithmetic only — no model call) ──────────────────
+    #[allow(clippy::cast_precision_loss)]
+    let estimated_worst_case_cost_usd = args
+        .per_task_budget_usd
+        .map(|budget| budget * task_count as f64);
+    if let (Some(cost), Some(limit)) = (estimated_worst_case_cost_usd, args.suite_cost_limit_usd) {
+        if cost > limit {
+            checks.push(CheckItem::warn(
+                "cost_ceiling",
+                None,
+                format!(
+                    "worst-case cost ${cost:.4} (per-task-budget-usd x task_count) exceeds \
+                     --suite-cost-limit-usd ${limit:.4}"
+                ),
+            ));
+        } else {
+            checks.push(CheckItem::pass("cost_ceiling", None));
+        }
+    }
+
+    let ok = !checks.iter().any(|c| c.status == CheckStatus::Fail);
+
+    Ok(SuiteCheckReport {
+        schema_version: SUITE_CHECK_SCHEMA_VERSION,
+        tasks_file: args.tasks_file.display().to_string(),
+        suite_name: args.suite_name.clone(),
+        task_count,
+        verify_check_count,
+        mcp_server_count,
+        hook_count,
+        estimated_worst_case_cost_usd,
+        suite_cost_limit_usd: args.suite_cost_limit_usd,
+        checks,
+        hazards,
+        strict: args.strict,
+        duration_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+        ok,
+    })
+}
+
+// ── format resolution ─────────────────────────────────────────────────────────
+
+fn resolve_format(path: &Path, format_override: Option<&str>) -> Result<TaskFileFormat, String> {
+    if let Some(s) = format_override {
+        return TaskFileFormat::parse(s)
+            .ok_or_else(|| format!("--format '{s}' is not valid; use yaml, jsonl, or toml"));
+    }
+    TaskFileFormat::from_extension(path).ok_or_else(|| {
+        format!(
+            "cannot detect format from '{}'; use --format yaml|jsonl|toml",
+            path.display()
+        )
+    })
+}
+
+// ── verify-check format + launchability ─────────────────────────────────────────
+
+fn check_verify_spec(target: Option<String>, spec: &str) -> CheckItem {
+    match parse_verify_checks(std::slice::from_ref(&spec.to_owned())) {
+        Ok(parsed) => {
+            let Some(check) = parsed.first() else {
+                return CheckItem::fail("verify", target, "empty --verify entry");
+            };
+            let check_id = format!("verify:{}", check.name);
+            match check_command_launchable(&check.command) {
+                Ok(()) => CheckItem::pass(check_id, target),
+                Err(reason) => CheckItem::fail(check_id, target, reason),
+            }
+        }
+        Err(e) => CheckItem::fail("verify", target, e.to_string()),
+    }
+}
+
+/// Best-effort *static* launchability check for a verify command: does the
+/// first program token resolve to something runnable? Never executes the
+/// command (see issue #821 Out of Scope — launchability only, not
+/// correctness). Complex shell constructs (subshells, command substitution)
+/// are not specially parsed; operators should keep verify commands to a
+/// simple `program args...` or `VAR=val program args...` shape.
+fn check_command_launchable(command: &str) -> Result<(), String> {
+    let Some(token) = extract_program_token(command) else {
+        return Err("verify command has no resolvable program token".to_owned());
+    };
+    if is_shell_builtin_or_keyword(&token) {
+        return Ok(());
+    }
+    if token.contains('/') || token.contains(std::path::MAIN_SEPARATOR) {
+        let path = Path::new(&token);
+        return if path.is_file() && is_executable(path) {
+            Ok(())
+        } else {
+            Err(format!("'{token}' does not resolve to an executable file"))
+        };
+    }
+    if resolve_on_path(&token).is_some() {
+        Ok(())
+    } else {
+        Err(format!("'{token}' was not found on PATH"))
+    }
+}
+
+/// Extract the first non-`VAR=value` token from a shell command string.
+fn extract_program_token(command: &str) -> Option<String> {
+    let mut rest = command;
+    loop {
+        let (word, remainder) = next_shell_word(rest)?;
+        rest = remainder;
+        if is_env_assignment(&word) {
+            continue;
+        }
+        return Some(word);
+    }
+}
+
+/// Pop the next whitespace-delimited word off `s`, honouring single/double
+/// quoting (quote characters themselves are stripped). Returns the word and
+/// the unconsumed remainder.
+fn next_shell_word(s: &str) -> Option<(String, &str)> {
+    let s = s.trim_start();
+    if s.is_empty() {
+        return None;
+    }
+    let mut word = String::new();
+    let mut quote: Option<char> = None;
+    let mut split_at = s.len();
+    for (i, c) in s.char_indices() {
+        if let Some(q) = quote {
+            if c == q {
+                quote = None;
+            } else {
+                word.push(c);
+            }
+            continue;
+        }
+        if c == '\'' || c == '"' {
+            quote = Some(c);
+        } else if c.is_whitespace() {
+            split_at = i;
+            break;
+        } else {
+            word.push(c);
+        }
+    }
+    if word.is_empty() {
+        return None;
+    }
+    Some((word, &s[split_at..]))
+}
+
+fn is_env_assignment(word: &str) -> bool {
+    let Some(eq) = word.find('=') else {
+        return false;
+    };
+    let name = &word[..eq];
+    !name.is_empty()
+        && name.chars().enumerate().all(|(i, c)| {
+            if i == 0 {
+                c.is_ascii_alphabetic() || c == '_'
+            } else {
+                c.is_ascii_alphanumeric() || c == '_'
+            }
+        })
+}
+
+const SHELL_BUILTINS_AND_KEYWORDS: &[&str] = &[
+    "cd", "pushd", "popd", "echo", "printf", "export", "unset", "set", "source", ".", "true",
+    "false", "test", "[", "[[", "exit", "return", "eval", "exec", "read", "type", "command",
+    "builtin", "pwd", "alias", "unalias", "local", "declare", "typeset", "readonly", "shift",
+    "trap", "wait", "jobs", "ulimit", "umask", "hash", "let", "time", "if", "then", "elif", "else",
+    "fi", "for", "while", "until", "do", "done", "case", "esac", "function", "select", "in", "not",
+    "{", "}",
+];
+
+fn is_shell_builtin_or_keyword(token: &str) -> bool {
+    SHELL_BUILTINS_AND_KEYWORDS.contains(&token)
+}
+
+// ── text renderer ─────────────────────────────────────────────────────────────
+
+#[must_use]
+pub fn render_text(report: &SuiteCheckReport) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let status = if report.ok { "PASS" } else { "FAIL" };
+    let _ = writeln!(
+        out,
+        "agent suite --check [{status}]  tasks-file={}  ({} ms)",
+        report.tasks_file, report.duration_ms
+    );
+    let _ = write!(
+        out,
+        "{} task(s), {} verify check(s), {} MCP server(s), {} hook(s)",
+        report.task_count, report.verify_check_count, report.mcp_server_count, report.hook_count
+    );
+    match (
+        report.estimated_worst_case_cost_usd,
+        report.suite_cost_limit_usd,
+    ) {
+        (Some(cost), Some(limit)) => {
+            let _ = write!(out, ", worst-case ${cost:.4} (limit ${limit:.4})");
+        }
+        (Some(cost), None) => {
+            let _ = write!(
+                out,
+                ", worst-case ${cost:.4} (no --suite-cost-limit-usd set)"
+            );
+        }
+        (None, _) => {
+            let _ = write!(
+                out,
+                ", worst-case cost unknown (no --per-task-budget-usd set)"
+            );
+        }
+    }
+    let _ = writeln!(out);
+
+    let failures: Vec<&CheckItem> = report
+        .checks
+        .iter()
+        .filter(|c| c.status == CheckStatus::Fail)
+        .collect();
+    if !failures.is_empty() {
+        let _ = writeln!(out, "\nFailures:");
+        for c in &failures {
+            let target = c.target.as_deref().unwrap_or("-");
+            let msg = c.message.as_deref().unwrap_or("");
+            let _ = writeln!(out, "  [FAIL] {:<24} id={:<20} {}", c.check, target, msg);
+        }
+    }
+
+    let warnings: Vec<&CheckItem> = report
+        .checks
+        .iter()
+        .filter(|c| c.status == CheckStatus::Warn)
+        .collect();
+    if !warnings.is_empty() {
+        let _ = writeln!(
+            out,
+            "\nWarnings (non-fatal{}):",
+            if report.strict {
+                ", escalated by --strict"
+            } else {
+                ""
+            }
+        );
+        for c in &warnings {
+            let target = c.target.as_deref().unwrap_or("-");
+            let msg = c.message.as_deref().unwrap_or("");
+            let _ = writeln!(out, "  [WARN] {:<24} id={:<20} {}", c.check, target, msg);
+        }
+    }
+
+    out
+}
+
+// ── Tests (RED → GREEN) ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+
+    fn base_args(tasks_file: PathBuf) -> SuiteCheckArgs {
+        SuiteCheckArgs {
+            tasks_file,
+            format_override: None,
+            suite_name: "test-suite".into(),
+            config: Config::defaults().unwrap(),
+            config_path: None,
+            verify: vec![],
+            suite_cost_limit_usd: None,
+            per_task_budget_usd: None,
+            step_limit_flag: None,
+            strict: false,
+        }
+    }
+
+    fn write_tasks(dir: &tempfile::TempDir, name: &str, content: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    // ── RED: happy path ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn valid_pack_with_no_mcp_or_hooks_passes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(
+            &dir,
+            "tasks.yaml",
+            "- id: t1\n  task: fix the bug\n- id: t2\n  task: add a feature\n",
+        );
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
+        assert_eq!(report.task_count, 2);
+        assert_eq!(report.mcp_server_count, 0);
+        assert_eq!(report.hook_count, 0);
+    }
+
+    #[tokio::test]
+    async fn valid_pack_makes_no_filesystem_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix the bug\n");
+        let before: Vec<_> = std::fs::read_dir(dir.path()).unwrap().collect();
+        let _ = run(&base_args(path)).await.unwrap();
+        let after: Vec<_> = std::fs::read_dir(dir.path()).unwrap().collect();
+        assert_eq!(
+            before.len(),
+            after.len(),
+            "--check must not write any files"
+        );
+        assert_eq!(after.len(), 1, "only the input tasks file should exist");
+    }
+
+    // ── RED: parse / structural failures ────────────────────────────────
+
+    #[tokio::test]
+    async fn malformed_yaml_fails_pack_parse_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "not: [valid, task, schema");
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(!report.ok);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "pack_parse" && c.status == CheckStatus::Fail)
+        );
+    }
+
+    #[tokio::test]
+    async fn undetectable_format_fails_without_panicking() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.txt", "irrelevant");
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(!report.ok);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "format_detect" && c.status == CheckStatus::Fail)
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_pack_fails_non_empty_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.jsonl", "");
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(!report.ok);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "pack_non_empty" && c.status == CheckStatus::Fail)
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_task_ids_reported_with_offending_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(
+            &dir,
+            "tasks.yaml",
+            "- id: dup\n  task: first\n- id: dup\n  task: second\n",
+        );
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(!report.ok);
+        let dup = report
+            .checks
+            .iter()
+            .find(|c| c.status == CheckStatus::Fail && c.target.as_deref() == Some("dup"))
+            .unwrap();
+        assert!(dup.message.as_deref().unwrap().contains("duplicate"));
+    }
+
+    #[tokio::test]
+    async fn multiple_bad_tasks_all_surface_not_just_first() {
+        // Mirrors the "task 47's verify command" motivating scenario: every
+        // violation must surface in one pass, not just the first.
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(
+            &dir,
+            "tasks.yaml",
+            "- id: t1\n  task: ok\n  verify:\n    - bad:not-a-format-without-colon-wait-it-has-one\n- id: t1\n  task: dup id\n",
+        );
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(!report.ok);
+        let fail_count = report
+            .checks
+            .iter()
+            .filter(|c| c.status == CheckStatus::Fail)
+            .count();
+        assert!(fail_count >= 2, "checks: {:?}", report.checks);
+    }
+
+    // ── RED: verify-check launchability ─────────────────────────────────
+
+    #[tokio::test]
+    async fn launchable_verify_command_passes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(
+            &dir,
+            "tasks.yaml",
+            "- id: t1\n  task: fix it\n  verify:\n    - smoke:true\n",
+        );
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "verify:smoke" && c.status == CheckStatus::Pass)
+        );
+    }
+
+    #[tokio::test]
+    async fn unlaunchable_verify_command_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(
+            &dir,
+            "tasks.yaml",
+            "- id: t1\n  task: fix it\n  verify:\n    - tests:__no_such_binary_xyz_suite_check__ -q\n",
+        );
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(!report.ok);
+        let failed = report
+            .checks
+            .iter()
+            .find(|c| c.check == "verify:tests")
+            .unwrap();
+        assert_eq!(failed.status, CheckStatus::Fail);
+        assert_eq!(failed.target.as_deref(), Some("t1"));
+    }
+
+    #[tokio::test]
+    async fn malformed_verify_spec_without_colon_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(
+            &dir,
+            "tasks.yaml",
+            "- id: t1\n  task: fix it\n  verify:\n    - \"no-colon-here\"\n",
+        );
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(!report.ok);
+    }
+
+    #[tokio::test]
+    async fn suite_level_verify_checked_even_when_no_per_task_verify() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let mut args = base_args(path);
+        args.verify = vec!["lint:__no_such_binary_xyz_suite_check__".to_owned()];
+        let report = run(&args).await.unwrap();
+        assert!(!report.ok);
+        assert_eq!(report.verify_check_count, 1);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "verify:lint" && c.target.is_none())
+        );
+    }
+
+    // ── RED: hazards ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn config_hazard_is_warning_not_fatal_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "[model]\nname = \"claude-sonnet-4-6\"\n").unwrap();
+
+        let mut args = base_args(path);
+        args.config_path = Some(config_path);
+        let report = run(&args).await.unwrap();
+        assert!(
+            report.ok,
+            "hazards must be non-fatal by default: {:?}",
+            report.checks
+        );
+        assert!(!report.hazards.is_empty());
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "hazard:model.name" && c.status == CheckStatus::Warn)
+        );
+    }
+
+    #[tokio::test]
+    async fn config_hazard_is_fatal_under_strict() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "[model]\nname = \"claude-sonnet-4-6\"\n").unwrap();
+
+        let mut args = base_args(path);
+        args.config_path = Some(config_path);
+        args.strict = true;
+        let report = run(&args).await.unwrap();
+        assert!(!report.ok);
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "hazard:model.name" && c.status == CheckStatus::Fail)
+        );
+    }
+
+    // ── RED: worst-case cost summary ────────────────────────────────────
+
+    #[tokio::test]
+    async fn worst_case_cost_computed_arithmetically() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(
+            &dir,
+            "tasks.yaml",
+            "- id: t1\n  task: a\n- id: t2\n  task: b\n- id: t3\n  task: c\n",
+        );
+        let mut args = base_args(path);
+        args.per_task_budget_usd = Some(0.10);
+        let report = run(&args).await.unwrap();
+        assert!((report.estimated_worst_case_cost_usd.unwrap() - 0.30).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn worst_case_cost_none_when_no_per_task_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: a\n");
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(report.estimated_worst_case_cost_usd.is_none());
+    }
+
+    #[tokio::test]
+    async fn worst_case_cost_over_limit_is_warning_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(
+            &dir,
+            "tasks.yaml",
+            "- id: t1\n  task: a\n- id: t2\n  task: b\n",
+        );
+        let mut args = base_args(path);
+        args.per_task_budget_usd = Some(1.0);
+        args.suite_cost_limit_usd = Some(0.5);
+        let report = run(&args).await.unwrap();
+        assert!(report.ok, "cost ceiling must be a warning, not fatal");
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|c| c.check == "cost_ceiling" && c.status == CheckStatus::Warn)
+        );
+    }
+
+    // ── RED: performance (success metric: <1s for 50 tasks, no MCP) ────────
+
+    #[tokio::test]
+    async fn fifty_task_pack_with_no_mcp_completes_under_one_second() {
+        use std::fmt::Write as _;
+        let dir = tempfile::tempdir().unwrap();
+        let mut content = String::new();
+        for i in 0..50 {
+            let _ = writeln!(content, "- id: t{i}\n  task: do thing {i}");
+        }
+        let path = write_tasks(&dir, "tasks.yaml", &content);
+        let start = std::time::Instant::now();
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(report.ok);
+        assert_eq!(report.task_count, 50);
+        assert!(
+            start.elapsed().as_secs_f64() < 1.0,
+            "preflight took {:?}, expected < 1s",
+            start.elapsed()
+        );
+    }
+
+    // ── RED: text renderer ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn render_text_shows_pass_summary() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: a\n");
+        let report = run(&base_args(path)).await.unwrap();
+        let text = render_text(&report);
+        assert!(text.contains("PASS"));
+        assert!(text.contains("1 task(s)"));
+    }
+
+    #[tokio::test]
+    async fn render_text_lists_failures_with_check_and_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(
+            &dir,
+            "tasks.yaml",
+            "- id: dup\n  task: a\n- id: dup\n  task: b\n",
+        );
+        let report = run(&base_args(path)).await.unwrap();
+        let text = render_text(&report);
+        assert!(text.contains("FAIL"));
+        assert!(text.contains("dup"));
+    }
+
+    // ── extract_program_token / launchability unit tests ────────────────
+
+    #[test]
+    fn extract_program_token_skips_env_assignments() {
+        assert_eq!(
+            extract_program_token("FOO=bar pytest -q"),
+            Some("pytest".to_owned())
+        );
+    }
+
+    #[test]
+    fn extract_program_token_handles_simple_command() {
+        assert_eq!(
+            extract_program_token("cargo test"),
+            Some("cargo".to_owned())
+        );
+    }
+
+    #[test]
+    fn extract_program_token_none_for_empty() {
+        assert_eq!(extract_program_token(""), None);
+        assert_eq!(extract_program_token("   "), None);
+    }
+
+    #[test]
+    fn shell_builtin_true_is_launchable() {
+        assert!(check_command_launchable("true").is_ok());
+    }
+
+    #[test]
+    fn unknown_binary_is_not_launchable() {
+        assert!(check_command_launchable("__definitely_not_a_real_binary_xyz__").is_err());
+    }
+
+    #[test]
+    fn path_resolvable_binary_is_launchable() {
+        // `cargo` must exist on PATH for the test harness itself to have run.
+        assert!(check_command_launchable("cargo --version").is_ok());
+    }
+}

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -552,6 +552,21 @@ fn check_verify_spec(target: Option<String>, spec: &str, skip_launchability: boo
                      static check does not emulate",
                 );
             }
+            if has_ambiguous_wrapper_option(&check.command) {
+                // A wrapper (time/exec/command/env/...) followed by what
+                // looks like an option flag (`time -p`, `command -v`,
+                // `env -i`) may take that flag's own argument before the
+                // real payload (e.g. `exec -a name cmd`), which this
+                // checker doesn't model per-wrapper. Guessing wrong in
+                // either direction is worse than admitting uncertainty.
+                return CheckItem::warn(
+                    check_id,
+                    target,
+                    "launchability not checked: a wrapper command (time/exec/command/eval/\
+                     builtin/env) is followed by what looks like an option flag, which this \
+                     static check does not parse",
+                );
+            }
             match check_command_launchable(&check.command) {
                 Ok(()) => CheckItem::pass(check_id, target),
                 Err(reason) => CheckItem::fail(check_id, target, reason),
@@ -573,11 +588,13 @@ fn check_command_launchable(command: &str) -> Result<(), String> {
         let Some((token, remainder)) = split_off_program_token(rest) else {
             return Err("verify command has no resolvable program token".to_owned());
         };
-        // `time foo`, `exec foo`, `command foo`, `eval foo`, and `builtin foo`
-        // don't launch anything themselves — the real payload is whatever
-        // follows. Unwrap the wrapper and check that instead, rather than
-        // asserting Ok on the wrapper's own name.
-        if WRAPPER_BUILTINS.contains(&token.as_str()) {
+        // `time foo`, `exec foo`, `command foo`, `eval foo`, `builtin foo`,
+        // and `env foo` don't launch anything themselves — the real payload
+        // is whatever follows. Unwrap the wrapper and check that instead,
+        // rather than asserting Ok on the wrapper's own name. (Any leading
+        // `NAME=VALUE` assignments after `env` are skipped automatically by
+        // `split_off_program_token`'s own inner loop on the next iteration.)
+        if WRAPPER_COMMANDS.contains(&token.as_str()) {
             rest = remainder;
             continue;
         }
@@ -600,10 +617,34 @@ fn check_command_launchable(command: &str) -> Result<(), String> {
     }
 }
 
-/// Builtins/keywords whose own name is not the thing being launched — the
+/// Builtins/commands whose own name is not the thing being launched — the
 /// command that follows them is. Checked before [`SHELL_BUILTINS_AND_KEYWORDS`]
-/// so `time __no_such_binary__` doesn't short-circuit on `time` alone.
-const WRAPPER_BUILTINS: &[&str] = &["time", "exec", "command", "eval", "builtin"];
+/// so `time __no_such_binary__` doesn't short-circuit on `time` alone. `env`
+/// is a real external program (not a shell builtin) but has the same
+/// wrapper shape: `env [OPTION]... [NAME=VALUE]... [COMMAND [ARG]...]`.
+const WRAPPER_COMMANDS: &[&str] = &["time", "exec", "command", "eval", "builtin", "env"];
+
+/// Whether `command`, after unwrapping any [`WRAPPER_COMMANDS`] prefixes, is
+/// followed by a token that looks like an option flag (`-...`) for that
+/// wrapper. Each wrapper has its own option grammar — some flags take their
+/// own argument (e.g. `exec -a name`) — which this checker doesn't model,
+/// so treat the launchability as inconclusive rather than misresolving the
+/// flag (or its argument) as the payload.
+fn has_ambiguous_wrapper_option(command: &str) -> bool {
+    let mut rest = command;
+    loop {
+        let Some((token, remainder)) = split_off_program_token(rest) else {
+            return false;
+        };
+        if !WRAPPER_COMMANDS.contains(&token.as_str()) {
+            return false;
+        }
+        if matches!(next_shell_word(remainder), Some((next, _)) if next.starts_with('-')) {
+            return true;
+        }
+        rest = remainder;
+    }
+}
 
 /// Extract the first non-`VAR=value` token from a shell command string,
 /// along with the unconsumed remainder of the command after it.
@@ -695,7 +736,7 @@ const SHELL_BUILTINS_AND_KEYWORDS: &[&str] = &[
     "case", "esac", "function", "select", "in", "not", "{",
     "}",
     // NOTE: "time", "exec", "command", "eval", "builtin" are intentionally
-    // absent — they're wrapper builtins handled by WRAPPER_BUILTINS above,
+    // absent — they're wrapper commands handled by WRAPPER_COMMANDS above,
     // which unwraps them and checks the command that actually follows.
 ];
 
@@ -1732,5 +1773,60 @@ mod tests {
         assert!(check_command_launchable("exec true").is_ok());
         // Nested wrappers unwrap one at a time.
         assert!(check_command_launchable("time exec cargo --version").is_ok());
+    }
+
+    #[test]
+    fn env_wrapper_resolves_the_command_it_launches() {
+        // `env` is a real external program, not a shell builtin, but has
+        // the same wrapper shape as time/exec/command/eval — the payload
+        // after its NAME=VALUE assignments is what's actually launched.
+        // Regression test for a gap found in review (issue #821):
+        // `env PYTHONPATH=. __no_such_binary__` previously passed because
+        // only `env` itself (which always resolves) was checked.
+        assert!(check_command_launchable("env PYTHONPATH=. cargo --version").is_ok());
+        assert!(
+            check_command_launchable("env PYTHONPATH=. __no_such_binary_xyz_suite_check__")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn has_ambiguous_wrapper_option_detects_option_after_wrapper() {
+        // `time -p`, `command -v`, `env -i` etc. are valid shell/coreutils
+        // invocations, but this checker doesn't model each wrapper's own
+        // option grammar (some flags take an argument, e.g. `exec -a
+        // name`), so guessing at the flag or its argument as the payload
+        // would misresolve either way. Regression test for a false-fail
+        // found in review (issue #821): `time -p cargo test` previously
+        // tried (and failed) to resolve "-p" as an executable.
+        assert!(has_ambiguous_wrapper_option("time -p cargo test"));
+        assert!(has_ambiguous_wrapper_option("command -v cargo"));
+        assert!(has_ambiguous_wrapper_option("env -i FOO=bar cargo test"));
+        assert!(has_ambiguous_wrapper_option("time exec -a name cargo"));
+    }
+
+    #[test]
+    fn has_ambiguous_wrapper_option_false_for_ordinary_commands() {
+        assert!(!has_ambiguous_wrapper_option("time cargo test"));
+        assert!(!has_ambiguous_wrapper_option("cargo -v test"));
+        assert!(!has_ambiguous_wrapper_option("env PYTHONPATH=. cargo test"));
+    }
+
+    #[tokio::test]
+    async fn verify_command_with_wrapper_option_is_inconclusive_not_fatal() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_tasks(
+            &dir,
+            "tasks.yaml",
+            "- id: t1\n  task: fix it\n  verify:\n    - tests:time -p cargo --version\n",
+        );
+        let report = run(&base_args(path)).await.unwrap();
+        assert!(report.ok, "checks: {:?}", report.checks);
+        let checked = report
+            .checks
+            .iter()
+            .find(|c| c.check == "verify:tests")
+            .unwrap();
+        assert_eq!(checked.status, CheckStatus::Warn);
     }
 }

--- a/tests/agent_suite_check.rs
+++ b/tests/agent_suite_check.rs
@@ -1,0 +1,302 @@
+//! `agent suite --check` — zero-spend preflight for an `agent suite` task pack
+//! (issue #821).
+//!
+//! Validates that a typo'd verify command, missing test binary, malformed
+//! pack, or silent config override is caught *before* any paid run — exit 3
+//! (`preflight_failure`) on a fatal check, exit 0 on a clean pack. Zero model
+//! calls; no writes to the output directory.
+//!
+//! RED phase: these tests fail until the CLI wiring exists.
+//! GREEN phase: `--check`/`--check-format`/`--strict` flags + `suite_check::run`.
+//! REFACTOR phase: clean up.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::process::Command;
+
+mod support;
+use support::binary_path;
+
+use maxwells_daemon::exit_code::ExitCode;
+
+fn write_tasks(dir: &tempfile::TempDir, name: &str, content: &str) -> std::path::PathBuf {
+    let path = dir.path().join(name);
+    std::fs::write(&path, content).unwrap();
+    path
+}
+
+/// A `Command` for the `max` binary with no provider credentials set, so any
+/// accidental real model call would fail loudly rather than silently spend.
+fn no_credentials_command() -> Command {
+    let mut cmd = Command::new(binary_path());
+    cmd.env_remove("ANTHROPIC_API_KEY")
+        .env_remove("OPENAI_API_KEY");
+    cmd
+}
+
+// ── exit code success / failure ─────────────────────────────────────────────
+
+#[test]
+fn cli_check_valid_pack_exits_zero_with_no_credentials() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_tasks(
+        &dir,
+        "tasks.yaml",
+        "- id: t1\n  task: fix the bug\n- id: t2\n  task: add a feature\n",
+    );
+
+    let out = no_credentials_command()
+        .args(["--log", "error", "agent", "suite", "--tasks-file"])
+        .arg(&path)
+        .args(["--check"])
+        .output()
+        .unwrap();
+
+    assert!(
+        out.status.success(),
+        "expected exit 0\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("PASS"), "stdout: {stdout}");
+    assert!(stdout.contains("2 task(s)"), "stdout: {stdout}");
+}
+
+#[test]
+fn cli_check_exits_preflight_failure_on_duplicate_ids() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_tasks(
+        &dir,
+        "tasks.yaml",
+        "- id: dup\n  task: first\n- id: dup\n  task: second\n",
+    );
+
+    let out = no_credentials_command()
+        .args(["--log", "error", "agent", "suite", "--tasks-file"])
+        .arg(&path)
+        .args(["--check"])
+        .output()
+        .unwrap();
+
+    assert!(!out.status.success());
+    assert_eq!(
+        out.status.code(),
+        Some(ExitCode::PreflightFailure.as_i32()),
+        "expected exit {} (preflight_failure)\nstdout: {}\nstderr: {}",
+        ExitCode::PreflightFailure.as_i32(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("dup"),
+        "stdout should name the bad id: {stdout}"
+    );
+}
+
+#[test]
+fn cli_check_exits_preflight_failure_on_unlaunchable_verify_command() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_tasks(
+        &dir,
+        "tasks.yaml",
+        "- id: t1\n  task: fix it\n  verify:\n    - tests:__no_such_binary_xyz_agent_suite_check__ -q\n",
+    );
+
+    let out = no_credentials_command()
+        .args(["--log", "error", "agent", "suite", "--tasks-file"])
+        .arg(&path)
+        .args(["--check"])
+        .output()
+        .unwrap();
+
+    assert!(!out.status.success());
+    assert_eq!(out.status.code(), Some(ExitCode::PreflightFailure.as_i32()));
+}
+
+#[test]
+fn cli_check_exits_preflight_failure_on_malformed_pack() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_tasks(&dir, "tasks.yaml", "not: [valid, task, schema");
+
+    let out = no_credentials_command()
+        .args(["--log", "error", "agent", "suite", "--tasks-file"])
+        .arg(&path)
+        .args(["--check"])
+        .output()
+        .unwrap();
+
+    assert!(!out.status.success());
+    assert_eq!(out.status.code(), Some(ExitCode::PreflightFailure.as_i32()));
+}
+
+// ── --check-format json ─────────────────────────────────────────────────────
+
+#[test]
+fn cli_check_format_json_produces_valid_schema_versioned_report() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+
+    let out = no_credentials_command()
+        .args(["--log", "error", "agent", "suite", "--tasks-file"])
+        .arg(&path)
+        .args(["--check", "--check-format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let value: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+    let report = &value["suite_check"];
+    assert_eq!(report["schema_version"], 1);
+    assert_eq!(report["task_count"], 1);
+    assert!(report["checks"].is_array());
+    assert!(report["ok"].as_bool().unwrap());
+}
+
+#[test]
+fn cli_check_format_json_lists_every_check_with_status() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_tasks(
+        &dir,
+        "tasks.yaml",
+        "- id: t1\n  task: fix it\n  verify:\n    - smoke:true\n",
+    );
+
+    let out = no_credentials_command()
+        .args(["--log", "error", "agent", "suite", "--tasks-file"])
+        .arg(&path)
+        .args(["--check", "--check-format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let checks = value["suite_check"]["checks"].as_array().unwrap();
+    assert!(!checks.is_empty());
+    for c in checks {
+        let status = c["status"].as_str().unwrap();
+        assert!(
+            ["pass", "fail", "warn"].contains(&status),
+            "unexpected status: {status}"
+        );
+    }
+    assert!(
+        checks
+            .iter()
+            .any(|c| c["check"] == "verify:smoke" && c["status"] == "pass")
+    );
+}
+
+// ── --strict escalates hazards ──────────────────────────────────────────────
+
+#[test]
+fn cli_check_hazard_is_warning_by_default_exit_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+    let config = tempfile::NamedTempFile::with_suffix(".toml").unwrap();
+    std::fs::write(config.path(), "[model]\nname = \"claude-sonnet-4-6\"\n").unwrap();
+
+    let out = no_credentials_command()
+        .args(["--log", "error", "agent", "suite", "--tasks-file"])
+        .arg(&path)
+        .args(["--check", "--config"])
+        .arg(config.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        out.status.success(),
+        "hazards must be non-fatal by default\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn cli_check_strict_escalates_hazard_to_preflight_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+    let config = tempfile::NamedTempFile::with_suffix(".toml").unwrap();
+    std::fs::write(config.path(), "[model]\nname = \"claude-sonnet-4-6\"\n").unwrap();
+
+    let out = no_credentials_command()
+        .args(["--log", "error", "agent", "suite", "--tasks-file"])
+        .arg(&path)
+        .args(["--check", "--strict", "--config"])
+        .arg(config.path())
+        .output()
+        .unwrap();
+
+    assert!(!out.status.success());
+    assert_eq!(out.status.code(), Some(ExitCode::PreflightFailure.as_i32()));
+}
+
+// ── No writes to the output directory ───────────────────────────────────────
+
+#[test]
+fn cli_check_makes_no_writes_to_output_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+    let outdir = tempfile::tempdir().unwrap();
+
+    let out = no_credentials_command()
+        .args(["--log", "error", "agent", "suite", "--tasks-file"])
+        .arg(&path)
+        .args(["--check", "--output"])
+        .arg(outdir.path())
+        .output()
+        .unwrap();
+
+    assert!(out.status.success());
+    let entries: Vec<_> = std::fs::read_dir(outdir.path()).unwrap().collect();
+    assert!(
+        entries.is_empty(),
+        "expected no writes to --output dir, found: {entries:?}"
+    );
+}
+
+// ── MCP server probe reuse (scriptability-check launchability standard) ────
+
+#[test]
+fn cli_check_with_broken_mcp_server_exits_preflight_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+
+    let out = no_credentials_command()
+        .args(["--log", "error", "agent", "suite", "--tasks-file"])
+        .arg(&path)
+        .args([
+            "--check",
+            "--mcp-server",
+            "__no_such_binary_xyz_agent_suite_check__",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!out.status.success());
+    assert_eq!(out.status.code(), Some(ExitCode::PreflightFailure.as_i32()));
+}
+
+// ── --check-format / --strict require --check ───────────────────────────────
+
+#[test]
+fn cli_check_format_without_check_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+
+    let out = no_credentials_command()
+        .args(["--log", "error", "agent", "suite", "--tasks-file"])
+        .arg(&path)
+        .args(["--check-format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !out.status.success(),
+        "--check-format without --check should be a usage error"
+    );
+}

--- a/tests/agent_suite_check.rs
+++ b/tests/agent_suite_check.rs
@@ -235,6 +235,56 @@ fn cli_check_strict_escalates_hazard_to_preflight_failure() {
     assert_eq!(out.status.code(), Some(ExitCode::PreflightFailure.as_i32()));
 }
 
+#[test]
+fn cli_check_explicit_default_model_flag_still_suppresses_hazard() {
+    // The operator explicitly passes `--model claude-opus-4-7` (the clap
+    // default value) to intentionally override a config file that sets a
+    // different model.name. Because `--model` has no clap default, this
+    // must be tracked as "explicitly passed" and suppress the hazard, even
+    // under --strict.
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+    let config = tempfile::NamedTempFile::with_suffix(".toml").unwrap();
+    std::fs::write(config.path(), "[model]\nname = \"claude-sonnet-4-6\"\n").unwrap();
+
+    let out = no_credentials_command()
+        .args(["--log", "error", "agent", "suite", "--tasks-file"])
+        .arg(&path)
+        .args([
+            "--check",
+            "--strict",
+            "--model",
+            "claude-opus-4-7",
+            "--config",
+        ])
+        .arg(config.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        out.status.success(),
+        "explicit --model (even matching the default) must suppress the hazard\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn cli_check_rejects_unsafe_suite_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_tasks(&dir, "tasks.yaml", "- id: t1\n  task: fix it\n");
+
+    let out = no_credentials_command()
+        .args(["--log", "error", "agent", "suite", "--tasks-file"])
+        .arg(&path)
+        .args(["--check", "--suite-name", "../escape"])
+        .output()
+        .unwrap();
+
+    assert!(!out.status.success());
+    assert_eq!(out.status.code(), Some(ExitCode::PreflightFailure.as_i32()));
+}
+
 // ── No writes to the output directory ───────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Implements `agent suite --check`, a zero-spend preflight validator for personal-eval task packs. This command validates everything needed before launching a paid agent loop—pack parsing, task fields, verify-check launchability, MCP/hook startup, and config-provenance hazards—without making any model calls or starting an agent loop.

## Key Changes

- **New module `src/run/suite_check.rs`** (946 lines): Core preflight validation engine
  - `SuiteCheckReport` and `CheckItem` types for structured validation results
  - `run()` function performing all checks: format detection, pack parsing, task field validation, verify-command launchability, MCP/hook probing (reusing `scriptability_check`), config hazard detection (reusing `config_resolve`), and worst-case cost arithmetic
  - `render_text()` for human-readable output formatting
  - Static command launchability checker (`check_command_launchable`) with shell-word parsing and PATH resolution
  - Comprehensive test suite covering happy paths, parse failures, verify-check issues, hazards, and cost calculations

- **CLI integration in `src/cli/args.rs` and `src/cli/mod.rs`**
  - New flags: `--check` (enable preflight mode), `--check-format text|json` (output format), `--strict` (escalate hazards to fatal)
  - Wiring in `agent_suite_cmd()` to invoke `suite_check::run()` and format output as JSON or text
  - Exit code `PreflightFailure` (3) on fatal checks, 0 on clean pack

- **Refactored task validation in `src/run/suite.rs`**
  - Extracted `collect_task_validation_issues()` function to collect *all* violations (not just first) for comprehensive reporting
  - New `TaskIssue` struct capturing task id and message
  - Made `parse_verify_checks()` public for reuse by `suite_check`
  - Updated `agent suite` run path to use the new validation function

- **Documentation in `docs/spec-agent-suite.md`**
  - Added `--check`, `--check-format`, and `--strict` flag documentation
  - New "Zero-Spend Preflight" section explaining validation scope, exit codes, and example usage

- **Integration tests in `tests/agent_suite_check.rs`** (302 lines)
  - CLI-level tests verifying exit codes, JSON schema compliance, hazard handling, and no-write guarantee
  - Tests for duplicate ids, unlaunchable verify commands, malformed packs, and MCP server failures

- **Minor updates**
  - Made `is_executable()` and `resolve_on_path()` public in `src/run/agent_doctor.rs` for command launchability checks
  - Updated `src/cli/catalog.rs` summary for `agent suite`
  - Added `suite_check` module export in `src/run/mod.rs`
  - Updated exit code documentation in `docs/exit-codes.md`

## Notable Implementation Details

- **No writes**: The preflight makes no filesystem writes (except transient MCP/hook probe processes) and takes no output directory
- **Reuses existing infrastructure**: Leverages `scriptability_check` for MCP/hook probing and `config_resolve` for hazard detection, ensuring consistency with other preflight tools
- **Comprehensive error collection**: Unlike `agent suite` which stops at the first validation error, `--check` collects and reports all issues in a single pass (e.g., "task 47's verify command AND task 89's duplicate id")
- **Static launchability only**: Command validation is static (PATH resolution, file existence) and never executes commands
- **Hazard handling**: Config-provenance hazards are warnings by default; `--strict` escalates them to fatal
- **Cost estimation**: Worst-case cost computed arithmetically as `per_task_budget_usd × task_count` when both are available

https://claude.ai/code/session_018jL5wCc5dV77oVz2rNzyVd