### PR TITLE
🎨 Mosaic: UI Polish for Merge Module

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("missing --network flag");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("missing my-image arg");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -10,6 +10,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
 use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -261,25 +262,49 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
 impl MergeReport {
     pub fn render_text(&self) {
         println!("Shards merged: {}", self.shards.len());
+
+        let mut shard_table = Table::new();
+        shard_table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Label", "Instances", "Directory"]);
+
         for s in &self.shards {
-            println!(
-                "  {:20}  {:6} instances  {}",
-                s.label, s.instance_count, s.dir
-            );
+            shard_table.add_row(vec![
+                s.label.clone(),
+                s.instance_count.to_string(),
+                s.dir.clone(),
+            ]);
         }
+        println!("{shard_table}");
         println!();
+
         println!(
             "Total instances: {} ({} duplicates resolved via {})",
             self.total_instances, self.duplicates, self.collision_policy
         );
         println!("Output: {}", self.output_dir);
         println!();
-        println!("Top-line metrics:");
-        println!("  total_cost_usd : {:.6}", self.total_cost_usd);
-        println!("  submitted      : {}", self.submitted);
-        println!("  errored        : {}", self.errored);
-        println!("  resolved       : {}", self.resolved);
-        println!("  pass_at_k      : {:.4}", self.pass_at_k);
+
+        let mut metrics_table = Table::new();
+        metrics_table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Metric", "Value"]);
+
+        metrics_table.add_row(vec![
+            "total_cost_usd".to_string(),
+            format!("{:.6}", self.total_cost_usd),
+        ]);
+        metrics_table.add_row(vec!["submitted".to_string(), self.submitted.to_string()]);
+        metrics_table.add_row(vec!["errored".to_string(), self.errored.to_string()]);
+        metrics_table.add_row(vec!["resolved".to_string(), self.resolved.to_string()]);
+        metrics_table.add_row(vec![
+            "pass_at_k".to_string(),
+            format!("{:.4}", self.pass_at_k),
+        ]);
+
+        println!("Top-line metrics:\n{metrics_table}");
     }
 }
 


### PR DESCRIPTION
🖌️ **Before:** The `bench merge` command emitted raw text blocks and unaligned `println!` lists for shard paths, instance counts, and aggregate metrics. This was difficult to scan and didn't align with the polished table-based output conventions used in other commands.

✨ **After:** Refactored the `MergeReport::render_text` module to use the repository standard `comfy-table` dependency (already present in `Cargo.toml`). The CLI now renders structured, rounded-corner tables. The upper table clearly aligns Shard Labels, Instance Counts, and Directories. The lower table presents Top-Line Metrics in a clean Key-Value format.

🖼️ **Visuals:** The "Shards merged" list is now a bordered `comfy-table`. The "Top-line metrics" list is also converted into a 2-column table (`Metric`, `Value`). The styling strictly uses `comfy_table::presets::UTF8_FULL` and `comfy_table::modifiers::UTF8_ROUND_CORNERS` to ensure consistency with the rest of the CLI dashboard.

---
*PR created automatically by Jules for task [6330993089558575044](https://jules.google.com/task/6330993089558575044) started by @madmax983*