### PR TITLE
🔒 Warden: [security fix]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -1372,6 +1372,7 @@ dependencies = [
  "sha2",
  "similar",
  "tar",
+ "temp-env",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -2274,6 +2275,16 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "futures",
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ tar = "0.4"
 # dispatch behind a single `completion()` call, which is what we want.
 
 [dev-dependencies]
+temp-env = { version = "0.3.6", features = ["async_closure"] }
 proptest = "1"
 insta = { version = "1", features = ["json"] }
 pretty_assertions = "1"

--- a/src/agent/confirm_tui.rs
+++ b/src/agent/confirm_tui.rs
@@ -8044,30 +8044,22 @@ mod tests {
     #[test]
     fn test_mouse_scroll_step_from_env() {
         // No env var: default of 3.
-        // SAFETY: test-only env mutation, no other thread reads this var
-        // concurrently within this process's test harness for this key.
-        unsafe {
-            std::env::remove_var("MAXWELL_MOUSE_SCROLL_STEP");
-        }
-        assert_eq!(mouse_scroll_step_from_env(), DEFAULT_MOUSE_SCROLL_STEP);
+        temp_env::with_var("MAXWELL_MOUSE_SCROLL_STEP", None::<String>, || {
+            assert_eq!(mouse_scroll_step_from_env(), DEFAULT_MOUSE_SCROLL_STEP);
+        });
 
-        unsafe {
-            std::env::set_var("MAXWELL_MOUSE_SCROLL_STEP", "7");
-        }
-        assert_eq!(mouse_scroll_step_from_env(), 7);
+        temp_env::with_var("MAXWELL_MOUSE_SCROLL_STEP", Some("7"), || {
+            assert_eq!(mouse_scroll_step_from_env(), 7);
+        });
 
         // Unparsable/zero falls back to the default.
-        unsafe {
-            std::env::set_var("MAXWELL_MOUSE_SCROLL_STEP", "not-a-number");
-        }
-        assert_eq!(mouse_scroll_step_from_env(), DEFAULT_MOUSE_SCROLL_STEP);
-        unsafe {
-            std::env::set_var("MAXWELL_MOUSE_SCROLL_STEP", "0");
-        }
-        assert_eq!(mouse_scroll_step_from_env(), DEFAULT_MOUSE_SCROLL_STEP);
-        unsafe {
-            std::env::remove_var("MAXWELL_MOUSE_SCROLL_STEP");
-        }
+        temp_env::with_var("MAXWELL_MOUSE_SCROLL_STEP", Some("not-a-number"), || {
+            assert_eq!(mouse_scroll_step_from_env(), DEFAULT_MOUSE_SCROLL_STEP);
+        });
+
+        temp_env::with_var("MAXWELL_MOUSE_SCROLL_STEP", Some("0"), || {
+            assert_eq!(mouse_scroll_step_from_env(), DEFAULT_MOUSE_SCROLL_STEP);
+        });
     }
 
     // `renderer_loop` uses `handle_mouse`'s return value to decide whether to

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,13 +529,11 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
         assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
+            args.get(network_pos + 1).map(String::as_str),
             Some("none")
         );
     }
@@ -552,8 +550,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected my-image in args");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/run/agent_doctor.rs
+++ b/src/run/agent_doctor.rs
@@ -627,12 +627,12 @@ mod tests {
         // Use a uniquely-named var to avoid clobbering real provider keys.
         let model = "weirdprov/model";
         let var = expected_credential_env(model).unwrap();
-        // SAFETY: single-threaded test; restore immediately after.
-        unsafe { std::env::set_var(&var, "TOPSECRETVALUE") };
-        let check = check_credential(model);
-        unsafe { std::env::remove_var(&var) };
-        assert_eq!(check.status, CheckStatus::Pass);
-        assert!(!check.detail.contains("TOPSECRETVALUE"));
+
+        temp_env::with_var(&var, Some("TOPSECRETVALUE"), || {
+            let check = check_credential(model);
+            assert_eq!(check.status, CheckStatus::Pass);
+            assert!(!check.detail.contains("TOPSECRETVALUE"));
+        });
     }
 
     #[test]
@@ -641,12 +641,13 @@ mod tests {
         // with a remediation hint naming the variable.
         let model = "zzznoprov/model";
         let var = expected_credential_env(model).unwrap();
-        // SAFETY: single-threaded test; ensure the var is absent.
-        unsafe { std::env::remove_var(&var) };
-        let check = check_credential(model);
-        assert_eq!(check.status, CheckStatus::Fail);
-        assert!(check.detail.contains(&var));
-        assert!(check.detail.contains("export"));
+
+        temp_env::with_var(&var, None::<String>, || {
+            let check = check_credential(model);
+            assert_eq!(check.status, CheckStatus::Fail);
+            assert!(check.detail.contains(&var));
+            assert!(check.detail.contains("export"));
+        });
     }
 
     // ── output dir failure path (AC#2d) ──────────────────────────────────

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -3956,14 +3956,12 @@ index 8a1218a..24c5735 100644\n\
         // Inject a fake secret as an environment variable that the redactor picks up.
         // We use a value that looks like a real API key pattern so the redactor fires.
         let fake_secret = "sk-ant-fake-secret-value-for-test-0123456789abcdef";
-        // SAFETY: test-only; single-threaded context for secret injection.
-        unsafe { std::env::set_var("TEST_MANIFEST_API_KEY", fake_secret) };
 
         let args = make_mini_args_for_manifest_test(tmp.path().to_path_buf(), "secret-test");
-        run(args).await.unwrap();
-
-        // Clean up env var
-        unsafe { std::env::remove_var("TEST_MANIFEST_API_KEY") };
+        temp_env::async_with_vars([("TEST_MANIFEST_API_KEY", Some(fake_secret))], async {
+            run(args).await.unwrap();
+        })
+        .await;
 
         let traj_path = tmp.path().join("secret-test.traj.json");
         let content = std::fs::read_to_string(&traj_path).unwrap();

--- a/src/run/redact_audit.rs
+++ b/src/run/redact_audit.rs
@@ -3133,21 +3133,20 @@ mod tests {
             "x.output.txt",
             "leaked: super-secret-ci-token-value-123\n",
         );
-        // SAFETY: set/remove a process-local var in a serial unit test.
-        unsafe {
-            std::env::set_var("DATABASE_PASSWORD", "super-secret-ci-token-value-123");
-        }
-        let report = audit(dir.path());
-        unsafe {
-            std::env::remove_var("DATABASE_PASSWORD");
-        }
-        assert!(
-            report
-                .findings
-                .iter()
-                .any(|f| f.match_class == "sensitive_env_value"),
-            "ambient env value missed: {:?}",
-            report.findings
+        temp_env::with_var(
+            "DATABASE_PASSWORD",
+            Some("super-secret-ci-token-value-123"),
+            || {
+                let report = audit(dir.path());
+                assert!(
+                    report
+                        .findings
+                        .iter()
+                        .any(|f| f.match_class == "sensitive_env_value"),
+                    "ambient env value missed: {:?}",
+                    report.findings
+                );
+            },
         );
     }
 

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -447,6 +447,7 @@ mod tests {
     // ── RED: redaction ─────────────────────────────────────────────────────
 
     #[tokio::test]
+    #[allow(clippy::large_futures)]
     async fn redactor_strips_sensitive_env_var_from_instance_id() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -455,28 +456,29 @@ mod tests {
         // Synthetic env var picked up automatically by from_config_lossy.
         let unique_val = format!("sk-deadbeef-sweep-wh-{}", addr.port());
         let env_name = format!("FAKE_API_KEY_SWH_{}", addr.port());
-        // SAFETY: single-threaded test context; no concurrent env reads.
-        unsafe { std::env::set_var(&env_name, &unique_val) };
-        let redactor = Redactor::default_enabled();
 
-        let sink = SweepWebhookSink::new(url, &[], redactor, "sweep-redact".to_owned()).unwrap();
-        sink.emit(SweepNotificationEvent::InstanceCompleted {
-            instance_id: unique_val.clone(),
-            resolved: false,
-            failure_category: None,
-            cost_usd: None,
-            duration_secs: None,
-        });
+        temp_env::async_with_vars([(&env_name, Some(unique_val.clone()))], async {
+            let redactor = Redactor::default_enabled();
 
-        let socket = accept(&listener).await;
-        let req = read_http(socket).await;
-        // SAFETY: single-threaded test context; no concurrent env reads.
-        unsafe { std::env::remove_var(&env_name) };
+            let sink =
+                SweepWebhookSink::new(url, &[], redactor, "sweep-redact".to_owned()).unwrap();
+            sink.emit(SweepNotificationEvent::InstanceCompleted {
+                instance_id: unique_val.clone(),
+                resolved: false,
+                failure_category: None,
+                cost_usd: None,
+                duration_secs: None,
+            });
 
-        assert!(
-            !req.contains(&unique_val),
-            "sensitive env var value must not appear verbatim in posted payload"
-        );
+            let socket = accept(&listener).await;
+            let req = read_http(socket).await;
+
+            assert!(
+                !req.contains(&unique_val),
+                "sensitive env var value must not appear verbatim in posted payload"
+            );
+        })
+        .await;
     }
 
     // ── RED: drop counting ─────────────────────────────────────────────────

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1168,14 +1168,13 @@ mod tests {
     fn resolve_endpoint_prefers_cli_flag() {
         let _guard = env_lock();
         // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-host:4318");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
-        let ep = resolve_endpoint(Some("http://cli-host:4318"));
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-        }
+        let ep = temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", Some("http://env-host:4318")),
+                ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None::<&str>),
+            ],
+            || resolve_endpoint(Some("http://cli-host:4318")),
+        );
         // CLI flag is a base URL; /v1/traces is appended.
         assert_eq!(ep.as_deref(), Some("http://cli-host:4318/v1/traces"));
     }
@@ -1184,14 +1183,13 @@ mod tests {
     fn resolve_endpoint_falls_back_to_env_var() {
         let _guard = env_lock();
         // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-host:4318");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
-        let ep = resolve_endpoint(None);
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-        }
+        let ep = temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", Some("http://env-host:4318")),
+                ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None::<&str>),
+            ],
+            || resolve_endpoint(None),
+        );
         // Generic env var is a base URL; /v1/traces is appended.
         assert_eq!(ep.as_deref(), Some("http://env-host:4318/v1/traces"));
     }
@@ -1200,17 +1198,16 @@ mod tests {
     fn resolve_endpoint_traces_env_var_used_as_full_url() {
         let _guard = env_lock();
         // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-            std::env::set_var(
-                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-                "http://traces-host:4318/v1/traces",
-            );
-        }
-        let ep = resolve_endpoint(None);
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
+        let ep = temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", None::<&str>),
+                (
+                    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+                    Some("http://traces-host:4318/v1/traces"),
+                ),
+            ],
+            || resolve_endpoint(None),
+        );
         // Trace-specific env var is a full URL; used as-is without appending.
         assert_eq!(ep.as_deref(), Some("http://traces-host:4318/v1/traces"));
     }
@@ -1219,11 +1216,13 @@ mod tests {
     fn resolve_endpoint_returns_none_when_unset() {
         let _guard = env_lock();
         // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
-        let ep = resolve_endpoint(None);
+        let ep = temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", None::<&str>),
+                ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None::<&str>),
+            ],
+            || resolve_endpoint(None),
+        );
         assert!(ep.is_none());
     }
 
@@ -1248,127 +1247,113 @@ mod tests {
     #[test]
     fn resolve_metrics_endpoint_prefers_cli_flag() {
         let _guard = env_lock();
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-host:4318");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
-        }
-        let ep = resolve_metrics_endpoint(Some("http://cli-host:4318"));
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-        }
+        let ep = temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", Some("http://env-host:4318")),
+                ("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", None::<&str>),
+            ],
+            || resolve_metrics_endpoint(Some("http://cli-host:4318")),
+        );
         assert_eq!(ep.as_deref(), Some("http://cli-host:4318/v1/metrics"));
     }
 
     #[test]
     fn resolve_metrics_endpoint_falls_back_to_env_var() {
         let _guard = env_lock();
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-host:4318");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
-        }
-        let ep = resolve_metrics_endpoint(None);
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-        }
+        let ep = temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", Some("http://env-host:4318")),
+                ("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", None::<&str>),
+            ],
+            || resolve_metrics_endpoint(None),
+        );
         assert_eq!(ep.as_deref(), Some("http://env-host:4318/v1/metrics"));
     }
 
     #[test]
     fn resolve_metrics_endpoint_metrics_env_var_used_as_full_url() {
         let _guard = env_lock();
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-            std::env::set_var(
-                "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
-                "http://metrics-host:4318/v1/metrics",
-            );
-        }
-        let ep = resolve_metrics_endpoint(None);
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
-        }
+        let ep = temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", None::<&str>),
+                (
+                    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+                    Some("http://metrics-host:4318/v1/metrics"),
+                ),
+            ],
+            || resolve_metrics_endpoint(None),
+        );
         assert_eq!(ep.as_deref(), Some("http://metrics-host:4318/v1/metrics"));
     }
 
     #[test]
     fn resolve_metrics_endpoint_returns_none_when_unset() {
         let _guard = env_lock();
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
-        }
-        let ep = resolve_metrics_endpoint(None);
+        let ep = temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", None::<&str>),
+                ("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", None::<&str>),
+            ],
+            || resolve_metrics_endpoint(None),
+        );
         assert!(ep.is_none());
     }
 
     #[test]
     fn resolve_metrics_interval_prefers_env_var() {
         let _guard = env_lock();
-        unsafe {
-            std::env::set_var("OTEL_METRIC_EXPORT_INTERVAL", "30000");
-        }
-        let interval = resolve_metrics_interval(Some(10));
-        unsafe {
-            std::env::remove_var("OTEL_METRIC_EXPORT_INTERVAL");
-        }
+        let interval = temp_env::with_var("OTEL_METRIC_EXPORT_INTERVAL", Some("30000"), || {
+            resolve_metrics_interval(Some(10))
+        });
         assert_eq!(interval, std::time::Duration::from_secs(30));
     }
 
     #[test]
     fn resolve_metrics_interval_prefers_cli_secs() {
         let _guard = env_lock();
-        unsafe {
-            std::env::remove_var("OTEL_METRIC_EXPORT_INTERVAL");
-        }
-        let interval = resolve_metrics_interval(Some(10));
+        let interval = temp_env::with_var("OTEL_METRIC_EXPORT_INTERVAL", None::<String>, || {
+            resolve_metrics_interval(Some(10))
+        });
         assert_eq!(interval, std::time::Duration::from_secs(10));
     }
 
     #[test]
     fn resolve_metrics_interval_defaults_to_15s() {
         let _guard = env_lock();
-        unsafe {
-            std::env::remove_var("OTEL_METRIC_EXPORT_INTERVAL");
-        }
-        let interval = resolve_metrics_interval(None);
+        let interval = temp_env::with_var("OTEL_METRIC_EXPORT_INTERVAL", None::<String>, || {
+            resolve_metrics_interval(None)
+        });
         assert_eq!(interval, std::time::Duration::from_secs(15));
     }
 
     #[test]
     fn resolve_metrics_interval_clamps_zero_env_var_to_1s() {
         let _guard = env_lock();
-        unsafe {
-            std::env::set_var("OTEL_METRIC_EXPORT_INTERVAL", "0");
-        }
-        let interval = resolve_metrics_interval(None);
-        unsafe {
-            std::env::remove_var("OTEL_METRIC_EXPORT_INTERVAL");
-        }
+        let interval = temp_env::with_var("OTEL_METRIC_EXPORT_INTERVAL", Some("0"), || {
+            resolve_metrics_interval(None)
+        });
         assert_eq!(interval, std::time::Duration::from_secs(1));
     }
 
     #[test]
     fn resolve_metrics_interval_clamps_zero_cli_secs_to_1s() {
         let _guard = env_lock();
-        unsafe {
-            std::env::remove_var("OTEL_METRIC_EXPORT_INTERVAL");
-        }
-        let interval = resolve_metrics_interval(Some(0));
+        let interval = temp_env::with_var("OTEL_METRIC_EXPORT_INTERVAL", None::<String>, || {
+            resolve_metrics_interval(Some(0))
+        });
         assert_eq!(interval, std::time::Duration::from_secs(1));
     }
 
     #[test]
     fn resolve_metrics_headers_prefers_metrics_var() {
         let _guard = env_lock();
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_HEADERS", "a=1,b=2");
-            std::env::set_var("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "c=3");
-        }
-        let headers = resolve_metrics_headers();
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_HEADERS");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_HEADERS");
-        }
+        let headers = temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_HEADERS", Some("a=1,b=2")),
+                ("OTEL_EXPORTER_OTLP_METRICS_HEADERS", Some("c=3")),
+            ],
+            resolve_metrics_headers,
+        );
         assert_eq!(headers, vec![("c".to_owned(), "3".to_owned())]);
     }
 


### PR DESCRIPTION
🦠 **Threat:** 
1. `anyhow` dependency vulnerability (RUSTSEC-2026-0190) which allows unsound behavior with `Error::downcast_mut()`.
2. Multiple test files were using `unsafe { std::env::set_var(...) }` and `unsafe { std::env::remove_var(...) }`. These are inherently thread-unsafe data races that can cause undefined behavior (segfaults) when run in standard multi-threaded testing harnesses (like `tokio::test` or `cargo test`). 

🛡️ **Defense:** 
1. Updated `anyhow` dependency to latest.
2. Replaced all `unsafe` process-wide environment variable mutations in test files (`src/stream/sweep_webhook.rs`, `src/run/mini.rs`, `src/run/agent_doctor.rs`, `src/run/redact_audit.rs`, `src/telemetry/mod.rs`, `src/agent/confirm_tui.rs`) with safe `temp_env::with_var` and `temp_env::async_with_vars` to scope env overrides tightly around assertions.
3. Replaced `unwrap()` calls on options with `let Some(v) = opt else { panic!() }` patterns to eliminate strict lint warnings in `src/env/docker.rs`.

💥 **Severity:** 
Medium. Test runner data races can lead to unpredictable test failures or deadlocks on shared CI infrastructure. The `anyhow` unsoundness is theoretically critical if downcasting is exposed to malicious input handling.

🧪 **Verification:** 
- `cargo audit` returns clean.
- `cargo clippy --all-targets --all-features -- -D warnings` passes without warnings.
- Scoped `cargo test` on all modified modules passes locally.

---
*PR created automatically by Jules for task [4418887852609574307](https://jules.google.com/task/4418887852609574307) started by @madmax983*