### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -28,8 +28,9 @@ use crate::model::{
 };
 use crate::policy::{PolicyDecision, PolicyEngine, PolicyProfile};
 use crate::prompt_guard::{PromptGuard, UntrustedKind};
-use crate::redaction::{RedactingSink, Redactor, surface};
+use crate::redaction::{Redactor, surface};
 use crate::stagnation::StagnationDetector;
+use crate::stream::RedactingSink;
 use crate::stream::{NullSink, StreamEvent, StreamSink};
 use crate::template::Renderer;
 use crate::tool::{

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2619,7 +2619,7 @@ fn validate_observation_head_ratio(value: f64) -> Result<(), Error> {
         Ok(())
     } else {
         Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "--observation-head-ratio must be a finite value in [0,1], got {value}"
+            "--observation-head-ratio must be a finite value in `[0,1]`, got {value}"
         ))))
     }
 }

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -534,10 +534,10 @@ mod tests {
             network_pos.is_some(),
             "expected --network flag in args: {args:?}"
         );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(pos) = network_pos else {
+            panic!("--network flag missing")
+        };
+        assert_eq!(args.get(pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +552,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("--network flag missing")
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("image name missing")
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::config::RedactionCfg;
-use crate::stream::{StreamEvent, StreamSink};
 
 // ── Public check types ────────────────────────────────────────────────────────
 
@@ -471,7 +470,7 @@ impl Redactor {
 
     /// Run redaction and return per-match annotations for operator verification.
     ///
-    /// Unlike [`redact_text`], this method does not update surface-level telemetry
+    /// Unlike `redact_text`, this method does not update surface-level telemetry
     /// counts and does not require a surface label. It is designed for the
     /// `agent redact-check` preflight command.
     #[must_use]
@@ -613,123 +612,6 @@ impl Redactor {
             }
             _ => false,
         }
-    }
-}
-
-pub struct RedactingSink {
-    inner: Arc<dyn StreamSink>,
-    redactor: Redactor,
-}
-
-impl RedactingSink {
-    pub fn new(inner: Arc<dyn StreamSink>, redactor: Redactor) -> Self {
-        Self { inner, redactor }
-    }
-}
-
-impl StreamSink for RedactingSink {
-    fn emit(&self, event: StreamEvent) {
-        self.inner.emit(redact_stream_event(&event, &self.redactor));
-    }
-}
-
-pub fn redact_stream_event(event: &StreamEvent, redactor: &Redactor) -> StreamEvent {
-    match event {
-        StreamEvent::RunStarted {
-            task,
-            model,
-            started_at,
-        } => StreamEvent::RunStarted {
-            task: redactor.redact_text(task, surface::STREAM).text,
-            model: redactor.redact_text(model, surface::STREAM).text,
-            started_at: started_at.clone(),
-        },
-        StreamEvent::AssistantMessage {
-            step,
-            content,
-            cost_usd,
-            timestamp,
-        } => StreamEvent::AssistantMessage {
-            step: *step,
-            content: redactor.redact_text(content, surface::STREAM).text,
-            cost_usd: *cost_usd,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::BashStart {
-            step,
-            command,
-            timestamp,
-        } => StreamEvent::BashStart {
-            step: *step,
-            command: redactor.redact_text(command, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::BashResult {
-            step,
-            exit_code,
-            stdout,
-            stderr,
-            timed_out,
-            timestamp,
-        } => StreamEvent::BashResult {
-            step: *step,
-            exit_code: *exit_code,
-            stdout: redactor.redact_text(stdout, surface::STREAM).text,
-            stderr: redactor.redact_text(stderr, surface::STREAM).text,
-            timed_out: *timed_out,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::ToolStart {
-            step,
-            label,
-            timestamp,
-        } => StreamEvent::ToolStart {
-            step: *step,
-            label: redactor.redact_text(label, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::ToolEnd { step, timestamp } => StreamEvent::ToolEnd {
-            step: *step,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::Observation {
-            step,
-            content,
-            timestamp,
-        } => StreamEvent::Observation {
-            step: *step,
-            content: redactor.redact_text(content, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::FormatError {
-            step,
-            content,
-            timestamp,
-        } => StreamEvent::FormatError {
-            step: *step,
-            content: redactor.redact_text(content, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::RunEnded {
-            exit_reason,
-            failure_category,
-            final_output,
-            steps,
-            total_cost_usd,
-            ended_at,
-        } => StreamEvent::RunEnded {
-            exit_reason: exit_reason.clone(),
-            failure_category: *failure_category,
-            final_output: final_output
-                .as_ref()
-                .map(|value| redactor.redact_text(value, surface::STREAM).text),
-            steps: *steps,
-            total_cost_usd: *total_cost_usd,
-            ended_at: ended_at.clone(),
-        },
-        StreamEvent::AutoApproveRuleCreated { scope } => StreamEvent::AutoApproveRuleCreated {
-            scope: redactor.redact_text(scope, surface::STREAM).text,
-        },
     }
 }
 

--- a/src/run/claude_driver.rs
+++ b/src/run/claude_driver.rs
@@ -4,7 +4,7 @@
 //! operator point the *same* run machinery at the Claude Code CLI instead.
 //! `claude` runs headless in `--output-format stream-json` mode; we read its
 //! newline-delimited message stream and translate each message into the
-//! harness [`Trajectory`](crate::trajectory::Trajectory) so that patch
+//! harness [crate::trajectory::Trajectory] so that patch
 //! capture, verification, `bench inspect`, and evaluation all keep working
 //! unchanged. The exploration question this answers: *can a more capable
 //! coding agent drive the loop and still leave us an inspectable receipt?*
@@ -405,10 +405,10 @@ fn record_claude_config(agent: &mut DefaultAgent, cwd: &Path, isolated: bool) {
 ///   OAuth/keychain auth, ambient `.claude` discovery (hooks, skills, plugins,
 ///   MCP, memory, `CLAUDE.md`), native session persistence, and the team's own
 ///   permission settings. The harness *records* the discovered config (see
-///   [`discover_claude_config`]) into the trajectory so the run is auditable
+///   `discover_claude_config`) into the trajectory so the run is auditable
 ///   without being sterilized. This is the enterprise-auditing case.
 /// - `true` (*isolation*): pass `--bare` (skip ambient discovery), `--tools`
-///   (restrict to [`ALLOWED_TOOLS`]), and `--no-session-persistence` for a
+///   (restrict to `ALLOWED_TOOLS`), and `--no-session-persistence` for a
 ///   reproducible measurement run. Note: `--bare` forces API-key-only auth, so
 ///   OAuth/keychain logins do not apply in this mode.
 #[allow(clippy::too_many_lines)]

--- a/src/run/codex_driver.rs
+++ b/src/run/codex_driver.rs
@@ -3,7 +3,7 @@
 //! Similar to `claude_driver.rs`, this module lets an operator point the *same*
 //! run machinery at the OpenAI Codex CLI instead of the built-in bash-first loop.
 //! `codex` runs in `--full-auto --json` mode; we read its newline-delimited JSON
-//! stream and translate each event into the harness [`Trajectory`] format so that
+//! stream and translate each event into the harness [crate::trajectory::Trajectory] format so that
 //! patch capture, verification, `bench inspect`, and evaluation all keep working
 //! unchanged.
 //!

--- a/src/run/contamination_check.rs
+++ b/src/run/contamination_check.rs
@@ -6,9 +6,9 @@
 //!
 //! | Signal | Description | Range |
 //! |--------|-------------|-------|
-//! | `edit_before_read_ratio` | Fraction of edited files never read before patching | [0,1] |
-//! | `patch_similarity_to_gold` | Normalised similarity between agent patch and gold patch | [0,1] |
-//! | `time_to_first_edit` | Suspicion from early first edit (step 0 → 1.0, last step → 0.0) | [0,1] |
+//! | `edit_before_read_ratio` | Fraction of edited files never read before patching | `[0,1]` |
+//! | `patch_similarity_to_gold` | Normalised similarity between agent patch and gold patch | `[0,1]` |
+//! | `time_to_first_edit` | Suspicion from early first edit (step 0 → 1.0, last step → 0.0) | `[0,1]` |
 //! | `verbatim_recall` | Whether agent message contains ≥ N tokens from gold patch surface | {0,1} |
 //!
 //! # Risk tiers
@@ -207,7 +207,7 @@ pub struct ContaminationSummary {
     pub contamination_adjusted_resolved_rate: f64,
 }
 
-/// Full contamination report returned by [`run`] and written to `contamination.json`.
+/// Full contamination report returned by `run` and written to `contamination.json`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContaminationReport {
     /// Schema identifier for machine-readable consumers.

--- a/src/run/export_otlp.rs
+++ b/src/run/export_otlp.rs
@@ -32,7 +32,7 @@ use crate::telemetry::{
 };
 use crate::trajectory::Trajectory;
 
-/// Inputs to [`run`].
+/// Inputs to `run`.
 #[derive(Debug, Clone)]
 pub struct ExportOtlpArgs {
     /// Completed sweep directory produced by `bench swebench`.

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -1003,7 +1003,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         // one from the config. The agent will build its own for trajectory/model
         // surfaces; this one covers the stream surface only.
         let redactor = crate::redaction::Redactor::from_config_lossy(&args.config.root.redaction);
-        Arc::new(crate::redaction::RedactingSink::new(ws, redactor)) as Arc<dyn StreamSink>
+        Arc::new(crate::stream::RedactingSink::new(ws, redactor)) as Arc<dyn StreamSink>
     });
     let event_log_sink: Option<Arc<dyn StreamSink>> = args.event_log.as_ref().and_then(|path| {
         match EventLogSink::new(
@@ -1028,10 +1028,10 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
                 }
                 let redactor =
                     crate::redaction::Redactor::from_config_lossy(&args.config.root.redaction);
-                Some(Arc::new(crate::redaction::RedactingSink::new(
-                    Arc::new(sink),
-                    redactor,
-                )) as Arc<dyn StreamSink>)
+                Some(
+                    Arc::new(crate::stream::RedactingSink::new(Arc::new(sink), redactor))
+                        as Arc<dyn StreamSink>,
+                )
             }
             Err(err) => {
                 let _ = std::io::Write::write_all(

--- a/src/run/redact_audit.rs
+++ b/src/run/redact_audit.rs
@@ -1,6 +1,6 @@
 //! `agent redact-audit <dir>` — post-hoc secret-leak detection for sweep artifacts.
 //!
-//! Issue #342. The runtime [`Redactor`](crate::redaction::Redactor) masks secrets
+//! Issue #342. The runtime [crate::redaction::Redactor] masks secrets
 //! *at write-time* and explicitly does not retroactively rewrite stored
 //! artifacts. Trajectories and sweep outputs are routinely shared (PRs, HTML
 //! exports, bundles), so a redaction-config bug or an unanticipated secret shape

--- a/src/run/self_check.rs
+++ b/src/run/self_check.rs
@@ -80,7 +80,7 @@ pub struct SelfCheckMetrics {
     pub brier_score: f64,
 }
 
-/// Top-level self-check report — the return value of [`run`].
+/// Top-level self-check report — the return value of `run`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SelfCheckReport {
     /// Schema identifier for machine-readable consumers.
@@ -173,7 +173,7 @@ fn load_eval_instances(sweep_dir: &Path) -> Result<Vec<serde_json::Value>, Error
     Ok(arr)
 }
 
-/// Mutable accumulator for the per-instance loop in [`run`].
+/// Mutable accumulator for the per-instance loop in `run`.
 #[derive(Default)]
 struct InstanceAccumulator {
     confusion: ConfusionCounts,

--- a/src/run/stagnation_report.rs
+++ b/src/run/stagnation_report.rs
@@ -103,7 +103,7 @@ pub struct StagnationTotals {
     pub total_usd_saved_estimate: Option<f64>,
 }
 
-/// Full stagnation report returned by [`run`].
+/// Full stagnation report returned by `run`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StagnationReport {
     pub sweep_path: String,

--- a/src/run/suite.rs
+++ b/src/run/suite.rs
@@ -8,8 +8,8 @@
 //! `--rerun-failed` (issue #825) re-runs only the tasks whose last recorded
 //! result was non-passing, carrying every already-passing result forward
 //! unchanged (zero model calls, zero fresh cost) into a freshly merged
-//! `suite-results.json`. See [`tasks_needing_rerun`] and
-//! [`load_prior_suite_state`].
+//! `suite-results.json`. See `tasks_needing_rerun` and
+//! `load_prior_suite_state`.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -1041,7 +1041,7 @@ pub(crate) struct TaskIssue {
 /// Validate every task's `id`/`task` fields and cross-task id uniqueness,
 /// returning *all* violations found rather than stopping at the first
 /// (unlike the `agent suite` run path, which bails on the first issue via
-/// [`run`]). Used by both `agent suite` (which reports only the first issue)
+/// `run`). Used by both `agent suite` (which reports only the first issue)
 /// and `agent suite --check` (which reports every issue it can find).
 pub(crate) fn collect_task_validation_issues(tasks: &[SuiteTaskSpec]) -> Vec<TaskIssue> {
     let mut issues = Vec::new();
@@ -1080,7 +1080,7 @@ pub(crate) fn collect_task_validation_issues(tasks: &[SuiteTaskSpec]) -> Vec<Tas
 
 /// Validate a suite name for safe use as an `--output` subdirectory path
 /// segment. Shared by `agent suite` (fails fast on the first violation via
-/// [`run`]) and `agent suite --check` (reports it as a preflight check).
+/// `run`) and `agent suite --check` (reports it as a preflight check).
 pub(crate) fn validate_suite_name(name: &str) -> Result<(), String> {
     if name.contains('/') || name.contains('\\') || name.contains("..") {
         Err(format!(

--- a/src/run/suite_check.rs
+++ b/src/run/suite_check.rs
@@ -90,7 +90,7 @@ impl CheckItem {
     }
 }
 
-/// Full report returned by [`run`].
+/// Full report returned by `run`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SuiteCheckReport {
     pub schema_version: u32,
@@ -121,7 +121,7 @@ pub struct SuiteCheckReport {
 
 // ── arguments ──────────────────────────────────────────────────────────────────
 
-/// Arguments for [`run`]. Deliberately has no output-directory field: a
+/// Arguments for `run`. Deliberately has no output-directory field: a
 /// preflight check makes no writes (AC: read-only except transient MCP/hook
 /// probe processes).
 pub struct SuiteCheckArgs {
@@ -639,7 +639,7 @@ fn resolve_format(path: &Path, format_override: Option<&str>) -> Result<TaskFile
 /// Build a [`CheckItem`] from a `scriptability_check` server/hook result.
 /// Only ever called for `environment.kind = local` — under `--env docker`
 /// the probe itself is skipped rather than run and downgraded (see the
-/// `is_docker` branch in [`run`]).
+/// `is_docker` branch in `run`).
 fn scriptability_check_item(
     check: String,
     target: String,

--- a/src/run/sweep_dashboard.rs
+++ b/src/run/sweep_dashboard.rs
@@ -10,8 +10,8 @@
 //! (`crate::run::inspect::build_inspect_steps_with_max`).
 //!
 //! The module is split so the state machine and rendering are pure,
-//! deterministic functions ([`handle_key`], [`draw`]) testable with
-//! ratatui's `TestBackend` — no real terminal required — while [`run`] is
+//! deterministic functions (`handle_key`, `draw`) testable with
+//! ratatui's `TestBackend` — no real terminal required — while `run` is
 //! the thin IO shell that owns the terminal and the poll loop.
 
 use std::collections::VecDeque;
@@ -86,7 +86,7 @@ impl DetailState {
     }
 }
 
-/// Full dashboard state. Pure data — no IO — so [`handle_key`] and [`draw`]
+/// Full dashboard state. Pure data — no IO — so `handle_key` and `draw`
 /// are unit-testable without a terminal.
 pub(crate) struct DashboardState {
     pub(crate) sweep_dir: PathBuf,

--- a/src/run/ui.rs
+++ b/src/run/ui.rs
@@ -39,7 +39,7 @@ pub struct InstanceEntry {
     pub traj_path: PathBuf,
 }
 
-/// Arguments forwarded from the CLI to [`run`].
+/// Arguments forwarded from the CLI to `run`.
 pub struct UiArgs {
     pub sweep: PathBuf,
     pub port: u16,

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -15,6 +15,7 @@ use serde::Serialize;
 
 pub mod broadcast;
 pub mod event_log;
+pub mod redacting;
 pub mod sse;
 #[cfg(feature = "webhook")]
 pub mod sweep_webhook;
@@ -23,6 +24,7 @@ pub mod webhook;
 
 pub use broadcast::BroadcastSink;
 pub use event_log::EventLogSink;
+pub use redacting::{RedactingSink, redact_stream_event};
 pub use sse::SseServer;
 #[cfg(feature = "webhook")]
 pub use sweep_webhook::{

--- a/src/stream/redacting.rs
+++ b/src/stream/redacting.rs
@@ -1,0 +1,120 @@
+use crate::redaction::{Redactor, surface};
+use crate::stream::{StreamEvent, StreamSink};
+use std::sync::Arc;
+
+pub struct RedactingSink {
+    inner: Arc<dyn StreamSink>,
+    redactor: Redactor,
+}
+
+impl RedactingSink {
+    pub fn new(inner: Arc<dyn StreamSink>, redactor: Redactor) -> Self {
+        Self { inner, redactor }
+    }
+}
+
+impl StreamSink for RedactingSink {
+    fn emit(&self, event: StreamEvent) {
+        self.inner.emit(redact_stream_event(&event, &self.redactor));
+    }
+}
+
+pub fn redact_stream_event(event: &StreamEvent, redactor: &Redactor) -> StreamEvent {
+    match event {
+        StreamEvent::RunStarted {
+            task,
+            model,
+            started_at,
+        } => StreamEvent::RunStarted {
+            task: redactor.redact_text(task, surface::STREAM).text,
+            model: redactor.redact_text(model, surface::STREAM).text,
+            started_at: started_at.clone(),
+        },
+        StreamEvent::AssistantMessage {
+            step,
+            content,
+            cost_usd,
+            timestamp,
+        } => StreamEvent::AssistantMessage {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            cost_usd: *cost_usd,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::BashStart {
+            step,
+            command,
+            timestamp,
+        } => StreamEvent::BashStart {
+            step: *step,
+            command: redactor.redact_text(command, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::BashResult {
+            step,
+            exit_code,
+            stdout,
+            stderr,
+            timed_out,
+            timestamp,
+        } => StreamEvent::BashResult {
+            step: *step,
+            exit_code: *exit_code,
+            stdout: redactor.redact_text(stdout, surface::STREAM).text,
+            stderr: redactor.redact_text(stderr, surface::STREAM).text,
+            timed_out: *timed_out,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::ToolStart {
+            step,
+            label,
+            timestamp,
+        } => StreamEvent::ToolStart {
+            step: *step,
+            label: redactor.redact_text(label, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::ToolEnd { step, timestamp } => StreamEvent::ToolEnd {
+            step: *step,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::Observation {
+            step,
+            content,
+            timestamp,
+        } => StreamEvent::Observation {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::FormatError {
+            step,
+            content,
+            timestamp,
+        } => StreamEvent::FormatError {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::RunEnded {
+            exit_reason,
+            failure_category,
+            final_output,
+            steps,
+            total_cost_usd,
+            ended_at,
+        } => StreamEvent::RunEnded {
+            exit_reason: exit_reason.clone(),
+            failure_category: *failure_category,
+            final_output: final_output
+                .as_ref()
+                .map(|value| redactor.redact_text(value, surface::STREAM).text),
+            steps: *steps,
+            total_cost_usd: *total_cost_usd,
+            ended_at: ended_at.clone(),
+        },
+        StreamEvent::AutoApproveRuleCreated { scope } => StreamEvent::AutoApproveRuleCreated {
+            scope: redactor.redact_text(scope, surface::STREAM).text,
+        },
+    }
+}

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -6,7 +6,7 @@
 //! narrative document, complete with headers and code blocks.
 //!
 //! You can extend this module with new formats by implementing the [`crate::trajectory::export::TrajectoryExporter`] trait.
-//! Every new exporter MUST register in [`registry`] and MUST apply redaction via
+//! Every new exporter MUST register in `registry` and MUST apply redaction via
 //! [`crate::redaction::Redactor::default_enabled`] on [`crate::redaction::surface::EXPORT`] before emitting any output.
 //! See `docs/spec-export.md` for the full governing contract.
 
@@ -103,7 +103,7 @@ pub fn registry() -> Vec<ExportFormat> {
 ///
 /// Used to emit a helpful "feature not compiled in" error when an operator requests a
 /// format whose feature is disabled. Compiled-in formats (with metadata and a render fn)
-/// live in [`registry`]; a format gated *out* of this build is absent from `registry()`
+/// live in `registry`; a format gated *out* of this build is absent from `registry()`
 /// but present here so the CLI can still route it and explain how to enable it.
 pub const FEATURE_GATED_FORMATS: &[(&str, &str)] = &[
     ("csv", "csv-export"),
@@ -116,22 +116,22 @@ pub const FEATURE_GATED_FORMATS: &[(&str, &str)] = &[
 ///
 /// CLI routing uses this so a request for a gated-out format still reaches the export
 /// dispatch path (and gets a helpful "rebuild with --features" error) instead of falling
-/// through to a generic "unknown format" message. This keeps [`registry`] the single
+/// through to a generic "unknown format" message. This keeps `registry` the single
 /// source of truth for *compiled* formats while still recognizing the full catalog.
 pub fn is_export_format(name: &str) -> bool {
     registry().iter().any(|f| f.name == name)
         || FEATURE_GATED_FORMATS.iter().any(|(n, _)| *n == name)
 }
 
-/// A contract for types that can convert a [`Trajectory`] into a specialized string format.
+/// A contract for types that can convert a [crate::trajectory::Trajectory] into a specialized string format.
 ///
 /// Implement this trait to provide a new serialization layout (e.g., Markdown, CSV).
 pub trait TrajectoryExporter {
-    /// Transforms the provided [`Trajectory`] into a formatted `String`.
+    /// Transforms the provided [crate::trajectory::Trajectory] into a formatted `String`.
     fn export(trajectory: &Trajectory) -> String;
 }
 
-/// Transforms a [`Trajectory`] into a structured Markdown document.
+/// Transforms a [crate::trajectory::Trajectory] into a structured Markdown document.
 ///
 /// It renders the task, outcome, and all messages sequentially under appropriate headers.
 ///
@@ -154,7 +154,7 @@ pub trait TrajectoryExporter {
 /// ```
 pub struct MarkdownExporter;
 
-/// Transforms a [`Trajectory`] into a flat CSV file, with `role` and `content` columns.
+/// Transforms a [crate::trajectory::Trajectory] into a flat CSV file, with `role` and `content` columns.
 ///
 /// Note: This exporter properly handles and escapes embedded quotes and newlines in message content.
 #[cfg(feature = "csv-export")]


### PR DESCRIPTION
🗺️ Atlas: [architectural change]

🕸️ Tangle: `redaction` imported from `stream` (`StreamEvent`, `StreamSink`) to provide `RedactingSink`, while `stream` heavily depended on `redaction` for the core redactor, forming a cycle.
📐 Blueprint: Extracted `RedactingSink` out of `src/redaction.rs` into its own module `src/stream/redacting.rs`. Now, `stream` depends on `redaction`, but `redaction` no longer needs `stream`.
🧱 Stability: A cleaner dependency graph that adheres to strict unidirectional flows. Also fixes several unwrap statements and cargo doc dead-links as standard maintenance.
🔬 Verification: Confirmed graph acyclicity manually via test scripts. `cargo fmt --all && cargo clippy --all-targets --all-features -- -D warnings && cargo test --lib && cargo doc --no-deps` passed seamlessly.

---
*PR created automatically by Jules for task [16417600588780573571](https://jules.google.com/task/16417600588780573571) started by @madmax983*