### PR TITLE
🌟 Nova: Table Trajectory Exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ litellm-rs = { version = "0.4.16", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 sha2 = "0.10"
 similar = "2"
-comfy-table = "7.2.2"
+comfy-table = { version = "7.2.2", optional = true }
 tempfile = "3"
 flate2 = "1.1"
 tar = "0.4"
@@ -92,8 +92,10 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+table-export = ["dep:comfy-table"]
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
+comfy-table = ["dep:comfy-table"]
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/docs/spec-export.md
+++ b/docs/spec-export.md
@@ -34,11 +34,12 @@ max bench inspect --list-formats
 | `csv` | stable | `csv-export` | spreadsheets, jq pipelines, tabular tools |
 | `html` | stable | `html-export` | self-contained browser view, shared notebooks |
 | `mermaid` | experimental | `mermaid-export` | Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live) |
+| `table` | stable | `table-export` | CLI viewers, text-based log readers |
 
 Feature-gated formats require rebuilding with the corresponding feature:
 
 ```bash
-cargo build --features csv-export,html-export,mermaid-export
+cargo build --features csv-export,html-export,mermaid-export,table-export
 ```
 
 When a format is requested but its Cargo feature was not compiled in, the command exits
@@ -121,6 +122,7 @@ markdown    stable        docs, PR review, human readers
 csv         stable        spreadsheets, jq pipelines, tabular tools
 html        stable        self-contained browser view, shared notebooks
 mermaid     experimental  Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live)
+table       stable        CLI viewers, text-based log readers
 ```
 
 The output lists only formats compiled into the running binary (feature-gated formats

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -534,10 +534,9 @@ mod tests {
             network_pos.is_some(),
             "expected --network flag in args: {args:?}"
         );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        #[allow(clippy::unwrap_used)]
+        let pos = network_pos.unwrap();
+        assert_eq!(args.get(pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,7 +551,9 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
+        #[allow(clippy::unwrap_used)]
         let network_pos = args.iter().position(|a| a == "--network").unwrap();
+        #[allow(clippy::unwrap_used)]
         let image_pos = args.iter().position(|a| a == "my-image").unwrap();
         assert!(
             network_pos < image_pos,

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -109,6 +109,7 @@ pub const FEATURE_GATED_FORMATS: &[(&str, &str)] = &[
     ("csv", "csv-export"),
     ("html", "html-export"),
     ("mermaid", "mermaid-export"),
+    ("table", "table-export"),
 ];
 
 /// Returns `true` if `name` is a trajectory export format known to this codebase,
@@ -358,8 +359,64 @@ impl TrajectoryExporter for MermaidExporter {
     }
 }
 
+#[cfg(feature = "table-export")]
+pub struct TableExporter;
+
+#[cfg(feature = "table-export")]
+impl TrajectoryExporter for TableExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut table = comfy_table::Table::new();
+        table.set_header(vec!["Role", "Content"]);
+
+        for msg in &trajectory.messages {
+            let role = msg.role.clone();
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            table.add_row(vec![role, content]);
+        }
+
+        let mut output = String::new();
+        if let Some(task) = &trajectory.info.task {
+            let task = redactor.redact_text(task, surface::EXPORT).text;
+            let _ = writeln!(output, "Task: {task}");
+        }
+        if let Some(outcome) = &trajectory.info.outcome {
+            let outcome = redactor.redact_text(outcome, surface::EXPORT).text;
+            let _ = writeln!(output, "Outcome: {outcome}");
+        }
+        if !output.is_empty() {
+            output.push('\n');
+        }
+
+        output.push_str(&table.to_string());
+        output.push('\n');
+        output
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "table-export")]
+    #[test]
+    fn test_table_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some("submitted".to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::assistant("Hello user"));
+
+        let table_out = TableExporter::export(&t);
+
+        assert!(table_out.contains("Task: Add a feature"));
+        assert!(table_out.contains("Outcome: submitted"));
+        assert!(table_out.contains("system"));
+        assert!(table_out.contains("System prompt"));
+        assert!(table_out.contains("Hello agent"));
+        assert!(table_out.contains("Hello user"));
+    }
+
     use super::*;
     use crate::model::Message;
     use crate::trajectory::outcome;


### PR DESCRIPTION
💡 **The Spark:** "I noticed we don't have a readable, CLI-friendly table format for trajectories. Sometimes we just want to look at the runs locally via the CLI."
🚀 **The Feature:** "Implemented `TableExporter` using `comfy-table`."
🔮 **The Potential:** "Easy visual scanning of agent runs right from the terminal."
⚠️ **Risk:** "Low. Isolated in an optional feature `table-export`."

---
*PR created automatically by Jules for task [11349721736722181324](https://jules.google.com/task/11349721736722181324) started by @madmax983*