### PR TITLE
🎨 Mosaic: UI Polish for `bench merge` and `bench shard`

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -532,10 +532,7 @@ mod tests {
         let Some(pos) = args.iter().position(|a| a == "--network") else {
             panic!("expected --network flag in args: {args:?}");
         };
-        assert_eq!(
-            args.get(pos + 1).map(String::as_str),
-            Some("none")
-        );
+        assert_eq!(args.get(pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,13 +529,11 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
+        let Some(pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
         assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
+            args.get(pos + 1).map(String::as_str),
             Some("none")
         );
     }
@@ -550,6 +548,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network").unwrap();

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -10,6 +10,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -261,12 +262,22 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
 impl MergeReport {
     pub fn render_text(&self) {
         println!("Shards merged: {}", self.shards.len());
+
+        let mut shard_table = Table::new();
+        shard_table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Label", "Instances", "Path"]);
+
         for s in &self.shards {
-            println!(
-                "  {:20}  {:6} instances  {}",
-                s.label, s.instance_count, s.dir
-            );
+            shard_table.add_row(vec![
+                s.label.clone(),
+                s.instance_count.to_string(),
+                s.dir.clone(),
+            ]);
         }
+        println!("{shard_table}");
+
         println!();
         println!(
             "Total instances: {} ({} duplicates resolved via {})",
@@ -274,12 +285,27 @@ impl MergeReport {
         );
         println!("Output: {}", self.output_dir);
         println!();
+
         println!("Top-line metrics:");
-        println!("  total_cost_usd : {:.6}", self.total_cost_usd);
-        println!("  submitted      : {}", self.submitted);
-        println!("  errored        : {}", self.errored);
-        println!("  resolved       : {}", self.resolved);
-        println!("  pass_at_k      : {:.4}", self.pass_at_k);
+        let mut metrics_table = Table::new();
+        metrics_table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Metric", "Value"]);
+
+        metrics_table.add_row(vec![
+            "total_cost_usd".to_string(),
+            format!("{:.6}", self.total_cost_usd),
+        ]);
+        metrics_table.add_row(vec!["submitted".to_string(), self.submitted.to_string()]);
+        metrics_table.add_row(vec!["errored".to_string(), self.errored.to_string()]);
+        metrics_table.add_row(vec!["resolved".to_string(), self.resolved.to_string()]);
+        metrics_table.add_row(vec![
+            "pass_at_k".to_string(),
+            format!("{:.4}", self.pass_at_k),
+        ]);
+
+        println!("{metrics_table}");
     }
 }
 

--- a/src/run/shard.rs
+++ b/src/run/shard.rs
@@ -18,6 +18,7 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
@@ -79,10 +80,20 @@ impl ShardReport {
         println!("  shards          {}", self.shard_count);
         println!("  total instances {}", self.total_instances);
         println!("  balance spread  {}", self.balance_spread);
-        for (i, count) in self.per_shard_counts.iter().enumerate() {
-            println!("  shard-{i:03}        {count} instances");
-        }
         println!("  dataset sha256  {}", self.source_dataset_sha256);
+        println!();
+
+        let mut table = Table::new();
+        table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Shard", "Instances"]);
+
+        for (i, count) in self.per_shard_counts.iter().enumerate() {
+            table.add_row(vec![format!("shard-{i:03}"), count.to_string()]);
+        }
+
+        println!("{table}");
     }
 }
 


### PR DESCRIPTION
🎨 Mosaic: UI Polish for `bench merge` and `bench shard`

🖌️ **Before:**
`max bench merge` and `max bench shard` output raw text blocks using standard `println!` macros. The structure was loose, not visually appealing, and harder to quickly scan.

✨ **After:**
Refactored the `render_text` outputs in both `src/run/merge.rs` and `src/run/shard.rs` to use `comfy-table`. The tables are rendered with the established `UTF8_FULL` preset and `UTF8_ROUND_CORNERS` modifier for a consistent, dashboard-like Human Interface.

🖼️ **Visuals:**
- Replaced the list of shards and top-line metrics in `bench merge` with two neatly formatted tables (`["Label", "Instances", "Path"]` and `["Metric", "Value"]`).
- Replaced the list of shards in `bench shard` with a beautifully boxed table (`["Shard", "Instances"]`).

---
*PR created automatically by Jules for task [5600414452321228950](https://jules.google.com/task/5600414452321228950) started by @madmax983*