### PR TITLE
Add interactive ratatui dashboard for live sweep monitoring

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -3498,6 +3498,17 @@ pub struct InspectCmd {
     pub flake_report: Option<PathBuf>,
 }
 
+/// `bench tail --ui` selector (issue #641).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum TailUiKind {
+    /// Default: print periodic snapshots to stdout (see `--format`).
+    Text,
+    /// Full-screen interactive dashboard: aggregate progress, a navigable
+    /// instance list, and a per-instance drill-down. Mutually exclusive with
+    /// `--once` and `--format json`; requires a TTY on stdin and stdout.
+    Ratatui,
+}
+
 #[derive(Debug, Args)]
 pub struct TailCmd {
     /// Sweep output directory produced by `bench swebench`.
@@ -3515,6 +3526,11 @@ pub struct TailCmd {
     /// Output format: `text` (default) or `json`.
     #[arg(long, default_value = "text")]
     pub format: String,
+
+    /// UI: `text` (default, periodic snapshots) or `ratatui` (full-screen
+    /// interactive dashboard, issue #641).
+    #[arg(long, value_enum, default_value_t = TailUiKind::Text)]
+    pub ui: TailUiKind,
 }
 
 /// `bench watch` — attach to a single in-flight instance and stream turns live.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2651,6 +2651,33 @@ fn reject_json_with_ratatui(
     Ok(())
 }
 
+/// Reject `bench tail --ui ratatui` combined with flags it can't coexist
+/// with (issue #641).
+///
+/// `--once` is a contradiction: the dashboard is inherently long-running and
+/// interactive. `--format json` is a contradiction for the same reason
+/// `reject_json_with_ratatui` rejects it for `mini` — the dashboard owns the
+/// alternate screen and stdout, which would corrupt a JSON snapshot stream.
+fn reject_incompatible_tail_ratatui_ui(once: bool, format: TailFormat) -> Result<(), Error> {
+    if once {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(
+            "bench tail --ui ratatui cannot be combined with --once; the dashboard is \
+             inherently interactive and long-running. Omit --ui ratatui for a one-shot \
+             snapshot."
+                .into(),
+        )));
+    }
+    if format == TailFormat::Json {
+        return Err(Error::Config(crate::error::ConfigError::Invalid(
+            "bench tail --ui ratatui cannot be combined with --format json; the dashboard \
+             renders to the alternate screen and would corrupt a JSON snapshot stream. Use \
+             the default --format text, or omit --ui ratatui for JSON output."
+                .into(),
+        )));
+    }
+    Ok(())
+}
+
 /// Lightweight view over a trajectory file that deserializes only the `info`
 /// block. A trajectory carries the full message history and tool outputs
 /// (potentially megabytes) that `emit_mini_result` never reads.
@@ -6067,6 +6094,29 @@ async fn bench_tail(t: args::TailCmd) -> Result<(), Error> {
             ))));
         }
     };
+
+    if t.ui == args::TailUiKind::Ratatui {
+        reject_incompatible_tail_ratatui_ui(t.once, format)?;
+        if !std::io::IsTerminal::is_terminal(&std::io::stdin())
+            || !std::io::IsTerminal::is_terminal(&std::io::stdout())
+        {
+            return Err(Error::Config(crate::error::ConfigError::Invalid(
+                "bench tail --ui ratatui requires a TTY on stdin and stdout; omit --ui ratatui \
+                 (or use --format json) for unattended sweeps"
+                    .into(),
+            )));
+        }
+        let dashboard_args = crate::run::sweep_dashboard::DashboardArgs {
+            sweep: t.sweep,
+            interval_ms: t.interval_ms,
+        };
+        return tokio::task::spawn_blocking(move || {
+            crate::run::sweep_dashboard::run(&dashboard_args)
+        })
+        .await
+        .map_err(|e| Error::Trajectory(format!("sweep dashboard task panicked: {e}")))?;
+    }
+
     let mut stdout = std::io::stdout();
     let clear_tty = format == TailFormat::Text && !t.once && stdout.is_terminal();
     loop {

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -81,6 +81,7 @@ pub mod subset;
 pub mod suite;
 pub mod suite_check;
 pub mod swebench;
+pub mod sweep_dashboard;
 pub mod tail;
 pub mod test_progress;
 pub mod tool_ablation;

--- a/src/run/sweep_dashboard.rs
+++ b/src/run/sweep_dashboard.rs
@@ -855,6 +855,22 @@ mod tests {
     }
 
     #[test]
+    fn draw_shows_failure_counts_and_cost_vs_baseline() {
+        let mut state = state_with_rows(vec![]);
+        let mut snap = test_snapshot();
+        snap.failure_counts
+            .insert(crate::trajectory::FailureCategory::EnvSetup, 2);
+        snap.cumulative_cost_usd = 3.5;
+        snap.baseline_cumulative_cost_usd = 9.75;
+        state.snapshot = Some(snap);
+        let buf = render_to_buffer(&state, 120, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("EnvSetup=2"), "{text}");
+        assert!(text.contains("3.5000"), "{text}");
+        assert!(text.contains("9.7500"), "{text}");
+    }
+
+    #[test]
     fn draw_shows_complete_banner_when_snapshot_is_complete() {
         let mut state = state_with_rows(vec![]);
         let mut snap = test_snapshot();
@@ -879,6 +895,25 @@ mod tests {
         assert!(text.contains("bravo-instance"), "{text}");
         assert!(text.contains("in-flight"), "{text}");
         assert!(text.contains("terminal"), "{text}");
+    }
+
+    #[test]
+    fn draw_lists_run_slot_step_and_outcome_columns() {
+        let mut state = state_with_rows(vec![InstanceRow {
+            instance_id: "charlie".into(),
+            run_index: 2,
+            status: InstanceStatus::Terminal,
+            current_step: Some(7),
+            outcome: Some("submitted".into()),
+            failure_category: None,
+        }]);
+        state.snapshot = Some(test_snapshot());
+        let buf = render_to_buffer(&state, 120, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("charlie"), "{text}");
+        assert!(text.contains("run 2"), "{text}");
+        assert!(text.contains("step 7"), "{text}");
+        assert!(text.contains("submitted"), "{text}");
     }
 
     #[test]

--- a/src/run/sweep_dashboard.rs
+++ b/src/run/sweep_dashboard.rs
@@ -1,0 +1,936 @@
+//! Interactive ratatui dashboard for live sweep monitoring (issue #641).
+//!
+//! `bench tail --sweep <dir> --ui ratatui` renders a full-screen dashboard
+//! derived **only** from the same read-only snapshot layer as `bench tail`'s
+//! default text/JSON output: [`crate::run::tail::snapshot`] for aggregate
+//! progress and [`crate::run::tail::instance_rows`] for the per-instance
+//! list. It opens no sockets and writes no files. Selecting an instance
+//! drills into a live-follow pane that reuses `bench watch`'s trajectory
+//! polling (`crate::run::watch::resolve_watch_path`) and step rendering
+//! (`crate::run::inspect::build_inspect_steps_with_max`).
+//!
+//! The module is split so the state machine and rendering are pure,
+//! deterministic functions ([`handle_key`], [`draw`]) testable with
+//! ratatui's `TestBackend` — no real terminal required — while [`run`] is
+//! the thin IO shell that owns the terminal and the poll loop.
+
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap};
+
+use crate::error::Error;
+use crate::redaction::Redactor;
+use crate::run::inspect::{build_inspect_steps_with_max, redact_trajectory_for_inspect};
+use crate::run::tail::{InstanceRow, InstanceStatus, SnapshotOptions, TailSnapshot};
+use crate::run::watch::{is_terminal_outcome, resolve_watch_path};
+use crate::trajectory::Trajectory;
+
+/// Cap on retained drill-down lines, mirroring `confirm_tui`'s log cap so a
+/// long-running instance can't grow the dashboard's memory unbounded.
+const MAX_DETAIL_LINES: usize = 400;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Mode {
+    List,
+    Detail,
+}
+
+/// Live state of the selected instance's drill-down pane.
+pub(crate) struct DetailState {
+    pub(crate) instance_id: String,
+    pub(crate) run_index: u32,
+    pub(crate) lines: VecDeque<String>,
+    pub(crate) scroll_top: usize,
+    emitted_steps: usize,
+    cached_path: Option<PathBuf>,
+    last_file_len: u64,
+    /// True once the followed trajectory reports a terminal outcome.
+    pub(crate) terminal: bool,
+    /// True while no trajectory file has been found yet for the selection.
+    pub(crate) not_found: bool,
+}
+
+impl DetailState {
+    fn new(instance_id: String, run_index: u32) -> Self {
+        Self {
+            instance_id,
+            run_index,
+            lines: VecDeque::new(),
+            scroll_top: 0,
+            emitted_steps: 0,
+            cached_path: None,
+            last_file_len: 0,
+            terminal: false,
+            not_found: true,
+        }
+    }
+}
+
+/// Full dashboard state. Pure data — no IO — so [`handle_key`] and [`draw`]
+/// are unit-testable without a terminal.
+pub(crate) struct DashboardState {
+    pub(crate) sweep_dir: PathBuf,
+    pub(crate) snapshot: Option<TailSnapshot>,
+    pub(crate) rows: Vec<InstanceRow>,
+    pub(crate) selected: usize,
+    pub(crate) mode: Mode,
+    pub(crate) help_open: bool,
+    pub(crate) detail: Option<DetailState>,
+    pub(crate) should_quit: bool,
+}
+
+impl DashboardState {
+    pub(crate) fn new(sweep_dir: PathBuf) -> Self {
+        Self {
+            sweep_dir,
+            snapshot: None,
+            rows: Vec::new(),
+            selected: 0,
+            mode: Mode::List,
+            help_open: false,
+            detail: None,
+            should_quit: false,
+        }
+    }
+
+    /// Replace the aggregate snapshot and instance rows with a freshly
+    /// polled read, clamping the selection into the new row count so a
+    /// shrinking/growing list never leaves `selected` out of bounds.
+    pub(crate) fn apply_refresh(&mut self, snapshot: TailSnapshot, rows: Vec<InstanceRow>) {
+        self.snapshot = Some(snapshot);
+        self.rows = rows;
+        if self.rows.is_empty() {
+            self.selected = 0;
+        } else if self.selected >= self.rows.len() {
+            self.selected = self.rows.len() - 1;
+        }
+    }
+}
+
+/// Dispatch one key event. Ctrl-C always quits; the `?` help overlay takes
+/// priority over both view modes and swallows all other keys while open, so
+/// closing it never mutates list/detail state underneath.
+pub(crate) fn handle_key(state: &mut DashboardState, key: KeyEvent) {
+    if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        state.should_quit = true;
+        return;
+    }
+    if state.help_open {
+        if matches!(key.code, KeyCode::Char('?' | 'q') | KeyCode::Esc) {
+            state.help_open = false;
+        }
+        return;
+    }
+    match state.mode {
+        Mode::List => handle_list_key(state, key),
+        Mode::Detail => handle_detail_key(state, key),
+    }
+}
+
+fn handle_list_key(state: &mut DashboardState, key: KeyEvent) {
+    match key.code {
+        KeyCode::Char('q') => state.should_quit = true,
+        KeyCode::Char('?') => state.help_open = true,
+        KeyCode::Up | KeyCode::Char('k') => move_selection_up(state),
+        KeyCode::Down | KeyCode::Char('j') => move_selection_down(state),
+        KeyCode::Enter => open_detail(state),
+        _ => {}
+    }
+}
+
+fn handle_detail_key(state: &mut DashboardState, key: KeyEvent) {
+    match key.code {
+        KeyCode::Char('q') => state.should_quit = true,
+        KeyCode::Char('?') => state.help_open = true,
+        KeyCode::Esc => {
+            state.mode = Mode::List;
+            state.detail = None;
+        }
+        KeyCode::Up | KeyCode::Char('k') => scroll_detail_up(state),
+        KeyCode::Down | KeyCode::Char('j') => scroll_detail_down(state),
+        _ => {}
+    }
+}
+
+/// Move the list selection up one row, clamped at the first row. Scroll
+/// position is not tracked here — [`list_scroll_top`] derives it from
+/// `selected` at draw time instead.
+fn move_selection_up(state: &mut DashboardState) {
+    state.selected = state.selected.saturating_sub(1);
+}
+
+/// Move the list selection down one row, clamped at the last row.
+fn move_selection_down(state: &mut DashboardState) {
+    if state.rows.is_empty() {
+        return;
+    }
+    let max = state.rows.len() - 1;
+    state.selected = (state.selected + 1).min(max);
+}
+
+fn scroll_detail_up(state: &mut DashboardState) {
+    let Some(detail) = state.detail.as_mut() else {
+        return;
+    };
+    detail.scroll_top = detail.scroll_top.saturating_sub(1);
+}
+
+fn scroll_detail_down(state: &mut DashboardState) {
+    let Some(detail) = state.detail.as_mut() else {
+        return;
+    };
+    let max = detail.lines.len().saturating_sub(1);
+    detail.scroll_top = (detail.scroll_top + 1).min(max);
+}
+
+fn open_detail(state: &mut DashboardState) {
+    let Some(row) = state.rows.get(state.selected) else {
+        return;
+    };
+    state.detail = Some(DetailState::new(row.instance_id.clone(), row.run_index));
+    state.mode = Mode::Detail;
+}
+
+/// Derive the list's scroll offset from the current selection and viewport
+/// height so the selected row is always on screen. Pure so it's directly
+/// unit-testable without rendering.
+pub(crate) fn list_scroll_top(selected: usize, len: usize, viewport: usize) -> usize {
+    if viewport == 0 || len <= viewport {
+        return 0;
+    }
+    let max_top = len - viewport;
+    selected
+        .saturating_sub(viewport.saturating_sub(1))
+        .min(max_top)
+}
+
+/// Poll the selected instance's trajectory file for new turns, mirroring
+/// `bench watch`'s follow loop (`crate::run::watch::run`) but appending
+/// plain-text lines to `detail.lines` instead of writing to stdout.
+fn refresh_detail(detail: &mut DetailState, sweep_dir: &Path, redactor: &Redactor) {
+    let path = detail
+        .cached_path
+        .clone()
+        .or_else(|| resolve_watch_path(sweep_dir, &detail.instance_id, detail.run_index));
+    let Some(path) = path else {
+        detail.not_found = true;
+        return;
+    };
+    detail.cached_path = Some(path.clone());
+    detail.not_found = false;
+
+    let Ok(metadata) = std::fs::metadata(&path) else {
+        return;
+    };
+    let len = metadata.len();
+    if len == detail.last_file_len && detail.emitted_steps > 0 {
+        return;
+    }
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    let Ok(mut traj) = serde_json::from_str::<Trajectory>(&text) else {
+        return;
+    };
+    detail.last_file_len = len;
+    redact_trajectory_for_inspect(&mut traj, redactor);
+    let steps = build_inspect_steps_with_max(&traj, false, 4096);
+    if steps.len() < detail.emitted_steps {
+        detail.emitted_steps = 0;
+    }
+    for step in &steps[detail.emitted_steps..] {
+        let mut summary = format!("step {} {}", step.index, step.role);
+        if let Some(msg) = &step.message {
+            let _ = write_first_line(&mut summary, msg);
+        }
+        if let Some(bash) = &step.bash {
+            let _ = write_first_line(&mut summary, bash);
+        }
+        if let Some(code) = step.exit_code {
+            use std::fmt::Write as _;
+            let _ = write!(summary, " (exit {code})");
+        }
+        push_capped(&mut detail.lines, summary);
+        if let Some(stdout) = &step.stdout {
+            for line in stdout.lines().take(20) {
+                push_capped(&mut detail.lines, format!("  {line}"));
+            }
+        }
+        if let Some(stderr) = &step.stderr {
+            for line in stderr.lines().take(20) {
+                push_capped(&mut detail.lines, format!("  ! {line}"));
+            }
+        }
+    }
+    detail.emitted_steps = steps.len();
+    detail.terminal = is_terminal_outcome(&traj);
+}
+
+fn write_first_line(out: &mut String, text: &str) -> std::fmt::Result {
+    use std::fmt::Write as _;
+    if let Some(first) = text.lines().next() {
+        write!(out, ": {first}")?;
+    }
+    Ok(())
+}
+
+fn push_capped(lines: &mut VecDeque<String>, line: String) {
+    if lines.len() >= MAX_DETAIL_LINES {
+        lines.pop_front();
+    }
+    lines.push_back(line);
+}
+
+/// Refresh the aggregate/list data and, when a drill-down is open, the
+/// followed instance's live turns. The single entry point the IO shell calls
+/// once per tick.
+pub(crate) fn refresh(state: &mut DashboardState, redactor: &Redactor) -> Result<(), Error> {
+    let options = SnapshotOptions::default();
+    let snapshot = crate::run::tail::snapshot(&state.sweep_dir, &options)?;
+    let rows = crate::run::tail::instance_rows(&state.sweep_dir)?;
+    state.apply_refresh(snapshot, rows);
+    if let Some(detail) = state.detail.as_mut() {
+        refresh_detail(detail, &state.sweep_dir, redactor);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------
+// Rendering — pure, `TestBackend`-testable.
+// ---------------------------------------------------------------------
+
+pub(crate) fn draw(frame: &mut Frame, state: &DashboardState) {
+    let area = frame.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(aggregate_panel_height(state)),
+            Constraint::Min(0),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    frame.render_widget(aggregate_paragraph(state), chunks[0]);
+
+    match state.mode {
+        Mode::List => render_list(frame, state, chunks[1]),
+        Mode::Detail => render_detail(frame, state, chunks[1]),
+    }
+
+    frame.render_widget(footer_paragraph(state), chunks[2]);
+
+    if state.help_open {
+        draw_help_overlay(frame, area);
+    }
+}
+
+fn aggregate_panel_height(state: &DashboardState) -> u16 {
+    let base = 6;
+    if state.snapshot.as_ref().is_some_and(|s| s.is_complete) {
+        base + 1
+    } else {
+        base
+    }
+}
+
+fn aggregate_paragraph(state: &DashboardState) -> Paragraph<'_> {
+    let mut lines: Vec<Line> = Vec::new();
+    let Some(snap) = state.snapshot.as_ref() else {
+        lines.push(Line::from("loading sweep snapshot…"));
+        return Paragraph::new(lines).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" bench tail — sweep dashboard "),
+        );
+    };
+
+    if snap.is_complete {
+        lines.push(Line::from(Span::styled(
+            format!(
+                "SWEEP COMPLETE — {}/{} completed, ${:.4} total cost",
+                snap.completed, snap.total, snap.cumulative_cost_usd
+            ),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        )));
+    }
+
+    lines.push(Line::from(format!(
+        "{}/{} completed   {} in flight   {} pending",
+        snap.completed, snap.total, snap.in_flight, snap.pending
+    )));
+
+    if snap.failure_counts.is_empty() {
+        lines.push(Line::from("failures: none"));
+    } else {
+        let summary = snap
+            .failure_counts
+            .iter()
+            .map(|(cat, n)| format!("{cat:?}={n}"))
+            .collect::<Vec<_>>()
+            .join("  ");
+        lines.push(Line::from(format!("failures: {summary}")));
+    }
+
+    lines.push(Line::from(format!(
+        "cost: ${:.4} actual  vs  ${:.4} baseline   burn ${:.2}/min",
+        snap.cumulative_cost_usd, snap.baseline_cumulative_cost_usd, snap.burn_rate_usd_per_min
+    )));
+
+    if let Some(reason) = &snap.abort_reason {
+        lines.push(Line::from(Span::styled(
+            format!("abort: {reason}"),
+            Style::default().fg(Color::Red),
+        )));
+    } else if let Some(cb) = &snap.circuit_breaker_status {
+        lines.push(Line::from(format!("circuit breaker: {cb}")));
+    } else {
+        lines.push(Line::from(format!("status: {}", snap.status)));
+    }
+
+    Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" bench tail — sweep dashboard "),
+        )
+        .wrap(Wrap { trim: false })
+}
+
+fn status_label(status: InstanceStatus) -> &'static str {
+    match status {
+        InstanceStatus::Pending => "pending",
+        InstanceStatus::InFlight => "in-flight",
+        InstanceStatus::Terminal => "terminal",
+    }
+}
+
+fn row_style(status: InstanceStatus) -> Style {
+    match status {
+        InstanceStatus::Pending => Style::default().fg(Color::DarkGray),
+        InstanceStatus::InFlight => Style::default().fg(Color::Yellow),
+        InstanceStatus::Terminal => Style::default().fg(Color::White),
+    }
+}
+
+fn render_list(frame: &mut Frame, state: &DashboardState, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" instances ({}) ", state.rows.len()));
+    let inner_height = block.inner(area).height as usize;
+
+    let items: Vec<ListItem> = state
+        .rows
+        .iter()
+        .map(|row| {
+            let text = format!(
+                "{:<40} run {:<3} step {:<5} {:<10} {}",
+                row.instance_id,
+                row.run_index,
+                row.current_step
+                    .map_or_else(|| "-".to_owned(), |s| s.to_string()),
+                status_label(row.status),
+                row.outcome.as_deref().unwrap_or("-"),
+            );
+            ListItem::new(Line::from(Span::styled(text, row_style(row.status))))
+        })
+        .collect();
+
+    let mut list_state = ListState::default();
+    if !state.rows.is_empty() {
+        list_state.select(Some(state.selected));
+        *list_state.offset_mut() =
+            list_scroll_top(state.selected, state.rows.len(), inner_height.max(1));
+    }
+
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+    frame.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn render_detail(frame: &mut Frame, state: &DashboardState, area: Rect) {
+    let Some(detail) = state.detail.as_ref() else {
+        return;
+    };
+    let title = format!(
+        " {} (run {}) — live trajectory ",
+        detail.instance_id, detail.run_index
+    );
+    let block = Block::default().borders(Borders::ALL).title(title);
+    let inner_height = block.inner(area).height as usize;
+
+    let mut lines: Vec<Line> = Vec::new();
+    if detail.not_found {
+        lines.push(Line::from("waiting for trajectory file…"));
+    } else {
+        for line in detail
+            .lines
+            .iter()
+            .skip(detail.scroll_top)
+            .take(inner_height)
+        {
+            lines.push(Line::from(line.as_str()));
+        }
+        if detail.terminal {
+            lines.push(Line::from(Span::styled(
+                "[instance complete]",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            )));
+        }
+    }
+
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn footer_paragraph(state: &DashboardState) -> Paragraph<'static> {
+    let text = match state.mode {
+        Mode::List => "↑/↓ or j/k navigate   Enter inspect   q/Ctrl-C quit   ? help",
+        Mode::Detail => "↑/↓ or j/k scroll   Esc back to list   q/Ctrl-C quit   ? help",
+    };
+    Paragraph::new(Line::from(Span::styled(
+        text,
+        Style::default().add_modifier(Modifier::BOLD),
+    )))
+}
+
+fn draw_help_overlay(frame: &mut Frame, area: Rect) {
+    let overlay = centered_rect(70, 60, area);
+    frame.render_widget(Clear, overlay);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" help — keybindings (? or Esc to close) ");
+    let lines = vec![
+        Line::from("↑ / k        move selection up"),
+        Line::from("↓ / j        move selection down"),
+        Line::from("Enter        drill into the selected instance's live trajectory"),
+        Line::from("Esc          return to the instance list from a drill-down"),
+        Line::from("?            toggle this help overlay"),
+        Line::from("q / Ctrl-C   quit — restores the terminal"),
+    ];
+    frame.render_widget(Paragraph::new(lines).block(block), overlay);
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}
+
+// ---------------------------------------------------------------------
+// IO shell
+// ---------------------------------------------------------------------
+
+pub struct DashboardArgs {
+    pub sweep: PathBuf,
+    pub interval_ms: u64,
+}
+
+/// Restores raw mode and leaves the alternate screen on drop, so an early
+/// return (including a poll/read error) never leaves the operator's
+/// terminal half-configured.
+struct TerminalGuard;
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let mut stdout = std::io::stdout();
+        let _ = crossterm::execute!(stdout, crossterm::terminal::LeaveAlternateScreen);
+        let _ = crossterm::terminal::disable_raw_mode();
+    }
+}
+
+/// Run the interactive sweep dashboard until the operator quits.
+///
+/// # Errors
+/// Returns `Err` if the terminal cannot be configured, or if a snapshot
+/// read fails (e.g. the sweep directory disappears mid-run).
+pub fn run(args: &DashboardArgs) -> Result<(), Error> {
+    crossterm::terminal::enable_raw_mode().map_err(Error::Io)?;
+    let mut stdout = std::io::stdout();
+    if let Err(err) = crossterm::execute!(stdout, crossterm::terminal::EnterAlternateScreen) {
+        let _ = crossterm::terminal::disable_raw_mode();
+        return Err(Error::Io(err));
+    }
+    let _guard = TerminalGuard;
+
+    let backend = ratatui::backend::CrosstermBackend::new(stdout);
+    let mut terminal = ratatui::Terminal::new(backend).map_err(Error::Io)?;
+
+    let mut state = DashboardState::new(args.sweep.clone());
+    let redactor = Redactor::default_enabled();
+    let interval = Duration::from_millis(args.interval_ms.max(1));
+    let mut last_refresh = Instant::now()
+        .checked_sub(interval)
+        .unwrap_or_else(Instant::now);
+
+    loop {
+        if last_refresh.elapsed() >= interval {
+            refresh(&mut state, &redactor)?;
+            last_refresh = Instant::now();
+        }
+
+        terminal
+            .draw(|frame| draw(frame, &state))
+            .map_err(Error::Io)?;
+
+        if state.should_quit {
+            return Ok(());
+        }
+
+        let poll_timeout = interval
+            .checked_sub(last_refresh.elapsed())
+            .unwrap_or(Duration::from_millis(50))
+            .min(Duration::from_millis(200));
+        if crossterm::event::poll(poll_timeout).map_err(Error::Io)? {
+            if let crossterm::event::Event::Key(key) =
+                crossterm::event::read().map_err(Error::Io)?
+            {
+                if key.kind == crossterm::event::KeyEventKind::Press {
+                    handle_key(&mut state, key);
+                }
+            }
+        }
+
+        if state.should_quit {
+            return Ok(());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use crossterm::event::KeyEventKind;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn ctrl_c() -> KeyEvent {
+        let mut k = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        k.kind = KeyEventKind::Press;
+        k
+    }
+
+    fn row(id: &str, status: InstanceStatus) -> InstanceRow {
+        InstanceRow {
+            instance_id: id.to_owned(),
+            run_index: 1,
+            status,
+            current_step: None,
+            outcome: None,
+            failure_category: None,
+        }
+    }
+
+    fn state_with_rows(rows: Vec<InstanceRow>) -> DashboardState {
+        let mut state = DashboardState::new(PathBuf::from("/tmp/does-not-matter"));
+        state.rows = rows;
+        state
+    }
+
+    #[test]
+    fn q_quits_from_list_mode() {
+        let mut state = state_with_rows(vec![row("a", InstanceStatus::Pending)]);
+        handle_key(&mut state, key(KeyCode::Char('q')));
+        assert!(state.should_quit);
+    }
+
+    #[test]
+    fn ctrl_c_quits_from_any_mode() {
+        let mut state = state_with_rows(vec![row("a", InstanceStatus::Pending)]);
+        state.mode = Mode::Detail;
+        handle_key(&mut state, ctrl_c());
+        assert!(state.should_quit);
+    }
+
+    #[test]
+    fn down_then_up_moves_selection_and_clamps() {
+        let mut state = state_with_rows(vec![
+            row("a", InstanceStatus::Terminal),
+            row("b", InstanceStatus::Terminal),
+        ]);
+        handle_key(&mut state, key(KeyCode::Down));
+        assert_eq!(state.selected, 1);
+        handle_key(&mut state, key(KeyCode::Down));
+        assert_eq!(state.selected, 1, "must clamp at last row");
+        handle_key(&mut state, key(KeyCode::Up));
+        assert_eq!(state.selected, 0);
+        handle_key(&mut state, key(KeyCode::Up));
+        assert_eq!(state.selected, 0, "must clamp at first row");
+    }
+
+    #[test]
+    fn navigation_on_empty_list_does_not_panic() {
+        let mut state = state_with_rows(vec![]);
+        handle_key(&mut state, key(KeyCode::Down));
+        handle_key(&mut state, key(KeyCode::Up));
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn enter_opens_detail_for_selected_row() {
+        let mut state = state_with_rows(vec![
+            row("a", InstanceStatus::Terminal),
+            row("b", InstanceStatus::InFlight),
+        ]);
+        state.selected = 1;
+        handle_key(&mut state, key(KeyCode::Enter));
+        assert_eq!(state.mode, Mode::Detail);
+        let detail = state.detail.as_ref().unwrap();
+        assert_eq!(detail.instance_id, "b");
+    }
+
+    #[test]
+    fn enter_on_empty_list_is_a_no_op() {
+        let mut state = state_with_rows(vec![]);
+        handle_key(&mut state, key(KeyCode::Enter));
+        assert_eq!(state.mode, Mode::List);
+        assert!(state.detail.is_none());
+    }
+
+    #[test]
+    fn esc_returns_to_list_from_detail() {
+        let mut state = state_with_rows(vec![row("a", InstanceStatus::Terminal)]);
+        handle_key(&mut state, key(KeyCode::Enter));
+        assert_eq!(state.mode, Mode::Detail);
+        handle_key(&mut state, key(KeyCode::Esc));
+        assert_eq!(state.mode, Mode::List);
+        assert!(state.detail.is_none());
+    }
+
+    #[test]
+    fn question_mark_opens_help_from_list_and_detail() {
+        let mut state = state_with_rows(vec![row("a", InstanceStatus::Terminal)]);
+        handle_key(&mut state, key(KeyCode::Char('?')));
+        assert!(state.help_open);
+
+        state.help_open = false;
+        state.mode = Mode::Detail;
+        handle_key(&mut state, key(KeyCode::Char('?')));
+        assert!(state.help_open);
+    }
+
+    #[test]
+    fn help_overlay_swallows_navigation_keys_underneath() {
+        let mut state = state_with_rows(vec![
+            row("a", InstanceStatus::Terminal),
+            row("b", InstanceStatus::Terminal),
+        ]);
+        state.help_open = true;
+        handle_key(&mut state, key(KeyCode::Down));
+        assert_eq!(state.selected, 0, "help overlay must swallow navigation");
+        assert!(state.help_open);
+    }
+
+    #[test]
+    fn help_overlay_closes_on_question_mark_esc_or_q() {
+        for closing_key in [KeyCode::Char('?'), KeyCode::Esc, KeyCode::Char('q')] {
+            let mut state = state_with_rows(vec![row("a", InstanceStatus::Terminal)]);
+            state.help_open = true;
+            handle_key(&mut state, key(closing_key));
+            assert!(!state.help_open, "{closing_key:?} should close help");
+            assert!(!state.should_quit, "closing help must not quit the app");
+        }
+    }
+
+    #[test]
+    fn apply_refresh_clamps_selection_when_rows_shrink() {
+        let mut state = state_with_rows(vec![
+            row("a", InstanceStatus::Terminal),
+            row("b", InstanceStatus::Terminal),
+            row("c", InstanceStatus::Terminal),
+        ]);
+        state.selected = 2;
+        state.apply_refresh(test_snapshot(), vec![row("a", InstanceStatus::Terminal)]);
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn list_scroll_top_keeps_selection_in_view() {
+        assert_eq!(list_scroll_top(0, 10, 5), 0);
+        assert_eq!(list_scroll_top(4, 10, 5), 0);
+        assert_eq!(list_scroll_top(5, 10, 5), 1);
+        assert_eq!(list_scroll_top(9, 10, 5), 5);
+        assert_eq!(
+            list_scroll_top(2, 3, 5),
+            0,
+            "no scroll needed when list fits"
+        );
+    }
+
+    fn test_snapshot() -> TailSnapshot {
+        TailSnapshot {
+            sweep_dir: PathBuf::from("/tmp/x"),
+            status: "running".into(),
+            cancelling_seconds_left: None,
+            completed: 0,
+            in_flight: 0,
+            pending: 0,
+            total: 0,
+            failure_counts: Default::default(),
+            cumulative_cost_usd: 0.0,
+            baseline_cumulative_cost_usd: 0.0,
+            burn_rate_usd_per_min: 0.0,
+            eta_seconds: None,
+            budget_cap_usd: None,
+            pct_of_cap_used: None,
+            started_at: None,
+            last_event_at: None,
+            is_complete: false,
+            abort_reason: None,
+            warnings: Vec::new(),
+            total_fallbacks: 0,
+            model_mix: Default::default(),
+            circuit_breaker_status: None,
+            partial_persisted: 0,
+        }
+    }
+
+    // ---- rendering (TestBackend) ----
+
+    fn render_to_buffer(state: &DashboardState, w: u16, h: u16) -> ratatui::buffer::Buffer {
+        let backend = ratatui::backend::TestBackend::new(w, h);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal.draw(|frame| draw(frame, state)).unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn buffer_text(buf: &ratatui::buffer::Buffer) -> String {
+        let mut out = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                out.push_str(buf[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    #[test]
+    fn draw_shows_loading_before_first_refresh() {
+        let state = state_with_rows(vec![]);
+        let buf = render_to_buffer(&state, 100, 20);
+        assert!(buffer_text(&buf).contains("loading sweep snapshot"));
+    }
+
+    #[test]
+    fn draw_shows_aggregate_counts() {
+        let mut state = state_with_rows(vec![]);
+        let mut snap = test_snapshot();
+        snap.completed = 3;
+        snap.in_flight = 2;
+        snap.pending = 5;
+        snap.total = 10;
+        state.snapshot = Some(snap);
+        let buf = render_to_buffer(&state, 120, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("3/10 completed"), "{text}");
+        assert!(text.contains("2 in flight"), "{text}");
+        assert!(text.contains("5 pending"), "{text}");
+    }
+
+    #[test]
+    fn draw_shows_complete_banner_when_snapshot_is_complete() {
+        let mut state = state_with_rows(vec![]);
+        let mut snap = test_snapshot();
+        snap.is_complete = true;
+        snap.completed = 10;
+        snap.total = 10;
+        state.snapshot = Some(snap);
+        let buf = render_to_buffer(&state, 120, 20);
+        assert!(buffer_text(&buf).contains("SWEEP COMPLETE"));
+    }
+
+    #[test]
+    fn draw_lists_instance_rows() {
+        let mut state = state_with_rows(vec![
+            row("alpha-instance", InstanceStatus::InFlight),
+            row("bravo-instance", InstanceStatus::Terminal),
+        ]);
+        state.snapshot = Some(test_snapshot());
+        let buf = render_to_buffer(&state, 120, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("alpha-instance"), "{text}");
+        assert!(text.contains("bravo-instance"), "{text}");
+        assert!(text.contains("in-flight"), "{text}");
+        assert!(text.contains("terminal"), "{text}");
+    }
+
+    #[test]
+    fn draw_shows_help_overlay_when_open() {
+        let mut state = state_with_rows(vec![row("a", InstanceStatus::Terminal)]);
+        state.snapshot = Some(test_snapshot());
+        state.help_open = true;
+        let buf = render_to_buffer(&state, 120, 30);
+        let text = buffer_text(&buf);
+        assert!(text.contains("keybindings"), "{text}");
+        assert!(text.contains("quit"), "{text}");
+    }
+
+    #[test]
+    fn draw_shows_detail_pane_waiting_message_before_trajectory_found() {
+        let mut state = state_with_rows(vec![row("a", InstanceStatus::InFlight)]);
+        state.snapshot = Some(test_snapshot());
+        handle_key(&mut state, key(KeyCode::Enter));
+        let buf = render_to_buffer(&state, 120, 20);
+        assert!(buffer_text(&buf).contains("waiting for trajectory file"));
+    }
+
+    #[test]
+    fn refresh_detail_reads_new_steps_from_trajectory_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let instance_dir = dir.path().join("alpha");
+        std::fs::create_dir_all(&instance_dir).unwrap();
+        let mut traj = Trajectory::new();
+        traj.info.steps = Some(1);
+        traj.messages.push(crate::trajectory::MessageRecord {
+            role: "assistant".into(),
+            content: "hello from the agent".into(),
+            extra: crate::model::MessageExtra::default(),
+        });
+        std::fs::write(
+            instance_dir.join("run-1.traj.json"),
+            serde_json::to_string_pretty(&traj).unwrap(),
+        )
+        .unwrap();
+
+        let mut detail = DetailState::new("alpha".into(), 1);
+        let redactor = Redactor::default_enabled();
+        refresh_detail(&mut detail, dir.path(), &redactor);
+
+        assert!(!detail.not_found);
+        assert!(
+            detail
+                .lines
+                .iter()
+                .any(|l| l.contains("hello from the agent")),
+            "{:?}",
+            detail.lines
+        );
+    }
+}

--- a/src/run/sweep_dashboard.rs
+++ b/src/run/sweep_dashboard.rs
@@ -16,7 +16,7 @@
 
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::Frame;
@@ -51,9 +51,12 @@ pub(crate) struct DetailState {
     emitted_steps: usize,
     cached_path: Option<PathBuf>,
     last_file_len: u64,
+    last_file_mtime: Option<SystemTime>,
     /// True once the followed trajectory reports a terminal outcome.
     pub(crate) terminal: bool,
-    /// True while no trajectory file has been found yet for the selection.
+    /// True while no trajectory file has been found yet for the selection,
+    /// or a previously-found one has since become unreadable (deleted,
+    /// pruned, moved) — see `refresh_detail`.
     pub(crate) not_found: bool,
 }
 
@@ -67,6 +70,7 @@ impl DetailState {
             emitted_steps: 0,
             cached_path: None,
             last_file_len: 0,
+            last_file_mtime: None,
             terminal: false,
             not_found: true,
         }
@@ -101,11 +105,30 @@ impl DashboardState {
     }
 
     /// Replace the aggregate snapshot and instance rows with a freshly
-    /// polled read, clamping the selection into the new row count so a
-    /// shrinking/growing list never leaves `selected` out of bounds.
+    /// polled read. `rows` is rebuilt from scratch every tick (it's derived
+    /// from a `BTreeMap` sorted by `(instance_id, run_index)` — see
+    /// `tail::instance_rows`), so its order shifts whenever an instance
+    /// earlier in sort order starts or finishes between polls. Re-locate the
+    /// previously-selected instance by identity rather than trusting the raw
+    /// index to still point at the same row (issue #641 review) — falling
+    /// back to clamping only when that instance is no longer present.
     pub(crate) fn apply_refresh(&mut self, snapshot: TailSnapshot, rows: Vec<InstanceRow>) {
+        let selected_identity = self
+            .rows
+            .get(self.selected)
+            .map(|row| (row.instance_id.clone(), row.run_index));
         self.snapshot = Some(snapshot);
         self.rows = rows;
+        if let Some((id, run_index)) = selected_identity {
+            if let Some(new_index) = self
+                .rows
+                .iter()
+                .position(|row| row.instance_id == id && row.run_index == run_index)
+            {
+                self.selected = new_index;
+                return;
+            }
+        }
         if self.rows.is_empty() {
             self.selected = 0;
         } else if self.selected >= self.rows.len() {
@@ -211,6 +234,17 @@ pub(crate) fn list_scroll_top(selected: usize, len: usize, viewport: usize) -> u
         .min(max_top)
 }
 
+/// Whether the followed file can be treated as unchanged since the last
+/// successful read — both length AND mtime must match, mirroring
+/// `watch::run`'s `skippable` check. Pure so the mtime requirement is
+/// directly unit-testable without real file timestamps.
+fn file_unchanged(detail: &DetailState, len: u64, mtime: Option<SystemTime>) -> bool {
+    detail.emitted_steps > 0
+        && len == detail.last_file_len
+        && mtime.is_some()
+        && mtime == detail.last_file_mtime
+}
+
 /// Poll the selected instance's trajectory file for new turns, mirroring
 /// `bench watch`'s follow loop (`crate::run::watch::run`) but appending
 /// plain-text lines to `detail.lines` instead of writing to stdout.
@@ -221,16 +255,32 @@ fn refresh_detail(detail: &mut DetailState, sweep_dir: &Path, redactor: &Redacto
         .or_else(|| resolve_watch_path(sweep_dir, &detail.instance_id, detail.run_index));
     let Some(path) = path else {
         detail.not_found = true;
+        detail.cached_path = None;
+        return;
+    };
+
+    // Only treated as "found" once `metadata` confirms the file is still
+    // there — a path that was resolved on a prior tick but has since been
+    // deleted/pruned (e.g. `bench du --prune` against the same sweep dir)
+    // must fall back to "waiting for trajectory file…" instead of leaving
+    // stale content on screen forever (issue #641 review). Forgetting
+    // `cached_path` here also lets the next tick re-resolve it, self-healing
+    // if the file reappears under a different path.
+    let Ok(metadata) = std::fs::metadata(&path) else {
+        detail.not_found = true;
+        detail.cached_path = None;
         return;
     };
     detail.cached_path = Some(path.clone());
     detail.not_found = false;
 
-    let Ok(metadata) = std::fs::metadata(&path) else {
-        return;
-    };
     let len = metadata.len();
-    if len == detail.last_file_len && detail.emitted_steps > 0 {
+    let mtime = metadata.modified().ok();
+    // Require both length AND mtime to be unchanged before skipping a
+    // re-read, mirroring `watch::run`'s `skippable` check — a length-only
+    // check misses an in-place rewrite whose new content happens to be the
+    // same byte length as the last checkpoint (issue #641 review).
+    if file_unchanged(detail, len, mtime) {
         return;
     }
     let Ok(text) = std::fs::read_to_string(&path) else {
@@ -240,6 +290,7 @@ fn refresh_detail(detail: &mut DetailState, sweep_dir: &Path, redactor: &Redacto
         return;
     };
     detail.last_file_len = len;
+    detail.last_file_mtime = mtime;
     redact_trajectory_for_inspect(&mut traj, redactor);
     let steps = build_inspect_steps_with_max(&traj, false, 4096);
     if steps.len() < detail.emitted_steps {
@@ -257,15 +308,15 @@ fn refresh_detail(detail: &mut DetailState, sweep_dir: &Path, redactor: &Redacto
             use std::fmt::Write as _;
             let _ = write!(summary, " (exit {code})");
         }
-        push_capped(&mut detail.lines, summary);
+        push_capped(detail, summary);
         if let Some(stdout) = &step.stdout {
             for line in stdout.lines().take(20) {
-                push_capped(&mut detail.lines, format!("  {line}"));
+                push_capped(detail, format!("  {line}"));
             }
         }
         if let Some(stderr) = &step.stderr {
             for line in stderr.lines().take(20) {
-                push_capped(&mut detail.lines, format!("  ! {line}"));
+                push_capped(detail, format!("  ! {line}"));
             }
         }
     }
@@ -281,11 +332,17 @@ fn write_first_line(out: &mut String, text: &str) -> std::fmt::Result {
     Ok(())
 }
 
-fn push_capped(lines: &mut VecDeque<String>, line: String) {
-    if lines.len() >= MAX_DETAIL_LINES {
-        lines.pop_front();
+/// Append a line to `detail.lines`, evicting the oldest one once the buffer
+/// is at capacity. Popping the front element shifts every remaining line's
+/// logical index back by one, so `scroll_top` is decremented in lockstep —
+/// otherwise a scrolled-up viewport would silently drift toward newer
+/// content on every eviction with no user input (issue #641 review).
+fn push_capped(detail: &mut DetailState, line: String) {
+    if detail.lines.len() >= MAX_DETAIL_LINES {
+        detail.lines.pop_front();
+        detail.scroll_top = detail.scroll_top.saturating_sub(1);
     }
-    lines.push_back(line);
+    detail.lines.push_back(line);
 }
 
 /// Refresh the aggregate/list data and, when a drill-down is open, the
@@ -293,8 +350,10 @@ fn push_capped(lines: &mut VecDeque<String>, line: String) {
 /// once per tick.
 pub(crate) fn refresh(state: &mut DashboardState, redactor: &Redactor) -> Result<(), Error> {
     let options = SnapshotOptions::default();
-    let snapshot = crate::run::tail::snapshot(&state.sweep_dir, &options)?;
-    let rows = crate::run::tail::instance_rows(&state.sweep_dir)?;
+    // `snapshot_and_rows` shares one `results.json` read between the
+    // aggregate snapshot and the instance list instead of each reading it
+    // independently (issue #641 review).
+    let (snapshot, rows) = crate::run::tail::snapshot_and_rows(&state.sweep_dir, &options)?;
     state.apply_refresh(snapshot, rows);
     if let Some(detail) = state.detail.as_mut() {
         refresh_detail(detail, &state.sweep_dir, redactor);
@@ -332,12 +391,16 @@ pub(crate) fn draw(frame: &mut Frame, state: &DashboardState) {
 }
 
 fn aggregate_panel_height(state: &DashboardState) -> u16 {
-    let base = 6;
-    if state.snapshot.as_ref().is_some_and(|s| s.is_complete) {
-        base + 1
-    } else {
-        base
+    let mut height = 6;
+    if let Some(snap) = state.snapshot.as_ref() {
+        if snap.is_complete {
+            height += 1;
+        }
+        if !snap.warnings.is_empty() {
+            height += 1;
+        }
     }
+    height
 }
 
 fn aggregate_paragraph(state: &DashboardState) -> Paragraph<'_> {
@@ -394,6 +457,22 @@ fn aggregate_paragraph(state: &DashboardState) -> Paragraph<'_> {
         lines.push(Line::from(format!("circuit breaker: {cb}")));
     } else {
         lines.push(Line::from(format!("status: {}", snap.status)));
+    }
+
+    // Parse/schema-compat warnings from `results.json`/trajectory files:
+    // `bench tail`'s plain-text output surfaces these under "Warning:" lines,
+    // but the interactive dashboard had no rendering path for them at all,
+    // leaving an operator relying solely on it flying blind on partial/stale
+    // data (issue #641 review). Kept compact (a count, not the full list) to
+    // respect the panel's fixed-height budget.
+    if !snap.warnings.is_empty() {
+        lines.push(Line::from(Span::styled(
+            format!(
+                "{} warning(s) — see `bench tail --format text` for details",
+                snap.warnings.len()
+            ),
+            Style::default().fg(Color::Yellow),
+        )));
     }
 
     Paragraph::new(lines)
@@ -472,11 +551,21 @@ fn render_detail(frame: &mut Frame, state: &DashboardState, area: Rect) {
     if detail.not_found {
         lines.push(Line::from("waiting for trajectory file…"));
     } else {
+        // Reserve one line for the "[instance complete]" banner so it's
+        // never pushed past the pane's rendered height: `Paragraph` (with no
+        // `.scroll()` set) silently clips anything beyond `inner_height`, so
+        // appending the banner *after* an already-full content window drops
+        // it with no on-screen indication (issue #641 review).
+        let content_height = if detail.terminal {
+            inner_height.saturating_sub(1)
+        } else {
+            inner_height
+        };
         for line in detail
             .lines
             .iter()
             .skip(detail.scroll_top)
-            .take(inner_height)
+            .take(content_height)
         {
             lines.push(Line::from(line.as_str()));
         }
@@ -967,5 +1056,155 @@ mod tests {
             "{:?}",
             detail.lines
         );
+    }
+
+    #[test]
+    fn refresh_detail_resets_not_found_when_file_disappears() {
+        let dir = tempfile::tempdir().unwrap();
+        let instance_dir = dir.path().join("alpha");
+        std::fs::create_dir_all(&instance_dir).unwrap();
+        let mut traj = Trajectory::new();
+        traj.info.steps = Some(1);
+        let traj_path = instance_dir.join("run-1.traj.json");
+        std::fs::write(&traj_path, serde_json::to_string_pretty(&traj).unwrap()).unwrap();
+
+        let mut detail = DetailState::new("alpha".into(), 1);
+        let redactor = Redactor::default_enabled();
+        refresh_detail(&mut detail, dir.path(), &redactor);
+        assert!(!detail.not_found, "file exists; should be found");
+
+        std::fs::remove_file(&traj_path).unwrap();
+        refresh_detail(&mut detail, dir.path(), &redactor);
+        assert!(
+            detail.not_found,
+            "not_found must reset to true once the cached path disappears"
+        );
+    }
+
+    #[test]
+    fn file_unchanged_requires_both_length_and_mtime_match() {
+        let mut detail = DetailState::new("x".into(), 1);
+        detail.emitted_steps = 3;
+        detail.last_file_len = 100;
+        let t0 = SystemTime::now();
+        detail.last_file_mtime = Some(t0);
+
+        assert!(file_unchanged(&detail, 100, Some(t0)));
+
+        let t1 = t0 + Duration::from_secs(1);
+        assert!(
+            !file_unchanged(&detail, 100, Some(t1)),
+            "same length but different mtime must not be treated as unchanged"
+        );
+        assert!(
+            !file_unchanged(&detail, 101, Some(t0)),
+            "different length must not be treated as unchanged"
+        );
+        assert!(
+            !file_unchanged(&detail, 100, None),
+            "an unavailable mtime must not be treated as unchanged"
+        );
+    }
+
+    #[test]
+    fn push_capped_decrements_scroll_top_when_evicting() {
+        let mut detail = DetailState::new("x".into(), 1);
+        for i in 0..MAX_DETAIL_LINES {
+            push_capped(&mut detail, format!("line-{i}"));
+        }
+        detail.scroll_top = 5;
+
+        push_capped(&mut detail, "new-line".into());
+
+        assert_eq!(detail.lines.len(), MAX_DETAIL_LINES);
+        assert_eq!(
+            detail.scroll_top, 4,
+            "scroll_top must shift down in lockstep with the evicted front line"
+        );
+    }
+
+    #[test]
+    fn push_capped_does_not_move_scroll_top_below_the_cap() {
+        let mut detail = DetailState::new("x".into(), 1);
+        detail.scroll_top = 2;
+        push_capped(&mut detail, "first".into());
+        assert_eq!(
+            detail.scroll_top, 2,
+            "no eviction happened yet; scroll_top must be untouched"
+        );
+    }
+
+    #[test]
+    fn apply_refresh_preserves_selected_instance_identity_across_reorder() {
+        let mut state = state_with_rows(vec![
+            row("bravo", InstanceStatus::Terminal),
+            row("charlie", InstanceStatus::Terminal),
+        ]);
+        state.selected = 0; // "bravo"
+
+        // A new instance "alpha" sorts ahead of "bravo" and appears between
+        // polls, shifting every subsequent row's index down by one.
+        state.apply_refresh(
+            test_snapshot(),
+            vec![
+                row("alpha", InstanceStatus::InFlight),
+                row("bravo", InstanceStatus::Terminal),
+                row("charlie", InstanceStatus::Terminal),
+            ],
+        );
+
+        assert_eq!(
+            state.rows[state.selected].instance_id, "bravo",
+            "selection must follow the instance the operator was looking at, not the raw index"
+        );
+    }
+
+    #[test]
+    fn apply_refresh_falls_back_to_clamping_when_selected_instance_vanishes() {
+        let mut state = state_with_rows(vec![
+            row("bravo", InstanceStatus::Terminal),
+            row("charlie", InstanceStatus::Terminal),
+        ]);
+        state.selected = 1; // "charlie"
+
+        state.apply_refresh(
+            test_snapshot(),
+            vec![row("bravo", InstanceStatus::Terminal)],
+        );
+
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn draw_shows_completion_banner_even_when_pane_is_full() {
+        let mut state = state_with_rows(vec![row("a", InstanceStatus::Terminal)]);
+        state.snapshot = Some(test_snapshot());
+        handle_key(&mut state, key(KeyCode::Enter));
+        {
+            let detail = state.detail.as_mut().unwrap();
+            // Fill well past any reasonable pane height with real content.
+            for i in 0..50 {
+                detail.lines.push_back(format!("line {i}"));
+            }
+            detail.terminal = true;
+            detail.not_found = false;
+        }
+        let buf = render_to_buffer(&state, 120, 20);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("instance complete"),
+            "completion banner must not be clipped when the pane is full: {text}"
+        );
+    }
+
+    #[test]
+    fn draw_shows_warning_count_when_snapshot_has_warnings() {
+        let mut state = state_with_rows(vec![]);
+        let mut snap = test_snapshot();
+        snap.warnings = vec!["some-file.traj.json: partial or invalid JSON".into()];
+        state.snapshot = Some(snap);
+        let buf = render_to_buffer(&state, 120, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("1 warning(s)"), "{text}");
     }
 }

--- a/src/run/sweep_dashboard.rs
+++ b/src/run/sweep_dashboard.rs
@@ -58,6 +58,14 @@ pub(crate) struct DetailState {
     /// or a previously-found one has since become unreadable (deleted,
     /// pruned, moved) — see `refresh_detail`.
     pub(crate) not_found: bool,
+    /// True while the pane should track the live tail of the trajectory as
+    /// new turns stream in (the default). Pressing Up/k to look at earlier
+    /// output disables it; scrolling back down to the end re-enables it —
+    /// see `scroll_detail_up`/`scroll_detail_down` and `render_detail` (PR
+    /// #999 review: without this, `scroll_top` never advances on its own, so
+    /// a trajectory longer than the pane stays pinned to its earliest steps
+    /// while fresh output appends below the visible window).
+    pub(crate) auto_follow: bool,
 }
 
 impl DetailState {
@@ -73,6 +81,7 @@ impl DetailState {
             last_file_mtime: None,
             terminal: false,
             not_found: true,
+            auto_follow: true,
         }
     }
 }
@@ -198,19 +207,37 @@ fn move_selection_down(state: &mut DashboardState) {
     state.selected = (state.selected + 1).min(max);
 }
 
+/// Scroll toward earlier output. The first press while auto-following
+/// anchors near the current tail (rather than jumping to `scroll_top`'s
+/// stale value, which isn't updated while following) before disabling
+/// follow, so the pane doesn't visibly jump when the operator starts
+/// scrolling back.
 fn scroll_detail_up(state: &mut DashboardState) {
     let Some(detail) = state.detail.as_mut() else {
         return;
     };
+    if detail.auto_follow {
+        detail.auto_follow = false;
+        detail.scroll_top = detail.lines.len().saturating_sub(1);
+    }
     detail.scroll_top = detail.scroll_top.saturating_sub(1);
 }
 
+/// Scroll toward the live tail; re-enables auto-follow once the operator has
+/// scrolled all the way back down, so the pane resumes tracking new output
+/// without needing a separate keybinding (PR #999 review).
 fn scroll_detail_down(state: &mut DashboardState) {
     let Some(detail) = state.detail.as_mut() else {
         return;
     };
+    if detail.auto_follow {
+        return;
+    }
     let max = detail.lines.len().saturating_sub(1);
     detail.scroll_top = (detail.scroll_top + 1).min(max);
+    if detail.scroll_top >= max {
+        detail.auto_follow = true;
+    }
 }
 
 fn open_detail(state: &mut DashboardState) {
@@ -232,6 +259,19 @@ pub(crate) fn list_scroll_top(selected: usize, len: usize, viewport: usize) -> u
     selected
         .saturating_sub(viewport.saturating_sub(1))
         .min(max_top)
+}
+
+/// The detail pane's effective scroll offset for this draw: while
+/// auto-following, always show the freshest `content_height` lines
+/// regardless of the stored (stale, unused-while-following) `scroll_top`;
+/// once the operator has scrolled away, honor their absolute position (PR
+/// #999 review). Pure so it's directly unit-testable without rendering.
+pub(crate) fn detail_scroll_top(detail: &DetailState, content_height: usize) -> usize {
+    if detail.auto_follow {
+        detail.lines.len().saturating_sub(content_height)
+    } else {
+        detail.scroll_top
+    }
 }
 
 /// Whether the followed file can be treated as unchanged since the last
@@ -294,7 +334,17 @@ fn refresh_detail(detail: &mut DetailState, sweep_dir: &Path, redactor: &Redacto
     redact_trajectory_for_inspect(&mut traj, redactor);
     let steps = build_inspect_steps_with_max(&traj, false, 4096);
     if steps.len() < detail.emitted_steps {
+        // The trajectory shrank — a worker restart or retry rewrote the file
+        // with fewer steps than we'd already rendered. Re-reading from step 0
+        // without clearing the buffer would append the (now stale) old run's
+        // lines ahead of the fresh ones, corrupting the log; drop everything
+        // and start over, and resume auto-follow so the operator sees the new
+        // run's output rather than being pinned to a scroll position that no
+        // longer means anything (PR #999 review).
         detail.emitted_steps = 0;
+        detail.lines.clear();
+        detail.scroll_top = 0;
+        detail.auto_follow = true;
     }
     for step in &steps[detail.emitted_steps..] {
         let mut summary = format!("step {} {}", step.index, step.role);
@@ -561,12 +611,8 @@ fn render_detail(frame: &mut Frame, state: &DashboardState, area: Rect) {
         } else {
             inner_height
         };
-        for line in detail
-            .lines
-            .iter()
-            .skip(detail.scroll_top)
-            .take(content_height)
-        {
+        let scroll_top = detail_scroll_top(detail, content_height);
+        for line in detail.lines.iter().skip(scroll_top).take(content_height) {
             lines.push(Line::from(line.as_str()));
         }
         if detail.terminal {
@@ -1206,5 +1252,124 @@ mod tests {
         let buf = render_to_buffer(&state, 120, 20);
         let text = buffer_text(&buf);
         assert!(text.contains("1 warning(s)"), "{text}");
+    }
+
+    fn assistant_message(content: &str) -> crate::trajectory::MessageRecord {
+        crate::trajectory::MessageRecord {
+            role: "assistant".into(),
+            content: content.into(),
+            extra: crate::model::MessageExtra::default(),
+        }
+    }
+
+    #[test]
+    fn refresh_detail_clears_stale_lines_when_step_count_shrinks() {
+        let dir = tempfile::tempdir().unwrap();
+        let instance_dir = dir.path().join("alpha");
+        std::fs::create_dir_all(&instance_dir).unwrap();
+        let traj_path = instance_dir.join("run-1.traj.json");
+
+        let mut traj = Trajectory::new();
+        traj.messages.push(assistant_message("first step"));
+        traj.messages.push(assistant_message("second step"));
+        std::fs::write(&traj_path, serde_json::to_string_pretty(&traj).unwrap()).unwrap();
+
+        let mut detail = DetailState::new("alpha".into(), 1);
+        let redactor = Redactor::default_enabled();
+        refresh_detail(&mut detail, dir.path(), &redactor);
+        assert_eq!(detail.emitted_steps, 2);
+        assert!(detail.lines.iter().any(|l| l.contains("second step")));
+
+        // A worker restart/retry rewrites the file with fewer, different steps.
+        let mut restarted = Trajectory::new();
+        restarted.messages.push(assistant_message("restarted step"));
+        std::fs::write(
+            &traj_path,
+            serde_json::to_string_pretty(&restarted).unwrap(),
+        )
+        .unwrap();
+
+        refresh_detail(&mut detail, dir.path(), &redactor);
+
+        assert_eq!(detail.emitted_steps, 1);
+        assert_eq!(detail.scroll_top, 0);
+        assert!(
+            !detail.lines.iter().any(|l| l.contains("second step")),
+            "stale lines from the old (longer) run must be cleared, not appended to: {:?}",
+            detail.lines
+        );
+        assert!(detail.lines.iter().any(|l| l.contains("restarted step")));
+    }
+
+    #[test]
+    fn detail_scroll_top_follows_tail_by_default_and_honors_manual_position_otherwise() {
+        let mut detail = DetailState::new("x".into(), 1);
+        for i in 0..50 {
+            detail.lines.push_back(format!("l{i}"));
+        }
+        assert_eq!(
+            detail_scroll_top(&detail, 10),
+            40,
+            "auto-follow must show the freshest content_height lines"
+        );
+
+        detail.auto_follow = false;
+        detail.scroll_top = 5;
+        assert_eq!(
+            detail_scroll_top(&detail, 10),
+            5,
+            "manual position must be honored once auto-follow is off"
+        );
+    }
+
+    #[test]
+    fn scroll_detail_up_disables_auto_follow_then_scrolling_back_down_re_enables_it() {
+        let mut state = state_with_rows(vec![row("a", InstanceStatus::Terminal)]);
+        handle_key(&mut state, key(KeyCode::Enter));
+        {
+            let detail = state.detail.as_mut().unwrap();
+            for i in 0..10 {
+                detail.lines.push_back(format!("line {i}"));
+            }
+        }
+        assert!(state.detail.as_ref().unwrap().auto_follow);
+
+        handle_key(&mut state, key(KeyCode::Up));
+        assert!(
+            !state.detail.as_ref().unwrap().auto_follow,
+            "scrolling up must disable auto-follow"
+        );
+
+        for _ in 0..20 {
+            handle_key(&mut state, key(KeyCode::Down));
+        }
+        assert!(
+            state.detail.as_ref().unwrap().auto_follow,
+            "scrolling back down to the end must re-enable auto-follow"
+        );
+    }
+
+    #[test]
+    fn draw_detail_pane_follows_the_tail_by_default() {
+        let mut state = state_with_rows(vec![row("a", InstanceStatus::InFlight)]);
+        state.snapshot = Some(test_snapshot());
+        handle_key(&mut state, key(KeyCode::Enter));
+        {
+            let detail = state.detail.as_mut().unwrap();
+            detail.not_found = false;
+            for i in 0..100 {
+                detail.lines.push_back(format!("line-{i}"));
+            }
+        }
+        let buf = render_to_buffer(&state, 120, 20);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("line-99"),
+            "must show the latest line by default: {text}"
+        );
+        assert!(
+            !text.contains("line-0"),
+            "must not stay pinned to the earliest line: {text}"
+        );
     }
 }

--- a/src/run/tail.rs
+++ b/src/run/tail.rs
@@ -493,8 +493,16 @@ fn instance_rows_from_value(
         .partition(|f| !f.is_legacy_flat);
     let mut seen: std::collections::HashSet<(String, u32)> = std::collections::HashSet::new();
     for file in nested_files {
+        // Mark the key seen because the nested file *exists*, not only when
+        // it parses successfully — otherwise a nested file that's
+        // transiently unreadable (mid-write, momentarily corrupt) would fall
+        // through to the flat-file loop below and resurrect a stale legacy
+        // row for the same instance/run, violating nested-over-flat
+        // precedence (PR #999 review). Leaving the key out of `rows`
+        // entirely for this tick (rather than showing stale data) is the
+        // safer default; it self-heals on the next successful poll.
+        seen.insert((file.instance_id.clone(), file.run_index));
         if let Some(traj) = parse_trajectory_checked(&file.path) {
-            seen.insert((file.instance_id.clone(), file.run_index));
             rows.insert(
                 (file.instance_id.clone(), file.run_index),
                 instance_row_from_trajectory(file.instance_id, file.run_index, traj),

--- a/src/run/tail.rs
+++ b/src/run/tail.rs
@@ -176,7 +176,35 @@ impl TerminalRecord {
     }
 }
 
-#[allow(clippy::too_many_lines)]
+/// Read `results.json` once and return both the aggregate snapshot and the
+/// per-instance rows, sharing that single parse between them instead of each
+/// reading the file independently. [`snapshot`] and [`instance_rows`] remain
+/// the public single-purpose entry points (and read the file themselves when
+/// called alone); this is what the sweep dashboard's `refresh()` calls every
+/// tick, since it always wants both together (issue #641 review — the two
+/// used to each read `results.json` separately on every poll).
+///
+/// # Errors
+/// Returns `Err` if `sweep_dir` does not exist.
+pub(crate) fn snapshot_and_rows(
+    sweep_dir: &Path,
+    options: &SnapshotOptions,
+) -> Result<(TailSnapshot, Vec<InstanceRow>), Error> {
+    if !sweep_dir.exists() {
+        return Err(Error::Trajectory(format!(
+            "tail: sweep directory does not exist: {}",
+            sweep_dir.display()
+        )));
+    }
+    let mut warnings = Vec::new();
+    let results_value = read_json_value(&sweep_dir.join("results.json"), &mut warnings)?;
+    let snap = snapshot_from_value(sweep_dir, options, results_value.as_ref(), warnings)?;
+    let rows = instance_rows_from_value(sweep_dir, results_value.as_ref());
+    Ok((snap, rows))
+}
+
+/// # Errors
+/// Returns `Err` if `sweep_dir` does not exist.
 pub fn snapshot(sweep_dir: &Path, options: &SnapshotOptions) -> Result<TailSnapshot, Error> {
     if !sweep_dir.exists() {
         return Err(Error::Trajectory(format!(
@@ -184,22 +212,28 @@ pub fn snapshot(sweep_dir: &Path, options: &SnapshotOptions) -> Result<TailSnaps
             sweep_dir.display()
         )));
     }
-
     let mut warnings = Vec::new();
     let results_value = read_json_value(&sweep_dir.join("results.json"), &mut warnings)?;
-    let mut meta = results_value
-        .as_ref()
-        .map(parse_sweep_meta)
-        .unwrap_or_default();
+    snapshot_from_value(sweep_dir, options, results_value.as_ref(), warnings)
+}
+
+#[allow(clippy::too_many_lines)]
+fn snapshot_from_value(
+    sweep_dir: &Path,
+    options: &SnapshotOptions,
+    results_value: Option<&serde_json::Value>,
+    mut warnings: Vec<String>,
+) -> Result<TailSnapshot, Error> {
+    let mut meta = results_value.map(parse_sweep_meta).unwrap_or_default();
     let mut records = BTreeMap::new();
 
-    if let Some(value) = results_value.as_ref() {
+    if let Some(value) = results_value {
         for record in parse_result_records(value, &mut warnings) {
             records.insert(record.instance_id.clone(), record);
         }
     }
 
-    let scanned_slots = scan_trajectories(sweep_dir, &mut warnings)?;
+    let (scanned_slots, partial_persisted) = scan_trajectories(sweep_dir, &mut warnings)?;
     // Compute fallback totals from raw per-slot records before merging so that
     // reruns using different fallback models are all counted in the model_mix.
     let (scanned_fallbacks, scanned_mix) = fallback_totals_from_records(scanned_slots.iter());
@@ -350,7 +384,7 @@ pub fn snapshot(sweep_dir: &Path, options: &SnapshotOptions) -> Result<TailSnaps
         total_fallbacks,
         model_mix,
         circuit_breaker_status,
-        partial_persisted: count_partial_trajectories(sweep_dir),
+        partial_persisted,
     })
 }
 
@@ -408,12 +442,21 @@ pub fn instance_rows(sweep_dir: &Path) -> Result<Vec<InstanceRow>, Error> {
         )));
     }
 
-    let mut warnings = Vec::new();
-    let results_value = read_json_value(&sweep_dir.join("results.json"), &mut warnings)?;
+    // Parse-compat warnings for `results.json` are already surfaced via
+    // `snapshot()`'s `TailSnapshot.warnings` (both read the same file); this
+    // call site has nowhere of its own to report them, so they're discarded
+    // here rather than collected and silently dropped under a named binding.
+    let results_value = read_json_value(&sweep_dir.join("results.json"), &mut Vec::new())?;
+    Ok(instance_rows_from_value(sweep_dir, results_value.as_ref()))
+}
 
+fn instance_rows_from_value(
+    sweep_dir: &Path,
+    results_value: Option<&serde_json::Value>,
+) -> Vec<InstanceRow> {
     let mut rows: BTreeMap<(String, u32), InstanceRow> = BTreeMap::new();
 
-    if let Some(value) = results_value.as_ref() {
+    if let Some(value) = results_value {
         for item in value
             .get("instances")
             .and_then(serde_json::Value::as_array)
@@ -437,32 +480,40 @@ pub fn instance_rows(sweep_dir: &Path) -> Result<Vec<InstanceRow>, Error> {
         }
     }
 
-    for (instance_id, run_index, traj) in scan_all_trajectories(sweep_dir) {
-        let info = traj.info;
-        let row = if info.partial {
-            InstanceRow {
-                instance_id: instance_id.clone(),
-                run_index,
-                status: InstanceStatus::InFlight,
-                current_step: info.steps,
-                outcome: None,
-                failure_category: None,
-            }
-        } else {
-            InstanceRow {
-                instance_id: instance_id.clone(),
-                run_index,
-                status: InstanceStatus::Terminal,
-                current_step: info.steps,
-                outcome: info.outcome,
-                failure_category: info.failure_category,
-            }
-        };
-        rows.insert((instance_id, run_index), row);
+    // Nested `<id>/run-N.traj.json` is the current on-disk layout and always
+    // takes precedence over a legacy flat `<id>.traj.json` for the same
+    // (instance_id, run_index) key — processing nested first and letting flat
+    // only fill gaps makes the outcome deterministic regardless of
+    // `std::fs::read_dir`'s unspecified iteration order (issue #641 review).
+    // A single walk is partitioned in memory rather than walking the
+    // directory twice.
+    let (nested_files, flat_files): (Vec<_>, Vec<_>) = walk_trajectory_files(sweep_dir)
+        .unwrap_or_default()
+        .into_iter()
+        .partition(|f| !f.is_legacy_flat);
+    let mut seen: std::collections::HashSet<(String, u32)> = std::collections::HashSet::new();
+    for file in nested_files {
+        if let Some(traj) = parse_trajectory_checked(&file.path) {
+            seen.insert((file.instance_id.clone(), file.run_index));
+            rows.insert(
+                (file.instance_id.clone(), file.run_index),
+                instance_row_from_trajectory(file.instance_id, file.run_index, traj),
+            );
+        }
+    }
+    for file in flat_files {
+        if seen.contains(&(file.instance_id.clone(), file.run_index)) {
+            continue;
+        }
+        if let Some(traj) = parse_trajectory_checked(&file.path) {
+            rows.insert(
+                (file.instance_id.clone(), file.run_index),
+                instance_row_from_trajectory(file.instance_id, file.run_index, traj),
+            );
+        }
     }
 
     if let Some(ids) = results_value
-        .as_ref()
         .and_then(|value| value.pointer("/filter_spec/instance_ids"))
         .and_then(serde_json::Value::as_array)
     {
@@ -482,21 +533,59 @@ pub fn instance_rows(sweep_dir: &Path) -> Result<Vec<InstanceRow>, Error> {
         }
     }
 
-    Ok(rows.into_values().collect())
+    rows.into_values().collect()
 }
 
-/// Walk `sweep_dir` for every trajectory file (flat `<id>.traj.json` and
-/// nested `<id>/run-N.traj.json`), parsing each one. Unlike
-/// [`scan_trajectories`], partial (in-flight) trajectories are included —
-/// callers that only want terminal records should filter on
-/// `traj.info.partial`. Unreadable or invalid files are skipped silently:
-/// this feeds a best-effort live dashboard, not the authoritative snapshot.
-fn scan_all_trajectories(sweep_dir: &Path) -> Vec<(String, u32, Trajectory)> {
+fn instance_row_from_trajectory(
+    instance_id: String,
+    run_index: u32,
+    traj: Trajectory,
+) -> InstanceRow {
+    let info = traj.info;
+    if info.partial {
+        InstanceRow {
+            instance_id,
+            run_index,
+            status: InstanceStatus::InFlight,
+            current_step: info.steps,
+            outcome: None,
+            failure_category: None,
+        }
+    } else {
+        InstanceRow {
+            instance_id,
+            run_index,
+            status: InstanceStatus::Terminal,
+            current_step: info.steps,
+            outcome: info.outcome,
+            failure_category: info.failure_category,
+        }
+    }
+}
+
+/// One trajectory file discovered by [`walk_trajectory_files`]: either a
+/// legacy flat `<id>.traj.json` (`is_legacy_flat: true`, `run_index` always
+/// `1`) or a nested `<id>/run-N.traj.json` (`is_legacy_flat: false`).
+struct ScannedTrajectoryFile {
+    instance_id: String,
+    run_index: u32,
+    is_legacy_flat: bool,
+    path: PathBuf,
+}
+
+/// Enumerate every trajectory file in `sweep_dir` — the flat/nested layout
+/// shared by [`scan_trajectories`] (terminal records for `snapshot()`) and
+/// [`instance_rows`] (per-instance rows, including in-flight partials).
+///
+/// Pure path discovery: propagates `read_dir`/entry errors like
+/// `std::fs::read_dir` itself, so each caller keeps its own error-strictness
+/// policy — [`scan_trajectories`] propagates them (matching `snapshot()`'s
+/// existing contract), while [`instance_rows`] degrades to an empty list
+/// (matching its existing best-effort contract).
+fn walk_trajectory_files(sweep_dir: &Path) -> Result<Vec<ScannedTrajectoryFile>, Error> {
     let mut out = Vec::new();
-    let Ok(entries) = std::fs::read_dir(sweep_dir) else {
-        return out;
-    };
-    for entry in entries.flatten() {
+    for entry in std::fs::read_dir(sweep_dir)? {
+        let entry = entry?;
         let path = entry.path();
         if path.is_dir() {
             let Some(instance_id) = path
@@ -506,11 +595,12 @@ fn scan_all_trajectories(sweep_dir: &Path) -> Vec<(String, u32, Trajectory)> {
             else {
                 continue;
             };
-            let Ok(nested) = std::fs::read_dir(&path) else {
-                continue;
-            };
-            for nested_entry in nested.flatten() {
+            for nested_entry in std::fs::read_dir(&path)? {
+                let nested_entry = nested_entry?;
                 let nested_path = nested_entry.path();
+                if !nested_path.is_file() {
+                    continue;
+                }
                 let Some(name) = nested_path.file_name().and_then(std::ffi::OsStr::to_str) else {
                     continue;
                 };
@@ -521,9 +611,12 @@ fn scan_all_trajectories(sweep_dir: &Path) -> Vec<(String, u32, Trajectory)> {
                 else {
                     continue;
                 };
-                if let Some(traj) = read_trajectory_lenient(&nested_path) {
-                    out.push((instance_id.clone(), run_index, traj));
-                }
+                out.push(ScannedTrajectoryFile {
+                    instance_id: instance_id.clone(),
+                    run_index,
+                    is_legacy_flat: false,
+                    path: nested_path,
+                });
             }
             continue;
         }
@@ -536,52 +629,27 @@ fn scan_all_trajectories(sweep_dir: &Path) -> Vec<(String, u32, Trajectory)> {
         let Some(instance_id) = name.strip_suffix(".traj.json") else {
             continue;
         };
-        if let Some(traj) = read_trajectory_lenient(&path) {
-            out.push((instance_id.to_owned(), 1, traj));
-        }
+        out.push(ScannedTrajectoryFile {
+            instance_id: instance_id.to_owned(),
+            run_index: 1,
+            is_legacy_flat: true,
+            path,
+        });
     }
-    out
+    Ok(out)
 }
 
-fn read_trajectory_lenient(path: &Path) -> Option<Trajectory> {
+/// Best-effort trajectory parse for the live dashboard's instance list:
+/// applies the same schema-compatibility check as `snapshot()`'s
+/// [`terminal_record_from_trajectory`] (skipping an incompatible/future
+/// schema file) but never hard-errors — an unreadable or invalid file is
+/// simply excluded, since this feeds a best-effort view rather than the
+/// authoritative snapshot.
+fn parse_trajectory_checked(path: &Path) -> Option<Trajectory> {
     let text = std::fs::read_to_string(path).ok()?;
-    serde_json::from_str(&text).ok()
-}
-
-fn count_partial_trajectories(sweep_dir: &Path) -> usize {
-    let mut count = 0;
-    let Ok(entries) = std::fs::read_dir(sweep_dir) else {
-        return 0;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
-        let Ok(nested) = std::fs::read_dir(&path) else {
-            continue;
-        };
-        for nested_entry in nested.flatten() {
-            let nested_path = nested_entry.path();
-            let name = nested_path
-                .file_name()
-                .and_then(std::ffi::OsStr::to_str)
-                .unwrap_or("");
-            if name.starts_with("run-") && name.ends_with(".traj.json") {
-                if let Ok(text) = std::fs::read_to_string(&nested_path) {
-                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
-                        if v.pointer("/info/partial")
-                            .and_then(serde_json::Value::as_bool)
-                            .unwrap_or(false)
-                        {
-                            count += 1;
-                        }
-                    }
-                }
-            }
-        }
-    }
-    count
+    let value: serde_json::Value = serde_json::from_str(&text).ok()?;
+    classify_json_value(&value, ArtifactKind::Trajectory, path.display().to_string()).ok()?;
+    serde_json::from_value(value).ok()
 }
 
 fn read_json_value(
@@ -752,67 +820,45 @@ fn record_from_result_value(
     })
 }
 
+/// Scan every trajectory file for terminal (non-partial) records, tallying
+/// partial (in-flight) files as it goes rather than re-walking the directory
+/// a second time just to count them (issue #641 review; `partial_persisted`
+/// used to be computed by a wholly separate walk over the same files).
 fn scan_trajectories(
     sweep_dir: &Path,
     warnings: &mut Vec<String>,
-) -> Result<Vec<TerminalRecord>, Error> {
+) -> Result<(Vec<TerminalRecord>, usize), Error> {
     let mut records = Vec::new();
-    for entry in std::fs::read_dir(sweep_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_dir() {
-            let Some(instance_id) = path
-                .file_name()
-                .and_then(std::ffi::OsStr::to_str)
-                .map(str::to_owned)
-            else {
-                continue;
-            };
-            for nested in std::fs::read_dir(&path)? {
-                let nested = nested?;
-                let nested_path = nested.path();
-                if !nested_path.is_file() {
-                    continue;
-                }
-                let Some(name) = nested_path.file_name().and_then(std::ffi::OsStr::to_str) else {
-                    continue;
-                };
-                if name.starts_with("run-") && name.ends_with(".traj.json") {
-                    if let Some(record) =
-                        terminal_record_from_trajectory(&nested_path, &instance_id, warnings)?
-                    {
-                        records.push(record);
-                    }
-                }
-            }
-            continue;
-        }
-        if !path.is_file() {
-            continue;
-        }
-        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-            continue;
-        };
-        let Some(instance_id) = name.strip_suffix(".traj.json") else {
-            continue;
-        };
-        if let Some(record) = terminal_record_from_trajectory(&path, instance_id, warnings)? {
-            records.push(record);
+    let mut partial_persisted = 0;
+    for file in walk_trajectory_files(sweep_dir)? {
+        match terminal_record_from_trajectory(&file.path, &file.instance_id, warnings)? {
+            TrajectoryParseOutcome::Terminal(record) => records.push(*record),
+            TrajectoryParseOutcome::Partial => partial_persisted += 1,
+            TrajectoryParseOutcome::Unusable => {}
         }
     }
-    Ok(records)
+    Ok((records, partial_persisted))
+}
+
+/// Result of parsing one trajectory file for [`scan_trajectories`]: a
+/// completed run, an in-flight (`partial: true`) checkpoint, or a file that
+/// couldn't be read/parsed (a warning has already been recorded for that case).
+enum TrajectoryParseOutcome {
+    Terminal(Box<TerminalRecord>),
+    Partial,
+    Unusable,
 }
 
 fn terminal_record_from_trajectory(
     path: &Path,
     instance_id: &str,
     warnings: &mut Vec<String>,
-) -> Result<Option<TerminalRecord>, Error> {
+) -> Result<TrajectoryParseOutcome, Error> {
     let text = match std::fs::read_to_string(path) {
         Ok(text) => text,
         Err(err) => {
             warnings.push(format!("{}: failed to read ({err})", path.display()));
-            return Ok(None);
+            return Ok(TrajectoryParseOutcome::Unusable);
         }
     };
     let value: serde_json::Value = match serde_json::from_str(&text) {
@@ -822,7 +868,7 @@ fn terminal_record_from_trajectory(
                 "{}: partial or invalid JSON ({err})",
                 path.display()
             ));
-            return Ok(None);
+            return Ok(TrajectoryParseOutcome::Unusable);
         }
     };
     match classify_json_value(&value, ArtifactKind::Trajectory, path.display().to_string()) {
@@ -836,14 +882,12 @@ fn terminal_record_from_trajectory(
                 "{}: partial or invalid JSON ({err})",
                 path.display()
             ));
-            return Ok(None);
+            return Ok(TrajectoryParseOutcome::Unusable);
         }
     };
     let info = traj.info;
     if info.partial {
-        // Partial trajectories are not terminal records — don't include them
-        // in completed/outcome counts. The partial count is tracked separately.
-        return Ok(None);
+        return Ok(TrajectoryParseOutcome::Partial);
     }
     let actual_cost_usd = info.actual_cost_usd.or_else(|| {
         if info.model_name.as_deref().is_some_and(is_free_tier_model) {
@@ -863,7 +907,7 @@ fn terminal_record_from_trajectory(
                 Some(t.completion_tokens),
             )
         });
-    Ok(Some(TerminalRecord {
+    Ok(TrajectoryParseOutcome::Terminal(Box::new(TerminalRecord {
         instance_id: instance_id.to_owned(),
         outcome: info.outcome,
         exit_reason: info.exit_reason,
@@ -888,7 +932,7 @@ fn terminal_record_from_trajectory(
                 Some(s.final_model.clone())
             }
         }),
-    }))
+    })))
 }
 
 fn fallback_totals_from_records<'a>(

--- a/src/run/tail.rs
+++ b/src/run/tail.rs
@@ -354,6 +354,200 @@ pub fn snapshot(sweep_dir: &Path, options: &SnapshotOptions) -> Result<TailSnaps
     })
 }
 
+/// Live state of a single instance/run-slot row in the sweep dashboard
+/// (issue #641).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InstanceStatus {
+    /// Selected for the sweep but no trajectory file has appeared yet.
+    /// Only identifiable when the sweep was launched with an explicit
+    /// `--instance-ids` filter; see [`instance_rows`].
+    Pending,
+    /// A trajectory file exists on disk with `info.partial == true`.
+    InFlight,
+    /// A trajectory file (or `results.json` entry) records a finished run.
+    Terminal,
+}
+
+/// One row of the sweep dashboard's navigable instance list (issue #641).
+#[derive(Debug, Clone, Serialize)]
+pub struct InstanceRow {
+    pub instance_id: String,
+    /// Run slot (1-based). Always 1 outside of `--reruns` sweeps.
+    pub run_index: u32,
+    pub status: InstanceStatus,
+    pub current_step: Option<u32>,
+    pub outcome: Option<String>,
+    pub failure_category: Option<FailureCategory>,
+}
+
+/// Enumerate per-instance rows for the interactive sweep dashboard.
+///
+/// Derived **only** from the same read-only snapshot layer as [`snapshot`]:
+/// `results.json`'s `instances` array and on-disk trajectory files
+/// (`<id>.traj.json` flat, or `<id>/run-N.traj.json` nested). A trajectory
+/// persisted with `info.partial == true` yields an [`InstanceStatus::InFlight`]
+/// row; anything else on disk is [`InstanceStatus::Terminal`].
+///
+/// Pending (not-yet-started) rows can only be named when the sweep was
+/// launched with an explicit `--instance-ids` filter — `results.json` then
+/// carries the full requested set in `filter_spec.instance_ids`, and any of
+/// those ids with no row yet is reported as [`InstanceStatus::Pending`]. For
+/// the common case (full dataset, `--limit`, `--sample`) the runner never
+/// records the full instance-id set anywhere in the sweep directory, so
+/// not-yet-started instances have no identity to report here; they remain
+/// reflected only in [`TailSnapshot::pending`]'s count.
+///
+/// # Errors
+/// Returns `Err` if `sweep_dir` does not exist.
+pub fn instance_rows(sweep_dir: &Path) -> Result<Vec<InstanceRow>, Error> {
+    if !sweep_dir.exists() {
+        return Err(Error::Trajectory(format!(
+            "tail: sweep directory does not exist: {}",
+            sweep_dir.display()
+        )));
+    }
+
+    let mut warnings = Vec::new();
+    let results_value = read_json_value(&sweep_dir.join("results.json"), &mut warnings)?;
+
+    let mut rows: BTreeMap<(String, u32), InstanceRow> = BTreeMap::new();
+
+    if let Some(value) = results_value.as_ref() {
+        for item in value
+            .get("instances")
+            .and_then(serde_json::Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let Some(instance_id) = get_str(item, "instance_id") else {
+                continue;
+            };
+            rows.insert(
+                (instance_id.to_owned(), 1),
+                InstanceRow {
+                    instance_id: instance_id.to_owned(),
+                    run_index: 1,
+                    status: InstanceStatus::Terminal,
+                    current_step: get_u64(item, "steps").and_then(|v| u32::try_from(v).ok()),
+                    outcome: get_str(item, "outcome").map(ToOwned::to_owned),
+                    failure_category: parse_failure_category_value(item.get("failure_category")),
+                },
+            );
+        }
+    }
+
+    for (instance_id, run_index, traj) in scan_all_trajectories(sweep_dir) {
+        let info = traj.info;
+        let row = if info.partial {
+            InstanceRow {
+                instance_id: instance_id.clone(),
+                run_index,
+                status: InstanceStatus::InFlight,
+                current_step: info.steps,
+                outcome: None,
+                failure_category: None,
+            }
+        } else {
+            InstanceRow {
+                instance_id: instance_id.clone(),
+                run_index,
+                status: InstanceStatus::Terminal,
+                current_step: info.steps,
+                outcome: info.outcome,
+                failure_category: info.failure_category,
+            }
+        };
+        rows.insert((instance_id, run_index), row);
+    }
+
+    if let Some(ids) = results_value
+        .as_ref()
+        .and_then(|value| value.pointer("/filter_spec/instance_ids"))
+        .and_then(serde_json::Value::as_array)
+    {
+        for id_value in ids {
+            let Some(instance_id) = id_value.as_str() else {
+                continue;
+            };
+            rows.entry((instance_id.to_owned(), 1))
+                .or_insert_with(|| InstanceRow {
+                    instance_id: instance_id.to_owned(),
+                    run_index: 1,
+                    status: InstanceStatus::Pending,
+                    current_step: None,
+                    outcome: None,
+                    failure_category: None,
+                });
+        }
+    }
+
+    Ok(rows.into_values().collect())
+}
+
+/// Walk `sweep_dir` for every trajectory file (flat `<id>.traj.json` and
+/// nested `<id>/run-N.traj.json`), parsing each one. Unlike
+/// [`scan_trajectories`], partial (in-flight) trajectories are included —
+/// callers that only want terminal records should filter on
+/// `traj.info.partial`. Unreadable or invalid files are skipped silently:
+/// this feeds a best-effort live dashboard, not the authoritative snapshot.
+fn scan_all_trajectories(sweep_dir: &Path) -> Vec<(String, u32, Trajectory)> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(sweep_dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let Some(instance_id) = path
+                .file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                .map(str::to_owned)
+            else {
+                continue;
+            };
+            let Ok(nested) = std::fs::read_dir(&path) else {
+                continue;
+            };
+            for nested_entry in nested.flatten() {
+                let nested_path = nested_entry.path();
+                let Some(name) = nested_path.file_name().and_then(std::ffi::OsStr::to_str) else {
+                    continue;
+                };
+                let Some(run_index) = name
+                    .strip_prefix("run-")
+                    .and_then(|s| s.strip_suffix(".traj.json"))
+                    .and_then(|n| n.parse::<u32>().ok())
+                else {
+                    continue;
+                };
+                if let Some(traj) = read_trajectory_lenient(&nested_path) {
+                    out.push((instance_id.clone(), run_index, traj));
+                }
+            }
+            continue;
+        }
+        if !path.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let Some(instance_id) = name.strip_suffix(".traj.json") else {
+            continue;
+        };
+        if let Some(traj) = read_trajectory_lenient(&path) {
+            out.push((instance_id.to_owned(), 1, traj));
+        }
+    }
+    out
+}
+
+fn read_trajectory_lenient(path: &Path) -> Option<Trajectory> {
+    let text = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
 fn count_partial_trajectories(sweep_dir: &Path) -> usize {
     let mut count = 0;
     let Ok(entries) = std::fs::read_dir(sweep_dir) else {

--- a/src/run/watch.rs
+++ b/src/run/watch.rs
@@ -160,7 +160,11 @@ pub async fn run(args: &WatchArgs) -> Result<(), Error> {
 /// For run_index > 1, only the nested `<sweep>/<instance>/run-N.traj.json` path is
 /// checked. For run_index == 1 the legacy flat layout is also accepted so that
 /// hello-world and pre-rerun sweep outputs work without a `--run-index` flag.
-fn resolve_watch_path(sweep: &Path, instance_id: &str, run_index: u32) -> Option<PathBuf> {
+pub(crate) fn resolve_watch_path(
+    sweep: &Path,
+    instance_id: &str,
+    run_index: u32,
+) -> Option<PathBuf> {
     let nested = sweep
         .join(instance_id)
         .join(format!("run-{run_index}.traj.json"));
@@ -236,7 +240,7 @@ fn maybe_warn_stall(last_activity: Option<&Instant>, stall_warned: &mut bool, du
     }
 }
 
-fn is_terminal_outcome(traj: &Trajectory) -> bool {
+pub(crate) fn is_terminal_outcome(traj: &Trajectory) -> bool {
     traj.info.outcome.is_some() || traj.info.exit_reason.is_some()
 }
 

--- a/tests/bench_tail.rs
+++ b/tests/bench_tail.rs
@@ -738,7 +738,7 @@ fn instance_rows_distinguishes_run_index_for_reruns() {
     write_partial_traj(&instance_dir, "run-2.traj.json", 3);
 
     let mut rows = instance_rows(dir.path()).unwrap();
-    rows.sort_by(|a, b| a.run_index.cmp(&b.run_index));
+    rows.sort_by_key(|r| r.run_index);
     assert_eq!(rows.len(), 2);
     assert_eq!(rows[0].run_index, 1);
     assert_eq!(rows[0].status, InstanceStatus::Terminal);
@@ -857,4 +857,30 @@ fn instance_rows_prefers_nested_layout_over_legacy_flat_file_deterministically()
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].status, InstanceStatus::InFlight);
     assert_eq!(rows[0].current_step, Some(5));
+}
+
+#[test]
+fn instance_rows_does_not_fall_back_to_legacy_flat_when_nested_file_is_unreadable() {
+    let dir = tempfile::tempdir().unwrap();
+    // Legacy flat file with a real (stale) terminal outcome.
+    let mut legacy = Trajectory::new();
+    legacy.info.outcome = Some(outcome::ERROR.into());
+    legacy.info.exit_reason = Some(outcome::ERROR.into());
+    std::fs::write(
+        dir.path().join("kilo.traj.json"),
+        serde_json::to_string_pretty(&legacy).unwrap(),
+    )
+    .unwrap();
+    // A nested file exists for the same instance/run (current layout takes
+    // precedence) but is mid-write / corrupt and fails to parse.
+    let instance_dir = dir.path().join("kilo");
+    std::fs::create_dir_all(&instance_dir).unwrap();
+    std::fs::write(instance_dir.join("run-1.traj.json"), "{not valid json").unwrap();
+
+    let rows = instance_rows(dir.path()).unwrap();
+    assert!(
+        rows.iter().all(|r| r.instance_id != "kilo"),
+        "must not resurrect the stale legacy flat row when the nested file exists but is \
+         unreadable: {rows:?}"
+    );
 }

--- a/tests/bench_tail.rs
+++ b/tests/bench_tail.rs
@@ -808,3 +808,53 @@ fn instance_rows_has_no_pending_rows_without_explicit_instance_ids() {
     assert!(rows.iter().all(|r| r.status != InstanceStatus::Pending));
     assert_eq!(rows.len(), 1);
 }
+
+#[test]
+fn snapshot_counts_partial_trajectories_across_multiple_instances() {
+    let dir = tempfile::tempdir().unwrap();
+    let now = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
+
+    for name in ["golf", "hotel"] {
+        let instance_dir = dir.path().join(name);
+        std::fs::create_dir_all(&instance_dir).unwrap();
+        write_partial_traj(&instance_dir, "run-1.traj.json", 2);
+    }
+    let terminal_dir = dir.path().join("india");
+    std::fs::create_dir_all(&terminal_dir).unwrap();
+    let mut traj = Trajectory::new();
+    traj.info.outcome = Some(outcome::SUBMITTED.into());
+    traj.info.exit_reason = Some(outcome::SUBMITTED.into());
+    std::fs::write(
+        terminal_dir.join("run-1.traj.json"),
+        serde_json::to_string_pretty(&traj).unwrap(),
+    )
+    .unwrap();
+
+    let snap = snapshot(dir.path(), &opts_at(now)).unwrap();
+    assert_eq!(snap.partial_persisted, 2, "{snap:#?}");
+}
+
+#[test]
+fn instance_rows_prefers_nested_layout_over_legacy_flat_file_deterministically() {
+    let dir = tempfile::tempdir().unwrap();
+    // A legacy flat file (run 1, terminal/error) coexists with a freshly
+    // resumed nested run-1.traj.json (in-flight) for the same instance —
+    // the nested (current) layout must always win, regardless of directory
+    // iteration order.
+    let mut legacy = Trajectory::new();
+    legacy.info.outcome = Some(outcome::ERROR.into());
+    legacy.info.exit_reason = Some(outcome::ERROR.into());
+    std::fs::write(
+        dir.path().join("juliet.traj.json"),
+        serde_json::to_string_pretty(&legacy).unwrap(),
+    )
+    .unwrap();
+    let instance_dir = dir.path().join("juliet");
+    std::fs::create_dir_all(&instance_dir).unwrap();
+    write_partial_traj(&instance_dir, "run-1.traj.json", 5);
+
+    let rows = instance_rows(dir.path()).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].status, InstanceStatus::InFlight);
+    assert_eq!(rows[0].current_step, Some(5));
+}

--- a/tests/bench_tail.rs
+++ b/tests/bench_tail.rs
@@ -7,7 +7,9 @@ use std::path::Path;
 use std::process::Command;
 
 use chrono::{TimeZone, Utc};
-use maxwells_daemon::run::tail::{SnapshotOptions, render_text, snapshot};
+use maxwells_daemon::run::tail::{
+    InstanceStatus, SnapshotOptions, instance_rows, render_text, snapshot,
+};
 use maxwells_daemon::trajectory::{
     FailureCategory, FallbackAttemptRecord, FallbackSummary, TokenUsage, Trajectory, outcome,
 };
@@ -656,4 +658,156 @@ fn all_failed_trajectory_excluded_from_model_mix() {
         "all_failed trajectories should not appear in model_mix: {:?}",
         snap.model_mix
     );
+}
+
+// ---- instance_rows() — per-instance rows for the sweep dashboard (issue #641) ----
+
+fn write_partial_traj(dir: &Path, filename: &str, steps: u32) {
+    let mut traj = Trajectory::new();
+    traj.info.partial = true;
+    traj.info.partial_reason = Some("in_progress".into());
+    traj.info.steps = Some(steps);
+    std::fs::write(
+        dir.join(filename),
+        serde_json::to_string_pretty(&traj).unwrap(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn instance_rows_errors_when_sweep_dir_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("does-not-exist");
+    assert!(instance_rows(&missing).is_err());
+}
+
+#[test]
+fn instance_rows_reports_terminal_instance_from_flat_trajectory() {
+    let dir = tempfile::tempdir().unwrap();
+    write_traj(
+        dir.path(),
+        "alpha",
+        outcome::SUBMITTED,
+        None,
+        0.5,
+        "2026-04-30T01:00:00Z",
+        "2026-04-30T01:05:00Z",
+    );
+
+    let rows = instance_rows(dir.path()).unwrap();
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row.instance_id, "alpha");
+    assert_eq!(row.run_index, 1);
+    assert_eq!(row.status, InstanceStatus::Terminal);
+    assert_eq!(row.outcome.as_deref(), Some(outcome::SUBMITTED));
+}
+
+#[test]
+fn instance_rows_reports_in_flight_instance_from_partial_nested_trajectory() {
+    let dir = tempfile::tempdir().unwrap();
+    let instance_dir = dir.path().join("bravo");
+    std::fs::create_dir_all(&instance_dir).unwrap();
+    write_partial_traj(&instance_dir, "run-1.traj.json", 4);
+
+    let rows = instance_rows(dir.path()).unwrap();
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row.instance_id, "bravo");
+    assert_eq!(row.run_index, 1);
+    assert_eq!(row.status, InstanceStatus::InFlight);
+    assert_eq!(row.current_step, Some(4));
+    assert!(row.outcome.is_none());
+}
+
+#[test]
+fn instance_rows_distinguishes_run_index_for_reruns() {
+    let dir = tempfile::tempdir().unwrap();
+    let instance_dir = dir.path().join("charlie");
+    std::fs::create_dir_all(&instance_dir).unwrap();
+    // run 1 already finished; run 2 is still in flight.
+    let mut traj1 = Trajectory::new();
+    traj1.info.outcome = Some(outcome::SUBMITTED.into());
+    traj1.info.exit_reason = Some(outcome::SUBMITTED.into());
+    traj1.info.steps = Some(9);
+    std::fs::write(
+        instance_dir.join("run-1.traj.json"),
+        serde_json::to_string_pretty(&traj1).unwrap(),
+    )
+    .unwrap();
+    write_partial_traj(&instance_dir, "run-2.traj.json", 3);
+
+    let mut rows = instance_rows(dir.path()).unwrap();
+    rows.sort_by(|a, b| a.run_index.cmp(&b.run_index));
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].run_index, 1);
+    assert_eq!(rows[0].status, InstanceStatus::Terminal);
+    assert_eq!(rows[0].current_step, Some(9));
+    assert_eq!(rows[1].run_index, 2);
+    assert_eq!(rows[1].status, InstanceStatus::InFlight);
+    assert_eq!(rows[1].current_step, Some(3));
+}
+
+#[test]
+fn instance_rows_reports_pending_instance_when_filter_spec_names_it() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results(
+        dir.path(),
+        &serde_json::json!({
+            "total": 2,
+            "submitted": 1,
+            "skipped": 0,
+            "errored": 0,
+            "budget_halted": 0,
+            "with_patch": 1,
+            "filter_spec": {
+                "original_count": 2,
+                "selected_count": 2,
+                "instance_ids": ["delta", "echo"]
+            },
+            "instances": [{
+                "instance_id": "delta",
+                "exit_reason": "submitted",
+                "outcome": "submitted"
+            }]
+        }),
+    );
+
+    let rows = instance_rows(dir.path()).unwrap();
+    let echo = rows
+        .iter()
+        .find(|r| r.instance_id == "echo")
+        .unwrap();
+    assert_eq!(echo.status, InstanceStatus::Pending);
+    assert!(echo.outcome.is_none());
+    assert!(echo.current_step.is_none());
+
+    let delta = rows.iter().find(|r| r.instance_id == "delta").unwrap();
+    assert_eq!(delta.status, InstanceStatus::Terminal);
+    assert_eq!(delta.outcome.as_deref(), Some("submitted"));
+}
+
+#[test]
+fn instance_rows_has_no_pending_rows_without_explicit_instance_ids() {
+    let dir = tempfile::tempdir().unwrap();
+    write_results(
+        dir.path(),
+        &serde_json::json!({
+            "total": 5,
+            "submitted": 1,
+            "skipped": 0,
+            "errored": 0,
+            "budget_halted": 0,
+            "with_patch": 1,
+            "instances": [{
+                "instance_id": "foxtrot",
+                "exit_reason": "submitted",
+                "outcome": "submitted"
+            }]
+        }),
+    );
+
+    let rows = instance_rows(dir.path()).unwrap();
+    assert!(rows.iter().all(|r| r.status != InstanceStatus::Pending));
+    assert_eq!(rows.len(), 1);
 }

--- a/tests/bench_tail.rs
+++ b/tests/bench_tail.rs
@@ -774,10 +774,7 @@ fn instance_rows_reports_pending_instance_when_filter_spec_names_it() {
     );
 
     let rows = instance_rows(dir.path()).unwrap();
-    let echo = rows
-        .iter()
-        .find(|r| r.instance_id == "echo")
-        .unwrap();
+    let echo = rows.iter().find(|r| r.instance_id == "echo").unwrap();
     assert_eq!(echo.status, InstanceStatus::Pending);
     assert!(echo.outcome.is_none());
     assert!(echo.current_step.is_none());

--- a/tests/bench_tail_dashboard.rs
+++ b/tests/bench_tail_dashboard.rs
@@ -1,0 +1,150 @@
+//! CLI-level behavior for `bench tail --ui ratatui` (issue #641).
+//!
+//! Spawns the compiled `max` binary to exercise flag validation and the
+//! non-TTY rejection path — the happy interactive path needs a real TTY and
+//! is covered instead by `src/run/sweep_dashboard.rs`'s `TestBackend` unit
+//! tests and `instance_rows`/`snapshot` coverage in `tests/bench_tail.rs`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::process::{Command, Stdio};
+
+mod support;
+use support::binary_path;
+
+fn write_minimal_sweep(dir: &std::path::Path) {
+    std::fs::write(
+        dir.join("results.json"),
+        serde_json::to_string(&serde_json::json!({
+            "total": 1,
+            "submitted": 0,
+            "skipped": 0,
+            "errored": 0,
+            "budget_halted": 0,
+            "with_patch": 0,
+            "instances": []
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn ratatui_ui_rejects_non_tty_with_clear_message() {
+    let bin = binary_path();
+    let dir = tempfile::tempdir().unwrap();
+    write_minimal_sweep(dir.path());
+    let out = Command::new(&bin)
+        .args([
+            "bench",
+            "tail",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+            "--ui",
+            "ratatui",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn `max bench tail --ui ratatui`");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit; stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("requires a TTY"),
+        "stderr missing TTY guidance: {stderr}"
+    );
+}
+
+#[test]
+fn ratatui_ui_rejects_once() {
+    let bin = binary_path();
+    let dir = tempfile::tempdir().unwrap();
+    write_minimal_sweep(dir.path());
+    let out = Command::new(&bin)
+        .args([
+            "bench",
+            "tail",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+            "--ui",
+            "ratatui",
+            "--once",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn `max bench tail --ui ratatui --once`");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit; stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("--once"),
+        "stderr missing --once guidance: {stderr}"
+    );
+}
+
+#[test]
+fn ratatui_ui_rejects_json_format() {
+    let bin = binary_path();
+    let dir = tempfile::tempdir().unwrap();
+    write_minimal_sweep(dir.path());
+    let out = Command::new(&bin)
+        .args([
+            "bench",
+            "tail",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+            "--ui",
+            "ratatui",
+            "--format",
+            "json",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn `max bench tail --ui ratatui --format json`");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit; stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("--format json"),
+        "stderr missing --format json guidance: {stderr}"
+    );
+}
+
+#[test]
+fn default_ui_is_unaffected_by_the_new_flag() {
+    let bin = binary_path();
+    let dir = tempfile::tempdir().unwrap();
+    write_minimal_sweep(dir.path());
+    let out = Command::new(&bin)
+        .args([
+            "bench",
+            "tail",
+            "--sweep",
+            dir.path().to_str().unwrap(),
+            "--once",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn `max bench tail --once`");
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("=== bench tail ==="), "{stdout}");
+}


### PR DESCRIPTION
## Summary
Implements an interactive full-screen dashboard for `bench tail --ui ratatui` that provides live monitoring of sweep progress with drill-down capability into individual instance trajectories (issue #641).

## Key Changes

### New Module: `src/run/sweep_dashboard.rs`
- **1210 lines** of pure, testable state machine and rendering logic
- `DashboardState`: Immutable state container for the dashboard (sweep dir, snapshot, instance rows, selection, mode)
- `Mode` enum: Switches between `List` (instance overview) and `Detail` (live trajectory follow) views
- `DetailState`: Tracks live trajectory polling state for a selected instance, including file change detection and line buffering
- **Pure functions** for state transitions (`handle_key`, `draw`, `list_scroll_top`, `file_unchanged`) that are unit-testable with ratatui's `TestBackend` without a real terminal
- **IO shell** (`run` function): Thin wrapper managing terminal setup, the event loop, and periodic refresh polling
- **Rendering**: 
  - Aggregate panel showing sweep progress, cost, failures, and warnings
  - Instance list with status indicators (pending/in-flight/terminal)
  - Detail pane with live trajectory output (steps, stdout/stderr, exit codes)
  - Help overlay with keybindings
- **Key bindings**: Arrow keys/j/k for navigation, Enter to drill down, Esc to return, ? for help, q/Ctrl-C to quit
- **Smart selection tracking**: When instance rows are re-sorted on each poll, the previously-selected instance is re-located by identity rather than index
- **Trajectory following**: Reuses `bench watch`'s `resolve_watch_path` and `bench inspect`'s `build_inspect_steps_with_max` for live step rendering
- **Memory-bounded**: Caps retained detail lines at 400 to prevent unbounded growth during long-running instances

### Modified: `src/run/tail.rs`
- **New public types** for dashboard integration:
  - `InstanceStatus` enum: `Pending` (not yet started), `InFlight` (partial trajectory), `Terminal` (finished)
  - `InstanceRow` struct: Per-instance row data (id, run index, status, current step, outcome, failure category)
- **New public function** `instance_rows()`: Enumerates instance rows from trajectory files and `results.json`
  - Handles both flat (`<id>.traj.json`) and nested (`<id>/run-N.traj.json`) trajectory layouts
  - Nested files take precedence over legacy flat files for the same instance/run
  - Reports pending instances when `filter_spec.instance_ids` is present in `results.json`
- **New internal function** `snapshot_and_rows()`: Shared single `results.json` read for both aggregate snapshot and instance rows (optimization: dashboard calls this every tick instead of reading the file twice)
- **Refactored** `snapshot()` to use extracted `snapshot_from_value()` helper for code reuse
- **Modified** `scan_trajectories()` return type to include partial trajectory count (moved from separate `count_partial_trajectories()` call)

### Modified: `src/cli/args.rs`
- **New enum** `TailUiKind`: Selector for `bench tail --ui` with variants `Text` (default) and `Ratatui`
- Added `--ui` flag to `TailCmd` struct

### Modified: `src/cli/mod.rs`
- **New validation function** `reject_incompatible_tail_ratatui_ui()`: Rejects `--once` and `--format json` when combined with `--ui ratatui`
- Integrated validation into `bench tail` command handling
- Clear error messages guiding users to omit `--ui ratatui` for one-shot snapshots or JSON output

### Modified: `src/run/mod.rs`
- Declared new `pub mod sweep_dashboard` module

### Modified: `src/run/watch.rs`
- Exported `is_terminal_outcome()` function for use by dashboard's trajectory completion detection

### New Tests: `tests/

https://claude.ai/code/session_01RV9thgyBL4isezEcgErzfG