### PR TITLE
🎨 Mosaic: UI Polish for Merge and Shard Reports

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -530,14 +530,10 @@ mod tests {
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(pos) = network_pos else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +548,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("missing --network flag");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("missing image name");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -260,26 +260,65 @@ pub fn run(args: &MergeCmd) -> Result<MergeReport, Error> {
 
 impl MergeReport {
     pub fn render_text(&self) {
-        println!("Shards merged: {}", self.shards.len());
+        use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+
+        println!("=== Bench Merge Report ===");
+
+        let mut summary_table = Table::new();
+        summary_table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Metric", "Value"]);
+
+        summary_table.add_row(vec![
+            "Shards Merged".to_string(),
+            self.shards.len().to_string(),
+        ]);
+        summary_table.add_row(vec![
+            "Total Instances".to_string(),
+            format!(
+                "{} ({} duplicates resolved via {})",
+                self.total_instances, self.duplicates, self.collision_policy
+            ),
+        ]);
+        summary_table.add_row(vec!["Output Dir".to_string(), self.output_dir.clone()]);
+        println!("{summary_table}");
+
+        println!("\n=== Shards Breakdown ===");
+        let mut shard_table = Table::new();
+        shard_table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Label", "Instances", "Directory"]);
+
         for s in &self.shards {
-            println!(
-                "  {:20}  {:6} instances  {}",
-                s.label, s.instance_count, s.dir
-            );
+            shard_table.add_row(vec![
+                s.label.clone(),
+                s.instance_count.to_string(),
+                s.dir.clone(),
+            ]);
         }
-        println!();
-        println!(
-            "Total instances: {} ({} duplicates resolved via {})",
-            self.total_instances, self.duplicates, self.collision_policy
-        );
-        println!("Output: {}", self.output_dir);
-        println!();
-        println!("Top-line metrics:");
-        println!("  total_cost_usd : {:.6}", self.total_cost_usd);
-        println!("  submitted      : {}", self.submitted);
-        println!("  errored        : {}", self.errored);
-        println!("  resolved       : {}", self.resolved);
-        println!("  pass_at_k      : {:.4}", self.pass_at_k);
+        println!("{shard_table}");
+
+        println!("\n=== Top-line Metrics ===");
+        let mut metrics_table = Table::new();
+        metrics_table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Metric", "Value"]);
+
+        metrics_table.add_row(vec![
+            "Total Cost (USD)".to_string(),
+            format!("{:.6}", self.total_cost_usd),
+        ]);
+        metrics_table.add_row(vec!["Submitted".to_string(), self.submitted.to_string()]);
+        metrics_table.add_row(vec!["Errored".to_string(), self.errored.to_string()]);
+        metrics_table.add_row(vec!["Resolved".to_string(), self.resolved.to_string()]);
+        metrics_table.add_row(vec![
+            "Pass at K".to_string(),
+            format!("{:.4}", self.pass_at_k),
+        ]);
+        println!("{metrics_table}");
     }
 }
 

--- a/src/run/shard.rs
+++ b/src/run/shard.rs
@@ -75,14 +75,44 @@ pub struct ShardReport {
 
 impl ShardReport {
     pub fn render_text(&self) {
-        println!("bench shard");
-        println!("  shards          {}", self.shard_count);
-        println!("  total instances {}", self.total_instances);
-        println!("  balance spread  {}", self.balance_spread);
+        use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+
+        println!("=== Bench Shard Report ===");
+
+        let mut table = Table::new();
+        table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Metric", "Value"]);
+
+        table.add_row(vec!["Shards".to_string(), self.shard_count.to_string()]);
+        table.add_row(vec![
+            "Total Instances".to_string(),
+            self.total_instances.to_string(),
+        ]);
+        table.add_row(vec![
+            "Balance Spread".to_string(),
+            self.balance_spread.to_string(),
+        ]);
+        table.add_row(vec![
+            "Dataset SHA256".to_string(),
+            self.source_dataset_sha256.clone(),
+        ]);
+
+        println!("{table}");
+
+        println!("\n=== Per-Shard Distribution ===");
+        let mut shard_table = Table::new();
+        shard_table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_header(vec!["Shard", "Instances"]);
+
         for (i, count) in self.per_shard_counts.iter().enumerate() {
-            println!("  shard-{i:03}        {count} instances");
+            shard_table.add_row(vec![format!("shard-{i:03}"), count.to_string()]);
         }
-        println!("  dataset sha256  {}", self.source_dataset_sha256);
+
+        println!("{shard_table}");
     }
 }
 


### PR DESCRIPTION
🖌️ **Before:** The `merge` and `shard` commands in the CLI logged raw text outputs. These lists lacked visual hierarchy, structural padding, and clear boundaries, which made them look like messy log files rather than a polished dashboard.

✨ **After:** 
- The text outputs in `MergeReport::render_text` and `ShardReport::render_text` have been replaced with `comfy-table`.
- Used `UTF8_FULL` and `UTF8_ROUND_CORNERS` to create beautiful tables for Shard Summaries, Run Reports, and Metrics.
- Cleaned up raw unwraps in `src/env/docker.rs` to satisfy clippy while providing clearer panic messages for errors.

🖼️ **Visuals:** The terminal now renders clean tables with clearly defined headers and round corners for all merge/shard reports. Important metrics stand out rather than blending into a wall of text.

---
*PR created automatically by Jules for task [3055064357185733420](https://jules.google.com/task/3055064357185733420) started by @madmax983*