### PR TITLE
🔒 Warden: [security fix]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected my-image flag in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"


### PR DESCRIPTION
🦠 Threat: 
- `RUSTSEC-2026-0190`: Unsoundness in `anyhow::Error::downcast_mut()` vulnerability within dependencies.
- `clippy::unwrap_used`: The codebase contained unsafe `.unwrap()` calls within the testing framework `src/env/docker.rs` that would result in panics without explicit diagnostic messages.

🛡️ Defense: 
- Updated `anyhow` to `v1.0.103` using `cargo update -p anyhow` to resolve the vulnerability.
- Replaced naked `.unwrap()` calls in `src/env/docker.rs` with `let Some(network_pos) = ... else { panic!("...") };` to safely destruct Options and provide clear panic bounds in case of test failures, enforcing pedantic clippy hygiene in the testing modules.

💥 Severity: Moderate. The vulnerability exists within dependencies but without immediate exploit paths identified in our app surface. The unwraps could result in untraced test panics.

🧪 Verification: 
- Ran `cargo audit` cleanly, returning no active vulnerabilities (outside ignored issues in `audit.toml`).
- Executed `cargo clippy --all-targets --all-features -- -D warnings`, receiving zero warnings.
- Executed `cargo test --lib -- env::docker` successfully.

---
*PR created automatically by Jules for task [4206483742288800197](https://jules.google.com/task/4206483742288800197) started by @madmax983*