### PR TITLE
🎨 Mosaic: UI Polish for dataset_stats

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,13 +529,11 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
         assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
+            args.get(network_pos + 1).map(String::as_str),
             Some("none")
         );
     }
@@ -552,8 +550,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("missing --network");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("missing my-image");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/run/dataset_stats.rs
+++ b/src/run/dataset_stats.rs
@@ -429,37 +429,52 @@ pub fn render_text(report: &DatasetStatsReport) -> String {
     }
     let _ = writeln!(out, "{table}");
 
-    let _ = writeln!(out, "\n--- Problem-Statement Tokens Distribution ---");
-    let _ = writeln!(
-        out,
-        "  Min: {}  |  P50: {}  |  P90: {}  |  Max: {}",
-        report.problem_statement_tokens.min,
-        report.problem_statement_tokens.p50,
-        report.problem_statement_tokens.p90,
-        report.problem_statement_tokens.max,
-    );
+    let _ = writeln!(out, "\n--- Distribution Summaries ---");
+    let mut stats_table = Table::new();
+    stats_table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec!["Metric", "Min", "P50", "P90", "Max"]);
 
-    let _ = writeln!(out, "\n--- Expected Tests Distribution ---");
-    let _ = writeln!(
-        out,
-        "  Min: {}  |  P50: {}  |  P90: {}  |  Max: {}",
-        report.expected_tests.min,
-        report.expected_tests.p50,
-        report.expected_tests.p90,
-        report.expected_tests.max,
-    );
+    stats_table.add_row(vec![
+        "Problem-Statement Tokens".to_string(),
+        report.problem_statement_tokens.min.to_string(),
+        report.problem_statement_tokens.p50.to_string(),
+        report.problem_statement_tokens.p90.to_string(),
+        report.problem_statement_tokens.max.to_string(),
+    ]);
 
-    let _ = writeln!(out, "\n--- Historical Sweep Resolved Rates ---");
+    stats_table.add_row(vec![
+        "Expected Tests".to_string(),
+        report.expected_tests.min.to_string(),
+        report.expected_tests.p50.to_string(),
+        report.expected_tests.p90.to_string(),
+        report.expected_tests.max.to_string(),
+    ]);
+
     if let Some(hist) = &report.historical_resolved_rate {
-        let _ = writeln!(
-            out,
-            "  Min: {:.4}  |  P50: {:.4}  |  Max: {:.4}",
-            hist.min, hist.p50, hist.max,
-        );
+        stats_table.add_row(vec![
+            "Hist. Resolved Rate".to_string(),
+            format!("{:.4}", hist.min),
+            format!("{:.4}", hist.p50),
+            "N/A".to_string(),
+            format!("{:.4}", hist.max),
+        ]);
     } else {
+        stats_table.add_row(vec![
+            "Hist. Resolved Rate".to_string(),
+            "N/A".to_string(),
+            "N/A".to_string(),
+            "N/A".to_string(),
+            "N/A".to_string(),
+        ]);
+    }
+
+    let _ = writeln!(out, "{stats_table}");
+    if report.historical_resolved_rate.is_none() {
         let _ = writeln!(
             out,
-            "  No prior completed sweeps found matching current dataset hash."
+            "  (No prior completed sweeps found matching current dataset hash.)"
         );
     }
 


### PR DESCRIPTION
🖌️ **Before:** The distribution summaries for `dataset-stats` were rendered as raw string-interpolated logs ("a giant text wall") that were difficult to scan and lacked clear structure. Error messages in `docker.rs` tests used raw `.unwrap()` calls leading to unhelpful panics.

✨ **After:** 
- The `dataset-stats` distributions are now nicely combined into a cohesive "Distribution Summaries" tabular dashboard using `comfy_table` with `UTF8_FULL` formatting and `UTF8_ROUND_CORNERS`.
- Test panic messages in `docker.rs` have been enhanced by avoiding `.unwrap()` and instead matching with descriptive `panic!` calls.

🖼️ **Visuals:** The `dataset-stats` output now contains a structured, high-contrast table mapping `Metric` to `Min`, `P50`, `P90`, and `Max` instead of disjoint string lines.

---
*PR created automatically by Jules for task [8707723850816320264](https://jules.google.com/task/8707723850816320264) started by @madmax983*