### PR TITLE
🛡️ Sentry: Replace unwrap() calls with robust guard clauses in docker tests

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected image name in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"


### PR DESCRIPTION
🎯 Target: `src/env/docker.rs` specifically the `build_run_args` tests (`build_run_args_include_network_none_when_mode_is_none` and `build_run_args_network_none_positioned_before_image`).

💣 Risk: Usage of `.unwrap()` on dynamic test data (like searching for index positions in `Vec<String>`). If a test fails because an argument is missing, the suite panics with a generic "Option::unwrap() on a None value" instead of revealing the actual missing element or the contents of the `args` array, severely hindering debuggability.

🧪 Strategy: Replaced `.unwrap()` calls with idiomatic `let Some(...) = ... else { panic!("...") };` guard clauses that format the entire `args` vector into the panic payload. Consolidated redundant assertions (`assert!(...is_some())` followed by `.unwrap()`) into single, safe bindings.

🔬 Verification: Run `cargo test --features docker --lib -- build_run_args` to execute the modified tests, along with full suite `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test`.

---
*PR created automatically by Jules for task [12456755422831584653](https://jules.google.com/task/12456755422831584653) started by @madmax983*