### PR TITLE
🛡️ Sentry: Add test coverage for cost accounting logic

### DIFF
--- a/src/cost.rs
+++ b/src/cost.rs
@@ -96,3 +96,153 @@ pub fn is_free_tier_model(model: &str) -> bool {
         .is_some_and(|name| name.ends_with(":free"))
         || model.ends_with(":free")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_return_correct_label_and_display() {
+        assert_eq!(CostSource::ProviderReported.label(), "provider_reported");
+        assert_eq!(CostSource::RateCardEstimate.label(), "rate_card_estimate");
+        assert_eq!(CostSource::FreeTierInferred.label(), "free_tier_inferred");
+        assert_eq!(CostSource::Unknown.label(), "unknown");
+
+        assert_eq!(
+            CostSource::ProviderReported.to_string(),
+            "provider_reported"
+        );
+    }
+
+    #[test]
+    fn should_combine_cost_sources_pessimistically() {
+        let cases = vec![
+            // Unknown dominates everything
+            (
+                CostSource::Unknown,
+                CostSource::ProviderReported,
+                CostSource::Unknown,
+            ),
+            (
+                CostSource::Unknown,
+                CostSource::RateCardEstimate,
+                CostSource::Unknown,
+            ),
+            (
+                CostSource::Unknown,
+                CostSource::FreeTierInferred,
+                CostSource::Unknown,
+            ),
+            (
+                CostSource::Unknown,
+                CostSource::Unknown,
+                CostSource::Unknown,
+            ),
+            (
+                CostSource::ProviderReported,
+                CostSource::Unknown,
+                CostSource::Unknown,
+            ),
+            (
+                CostSource::RateCardEstimate,
+                CostSource::Unknown,
+                CostSource::Unknown,
+            ),
+            // RateCardEstimate dominates ProviderReported and FreeTierInferred
+            (
+                CostSource::RateCardEstimate,
+                CostSource::ProviderReported,
+                CostSource::RateCardEstimate,
+            ),
+            (
+                CostSource::RateCardEstimate,
+                CostSource::FreeTierInferred,
+                CostSource::RateCardEstimate,
+            ),
+            (
+                CostSource::RateCardEstimate,
+                CostSource::RateCardEstimate,
+                CostSource::RateCardEstimate,
+            ),
+            (
+                CostSource::ProviderReported,
+                CostSource::RateCardEstimate,
+                CostSource::RateCardEstimate,
+            ),
+            // ProviderReported dominates FreeTierInferred
+            (
+                CostSource::ProviderReported,
+                CostSource::FreeTierInferred,
+                CostSource::ProviderReported,
+            ),
+            (
+                CostSource::FreeTierInferred,
+                CostSource::ProviderReported,
+                CostSource::ProviderReported,
+            ),
+            (
+                CostSource::ProviderReported,
+                CostSource::ProviderReported,
+                CostSource::ProviderReported,
+            ),
+            // FreeTierInferred only if both are FreeTierInferred
+            (
+                CostSource::FreeTierInferred,
+                CostSource::FreeTierInferred,
+                CostSource::FreeTierInferred,
+            ),
+        ];
+
+        for (a, b, expected) in cases {
+            assert_eq!(
+                a.combine(b),
+                expected,
+                "failed for {a:?} combined with {b:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn should_estimate_cost_usd_for_anthropic_model() {
+        // Anthropic models get special multipliers: 0.10 for cache read, 1.25 for cache creation.
+        // SONNET_INPUT_USD_PER_MTOK = 3.0, SONNET_OUTPUT_USD_PER_MTOK = 15.0
+        let p = 1_000_000; // $3.0
+        let cr = 1_000_000; // $3.0 * 0.10 = $0.30
+        let cc = 1_000_000; // $3.0 * 1.25 = $3.75
+        let c = 1_000_000; // $15.0
+        let expected = 3.0 + 0.30 + 3.75 + 15.0; // 22.05
+
+        let cost = estimate_cost_usd(p, cr, cc, c, "claude-3-5-sonnet-20241022");
+        assert!(
+            (cost - expected).abs() < f64::EPSILON,
+            "Cost was {cost}, expected {expected}"
+        );
+    }
+
+    #[test]
+    fn should_estimate_cost_usd_for_non_anthropic_model() {
+        // Non-Anthropic models use 1.0 multiplier for both cache operations.
+        let p = 1_000_000; // $3.0
+        let cr = 1_000_000; // $3.0 * 1.0 = $3.0
+        let cc = 1_000_000; // $3.0 * 1.0 = $3.0
+        let c = 1_000_000; // $15.0
+        let expected = 3.0 + 3.0 + 3.0 + 15.0; // 24.0
+
+        let cost = estimate_cost_usd(p, cr, cc, c, "gpt-4o");
+        assert!(
+            (cost - expected).abs() < f64::EPSILON,
+            "Cost was {cost}, expected {expected}"
+        );
+    }
+
+    #[test]
+    fn should_identify_free_tier_model() {
+        assert!(is_free_tier_model("google/gemini-2.5-flash:free"));
+        assert!(is_free_tier_model("deepseek-r1:free"));
+        assert!(is_free_tier_model(":free"));
+
+        assert!(!is_free_tier_model("google/gemini-2.5-flash"));
+        assert!(!is_free_tier_model("claude-3-5-sonnet"));
+        assert!(!is_free_tier_model("free-model-not-ending-with-free"));
+    }
+}

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -530,14 +530,10 @@ mod tests {
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = network_pos else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +548,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected my-image in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"


### PR DESCRIPTION
🎯 Target: `src/cost.rs` (`CostSource`, `estimate_cost_usd`, `is_free_tier_model`) and `src/env/docker.rs`.
💣 Risk: Missing test coverage for cost parsing/multipliers and panic risks due to unhandled `.unwrap()` calls in tests.
🧪 Strategy: Replaced unwraps with `let Some(...) = ... else { panic!(...) }`. Appended table-driven tests for combining cost sources and precise unit tests for cache token cost estimation calculations.
🔭 Verification: `cargo test --lib cost` and `cargo clippy --all-targets --all-features -- -D warnings`.

---
*PR created automatically by Jules for task [8847915878235319922](https://jules.google.com/task/8847915878235319922) started by @madmax983*