### PR TITLE
🎨 Mosaic: UI Polish for bench merge and shard

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,13 +529,11 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
         assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
+            args.get(network_pos + 1).map(String::as_str),
             Some("none")
         );
     }
@@ -552,8 +550,8 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else { panic!("missing --network flag") };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else { panic!("missing image arg") };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -260,26 +260,51 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
 
 impl MergeReport {
     pub fn render_text(&self) {
+        use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+
+        println!("\n=== bench merge ===");
         println!("Shards merged: {}", self.shards.len());
-        for s in &self.shards {
-            println!(
-                "  {:20}  {:6} instances  {}",
-                s.label, s.instance_count, s.dir
-            );
-        }
-        println!();
         println!(
             "Total instances: {} ({} duplicates resolved via {})",
             self.total_instances, self.duplicates, self.collision_policy
         );
-        println!("Output: {}", self.output_dir);
-        println!();
-        println!("Top-line metrics:");
-        println!("  total_cost_usd : {:.6}", self.total_cost_usd);
-        println!("  submitted      : {}", self.submitted);
-        println!("  errored        : {}", self.errored);
-        println!("  resolved       : {}", self.resolved);
-        println!("  pass_at_k      : {:.4}", self.pass_at_k);
+        println!("Output: {}\n", self.output_dir);
+
+        if !self.shards.is_empty() {
+            let mut shard_table = Table::new();
+            shard_table
+                .load_preset(UTF8_FULL)
+                .apply_modifier(UTF8_ROUND_CORNERS)
+                .set_header(vec!["Label", "Instances", "Directory"]);
+
+            for s in &self.shards {
+                shard_table.add_row(vec![
+                    s.label.clone(),
+                    s.instance_count.to_string(),
+                    s.dir.clone(),
+                ]);
+            }
+            println!("── Shards ──");
+            println!("{shard_table}\n");
+        }
+
+        let mut metrics = Table::new();
+        metrics
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Metric", "Value"]);
+
+        metrics.add_row(vec![
+            "total_cost_usd".to_string(),
+            format!("${:.6}", self.total_cost_usd),
+        ]);
+        metrics.add_row(vec!["submitted".to_string(), self.submitted.to_string()]);
+        metrics.add_row(vec!["errored".to_string(), self.errored.to_string()]);
+        metrics.add_row(vec!["resolved".to_string(), self.resolved.to_string()]);
+        metrics.add_row(vec!["pass_at_k".to_string(), format!("{:.4}", self.pass_at_k)]);
+
+        println!("── Top-line metrics ──");
+        println!("{metrics}");
     }
 }
 

--- a/src/run/shard.rs
+++ b/src/run/shard.rs
@@ -75,14 +75,24 @@ pub struct ShardReport {
 
 impl ShardReport {
     pub fn render_text(&self) {
-        println!("bench shard");
-        println!("  shards          {}", self.shard_count);
-        println!("  total instances {}", self.total_instances);
-        println!("  balance spread  {}", self.balance_spread);
+        use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+
+        let mut table = Table::new();
+        table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Shard", "Instances"]);
+
         for (i, count) in self.per_shard_counts.iter().enumerate() {
-            println!("  shard-{i:03}        {count} instances");
+            table.add_row(vec![format!("shard-{i:03}"), count.to_string()]);
         }
-        println!("  dataset sha256  {}", self.source_dataset_sha256);
+
+        println!("\n=== bench shard ===");
+        println!("Shards: {}", self.shard_count);
+        println!("Total instances: {}", self.total_instances);
+        println!("Balance spread: {}", self.balance_spread);
+        println!("Dataset SHA256: {}", self.source_dataset_sha256);
+        println!("\n{table}");
     }
 }
 


### PR DESCRIPTION
🖌️ **Before:**
The `max bench merge` and `max bench shard` commands dumped raw logs, lists, and summary statistics to the terminal via simple `println!` calls. It lacked visual hierarchy, meaning the user had to parse through a plain wall of text to understand shards distributions and top-line metrics. 

✨ **After:**
The CLI outputs now behave like proper dashboard summaries. Both commands render data using properly styled `comfy_table` instances (utilizing `UTF8_FULL` and `UTF8_ROUND_CORNERS`), separating the lists (shards distributions) from the top-line summary metrics.

🖼️ **Visuals:**
- Included prominent section headers (e.g., `=== bench merge ===`).
- Shard distributions are neatly tabulated.
- In `merge.rs`, "Top-line metrics" has been upgraded into its own polished table containing clear Key-Value rows.
- No raw JSON or jagged columns are printed; all whitespace padding is handled perfectly by the tables.

---
*PR created automatically by Jules for task [8406587872811661564](https://jules.google.com/task/8406587872811661564) started by @madmax983*