### PR TITLE
⚒️ Forge: Refactor docker test unwraps with guard clauses

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("missing --network flag in args");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("missing my-image in args");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"


### PR DESCRIPTION
🚮 Smell: 
Unit tests in `src/env/docker.rs` were using unidiomatic `.unwrap()` calls on `Option` values, which triggers `clippy::unwrap_used` warnings and produces generic, unhelpful panic messages on test failures. In one instance, an `.is_some()` assertion was used followed by a subsequent `.unwrap()` on the same value, separating the check from the extraction.

✨ Solution: 
Replaced the `.unwrap()` calls with modern Rust `let Some(...) = ... else { panic!("...") };` guard clauses. This combines the presence check and the value extraction into a single, safe binding while allowing for a custom, descriptive panic message.

🧼 Benefit: 
Eliminates compiler warnings for `unwrap_used`. The tests now fail with highly descriptive messages indicating exactly what went wrong (e.g., "missing --network flag in args") rather than a generic "called `Option::unwrap()` on a `None` value", significantly reducing cognitive load during test debugging.

🛡️ Verification: 
Ran `cargo clippy --all-targets --all-features -- -D warnings`, which passed with zero warnings. Ran the entire test suite and verified that all tests passed, confirming that the logic and assertions remain perfectly intact.

---
*PR created automatically by Jules for task [9770161969183300829](https://jules.google.com/task/9770161969183300829) started by @madmax983*