### PR TITLE
Add budget burn-down and elapsed clock to dashboard header

### DIFF
--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -711,8 +711,20 @@ impl StreamSink for RatatuiDashboard {
                         .state
                         .lock()
                         .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    // `cost_usd` here is this single response's cost
+                    // (`resp.usage.cost_usd`, computed per-call from that
+                    // response's token usage — see `DefaultAgent::step` and
+                    // `ModelUsage`), not a running total, so it must
+                    // accumulate rather than overwrite. Overwriting made the
+                    // header's cost display silently regress to the last
+                    // turn's cost on every assistant message; harmless when
+                    // only a raw "cost $X" was shown, but it under-reports
+                    // budget usage against the burn-down's `%`/warning
+                    // threshold on any run that doesn't hit another confirm
+                    // prompt (e.g. auto-approved bash) to re-sync it from
+                    // the agent's true cumulative total (PR #992 review).
                     if let Some(cost) = cost_usd {
-                        s.cost_usd = cost;
+                        s.cost_usd += cost;
                     }
                     s.step = step;
                     // The model has returned: the thinking window closes. The
@@ -4497,6 +4509,69 @@ mod tests {
         let s = snap(&d);
         assert_eq!(s.step, 2);
         assert!((s.cost_usd - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn emit_assistant_message_accumulates_per_turn_cost_into_cumulative_spend() {
+        // Regression for PR #992 review: `cost_usd` on `AssistantMessage` is
+        // this response's own cost, not a running total (see
+        // `DefaultAgent::step`'s `resp.usage.cost_usd`). Two $0.04 turns with
+        // no intervening confirm prompt (e.g. auto-approved bash) must read
+        // as $0.08 cumulative, not silently regress to the last turn's $0.04.
+        let d = make_dashboard();
+        d.emit(StreamEvent::AssistantMessage {
+            step: 1,
+            content: "x".into(),
+            cost_usd: Some(0.04),
+            timestamp: "t".into(),
+        });
+        d.emit(StreamEvent::AssistantMessage {
+            step: 2,
+            content: "y".into(),
+            cost_usd: Some(0.04),
+            timestamp: "t".into(),
+        });
+        let s = snap(&d);
+        assert!(
+            (s.cost_usd - 0.08).abs() < f64::EPSILON,
+            "expected cumulative $0.08 after two $0.04 turns, got {}",
+            s.cost_usd
+        );
+    }
+
+    #[test]
+    fn header_burn_down_reflects_cumulative_spend_across_turns_without_a_confirm_prompt() {
+        // End-to-end version of the above through the actual header render:
+        // two $0.04 assistant turns against a $0.10 cap, with no confirm
+        // prompt in between, must show 80% (and the warning color it
+        // crosses at), not 40%.
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.cost_cap_usd = Some(0.10);
+        }
+        d.emit(StreamEvent::AssistantMessage {
+            step: 1,
+            content: "x".into(),
+            cost_usd: Some(0.04),
+            timestamp: "t".into(),
+        });
+        d.emit(StreamEvent::AssistantMessage {
+            step: 2,
+            content: "y".into(),
+            cost_usd: Some(0.04),
+            timestamp: "t".into(),
+        });
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("cost $0.0800 / $0.10 (80%)"),
+            "should show cumulative 80% consumed, not 40%; got:\n{text}"
+        );
+        assert!(
+            header_has_fg(&buf, Color::Red),
+            "80% consumed should already be at the warning threshold; got:\n{text}"
+        );
     }
 
     #[test]

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -154,11 +154,12 @@ fn truncate_to_cap(mut s: String) -> String {
 struct DashboardState {
     task: Option<String>,
     model: Option<String>,
-    started_at: Option<String>,
-    /// Monotonic anchor for `started_at`, captured locally when `RunStarted`
-    /// arrives (issue #640). Used to render the live elapsed wall-clock;
-    /// kept separate from the RFC3339 `started_at` string so the header
-    /// never has to parse/re-derive a `Duration` from wall-clock text.
+    /// Monotonic anchor captured locally when `RunStarted` arrives (issue
+    /// #640), used to render the live elapsed wall-clock. A monotonic
+    /// `Instant` rather than the RFC3339 `started_at` string carried by
+    /// `StreamEvent::RunStarted` — the dashboard never needs to parse or
+    /// re-derive a `Duration` from wall-clock text, and (unlike a wall-clock
+    /// timestamp) it can't be skewed by clock adjustments during the run.
     started_at_instant: Option<Instant>,
     cost_usd: f64,
     /// Effective per-task cost ceiling for the header burn-down (issue
@@ -233,7 +234,6 @@ impl Default for DashboardState {
         Self {
             task: None,
             model: None,
-            started_at: None,
             started_at_instant: None,
             cost_usd: 0.0,
             cost_cap_usd: None,
@@ -544,11 +544,19 @@ impl RatatuiDashboard {
     /// header burn-down (issue #640) — see [`effective_cost_cap_usd`]. Pass
     /// `None` when no cap is configured, or for surfaces (e.g. the
     /// `--yolo` monitor) that don't render one.
+    ///
+    /// `step_limit` is `config.agent.step_limit`, seeded into the header
+    /// from construction (issue #640 review) rather than left at its
+    /// `Default` of `0` until the first operator confirm prompt populates
+    /// it — a run with no confirm prompts (e.g. every command auto-approved)
+    /// would otherwise never show a real step count or trip the step-limit
+    /// warning color.
     pub fn start(
         is_monitor: bool,
         cancel_tx: Option<watch::Sender<bool>>,
         bell_enabled: bool,
         cost_cap_usd: Option<f64>,
+        step_limit: u32,
     ) -> std::io::Result<RatatuiDashboardHandle> {
         enable_raw_mode()?;
         let mut stdout = std::io::stdout();
@@ -587,6 +595,7 @@ impl RatatuiDashboard {
                 stall_threshold: stall_threshold_from_env(),
                 mouse_scroll_step: mouse_scroll_step_from_env(),
                 cost_cap_usd,
+                step_limit,
                 ..DashboardState::default()
             }),
             notify: RedrawNotify::new(),
@@ -668,7 +677,7 @@ impl StreamSink for RatatuiDashboard {
             StreamEvent::RunStarted {
                 task,
                 model,
-                started_at,
+                started_at: _,
             } => {
                 {
                     let mut s = self
@@ -677,7 +686,6 @@ impl StreamSink for RatatuiDashboard {
                         .unwrap_or_else(std::sync::PoisonError::into_inner);
                     s.task = Some(task.clone());
                     s.model = Some(model.clone());
-                    s.started_at = Some(started_at);
                     s.started_at_instant = Some(Instant::now());
                     // The step-1 model call begins now (issue #649): there is
                     // no `model-call-started` event, so the first model-thinking
@@ -2108,7 +2116,10 @@ fn draw_frame(
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),
+            // 2 content rows (issue #640 review): step/cost/elapsed on one
+            // line, model/task on the next, so neither can crowd the other
+            // off-screen. Must stay in sync with `draw`'s identical layout.
+            Constraint::Length(4),
             Constraint::Min(0),
             Constraint::Length(3),
         ])
@@ -2251,7 +2262,10 @@ fn draw(frame: &mut ratatui::Frame, dash: &Arc<RatatuiDashboard>, snap: &Dashboa
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),
+            // 2 content rows (issue #640 review): step/cost/elapsed on one
+            // line, model/task on the next, so neither can crowd the other
+            // off-screen. Must stay in sync with `draw`'s identical layout.
+            Constraint::Length(4),
             Constraint::Min(0),
             Constraint::Length(3),
         ])
@@ -2377,13 +2391,23 @@ fn header_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
         Style::default().fg(Color::Cyan)
     };
 
-    // Cost burn-down (issue #640, AC1): when a cap is configured, show
-    // spend/cap/percent and escalate to a warning style at >=80% consumed.
-    // With no cap configured, fall back to the plain "cost $X" form — no
-    // "/ $0" artifact and no division by zero.
+    // Cost burn-down (issue #640, AC1): when a cap is configured — including
+    // a $0.00 "no spend allowed" kill switch, or (nonsensically but safely) a
+    // negative one — show spend/cap/percent and escalate to a warning style
+    // at >=80% consumed. A zero-or-negative cap can't drive the normal
+    // spend/cap*100 division (it would divide by zero or go negative), so it
+    // is treated as already fully consumed the moment any spend has
+    // occurred. With no cap configured, fall back to the plain "cost $X"
+    // form — no "/ $0" artifact and no division by zero.
     let cost_span = match snap.cost_cap_usd {
-        Some(cap) if cap > 0.0 => {
-            let pct = (snap.cost_usd / cap * 100.0).max(0.0);
+        Some(cap) => {
+            let pct = if cap > 0.0 {
+                (snap.cost_usd / cap * 100.0).max(0.0)
+            } else if snap.cost_usd > 0.0 {
+                100.0
+            } else {
+                0.0
+            };
             let style = if pct >= BUDGET_WARNING_PCT {
                 budget_warning_style()
             } else {
@@ -2394,13 +2418,13 @@ fn header_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
                 style,
             )
         }
-        _ => Span::styled(
+        None => Span::styled(
             format!("cost ${:.4}  ", snap.cost_usd),
             Style::default().fg(Color::Yellow),
         ),
     };
 
-    let mut spans = vec![
+    let mut top_spans = vec![
         Span::styled(
             format!("step {}/{}  ", snap.step, snap.step_limit),
             step_style,
@@ -2410,20 +2434,27 @@ fn header_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
     // Live elapsed wall-clock since the run started (issue #640, AC3); absent
     // until the first `RunStarted` event lands.
     if let Some(elapsed) = snap.elapsed {
-        spans.push(Span::styled(
-            format!("elapsed {}  ", format_elapsed(elapsed)),
+        top_spans.push(Span::styled(
+            format!("elapsed {}", format_elapsed(elapsed)),
             Style::default().fg(Color::Gray),
         ));
     }
-    spans.push(Span::styled(
-        format!("model: {model}  "),
-        Style::default().fg(Color::Green),
-    ));
-    spans.push(Span::styled(
-        format!("task: {title}"),
-        Style::default().add_modifier(Modifier::DIM),
-    ));
-    let line = Line::from(spans);
+    // Model/task get their own line (issue #640 review): the burn-down and
+    // elapsed spans above can run long (a configured cap plus an hours-long
+    // elapsed time), and packing everything onto one row risked silently
+    // clipping the model name and task title — the fields an operator most
+    // needs to identify the run — off the edge of a normal-width terminal.
+    let bottom_spans = vec![
+        Span::styled(
+            format!("model: {model}  "),
+            Style::default().fg(Color::Green),
+        ),
+        Span::styled(
+            format!("task: {title}"),
+            Style::default().add_modifier(Modifier::DIM),
+        ),
+    ];
+    let lines = vec![Line::from(top_spans), Line::from(bottom_spans)];
     let block_title = if snap.is_monitor {
         " maxwell's daemon — monitor ".to_string()
     } else if snap.active_rules.is_empty() {
@@ -2434,7 +2465,7 @@ fn header_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
             snap.active_rules.join(", ")
         )
     };
-    Paragraph::new(line).block(Block::default().borders(Borders::ALL).title(block_title))
+    Paragraph::new(lines).block(Block::default().borders(Borders::ALL).title(block_title))
 }
 
 fn line_base_style(kind: LineKind) -> Style {
@@ -4274,6 +4305,102 @@ mod tests {
         assert!(
             !text.contains("/ $0"),
             "must not render a cap/percent artifact with no cap configured; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn header_shows_burn_down_for_a_zero_cost_cap_kill_switch() {
+        // A $0.00 cap (e.g. `cost_limit_usd = 0.0`) is a legal "no spend
+        // allowed" config, not "no cap configured" — code-review fix: the
+        // old `cap > 0.0` guard silently hid it behind the plain fallback
+        // right as the run was about to terminate on it.
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.cost_usd = 0.01;
+            s.cost_cap_usd = Some(0.0);
+        }
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("cost $0.0100 / $0.00 (100%)"),
+            "a $0 cap with any spend should show as fully consumed; got:\n{text}"
+        );
+        assert!(
+            header_has_fg(&buf, Color::Red),
+            "a $0 cap with any spend should escalate to the warning style; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn header_shows_zero_percent_for_a_zero_cost_cap_before_any_spend() {
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.cost_usd = 0.0;
+            s.cost_cap_usd = Some(0.0);
+        }
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("cost $0.0000 / $0.00 (0%)"),
+            "a $0 cap with no spend yet should show 0%, not crash/NaN/inf; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn header_shows_burn_down_for_a_negative_cost_cap_without_crashing() {
+        // Negative caps are nonsensical but not rejected by config
+        // validation; the header must degrade gracefully rather than
+        // divide by a negative number or format NaN/inf.
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.cost_usd = 0.01;
+            s.cost_cap_usd = Some(-1.0);
+        }
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        let text = buffer_text(&buf);
+        assert!(
+            !text.contains("NaN") && !text.contains("inf"),
+            "must not render NaN/inf for a negative cap; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn header_keeps_model_and_task_visible_alongside_a_full_burn_down_and_elapsed_clock() {
+        // Code-review fix: packing cost-cap/percent and elapsed onto the
+        // same line as model/task could silently clip the latter off an
+        // 80-column terminal. Model/task now get their own header line.
+        let d = make_dashboard();
+        d.emit(StreamEvent::RunStarted {
+            task: "fix the flaky retry test".into(),
+            model: "claude-opus-4-7".into(),
+            started_at: "2026-05-18T12:00:00Z".into(),
+        });
+        {
+            let mut s = d.state.lock().unwrap();
+            s.cost_usd = 12.3456;
+            s.cost_cap_usd = Some(15.0);
+            s.started_at_instant = Some(ago(3 * 3600 + 45 * 60 + 12)); // 3h45m12s
+        }
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("cost $12.3456 / $15.00"),
+            "burn-down should still render; got:\n{text}"
+        );
+        assert!(
+            text.contains("elapsed 3h45m12s"),
+            "elapsed should still render; got:\n{text}"
+        );
+        assert!(
+            text.contains("claude-opus-4-7"),
+            "model must not be clipped off-screen; got:\n{text}"
+        );
+        assert!(
+            text.contains("fix the flaky retry test"),
+            "task title must not be clipped off-screen; got:\n{text}"
         );
     }
 

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -551,12 +551,24 @@ impl RatatuiDashboard {
     /// it — a run with no confirm prompts (e.g. every command auto-approved)
     /// would otherwise never show a real step count or trip the step-limit
     /// warning color.
+    ///
+    /// `initial_cost_usd` seeds the running cost total shown by the burn-down
+    /// (PR #992 review). It's `0.0` for a fresh run, but on `mini --resume`/
+    /// `--continue` the agent's `RunStarted` event fires *before*
+    /// `ResumeState.total_cost_usd` is folded into `DefaultAgent`, so no
+    /// stream event ever carries the prior spend to the dashboard — every
+    /// subsequent `AssistantMessage` accumulates on top of whatever this
+    /// starts at (see the `RunStarted`/`AssistantMessage` handlers below), so
+    /// omitting it would under-report a resumed run's true spend by its
+    /// entire pre-resume cost until a confirm prompt or `RunEnded`
+    /// happened to re-sync it from the agent's authoritative total.
     pub fn start(
         is_monitor: bool,
         cancel_tx: Option<watch::Sender<bool>>,
         bell_enabled: bool,
         cost_cap_usd: Option<f64>,
         step_limit: u32,
+        initial_cost_usd: f64,
     ) -> std::io::Result<RatatuiDashboardHandle> {
         enable_raw_mode()?;
         let mut stdout = std::io::stdout();
@@ -596,6 +608,7 @@ impl RatatuiDashboard {
                 mouse_scroll_step: mouse_scroll_step_from_env(),
                 cost_cap_usd,
                 step_limit,
+                cost_usd: initial_cost_usd,
                 ..DashboardState::default()
             }),
             notify: RedrawNotify::new(),
@@ -4571,6 +4584,35 @@ mod tests {
         assert!(
             header_has_fg(&buf, Color::Red),
             "80% consumed should already be at the warning threshold; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn resumed_prior_spend_seeded_at_construction_accumulates_with_new_turns() {
+        // Regression for PR #992 review: `mini --resume`/`--continue` emits
+        // `RunStarted` before folding `ResumeState.total_cost_usd` in, so no
+        // stream event carries prior spend — `RatatuiDashboard::start` now
+        // seeds `DashboardState.cost_usd` directly (simulated here since
+        // `start()` needs a real terminal). Confirms it composes correctly
+        // with the accumulate-not-overwrite fix above: new turns must add to
+        // the resumed total, not replace it.
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.cost_usd = 0.30; // simulates a resumed run's prior spend
+            s.cost_cap_usd = Some(0.50);
+        }
+        d.emit(StreamEvent::AssistantMessage {
+            step: 1,
+            content: "x".into(),
+            cost_usd: Some(0.04),
+            timestamp: "t".into(),
+        });
+        let s = snap(&d);
+        assert!(
+            (s.cost_usd - 0.34).abs() < f64::EPSILON,
+            "expected resumed $0.30 + new $0.04 = $0.34, got {}",
+            s.cost_usd
         );
     }
 

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -962,6 +962,16 @@ impl ConfirmCallback for RatatuiDashboard {
     }
 }
 
+/// Whether `renderer_loop`'s elapsed-clock tick should be armed this
+/// iteration (issue #640 review): the run has started and hasn't finished
+/// yet. Extracted as a pure predicate — separate from the spinner's `active`
+/// gate — so the elapsed clock keeps advancing once a second even while
+/// `Activity::Idle` (e.g. sitting at a confirm prompt), without reaching
+/// into the async `renderer_loop` itself to test the gating logic.
+fn elapsed_tick_should_arm(started_at_instant: Option<Instant>, finished: Option<&str>) -> bool {
+    started_at_instant.is_some() && finished.is_none()
+}
+
 async fn renderer_loop(
     dash: Arc<RatatuiDashboard>,
     mut terminal: Terminal<CrosstermBackend<Stdout>>,
@@ -976,6 +986,19 @@ async fn renderer_loop(
     // idle gap during which the interval was never awaited.
     let mut tick = tokio::time::interval(Duration::from_millis(100));
     tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Elapsed-clock cadence (issue #640 review): the header's live "elapsed"
+    // value is recomputed only when a frame is actually drawn, but the spinner
+    // tick above only fires `if active` (Thinking/Running) — so sitting at a
+    // confirm prompt (`Activity::Idle`) would otherwise freeze the elapsed
+    // clock at the moment the modal opened until a keystroke/mouse event,
+    // then jump forward, defeating the point of a *live* clock during exactly
+    // the wait the operator most needs it accurate for. A separate, much
+    // cheaper 1s tick (vs. the spinner's 100ms) keeps it ticking for the
+    // whole run — gated on the run having started and not yet finished, so
+    // it costs nothing before `RunStarted` or after the dashboard goes
+    // permanently idle at run end.
+    let mut elapsed_tick = tokio::time::interval(Duration::from_secs(1));
+    elapsed_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     // Whether the *next* loop iteration should redraw. Defaults true (every
     // event redraws, as before); the mouse arm below can clear it. Needed
     // because `EnableMouseCapture` requests any-event motion tracking, so a
@@ -1007,12 +1030,16 @@ async fn renderer_loop(
         tokio::pin!(notified);
         notified.as_mut().enable();
 
-        let (exit, active) = {
+        let (exit, active, elapsed_live) = {
             let s = dash
                 .state
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            (s.should_exit, s.activity.is_active())
+            (
+                s.should_exit,
+                s.activity.is_active(),
+                elapsed_tick_should_arm(s.started_at_instant, s.finished.as_deref()),
+            )
         };
         if exit {
             break;
@@ -1041,6 +1068,7 @@ async fn renderer_loop(
             _ = &mut shutdown => break,
             () = &mut notified => {}
             _ = tick.tick(), if active => {}
+            _ = elapsed_tick.tick(), if elapsed_live && !active => {}
             ev = events.next() => {
                 match ev {
                     Some(Ok(Event::Key(key))) => handle_key(&dash, key),
@@ -4241,6 +4269,23 @@ mod tests {
         assert_eq!(format_elapsed(Duration::from_secs(60)), "1m00s");
         assert_eq!(format_elapsed(Duration::from_secs(134)), "2m14s");
         assert_eq!(format_elapsed(Duration::from_secs(3661)), "1h01m01s");
+    }
+
+    #[test]
+    fn elapsed_tick_arms_once_started_and_disarms_once_finished() {
+        // Regression for PR #992 review: confirm() leaves Activity::Idle, so
+        // the elapsed clock must keep ticking from `started_at_instant`
+        // alone — independent of the spinner's `active` gate — for the
+        // entire in-progress run, and stop once the run has actually ended.
+        assert!(!elapsed_tick_should_arm(None, None), "not yet started");
+        assert!(
+            elapsed_tick_should_arm(Some(Instant::now()), None),
+            "started and still in progress (including idle waits, e.g. a confirm prompt)"
+        );
+        assert!(
+            !elapsed_tick_should_arm(Some(Instant::now()), Some("submitted")),
+            "run has finished; no need to keep ticking a static elapsed time"
+        );
     }
 
     #[test]

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -118,6 +118,26 @@ pub fn bell_enabled(
     !no_bell_flag && !env_suppresses && stdout_is_tty
 }
 
+/// Resolve the effective per-task cost cap to show in the header burn-down
+/// (issue #640) from the two independently-enforced budget caps
+/// (`agent.cost_limit_usd`, `agent.per_task_budget_usd`). Both are checked
+/// against cumulative spend every step (see `DefaultAgent::step`), so
+/// whichever is smaller fires first; the smaller of the two configured
+/// values is therefore the cap that actually governs the run and is what
+/// the operator needs to watch. `None` when neither is configured.
+#[must_use]
+pub fn effective_cost_cap_usd(
+    cost_limit_usd: Option<f64>,
+    per_task_budget_usd: Option<f64>,
+) -> Option<f64> {
+    match (cost_limit_usd, per_task_budget_usd) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
 fn truncate_to_cap(mut s: String) -> String {
     if s.len() > MAX_RETAINED_ENTRY_BYTES {
         let mut cut = MAX_RETAINED_ENTRY_BYTES;
@@ -135,7 +155,17 @@ struct DashboardState {
     task: Option<String>,
     model: Option<String>,
     started_at: Option<String>,
+    /// Monotonic anchor for `started_at`, captured locally when `RunStarted`
+    /// arrives (issue #640). Used to render the live elapsed wall-clock;
+    /// kept separate from the RFC3339 `started_at` string so the header
+    /// never has to parse/re-derive a `Duration` from wall-clock text.
+    started_at_instant: Option<Instant>,
     cost_usd: f64,
+    /// Effective per-task cost ceiling for the header burn-down (issue
+    /// #640): `min(cost_limit_usd, per_task_budget_usd)` over whichever of
+    /// the two is configured, resolved once at dashboard construction (see
+    /// [`effective_cost_cap_usd`]). `None` when neither cap is configured.
+    cost_cap_usd: Option<f64>,
     step: u32,
     step_limit: u32,
     log: VecDeque<LogLine>,
@@ -204,7 +234,9 @@ impl Default for DashboardState {
             task: None,
             model: None,
             started_at: None,
+            started_at_instant: None,
             cost_usd: 0.0,
+            cost_cap_usd: None,
             step: 0,
             step_limit: 0,
             log: VecDeque::new(),
@@ -507,10 +539,16 @@ impl RatatuiDashboard {
     /// alt-screen mode. On failure the terminal is restored to cooked
     /// mode and the alt-screen is left, so the caller never observes a
     /// half-initialised terminal.
+    ///
+    /// `cost_cap_usd` is the effective per-task cost ceiling to show in the
+    /// header burn-down (issue #640) — see [`effective_cost_cap_usd`]. Pass
+    /// `None` when no cap is configured, or for surfaces (e.g. the
+    /// `--yolo` monitor) that don't render one.
     pub fn start(
         is_monitor: bool,
         cancel_tx: Option<watch::Sender<bool>>,
         bell_enabled: bool,
+        cost_cap_usd: Option<f64>,
     ) -> std::io::Result<RatatuiDashboardHandle> {
         enable_raw_mode()?;
         let mut stdout = std::io::stdout();
@@ -548,6 +586,7 @@ impl RatatuiDashboard {
                 is_monitor,
                 stall_threshold: stall_threshold_from_env(),
                 mouse_scroll_step: mouse_scroll_step_from_env(),
+                cost_cap_usd,
                 ..DashboardState::default()
             }),
             notify: RedrawNotify::new(),
@@ -639,6 +678,7 @@ impl StreamSink for RatatuiDashboard {
                     s.task = Some(task.clone());
                     s.model = Some(model.clone());
                     s.started_at = Some(started_at);
+                    s.started_at_instant = Some(Instant::now());
                     // The step-1 model call begins now (issue #649): there is
                     // no `model-call-started` event, so the first model-thinking
                     // window opens at run start and closes at `AssistantMessage`.
@@ -2139,6 +2179,8 @@ fn draw_frame(
             step: s.step,
             step_limit: s.step_limit,
             cost_usd: s.cost_usd,
+            cost_cap_usd: s.cost_cap_usd,
+            elapsed: s.started_at_instant.map(|since| since.elapsed()),
             finished: s.finished.clone(),
             log: s.log.iter().cloned().collect(),
             pending: s.pending.as_ref().map(|p| p.ctx.clone()),
@@ -2174,6 +2216,12 @@ struct DashboardSnapshot {
     step: u32,
     step_limit: u32,
     cost_usd: f64,
+    /// See [`DashboardState::cost_cap_usd`].
+    cost_cap_usd: Option<f64>,
+    /// Wall-clock elapsed since `RunStarted`, resolved from
+    /// `DashboardState::started_at_instant` at snapshot time (issue #640).
+    /// `None` before the run has started.
+    elapsed: Option<Duration>,
     finished: Option<String>,
     log: Vec<LogLine>,
     pending: Option<ConfirmContext>,
@@ -2278,6 +2326,36 @@ fn draw(frame: &mut ratatui::Frame, dash: &Arc<RatatuiDashboard>, snap: &Dashboa
     }
 }
 
+/// Percent-of-cap consumed at or above which a budget indicator escalates to
+/// [`budget_warning_style`] (issue #640, AC2).
+const BUDGET_WARNING_PCT: f64 = 80.0;
+
+/// Style for a budget indicator (cost or step) that has crossed
+/// [`BUDGET_WARNING_PCT`]. Reuses the dashboard's existing danger color
+/// (`Color::Red`, already used by `LineKind::BashErr` and the stop-run
+/// confirmation) rather than `Color::Yellow`, since cost's normal color is
+/// already yellow and wouldn't visibly change.
+fn budget_warning_style() -> Style {
+    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+}
+
+/// Format a `Duration` as a compact elapsed-time string: `"45s"`,
+/// `"2m14s"`, or `"1h02m03s"`. Sub-minute values omit the minutes field
+/// entirely rather than rendering `"0m45s"`.
+fn format_elapsed(d: Duration) -> String {
+    let total = d.as_secs();
+    let hours = total / 3600;
+    let minutes = (total % 3600) / 60;
+    let seconds = total % 60;
+    if hours > 0 {
+        format!("{hours}h{minutes:02}m{seconds:02}s")
+    } else if minutes > 0 {
+        format!("{minutes}m{seconds:02}s")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
 fn header_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
     let title = snap
         .task
@@ -2287,24 +2365,65 @@ fn header_paragraph(snap: &DashboardSnapshot) -> Paragraph<'_> {
         .next()
         .unwrap_or("");
     let model = snap.model.as_deref().unwrap_or("(no model)");
-    let line = Line::from(vec![
-        Span::styled(
-            format!("step {}/{}  ", snap.step, snap.step_limit),
-            Style::default().fg(Color::Cyan),
-        ),
-        Span::styled(
+
+    let step_pct = if snap.step_limit > 0 {
+        f64::from(snap.step) / f64::from(snap.step_limit) * 100.0
+    } else {
+        0.0
+    };
+    let step_style = if step_pct >= BUDGET_WARNING_PCT {
+        budget_warning_style()
+    } else {
+        Style::default().fg(Color::Cyan)
+    };
+
+    // Cost burn-down (issue #640, AC1): when a cap is configured, show
+    // spend/cap/percent and escalate to a warning style at >=80% consumed.
+    // With no cap configured, fall back to the plain "cost $X" form — no
+    // "/ $0" artifact and no division by zero.
+    let cost_span = match snap.cost_cap_usd {
+        Some(cap) if cap > 0.0 => {
+            let pct = (snap.cost_usd / cap * 100.0).max(0.0);
+            let style = if pct >= BUDGET_WARNING_PCT {
+                budget_warning_style()
+            } else {
+                Style::default().fg(Color::Yellow)
+            };
+            Span::styled(
+                format!("cost ${:.4} / ${cap:.2} ({pct:.0}%)  ", snap.cost_usd),
+                style,
+            )
+        }
+        _ => Span::styled(
             format!("cost ${:.4}  ", snap.cost_usd),
             Style::default().fg(Color::Yellow),
         ),
+    };
+
+    let mut spans = vec![
         Span::styled(
-            format!("model: {model}  "),
-            Style::default().fg(Color::Green),
+            format!("step {}/{}  ", snap.step, snap.step_limit),
+            step_style,
         ),
-        Span::styled(
-            format!("task: {title}"),
-            Style::default().add_modifier(Modifier::DIM),
-        ),
-    ]);
+        cost_span,
+    ];
+    // Live elapsed wall-clock since the run started (issue #640, AC3); absent
+    // until the first `RunStarted` event lands.
+    if let Some(elapsed) = snap.elapsed {
+        spans.push(Span::styled(
+            format!("elapsed {}  ", format_elapsed(elapsed)),
+            Style::default().fg(Color::Gray),
+        ));
+    }
+    spans.push(Span::styled(
+        format!("model: {model}  "),
+        Style::default().fg(Color::Green),
+    ));
+    spans.push(Span::styled(
+        format!("task: {title}"),
+        Style::default().add_modifier(Modifier::DIM),
+    ));
+    let line = Line::from(spans);
     let block_title = if snap.is_monitor {
         " maxwell's daemon — monitor ".to_string()
     } else if snap.active_rules.is_empty() {
@@ -3997,6 +4116,8 @@ mod tests {
             step: s.step,
             step_limit: s.step_limit,
             cost_usd: s.cost_usd,
+            cost_cap_usd: s.cost_cap_usd,
+            elapsed: s.started_at_instant.map(|since| since.elapsed()),
             finished: s.finished.clone(),
             log: s.log.iter().cloned().collect(),
             pending: s.pending.as_ref().map(|p| p.ctx.clone()),
@@ -4039,6 +4160,163 @@ mod tests {
             out.push('\n');
         }
         out
+    }
+
+    // ---- budget burn-down and elapsed clock (issue #640) ----
+
+    /// True if any cell in the top 3 rows (the header) carries `color` as
+    /// its foreground — mirrors `footer_has_fg` below for header assertions.
+    fn header_has_fg(buf: &Buffer, color: Color) -> bool {
+        for y in 0..buf.area.height.min(3) {
+            for x in 0..buf.area.width {
+                if buf[(x, y)].style().fg == Some(color) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    #[test]
+    fn format_elapsed_formats_seconds_minutes_and_hours() {
+        assert_eq!(format_elapsed(Duration::from_secs(0)), "0s");
+        assert_eq!(format_elapsed(Duration::from_secs(45)), "45s");
+        assert_eq!(format_elapsed(Duration::from_secs(60)), "1m00s");
+        assert_eq!(format_elapsed(Duration::from_secs(134)), "2m14s");
+        assert_eq!(format_elapsed(Duration::from_secs(3661)), "1h01m01s");
+    }
+
+    #[test]
+    fn effective_cost_cap_prefers_the_tighter_configured_cap() {
+        assert_eq!(effective_cost_cap_usd(None, None), None);
+        assert_eq!(effective_cost_cap_usd(Some(1.0), None), Some(1.0));
+        assert_eq!(effective_cost_cap_usd(None, Some(0.5)), Some(0.5));
+        // Both configured: the smaller one is what actually fires first.
+        assert_eq!(effective_cost_cap_usd(Some(1.0), Some(0.5)), Some(0.5));
+        assert_eq!(effective_cost_cap_usd(Some(0.5), Some(1.0)), Some(0.5));
+    }
+
+    #[test]
+    fn header_shows_cost_burn_down_when_cap_configured() {
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.cost_usd = 0.042;
+            s.cost_cap_usd = Some(0.50);
+        }
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("cost $0.0420 / $0.50 (8%)"),
+            "burn-down should show spend, cap, and percent; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn header_cost_indicator_warns_at_80_percent_consumed() {
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.cost_usd = 0.42;
+            s.cost_cap_usd = Some(0.50); // 84% consumed
+        }
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        assert!(
+            header_has_fg(&buf, Color::Red),
+            "cost indicator should escalate to warning style at >=80% consumed"
+        );
+    }
+
+    #[test]
+    fn header_cost_indicator_stays_normal_style_below_warning_threshold() {
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.cost_usd = 0.042;
+            s.cost_cap_usd = Some(0.50); // 8% consumed
+        }
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        assert!(
+            !header_has_fg(&buf, Color::Red),
+            "cost indicator should not warn well below the threshold"
+        );
+    }
+
+    #[test]
+    fn header_step_indicator_warns_at_80_percent_of_step_limit() {
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.step = 8;
+            s.step_limit = 10; // 80% of step limit consumed
+        }
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        assert!(
+            header_has_fg(&buf, Color::Red),
+            "step indicator should escalate to warning style at >=80% of step_limit"
+        );
+    }
+
+    #[test]
+    fn header_falls_back_to_raw_cost_when_no_cap_configured() {
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.cost_usd = 0.042;
+            s.cost_cap_usd = None;
+        }
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("cost $0.0420"),
+            "should fall back to the raw cost form; got:\n{text}"
+        );
+        assert!(
+            !text.contains("/ $0"),
+            "must not render a cap/percent artifact with no cap configured; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn header_shows_elapsed_wall_clock_since_run_started() {
+        let d = make_dashboard();
+        {
+            let mut s = d.state.lock().unwrap();
+            s.started_at_instant = Some(ago(134));
+        }
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("elapsed 2m14s"),
+            "header should show live elapsed wall-clock; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn header_omits_elapsed_before_run_started() {
+        let d = make_dashboard();
+        // Default state: no RunStarted event has landed yet.
+        let buf = render_to_buffer(&snap(&d), 80, 12);
+        let text = buffer_text(&buf);
+        assert!(
+            !text.contains("elapsed"),
+            "elapsed should not render before the run has started; got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn emit_run_started_captures_started_at_instant() {
+        let d = make_dashboard();
+        d.emit(StreamEvent::RunStarted {
+            task: "t".into(),
+            model: "m".into(),
+            started_at: "2026-05-18T12:00:00Z".into(),
+        });
+        let s = snap(&d);
+        assert!(
+            s.elapsed.is_some(),
+            "RunStarted should populate the elapsed anchor"
+        );
     }
 
     #[test]

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -4195,10 +4195,11 @@ mod tests {
 
     // ---- budget burn-down and elapsed clock (issue #640) ----
 
-    /// True if any cell in the top 3 rows (the header) carries `color` as
-    /// its foreground — mirrors `footer_has_fg` below for header assertions.
+    /// True if any cell in the top 4 rows (the header, now 2 content rows
+    /// plus borders — issue #640 review) carries `color` as its foreground —
+    /// mirrors `footer_has_fg` below for header assertions.
     fn header_has_fg(buf: &Buffer, color: Color) -> bool {
-        for y in 0..buf.area.height.min(3) {
+        for y in 0..buf.area.height.min(4) {
             for x in 0..buf.area.width {
                 if buf[(x, y)].style().fg == Some(color) {
                     return true;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -18,7 +18,9 @@ pub mod parse;
 
 pub use confirm::{ConfirmCallback, ConfirmContext, ConfirmDecision, ScriptedConfirmer};
 pub use confirm_cli::StderrCliConfirmer;
-pub use confirm_tui::{RatatuiDashboard, RatatuiDashboardHandle, bell_enabled};
+pub use confirm_tui::{
+    RatatuiDashboard, RatatuiDashboardHandle, bell_enabled, effective_cost_cap_usd,
+};
 
 pub use default::DefaultAgent;
 pub use interactive::InteractiveAgent;

--- a/src/run/budget_fit.rs
+++ b/src/run/budget_fit.rs
@@ -819,10 +819,16 @@ fn check_retry_cap_overrides(sweep_dir: &Path) -> Result<(), Error> {
         .unwrap_or(cli_default_step_limit);
     let orig_timeout: Option<f64> =
         argv_f64("--task-timeout-secs").or_else(|| toml_f64("task_timeout_secs"));
-    // per_task_budget_usd and cost_limit_usd are mutually exclusive per-instance cost
-    // caps (mixed use is already rejected earlier in compute_budget_fit).  Track both
-    // here so that a retry that omits the cost cap is caught regardless of which key
-    // the original manifest used.
+    // per_task_budget_usd and cost_limit_usd are NOT mutually exclusive at the
+    // config level — the agent enforces both independently, and whichever is
+    // numerically tighter fires first (see `effective_cost_cap_usd` in
+    // agent/confirm_tui.rs for the general "resolve to one effective cap"
+    // logic used elsewhere). `compute_budget_fit` above rejects setting both
+    // only when the cost_usd axis is actually being analyzed (an ambiguous
+    // single-cap percentile isn't meaningful when two different caps could
+    // have fired); `--axis steps`/`--axis wall_clock_s` runs can still have
+    // both set. Track both here so that a retry that omits the cost cap is
+    // caught regardless of which key the original manifest used.
     let orig_budget: Option<f64> =
         argv_f64("--per-task-budget-usd").or_else(|| toml_f64("per_task_budget_usd"));
     let orig_cost_limit: Option<f64> = toml_f64("cost_limit_usd");

--- a/src/run/claude_driver.rs
+++ b/src/run/claude_driver.rs
@@ -448,13 +448,10 @@ pub async fn drive(
     // Honor the operator's configured spend cap by forwarding it to Claude
     // Code's own `--max-budget-usd`; an over-budget result is also downgraded
     // post-hoc in `finalize` so spend controls hold even if the cap is fuzzy.
-    let cost_cap = [
+    let cost_cap = crate::agent::effective_cost_cap_usd(
         agent.config.root.agent.cost_limit_usd,
         agent.config.root.agent.per_task_budget_usd,
-    ]
-    .into_iter()
-    .flatten()
-    .min_by(f64::total_cmp);
+    );
 
     // Cancellation token (sweep Ctrl-C) shared by the agent; cloned so we can
     // race it against the child without holding a borrow on `agent`.

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -981,8 +981,13 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         args.config.root.agent.cost_limit_usd,
         args.config.root.agent.per_task_budget_usd,
     );
-    let (confirm_callback, dashboard) =
-        build_interactive_pieces(args.interactive_mode, cancel_tx, args.no_bell, cost_cap_usd)?;
+    let (confirm_callback, dashboard) = build_interactive_pieces(
+        args.interactive_mode,
+        cancel_tx,
+        args.no_bell,
+        cost_cap_usd,
+        args.config.root.agent.step_limit,
+    )?;
 
     // Redact the webhook sink so secrets are stripped before each POST.
     let webhook_sink_redacted: Option<Arc<dyn StreamSink>> = webhook_sink_opt.map(|ws| {
@@ -1466,6 +1471,7 @@ fn build_interactive_pieces(
     cancel_tx: Option<tokio::sync::watch::Sender<bool>>,
     no_bell: bool,
     cost_cap_usd: Option<f64>,
+    step_limit: u32,
 ) -> Result<InteractivePieces, Error> {
     match mode {
         InteractiveMode::Off | InteractiveMode::YoloStatusOnly => Ok((None, None)),
@@ -1495,11 +1501,14 @@ fn build_interactive_pieces(
                 std::env::var_os("NO_BELL"),
                 std::io::IsTerminal::is_terminal(&std::io::stdout()),
             );
-            let handle =
-                crate::agent::RatatuiDashboard::start(false, cancel_tx, bell_on, cost_cap_usd)
-                    .map_err(|e| {
-                        Error::Trajectory(format!("failed to start ratatui dashboard: {e}"))
-                    })?;
+            let handle = crate::agent::RatatuiDashboard::start(
+                false,
+                cancel_tx,
+                bell_on,
+                cost_cap_usd,
+                step_limit,
+            )
+            .map_err(|e| Error::Trajectory(format!("failed to start ratatui dashboard: {e}")))?;
             let cb = handle.confirm_callback();
             Ok((Some(cb), Some(handle)))
         }
@@ -1517,11 +1526,15 @@ fn build_interactive_pieces(
             // attention bells are out of scope here (issue #648); always muted.
             // The budget burn-down (issue #640) likewise targets the
             // interactive header only — the monitor gets no cap here, though
-            // the same header helper can be reused for it later.
-            let handle = crate::agent::RatatuiDashboard::start(true, cancel_tx, false, None)
-                .map_err(|e| {
-                    Error::Trajectory(format!("failed to start ratatui dashboard: {e}"))
-                })?;
+            // the same header helper can be reused for it later. The step
+            // limit, unlike the cost cap, is pre-existing monitor-mode
+            // display (the "step N/M" counter) and gets the same
+            // seeded-at-construction fix as the interactive path.
+            let handle =
+                crate::agent::RatatuiDashboard::start(true, cancel_tx, false, None, step_limit)
+                    .map_err(|e| {
+                        Error::Trajectory(format!("failed to start ratatui dashboard: {e}"))
+                    })?;
             Ok((None, Some(handle)))
         }
     }
@@ -2234,7 +2247,8 @@ mod tests {
 
     #[test]
     fn build_interactive_pieces_off_yields_no_callback() {
-        let (cb, dash) = build_interactive_pieces(InteractiveMode::Off, None, false, None).unwrap();
+        let (cb, dash) =
+            build_interactive_pieces(InteractiveMode::Off, None, false, None, 5).unwrap();
         assert!(cb.is_none());
         assert!(dash.is_none());
     }
@@ -2242,7 +2256,8 @@ mod tests {
     #[test]
     fn build_interactive_pieces_yolo_status_only_yields_no_callback() {
         let (cb, dash) =
-            build_interactive_pieces(InteractiveMode::YoloStatusOnly, None, false, None).unwrap();
+            build_interactive_pieces(InteractiveMode::YoloStatusOnly, None, false, None, 5)
+                .unwrap();
         assert!(cb.is_none());
         assert!(dash.is_none());
     }

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -974,8 +974,15 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
     } else {
         None
     };
+    // Effective cap for the dashboard's budget burn-down (issue #640): the
+    // tighter of the two independently-enforced cost caps, since that's the
+    // one that actually governs when the run terminates.
+    let cost_cap_usd = crate::agent::effective_cost_cap_usd(
+        args.config.root.agent.cost_limit_usd,
+        args.config.root.agent.per_task_budget_usd,
+    );
     let (confirm_callback, dashboard) =
-        build_interactive_pieces(args.interactive_mode, cancel_tx, args.no_bell)?;
+        build_interactive_pieces(args.interactive_mode, cancel_tx, args.no_bell, cost_cap_usd)?;
 
     // Redact the webhook sink so secrets are stripped before each POST.
     let webhook_sink_redacted: Option<Arc<dyn StreamSink>> = webhook_sink_opt.map(|ws| {
@@ -1458,6 +1465,7 @@ fn build_interactive_pieces(
     mode: InteractiveMode,
     cancel_tx: Option<tokio::sync::watch::Sender<bool>>,
     no_bell: bool,
+    cost_cap_usd: Option<f64>,
 ) -> Result<InteractivePieces, Error> {
     match mode {
         InteractiveMode::Off | InteractiveMode::YoloStatusOnly => Ok((None, None)),
@@ -1488,9 +1496,10 @@ fn build_interactive_pieces(
                 std::io::IsTerminal::is_terminal(&std::io::stdout()),
             );
             let handle =
-                crate::agent::RatatuiDashboard::start(false, cancel_tx, bell_on).map_err(|e| {
-                    Error::Trajectory(format!("failed to start ratatui dashboard: {e}"))
-                })?;
+                crate::agent::RatatuiDashboard::start(false, cancel_tx, bell_on, cost_cap_usd)
+                    .map_err(|e| {
+                        Error::Trajectory(format!("failed to start ratatui dashboard: {e}"))
+                    })?;
             let cb = handle.confirm_callback();
             Ok((Some(cb), Some(handle)))
         }
@@ -1506,8 +1515,11 @@ fn build_interactive_pieces(
             }
             // The read-only --yolo monitor never blocks on a confirm modal, so
             // attention bells are out of scope here (issue #648); always muted.
-            let handle =
-                crate::agent::RatatuiDashboard::start(true, cancel_tx, false).map_err(|e| {
+            // The budget burn-down (issue #640) likewise targets the
+            // interactive header only — the monitor gets no cap here, though
+            // the same header helper can be reused for it later.
+            let handle = crate::agent::RatatuiDashboard::start(true, cancel_tx, false, None)
+                .map_err(|e| {
                     Error::Trajectory(format!("failed to start ratatui dashboard: {e}"))
                 })?;
             Ok((None, Some(handle)))
@@ -2222,7 +2234,7 @@ mod tests {
 
     #[test]
     fn build_interactive_pieces_off_yields_no_callback() {
-        let (cb, dash) = build_interactive_pieces(InteractiveMode::Off, None, false).unwrap();
+        let (cb, dash) = build_interactive_pieces(InteractiveMode::Off, None, false, None).unwrap();
         assert!(cb.is_none());
         assert!(dash.is_none());
     }
@@ -2230,7 +2242,7 @@ mod tests {
     #[test]
     fn build_interactive_pieces_yolo_status_only_yields_no_callback() {
         let (cb, dash) =
-            build_interactive_pieces(InteractiveMode::YoloStatusOnly, None, false).unwrap();
+            build_interactive_pieces(InteractiveMode::YoloStatusOnly, None, false, None).unwrap();
         assert!(cb.is_none());
         assert!(dash.is_none());
     }

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -981,12 +981,20 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         args.config.root.agent.cost_limit_usd,
         args.config.root.agent.per_task_budget_usd,
     );
+    // On `mini --resume`/`--continue`, `DefaultAgent::build` emits
+    // `RunStarted` before folding `ResumeState.total_cost_usd` into its own
+    // running total, so no stream event ever carries the prior spend to the
+    // dashboard (PR #992 review) — every `AssistantMessage` afterward would
+    // accumulate on top of $0.00 instead of the resumed total. Seed it here,
+    // from the same `resume_state` `DefaultAgentBuilder` is about to consume.
+    let initial_cost_usd = resume_state.as_ref().map_or(0.0, |r| r.total_cost_usd);
     let (confirm_callback, dashboard) = build_interactive_pieces(
         args.interactive_mode,
         cancel_tx,
         args.no_bell,
         cost_cap_usd,
         args.config.root.agent.step_limit,
+        initial_cost_usd,
     )?;
 
     // Redact the webhook sink so secrets are stripped before each POST.
@@ -1472,6 +1480,7 @@ fn build_interactive_pieces(
     no_bell: bool,
     cost_cap_usd: Option<f64>,
     step_limit: u32,
+    initial_cost_usd: f64,
 ) -> Result<InteractivePieces, Error> {
     match mode {
         InteractiveMode::Off | InteractiveMode::YoloStatusOnly => Ok((None, None)),
@@ -1507,6 +1516,7 @@ fn build_interactive_pieces(
                 bell_on,
                 cost_cap_usd,
                 step_limit,
+                initial_cost_usd,
             )
             .map_err(|e| Error::Trajectory(format!("failed to start ratatui dashboard: {e}")))?;
             let cb = handle.confirm_callback();
@@ -1527,14 +1537,19 @@ fn build_interactive_pieces(
             // The budget burn-down (issue #640) likewise targets the
             // interactive header only — the monitor gets no cap here, though
             // the same header helper can be reused for it later. The step
-            // limit, unlike the cost cap, is pre-existing monitor-mode
-            // display (the "step N/M" counter) and gets the same
-            // seeded-at-construction fix as the interactive path.
-            let handle =
-                crate::agent::RatatuiDashboard::start(true, cancel_tx, false, None, step_limit)
-                    .map_err(|e| {
-                        Error::Trajectory(format!("failed to start ratatui dashboard: {e}"))
-                    })?;
+            // limit and initial (resumed) cost, unlike the cost cap, are
+            // pre-existing monitor-mode display (the "step N/M"/"cost $X"
+            // counters) and get the same seeded-at-construction fix as the
+            // interactive path.
+            let handle = crate::agent::RatatuiDashboard::start(
+                true,
+                cancel_tx,
+                false,
+                None,
+                step_limit,
+                initial_cost_usd,
+            )
+            .map_err(|e| Error::Trajectory(format!("failed to start ratatui dashboard: {e}")))?;
             Ok((None, Some(handle)))
         }
     }
@@ -2248,7 +2263,7 @@ mod tests {
     #[test]
     fn build_interactive_pieces_off_yields_no_callback() {
         let (cb, dash) =
-            build_interactive_pieces(InteractiveMode::Off, None, false, None, 5).unwrap();
+            build_interactive_pieces(InteractiveMode::Off, None, false, None, 5, 0.0).unwrap();
         assert!(cb.is_none());
         assert!(dash.is_none());
     }
@@ -2256,7 +2271,7 @@ mod tests {
     #[test]
     fn build_interactive_pieces_yolo_status_only_yields_no_callback() {
         let (cb, dash) =
-            build_interactive_pieces(InteractiveMode::YoloStatusOnly, None, false, None, 5)
+            build_interactive_pieces(InteractiveMode::YoloStatusOnly, None, false, None, 5, 0.0)
                 .unwrap();
         assert!(cb.is_none());
         assert!(dash.is_none());


### PR DESCRIPTION
## Summary
Enhances the interactive dashboard header to display real-time budget consumption and elapsed wall-clock time, providing operators with better visibility into cost and step limits during runs.

## Key Changes

- **New `effective_cost_cap_usd()` function**: Resolves the effective per-task cost ceiling by taking the minimum of `cost_limit_usd` and `per_task_budget_usd`, since both are independently enforced and whichever is tighter fires first. Returns `None` when neither cap is configured.

- **Dashboard header layout expansion**: Increased header height from 3 to 4 lines to accommodate:
  - Line 1: step counter, cost burn-down (when capped), and elapsed time
  - Line 2: model and task information
  - This prevents the model name and task title from being clipped off-screen on normal-width terminals

- **Cost burn-down display**: When a cost cap is configured, shows `cost $X.XXXX / $CAP.XX (YY%)` format with:
  - Graceful handling of edge cases (zero caps, negative caps, no spend yet)
  - Warning style (red, bold) when consumption reaches ≥80% of cap
  - Fallback to plain `cost $X.XXXX` when no cap is configured

- **Step limit warning**: Step counter now escalates to warning style when ≥80% of `step_limit` is consumed

- **Live elapsed clock**: Displays wall-clock elapsed time since `RunStarted` event in compact format (`45s`, `2m14s`, `1h02m03s`), using monotonic `Instant` to avoid clock-skew issues

- **Dashboard state changes**:
  - Replaced `started_at: Option<String>` with `started_at_instant: Option<Instant>` for monotonic elapsed time calculation
  - Added `cost_cap_usd: Option<f64>` field seeded at dashboard construction
  - Updated `RatatuiDashboard::start()` signature to accept `cost_cap_usd` and `step_limit` parameters

- **Integration points**:
  - `src/run/mini.rs`: Computes effective cost cap and passes it to dashboard initialization
  - `src/run/claude_driver.rs`: Uses `effective_cost_cap_usd()` to determine Claude API budget cap
  - `src/run/budget_fit.rs`: Updated comments clarifying that cost caps are not mutually exclusive at config level

## Notable Implementation Details

- The 80% warning threshold (`BUDGET_WARNING_PCT`) applies to both cost and step budgets for consistency
- Zero and negative cost caps are treated as "fully consumed" when any spend occurs, preventing division-by-zero or NaN artifacts
- Elapsed time is calculated at snapshot time from the monotonic anchor, ensuring accuracy across terminal redraws
- The monitor mode (`--yolo`) receives `step_limit` but no `cost_cap_usd`, as the budget burn-down targets interactive mode only
- Comprehensive test coverage for edge cases: zero caps, negative caps, warning thresholds, and layout preservation

https://claude.ai/code/session_01JWuBSPxac3LzVm9nyE1U69