### PR TITLE
⚒️ Forge: remove unwrap() in docker.rs tests

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected my-image in args");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"


### PR DESCRIPTION
🚰 Smell: In `src/env/docker.rs` tests, `unwrap()` was used on `Option` types without proper fallback or error messages, violating the codebase's `unwrap_used` lint policy and making test failures harder to debug.
✨ Solution: Replaced explicit `.unwrap()` calls with idiomatic guard clauses using `let Some(...) = ... else { panic!(...); }`, ensuring clear failure messages with surrounding context.
🧼 Benefit: Improves readability and debuggability of tests, adhering to idiomatic Rust error handling and fulfilling the Forge persona's strict avoidance of `unwrap()`.
🛡️ Verification: Ran `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and scoped test execution (`cargo test --features docker --lib -- env::docker::tests`). All passed cleanly. No runtime logic was modified.

---
*PR created automatically by Jules for task [5597704367234042311](https://jules.google.com/task/5597704367234042311) started by @madmax983*