### PR TITLE
🎨 Mosaic: UI Polish for Merge and Shard Reports

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -527,6 +527,7 @@ mod tests {
     // ── Network mode RED-phase tests ─────────────────────────────────────────
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
@@ -550,6 +551,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network").unwrap();

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -260,26 +260,63 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
 
 impl MergeReport {
     pub fn render_text(&self) {
-        println!("Shards merged: {}", self.shards.len());
+        use comfy_table::Table;
+        use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+        use comfy_table::presets::UTF8_FULL;
+
+        println!("=== bench merge ===");
+
+        let mut shard_table = Table::new();
+        shard_table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Label", "Instances", "Directory"]);
+
         for s in &self.shards {
-            println!(
-                "  {:20}  {:6} instances  {}",
-                s.label, s.instance_count, s.dir
-            );
+            shard_table.add_row(vec![
+                s.label.clone(),
+                s.instance_count.to_string(),
+                s.dir.clone(),
+            ]);
         }
-        println!();
-        println!(
-            "Total instances: {} ({} duplicates resolved via {})",
-            self.total_instances, self.duplicates, self.collision_policy
-        );
-        println!("Output: {}", self.output_dir);
-        println!();
-        println!("Top-line metrics:");
-        println!("  total_cost_usd : {:.6}", self.total_cost_usd);
-        println!("  submitted      : {}", self.submitted);
-        println!("  errored        : {}", self.errored);
-        println!("  resolved       : {}", self.resolved);
-        println!("  pass_at_k      : {:.4}", self.pass_at_k);
+        println!("{shard_table}");
+
+        let mut metrics_table = Table::new();
+        metrics_table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Metric", "Value"]);
+
+        metrics_table.add_row(vec![
+            "Shards merged".to_string(),
+            self.shards.len().to_string(),
+        ]);
+        metrics_table.add_row(vec![
+            "Total instances".to_string(),
+            self.total_instances.to_string(),
+        ]);
+        metrics_table.add_row(vec!["Duplicates".to_string(), self.duplicates.to_string()]);
+        metrics_table.add_row(vec![
+            "Collision policy".to_string(),
+            self.collision_policy.clone(),
+        ]);
+        metrics_table.add_row(vec![
+            "Output directory".to_string(),
+            self.output_dir.clone(),
+        ]);
+        metrics_table.add_row(vec![
+            "Total cost USD".to_string(),
+            format!("{:.6}", self.total_cost_usd),
+        ]);
+        metrics_table.add_row(vec!["Submitted".to_string(), self.submitted.to_string()]);
+        metrics_table.add_row(vec!["Errored".to_string(), self.errored.to_string()]);
+        metrics_table.add_row(vec!["Resolved".to_string(), self.resolved.to_string()]);
+        metrics_table.add_row(vec![
+            "Pass at k".to_string(),
+            format!("{:.4}", self.pass_at_k),
+        ]);
+
+        println!("{metrics_table}");
     }
 }
 

--- a/src/run/shard.rs
+++ b/src/run/shard.rs
@@ -75,14 +75,45 @@ pub struct ShardReport {
 
 impl ShardReport {
     pub fn render_text(&self) {
-        println!("bench shard");
-        println!("  shards          {}", self.shard_count);
-        println!("  total instances {}", self.total_instances);
-        println!("  balance spread  {}", self.balance_spread);
+        use comfy_table::Table;
+        use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+        use comfy_table::presets::UTF8_FULL;
+
+        println!("=== bench shard ===");
+
+        let mut summary_table = Table::new();
+        summary_table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Property", "Value"]);
+
+        summary_table.add_row(vec!["Shards".to_string(), self.shard_count.to_string()]);
+        summary_table.add_row(vec![
+            "Total instances".to_string(),
+            self.total_instances.to_string(),
+        ]);
+        summary_table.add_row(vec![
+            "Balance spread".to_string(),
+            self.balance_spread.to_string(),
+        ]);
+        summary_table.add_row(vec![
+            "Dataset SHA256".to_string(),
+            self.source_dataset_sha256.clone(),
+        ]);
+
+        println!("{summary_table}");
+
+        let mut counts_table = Table::new();
+        counts_table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Shard Index", "Instance Count"]);
+
         for (i, count) in self.per_shard_counts.iter().enumerate() {
-            println!("  shard-{i:03}        {count} instances");
+            counts_table.add_row(vec![format!("shard-{i:03}"), count.to_string()]);
         }
-        println!("  dataset sha256  {}", self.source_dataset_sha256);
+
+        println!("{counts_table}");
     }
 }
 


### PR DESCRIPTION
🖌️ **Before:** The `bench merge` and `bench shard` CLI commands generated raw, unaligned textual logs with simple `println!` calls. It felt like reading unstructured debug output rather than a clear summary of dataset operations.

✨ **After:** Both reports now utilize `comfy_table` with `UTF8_FULL` presets and rounded corners. Information is cleanly separated into distinct, aligned tables (e.g., Shard details, Metric summaries) using a Z-pattern visual flow, acting much more like an operator dashboard.

🖼️ **Visuals:** The `bench merge` command now outputs a table of merged shards followed by a metrics summary table. The `bench shard` command outputs a global properties summary table followed by a detailed per-shard allocation table.

---
*PR created automatically by Jules for task [3418591139834448324](https://jules.google.com/task/3418591139834448324) started by @madmax983*