### PR TITLE
👺 Havoc: Add fuzzing tests for critical parsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -1372,6 +1372,7 @@ dependencies = [
  "sha2",
  "similar",
  "tar",
+ "temp-env",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -2274,6 +2275,16 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "futures",
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ proptest = "1"
 insta = { version = "1", features = ["json"] }
 pretty_assertions = "1"
 tokio = { version = "1", features = ["full", "test-util"] }
+temp-env = { version = "0.3.6", features = ["async_closure"] }
 
 [features]
 default = ["webhook"]

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -530,14 +530,10 @@ mod tests {
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = network_pos else {
+            panic!("expected --network flag in args: {args:?}")
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +548,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("network flag missing")
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("image missing")
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -1254,3 +1254,15 @@ impl PolicyCounts {
         self.allowed == 0 && self.asked == 0 && self.blocked == 0 && self.yolo_bypassed == 0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    proptest! {
+        #[test]
+        fn test_interpreter_invokes_file_no_panic(region in "\\\\PC*", file in "\\\\PC*") {
+            let _ = interpreter_invokes_file(&region, &file);
+        }
+    }
+}

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -995,6 +995,17 @@ mod redaction_unsafe_tests {
     #![allow(clippy::unwrap_used)]
     use super::*;
 
+    use proptest::prelude::*;
+    proptest! {
+        #[test]
+        fn test_redact_text_no_panic(input in "\\PC*", surface in "\\PC*") {
+            let redactor = Redactor::default_enabled();
+            let _ = redactor.redact_text(&input, &surface);
+            let _ = redactor.unredact_text(&input);
+            let _ = redactor.check(&input);
+        }
+    }
+
     #[test]
     fn should_return_true_when_unsafe_allow_secret_leaks_is_true() {
         let cfg = RedactionCfg {

--- a/src/run/bundle.rs
+++ b/src/run/bundle.rs
@@ -1572,4 +1572,12 @@ mod tests {
             "path=./file"
         );
     }
+
+    use proptest::prelude::*;
+    proptest! {
+        #[test]
+        fn test_normalize_archive_path_no_panic(path in "\\\\PC*") {
+            let _ = super::normalize_archive_path(std::path::Path::new(&path));
+        }
+    }
 }

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -2290,6 +2290,14 @@ mod tests {
         assert_eq!(slugify("A/B/C"), "a-b-c");
     }
 
+    use proptest::prelude::*;
+    proptest! {
+        #[test]
+        fn test_slugify_no_panic(s in "\\PC*") {
+            let _ = slugify(&s);
+        }
+    }
+
     #[test]
     fn validate_git_rev_accepts_revspec_chars_and_rejects_empty_or_control() {
         assert_eq!(validate_git_rev("HEAD"), Ok("HEAD"));


### PR DESCRIPTION
👺 Havoc: Add fuzzing tests for critical parsers

🧨 The Trigger: Potential inputs lacking valid boundary tests.
📉 The Stack Trace: Found no specific stack traces but tests now cover these cases.
🧪 Reproduction: run `cargo test` in modified areas
😈 Comment: Proptests added for safe inputs.

---
*PR created automatically by Jules for task [11356693298836509344](https://jules.google.com/task/11356693298836509344) started by @madmax983*