### PR TITLE
⚒️ Forge: Refactor unwrap() calls in docker.rs tests

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected my-image positional arg in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"


### PR DESCRIPTION
🚮 Smell: Unidiomatic use of `assert!(is_some())` combined with `.unwrap()` on `Option`s in tests, violating project linting rules (`-D clippy::unwrap_used`).
✨ Solution: Replaced sequential `assert!` and `unwrap()` calls with modern, idiomatic `let Some(...) = ... else { panic!(...); }` guard clauses with descriptive fallback messages.
🧼 Benefit: Provides clearer context on panic, safely handles extraction, removes unidiomatic `unwrap`s, and flattens logic without altering test semantics.
🛡️ Verification: Tests passed (`cargo test --lib -- env::docker::tests`). No logic changed. `cargo clippy --all-targets --all-features -- -D warnings` passes clean.

---
*PR created automatically by Jules for task [10350045279064775646](https://jules.google.com/task/10350045279064775646) started by @madmax983*