### PR TITLE
👹 Havoc: [Concurrency] Fix DeterministicModel data races & Model step advancing bugs

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("must have network flag");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("must have network flag");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("must have image name");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -532,7 +532,10 @@ mod tests {
         let Some(network_pos) = args.iter().position(|a| a == "--network") else {
             panic!("must have network flag");
         };
-        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
+        assert_eq!(
+            args.get(network_pos + 1).map(String::as_str),
+            Some("none")
+        );
     }
 
     #[test]

--- a/src/model/deterministic.rs
+++ b/src/model/deterministic.rs
@@ -83,30 +83,20 @@ impl Model for DeterministicModel {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             rec.push(messages.to_vec());
         }
-        {
+        let content = {
             let mut count = self
                 .call_count
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let idx = *count;
             *count += 1;
-        }
+            drop(count);
 
-        // call_count was just incremented above; subtract 1 for 0-indexed step.
-        let step_index = {
-            let count = self
-                .call_count
+            self.responses
                 .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            count.saturating_sub(1)
-        };
-
-        let content = {
-            let mut q = self
-                .responses
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            q.pop_front()
-                .ok_or(ModelError::ResponsesExhausted(step_index))?
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .pop_front()
+                .ok_or(ModelError::ResponsesExhausted(idx))?
         };
 
         // Sentinel: "__rate_limited__:N" → ModelError::RateLimited with

--- a/src/run/fork.rs
+++ b/src/run/fork.rs
@@ -127,12 +127,6 @@ impl Model for ForkingModel {
                 _ => {}
             }
 
-            // Advance step counter only after checking fingerprint.
-            *self
-                .step
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner) = step + 1;
-
             let mut resp = self
                 .inner_deterministic
                 .query(messages, opts)
@@ -141,6 +135,12 @@ impl Model for ForkingModel {
                     ModelError::ResponsesExhausted(n) => ModelError::ScriptedResponsesExhausted(n),
                     other => other,
                 })?;
+
+            // Advance step counter only after checking fingerprint and successfully querying.
+            *self
+                .step
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = step + 1;
 
             // Strictly $0 cost attribute to the prefix.
             resp.usage = ModelUsage {

--- a/src/run/replay.rs
+++ b/src/run/replay.rs
@@ -496,19 +496,25 @@ impl Model for FingerprintCheckingModel {
             }
         }
 
-        // Advance step counter only after the fingerprint check passes.
+        // Translate the generic scripted-model exhaustion into the
+        // replay-specific variant so that `ExitCode::from_error` maps it to
+        // `ReplayResponseExhausted` (10) only in replay context.
+        let resp = self
+            .inner
+            .query(messages, opts)
+            .await
+            .map_err(|e| match e {
+                ModelError::ResponsesExhausted(n) => ModelError::ScriptedResponsesExhausted(n),
+                other => other,
+            })?;
+
+        // Advance step counter only after the fingerprint check passes and querying succeeds.
         *self
             .step
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = step + 1;
 
-        // Translate the generic scripted-model exhaustion into the
-        // replay-specific variant so that `ExitCode::from_error` maps it to
-        // `ReplayResponseExhausted` (10) only in replay context.
-        self.inner.query(messages, opts).await.map_err(|e| match e {
-            ModelError::ResponsesExhausted(n) => ModelError::ScriptedResponsesExhausted(n),
-            other => other,
-        })
+        Ok(resp)
     }
 }
 

--- a/tests/concurrent_model.rs
+++ b/tests/concurrent_model.rs
@@ -5,27 +5,25 @@ use maxwells_daemon::model::{Model, QueryOpts};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_deterministic_model_concurrent_query() {
-    let model = std::sync::Arc::new(DeterministicModel::new(vec![
-        "A".into(),
-        "B".into(),
-        "C".into(),
-        "D".into(),
-    ]));
+    let mut vec = Vec::new();
+    for i in 0..1000 {
+        vec.push(i.to_string());
+    }
 
-    let m1 = model.clone();
-    let h1 = tokio::spawn(async move {
-        let opts = QueryOpts::default();
-        let _ = m1.query(&[], &opts).await;
-    });
+    let model = std::sync::Arc::new(DeterministicModel::new(vec));
 
-    let m2 = model.clone();
-    let h2 = tokio::spawn(async move {
-        let opts = QueryOpts::default();
-        let _ = m2.query(&[], &opts).await;
-    });
+    let mut handles = vec![];
+    for _ in 0..1000 {
+        let m = model.clone();
+        handles.push(tokio::spawn(async move {
+            let opts = QueryOpts::default();
+            let _ = m.query(&[], &opts).await;
+        }));
+    }
 
-    let _ = h1.await;
-    let _ = h2.await;
+    for h in handles {
+        let _ = h.await;
+    }
 
-    assert_eq!(model.call_count(), 2);
+    assert_eq!(model.call_count(), 1000);
 }


### PR DESCRIPTION
🧨 **The Trigger:** 
Concurrent calls to `DeterministicModel::query()` caused a data race on `call_count` reading and response retrieval. The `FingerprintCheckingModel` and `ForkingModel` advanced the `step` counter before ensuring the underlying scripts successfully produced a response, causing out-of-sync steps in crash-recovery scenarios.

📉 **The Stack Trace:**
(Panics on ResponsesExhausted when the thread interleaves or crashes with step count desynchronizations)

🧪 **Reproduction:** 
Run concurrent queries against a single deterministic model or fail the inner scripted query during a replay session.

😈 **Comment:** 
You assumed that reading a counter, dropping the lock, and then trying to fetch from the queue using that counter was safe. You were wrong.

---
*PR created automatically by Jules for task [8634490974244648156](https://jules.google.com/task/8634490974244648156) started by @madmax983*