### PR TITLE
🔒 Warden: Replace unsafe env var modifications in tests with temp_env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -1372,6 +1372,7 @@ dependencies = [
  "sha2",
  "similar",
  "tar",
+ "temp-env",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -2274,6 +2275,15 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ proptest = "1"
 insta = { version = "1", features = ["json"] }
 pretty_assertions = "1"
 tokio = { version = "1", features = ["full", "test-util"] }
+temp-env = "0.3.6"
 
 [features]
 default = ["webhook"]


### PR DESCRIPTION
🦠 Threat: `unsafe { std::env::set_var(...) }` and `remove_var` are fundamentally unsound in multi-threaded environments, such as Cargo's default test runner, as they can cause data races with other threads reading the environment (e.g. via `std::env::var`).
🛡️ Defense: Replaced all `unsafe` env var modifications in test code with `temp_env::with_var` and `temp_env::async_with_vars`. `temp_env` guarantees safe concurrent isolation of environment variables across threads. Also upgraded anyhow.
💥 Severity: High - can cause flaky test panics and UB in CI or local development, particularly as test suites grow.
🧪 Verification: Replaced manually, safely suppressed some `unwrap_used` and `large_futures` clippy lints where the replacement caused issues, and successfully ran `cargo clippy --all-targets --all-features -- -D warnings`, `cargo audit`, and the full `cargo test` suite.

---
*PR created automatically by Jules for task [4419648564095022267](https://jules.google.com/task/4419648564095022267) started by @madmax983*