### PR TITLE
👹 Havoc: [Fix test data races and concurrency bugs]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,6 +1372,7 @@ dependencies = [
  "sha2",
  "similar",
  "tar",
+ "temp-env",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -2274,6 +2275,16 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "futures",
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ proptest = "1"
 insta = { version = "1", features = ["json"] }
 pretty_assertions = "1"
 tokio = { version = "1", features = ["full", "test-util"] }
+temp-env = { version = "0.3.6", features = ["async_closure"] }
 
 [features]
 default = ["webhook"]

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -534,10 +534,9 @@ mod tests {
             network_pos.is_some(),
             "expected --network flag in args: {args:?}"
         );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        if let Some(pos) = network_pos {
+            assert_eq!(args.get(pos + 1).map(String::as_str), Some("none"));
+        }
     }
 
     #[test]
@@ -552,11 +551,11 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
-        assert!(
-            network_pos < image_pos,
-            "--network must appear before the image name"
-        );
+        let network_pos = args.iter().position(|a| a == "--network");
+        let image_pos = args.iter().position(|a| a == "my-image");
+        assert!(network_pos.is_some() && image_pos.is_some());
+        if let (Some(net_p), Some(img_p)) = (network_pos, image_pos) {
+            assert!(net_p < img_p, "--network must appear before the image name");
+        }
     }
 }

--- a/src/run/agent_doctor.rs
+++ b/src/run/agent_doctor.rs
@@ -627,12 +627,11 @@ mod tests {
         // Use a uniquely-named var to avoid clobbering real provider keys.
         let model = "weirdprov/model";
         let var = expected_credential_env(model).unwrap();
-        // SAFETY: single-threaded test; restore immediately after.
-        unsafe { std::env::set_var(&var, "TOPSECRETVALUE") };
-        let check = check_credential(model);
-        unsafe { std::env::remove_var(&var) };
-        assert_eq!(check.status, CheckStatus::Pass);
-        assert!(!check.detail.contains("TOPSECRETVALUE"));
+        temp_env::with_var(&var, Some("TOPSECRETVALUE"), || {
+            let check = check_credential(model);
+            assert_eq!(check.status, CheckStatus::Pass);
+            assert!(!check.detail.contains("TOPSECRETVALUE"));
+        });
     }
 
     #[test]
@@ -641,12 +640,12 @@ mod tests {
         // with a remediation hint naming the variable.
         let model = "zzznoprov/model";
         let var = expected_credential_env(model).unwrap();
-        // SAFETY: single-threaded test; ensure the var is absent.
-        unsafe { std::env::remove_var(&var) };
-        let check = check_credential(model);
-        assert_eq!(check.status, CheckStatus::Fail);
-        assert!(check.detail.contains(&var));
-        assert!(check.detail.contains("export"));
+        temp_env::with_var(&var, None::<&str>, || {
+            let check = check_credential(model);
+            assert_eq!(check.status, CheckStatus::Fail);
+            assert!(check.detail.contains(&var));
+            assert!(check.detail.contains("export"));
+        });
     }
 
     // ── output dir failure path (AC#2d) ──────────────────────────────────

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -3956,22 +3956,20 @@ index 8a1218a..24c5735 100644\n\
         // Inject a fake secret as an environment variable that the redactor picks up.
         // We use a value that looks like a real API key pattern so the redactor fires.
         let fake_secret = "sk-ant-fake-secret-value-for-test-0123456789abcdef";
-        // SAFETY: test-only; single-threaded context for secret injection.
-        unsafe { std::env::set_var("TEST_MANIFEST_API_KEY", fake_secret) };
+        #[allow(clippy::large_futures)]
+        temp_env::async_with_vars([("TEST_MANIFEST_API_KEY", Some(fake_secret))], async move {
+            let args = make_mini_args_for_manifest_test(tmp.path().to_path_buf(), "secret-test");
+            run(args).await.unwrap();
 
-        let args = make_mini_args_for_manifest_test(tmp.path().to_path_buf(), "secret-test");
-        run(args).await.unwrap();
+            let traj_path = tmp.path().join("secret-test.traj.json");
+            let content = std::fs::read_to_string(&traj_path).unwrap();
 
-        // Clean up env var
-        unsafe { std::env::remove_var("TEST_MANIFEST_API_KEY") };
-
-        let traj_path = tmp.path().join("secret-test.traj.json");
-        let content = std::fs::read_to_string(&traj_path).unwrap();
-
-        assert!(
-            !content.contains(fake_secret),
-            "serialized manifest must not contain secret value from env; found in: {content}"
-        );
+            assert!(
+                !content.contains(fake_secret),
+                "serialized manifest must not contain secret value from env; found in: {content}"
+            );
+        })
+        .await;
     }
 
     #[tokio::test]

--- a/src/run/redact_audit.rs
+++ b/src/run/redact_audit.rs
@@ -3133,21 +3133,20 @@ mod tests {
             "x.output.txt",
             "leaked: super-secret-ci-token-value-123\n",
         );
-        // SAFETY: set/remove a process-local var in a serial unit test.
-        unsafe {
-            std::env::set_var("DATABASE_PASSWORD", "super-secret-ci-token-value-123");
-        }
-        let report = audit(dir.path());
-        unsafe {
-            std::env::remove_var("DATABASE_PASSWORD");
-        }
-        assert!(
-            report
-                .findings
-                .iter()
-                .any(|f| f.match_class == "sensitive_env_value"),
-            "ambient env value missed: {:?}",
-            report.findings
+        temp_env::with_var(
+            "DATABASE_PASSWORD",
+            Some("super-secret-ci-token-value-123"),
+            || {
+                let report = audit(dir.path());
+                assert!(
+                    report
+                        .findings
+                        .iter()
+                        .any(|f| f.match_class == "sensitive_env_value"),
+                    "ambient env value missed: {:?}",
+                    report.findings
+                );
+            },
         );
     }
 

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -455,28 +455,31 @@ mod tests {
         // Synthetic env var picked up automatically by from_config_lossy.
         let unique_val = format!("sk-deadbeef-sweep-wh-{}", addr.port());
         let env_name = format!("FAKE_API_KEY_SWH_{}", addr.port());
-        // SAFETY: single-threaded test context; no concurrent env reads.
-        unsafe { std::env::set_var(&env_name, &unique_val) };
-        let redactor = Redactor::default_enabled();
+        let unique_val_clone = unique_val.clone();
+        #[allow(clippy::large_futures)]
+        temp_env::async_with_vars([(&env_name, Some(&unique_val))], async move {
+            let redactor = Redactor::default_enabled();
+            let unique_val = unique_val_clone;
 
-        let sink = SweepWebhookSink::new(url, &[], redactor, "sweep-redact".to_owned()).unwrap();
-        sink.emit(SweepNotificationEvent::InstanceCompleted {
-            instance_id: unique_val.clone(),
-            resolved: false,
-            failure_category: None,
-            cost_usd: None,
-            duration_secs: None,
-        });
+            let sink =
+                SweepWebhookSink::new(url, &[], redactor, "sweep-redact".to_owned()).unwrap();
+            sink.emit(SweepNotificationEvent::InstanceCompleted {
+                instance_id: unique_val.clone(),
+                resolved: false,
+                failure_category: None,
+                cost_usd: None,
+                duration_secs: None,
+            });
 
-        let socket = accept(&listener).await;
-        let req = read_http(socket).await;
-        // SAFETY: single-threaded test context; no concurrent env reads.
-        unsafe { std::env::remove_var(&env_name) };
+            let socket = accept(&listener).await;
+            let req = read_http(socket).await;
 
-        assert!(
-            !req.contains(&unique_val),
-            "sensitive env var value must not appear verbatim in posted payload"
-        );
+            assert!(
+                !req.contains(&unique_val),
+                "sensitive env var value must not appear verbatim in posted payload"
+            );
+        })
+        .await;
     }
 
     // ── RED: drop counting ─────────────────────────────────────────────────

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1124,17 +1124,6 @@ pub(crate) mod build {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
-
-    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        ENV_LOCK
-            .get_or_init(Mutex::default)
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
-
     #[test]
     fn trace_id_is_32_hex_chars() {
         let tid = new_trace_id("django__django__1234", "sweep-abc");
@@ -1166,65 +1155,64 @@ mod tests {
 
     #[test]
     fn resolve_endpoint_prefers_cli_flag() {
-        let _guard = env_lock();
-        // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-host:4318");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
-        let ep = resolve_endpoint(Some("http://cli-host:4318"));
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-        }
-        // CLI flag is a base URL; /v1/traces is appended.
-        assert_eq!(ep.as_deref(), Some("http://cli-host:4318/v1/traces"));
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", Some("http://env-host:4318")),
+                ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None),
+            ],
+            || {
+                let ep = resolve_endpoint(Some("http://cli-host:4318"));
+                // CLI flag is a base URL; /v1/traces is appended.
+                assert_eq!(ep.as_deref(), Some("http://cli-host:4318/v1/traces"));
+            },
+        );
     }
 
     #[test]
     fn resolve_endpoint_falls_back_to_env_var() {
-        let _guard = env_lock();
-        // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-host:4318");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
-        let ep = resolve_endpoint(None);
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-        }
-        // Generic env var is a base URL; /v1/traces is appended.
-        assert_eq!(ep.as_deref(), Some("http://env-host:4318/v1/traces"));
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", Some("http://env-host:4318")),
+                ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None),
+            ],
+            || {
+                let ep = resolve_endpoint(None);
+                // Generic env var is a base URL; /v1/traces is appended.
+                assert_eq!(ep.as_deref(), Some("http://env-host:4318/v1/traces"));
+            },
+        );
     }
 
     #[test]
     fn resolve_endpoint_traces_env_var_used_as_full_url() {
-        let _guard = env_lock();
-        // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-            std::env::set_var(
-                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-                "http://traces-host:4318/v1/traces",
-            );
-        }
-        let ep = resolve_endpoint(None);
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
-        // Trace-specific env var is a full URL; used as-is without appending.
-        assert_eq!(ep.as_deref(), Some("http://traces-host:4318/v1/traces"));
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", None),
+                (
+                    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+                    Some("http://traces-host:4318/v1/traces"),
+                ),
+            ],
+            || {
+                let ep = resolve_endpoint(None);
+                // Trace-specific env var is a full URL; used as-is without appending.
+                assert_eq!(ep.as_deref(), Some("http://traces-host:4318/v1/traces"));
+            },
+        );
     }
 
     #[test]
     fn resolve_endpoint_returns_none_when_unset() {
-        let _guard = env_lock();
-        // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
-        let ep = resolve_endpoint(None);
-        assert!(ep.is_none());
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", None::<&str>),
+                ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None),
+            ],
+            || {
+                let ep = resolve_endpoint(None);
+                assert!(ep.is_none());
+            },
+        );
     }
 
     #[test]
@@ -1247,129 +1235,115 @@ mod tests {
 
     #[test]
     fn resolve_metrics_endpoint_prefers_cli_flag() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-host:4318");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
-        }
-        let ep = resolve_metrics_endpoint(Some("http://cli-host:4318"));
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-        }
-        assert_eq!(ep.as_deref(), Some("http://cli-host:4318/v1/metrics"));
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", Some("http://env-host:4318")),
+                ("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", None),
+            ],
+            || {
+                let ep = resolve_metrics_endpoint(Some("http://cli-host:4318"));
+                assert_eq!(ep.as_deref(), Some("http://cli-host:4318/v1/metrics"));
+            },
+        );
     }
 
     #[test]
     fn resolve_metrics_endpoint_falls_back_to_env_var() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-host:4318");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
-        }
-        let ep = resolve_metrics_endpoint(None);
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-        }
-        assert_eq!(ep.as_deref(), Some("http://env-host:4318/v1/metrics"));
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", Some("http://env-host:4318")),
+                ("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", None),
+            ],
+            || {
+                let ep = resolve_metrics_endpoint(None);
+                assert_eq!(ep.as_deref(), Some("http://env-host:4318/v1/metrics"));
+            },
+        );
     }
 
     #[test]
     fn resolve_metrics_endpoint_metrics_env_var_used_as_full_url() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-            std::env::set_var(
-                "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
-                "http://metrics-host:4318/v1/metrics",
-            );
-        }
-        let ep = resolve_metrics_endpoint(None);
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
-        }
-        assert_eq!(ep.as_deref(), Some("http://metrics-host:4318/v1/metrics"));
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", None),
+                (
+                    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+                    Some("http://metrics-host:4318/v1/metrics"),
+                ),
+            ],
+            || {
+                let ep = resolve_metrics_endpoint(None);
+                assert_eq!(ep.as_deref(), Some("http://metrics-host:4318/v1/metrics"));
+            },
+        );
     }
 
     #[test]
     fn resolve_metrics_endpoint_returns_none_when_unset() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
-        }
-        let ep = resolve_metrics_endpoint(None);
-        assert!(ep.is_none());
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", None::<&str>),
+                ("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", None),
+            ],
+            || {
+                let ep = resolve_metrics_endpoint(None);
+                assert!(ep.is_none());
+            },
+        );
     }
 
     #[test]
     fn resolve_metrics_interval_prefers_env_var() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::set_var("OTEL_METRIC_EXPORT_INTERVAL", "30000");
-        }
-        let interval = resolve_metrics_interval(Some(10));
-        unsafe {
-            std::env::remove_var("OTEL_METRIC_EXPORT_INTERVAL");
-        }
-        assert_eq!(interval, std::time::Duration::from_secs(30));
+        temp_env::with_var("OTEL_METRIC_EXPORT_INTERVAL", Some("30000"), || {
+            let interval = resolve_metrics_interval(Some(10));
+            assert_eq!(interval, std::time::Duration::from_secs(30));
+        });
     }
 
     #[test]
     fn resolve_metrics_interval_prefers_cli_secs() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::remove_var("OTEL_METRIC_EXPORT_INTERVAL");
-        }
-        let interval = resolve_metrics_interval(Some(10));
-        assert_eq!(interval, std::time::Duration::from_secs(10));
+        temp_env::with_var("OTEL_METRIC_EXPORT_INTERVAL", None::<&str>, || {
+            let interval = resolve_metrics_interval(Some(10));
+            assert_eq!(interval, std::time::Duration::from_secs(10));
+        });
     }
 
     #[test]
     fn resolve_metrics_interval_defaults_to_15s() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::remove_var("OTEL_METRIC_EXPORT_INTERVAL");
-        }
-        let interval = resolve_metrics_interval(None);
-        assert_eq!(interval, std::time::Duration::from_secs(15));
+        temp_env::with_var("OTEL_METRIC_EXPORT_INTERVAL", None::<&str>, || {
+            let interval = resolve_metrics_interval(None);
+            assert_eq!(interval, std::time::Duration::from_secs(15));
+        });
     }
 
     #[test]
     fn resolve_metrics_interval_clamps_zero_env_var_to_1s() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::set_var("OTEL_METRIC_EXPORT_INTERVAL", "0");
-        }
-        let interval = resolve_metrics_interval(None);
-        unsafe {
-            std::env::remove_var("OTEL_METRIC_EXPORT_INTERVAL");
-        }
-        assert_eq!(interval, std::time::Duration::from_secs(1));
+        temp_env::with_var("OTEL_METRIC_EXPORT_INTERVAL", Some("0"), || {
+            let interval = resolve_metrics_interval(None);
+            assert_eq!(interval, std::time::Duration::from_secs(1));
+        });
     }
 
     #[test]
     fn resolve_metrics_interval_clamps_zero_cli_secs_to_1s() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::remove_var("OTEL_METRIC_EXPORT_INTERVAL");
-        }
-        let interval = resolve_metrics_interval(Some(0));
-        assert_eq!(interval, std::time::Duration::from_secs(1));
+        temp_env::with_var("OTEL_METRIC_EXPORT_INTERVAL", None::<&str>, || {
+            let interval = resolve_metrics_interval(Some(0));
+            assert_eq!(interval, std::time::Duration::from_secs(1));
+        });
     }
 
     #[test]
     fn resolve_metrics_headers_prefers_metrics_var() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_HEADERS", "a=1,b=2");
-            std::env::set_var("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "c=3");
-        }
-        let headers = resolve_metrics_headers();
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_HEADERS");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_HEADERS");
-        }
-        assert_eq!(headers, vec![("c".to_owned(), "3".to_owned())]);
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_HEADERS", Some("a=1,b=2")),
+                ("OTEL_EXPORTER_OTLP_METRICS_HEADERS", Some("c=3")),
+            ],
+            || {
+                let headers = resolve_metrics_headers();
+                assert_eq!(headers, vec![("c".to_owned(), "3".to_owned())]);
+            },
+        );
     }
 
     #[test]


### PR DESCRIPTION
🧨 **The Trigger:** Invoking multithreaded `cargo test` suites spanning multiple `#[tokio::test]` functions that all call `unsafe { std::env::set_var(...) }`.
📉 **The Stack Trace:** Intermittent `SIGSEGV` or logic test failures where environment variable assertions return unexpected results because a parallel test mutated the global environment state simultaneously.
🧪 **Reproduction:** Run `cargo test` on a multi-core machine under heavy load, causing interleaved execution between `mini_manifest_does_not_contain_env_secrets` and `redactor_strips_sensitive_env_var_from_instance_id`.
😈 **Comment:** "Thread-safe is a lie until proven. You assumed mutating the global process environment inside an asynchronous test runner wouldn't corrupt other concurrent tests. You were wrong."

---
*PR created automatically by Jules for task [4904392706543197046](https://jules.google.com/task/4904392706543197046) started by @madmax983*