### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,13 +529,11 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
         assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
+            args.get(network_pos + 1).map(String::as_str),
             Some("none")
         );
     }
@@ -552,8 +550,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected image name");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -540,16 +540,26 @@ fn searchable_tokens(name: &str, description: &str) -> BTreeSet<String> {
         .collect()
 }
 
+/// Normalizes search text into lowercase alphanumeric space-delimited tokens.
+///
+/// ⚡ Bolt optimization: This function runs in a single pass without allocating
+/// intermediate `Vec` collections or triggering redundant heap allocations
+/// from `.split_whitespace().collect::<Vec<_>>().join(" ")`.
 fn normalize_search_text(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
+    let mut needs_space = false;
     for ch in text.chars() {
         if ch.is_ascii_alphanumeric() || ch == '$' || ch == '@' || ch == '/' {
+            if needs_space && !out.is_empty() {
+                out.push(' ');
+            }
             out.push(ch.to_ascii_lowercase());
+            needs_space = false;
         } else {
-            out.push(' ');
+            needs_space = true;
         }
     }
-    out.split_whitespace().collect::<Vec<_>>().join(" ")
+    out
 }
 
 fn is_stopword(token: &str) -> bool {
@@ -623,4 +633,30 @@ fn expand_skill_path(path: &String) -> PathBuf {
         }
     }
     PathBuf::from(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_search_text() {
+        assert_eq!(normalize_search_text(" a  b c "), "a b c");
+        assert_eq!(
+            normalize_search_text("hello-world!!test/foo@bar$"),
+            "hello world test/foo@bar$"
+        );
+        assert_eq!(normalize_search_text("   $  @  /  "), "$ @ /");
+        assert_eq!(normalize_search_text("already normal"), "already normal");
+        assert_eq!(normalize_search_text("  leading"), "leading");
+        assert_eq!(normalize_search_text("trailing  "), "trailing");
+        assert_eq!(
+            normalize_search_text("multiple   spaces   between"),
+            "multiple spaces between"
+        );
+        assert_eq!(
+            normalize_search_text("tabs\tand\nnewlines\r"),
+            "tabs and newlines"
+        );
+    }
 }


### PR DESCRIPTION
💡 What: Rewrote `normalize_search_text` in `src/skills.rs` to parse the string in a single pass without using `split_whitespace().collect::<Vec<_>>().join(" ")`.
🎯 Why: The original implementation triggered multiple redundant heap allocations by first building a heavily spaced string, then allocating a new `Vec` of strings, and finally allocating yet another joined string.
📊 Impact: Removes the intermediate `Vec` allocation and a final `String` allocation, significantly reducing heap churn when searching for matching skills.
🔬 Measurement: Verified functionality by running `cargo test --lib -- skills` (specifically `test_normalize_search_text`), and ensured tests pass.

---
*PR created automatically by Jules for task [3136994660942165308](https://jules.google.com/task/3136994660942165308) started by @madmax983*