### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("--network missing");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("image missing");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/stream/event_log.rs
+++ b/src/stream/event_log.rs
@@ -92,24 +92,114 @@ impl StreamSink for EventLogSink {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
     use super::*;
 
     #[test]
-    fn includes_required_fields() {
-        let dir = tempfile::tempdir().unwrap();
+    fn reopens_file_on_request_and_writes_to_new_file() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("events.jsonl");
-        let sink = EventLogSink::new(&path, "mini".into()).unwrap();
+        let sink = EventLogSink::new(&path, "mini".into())?;
+
+        // Write initial event
+        sink.emit(StreamEvent::RunStarted {
+            task: "t1".into(),
+            model: "m1".into(),
+            started_at: "s1".into(),
+        });
+
+        // Rename original file, simulating logrotate
+        let rotated_path = dir.path().join("events.jsonl.1");
+        std::fs::rename(&path, &rotated_path)?;
+
+        // Request reopen and emit second event
+        sink.request_reopen();
+        sink.emit(StreamEvent::RunStarted {
+            task: "t2".into(),
+            model: "m2".into(),
+            started_at: "s2".into(),
+        });
+
+        // Assert old file has only the first event
+        let old_content = std::fs::read_to_string(&rotated_path)?;
+        assert_eq!(old_content.lines().count(), 1);
+        assert!(old_content.contains("\"task\":\"t1\""));
+
+        // Assert new file was created and has only the second event
+        let new_content = std::fs::read_to_string(&path)?;
+        assert_eq!(new_content.lines().count(), 1);
+        assert!(new_content.contains("\"task\":\"t2\""));
+
+        Ok(())
+    }
+
+    #[test]
+    fn handles_reopen_failure_gracefully() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("events.jsonl");
+        let sink = EventLogSink::new(&path, "mini".into())?;
+
+        // Remove the parent directory so creation of the new file fails
+        std::fs::remove_dir_all(dir.path())?;
+
+        sink.request_reopen();
+        sink.emit(StreamEvent::RunStarted {
+            task: "t1".into(),
+            model: "m1".into(),
+            started_at: "s1".into(),
+        });
+
+        assert_eq!(sink.dropped_reopen_failures.load(Ordering::SeqCst), 1);
+        assert!(sink.warned.load(Ordering::SeqCst));
+
+        Ok(())
+    }
+
+    #[test]
+    fn handles_poisoned_lock_gracefully() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("events.jsonl");
+        let sink = EventLogSink::new(&path, "mini".into())?;
+
+        let writer_clone = sink.writer.clone();
+        let _ = std::thread::spawn(move || {
+            let Ok(_lock) = writer_clone.lock() else {
+                panic!("Locking shouldn't fail initially");
+            };
+            panic!("Poisoning the lock");
+        })
+        .join();
+
+        // This should not panic
+        sink.emit(StreamEvent::RunStarted {
+            task: "t1".into(),
+            model: "m1".into(),
+            started_at: "s1".into(),
+        });
+
+        assert!(sink.warned.load(Ordering::SeqCst));
+
+        Ok(())
+    }
+
+    #[test]
+    fn includes_required_fields() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("events.jsonl");
+        let sink = EventLogSink::new(&path, "mini".into())?;
         sink.emit(StreamEvent::RunStarted {
             task: "t".into(),
             model: "m".into(),
             started_at: "s".into(),
         });
-        let line = std::fs::read_to_string(path).unwrap();
-        let v: Value = serde_json::from_str(line.lines().next().unwrap()).unwrap();
+        let line = std::fs::read_to_string(path)?;
+        let Some(first_line) = line.lines().next() else {
+            anyhow::bail!("log file is empty");
+        };
+        let v: Value = serde_json::from_str(first_line)?;
         assert_eq!(v["schema"], "event-log-v1");
         assert_eq!(v["event_type"], "run_started");
         assert_eq!(v["instance_id"], "mini");
         assert!(v["ts"].as_str().is_some());
+        Ok(())
     }
 }


### PR DESCRIPTION
🎯 Target: `src/stream/event_log.rs` tests.
💣 Risk: Use of `#![allow(clippy::unwrap_used)]` meant test failures could panic cryptically. Untested file reopen failure handling, missing test for successful file rotation, and absent tests for mutex poisoning edge cases hid logic paths from validation.
🧪 Strategy: Replaced all `.unwrap()` and `.expect()` calls with `anyhow::Result<()>` and safe pattern matching (`let Some() = ... else { panic!(...) }`). Added tests for `reopens_file_on_request_and_writes_to_new_file`, `handles_reopen_failure_gracefully`, and `handles_poisoned_lock_gracefully`.
🔬 Verification: `cargo test --lib -- stream::event_log && cargo clippy --all-targets --all-features -- -D warnings`

---
*PR created automatically by Jules for task [8835454168760256757](https://jules.google.com/task/8835454168760256757) started by @madmax983*