### PR TITLE
🌟 Nova: [XML Trajectory Exporter]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+xml-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
 

--- a/docs/spec-export.md
+++ b/docs/spec-export.md
@@ -34,6 +34,7 @@ max bench inspect --list-formats
 | `csv` | stable | `csv-export` | spreadsheets, jq pipelines, tabular tools |
 | `html` | stable | `html-export` | self-contained browser view, shared notebooks |
 | `mermaid` | experimental | `mermaid-export` | Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live) |
+| `xml` | experimental | `xml-export` | external XML parsers and enterprise systems |
 
 Feature-gated formats require rebuilding with the corresponding feature:
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -3462,7 +3462,7 @@ pub struct InspectCmd {
     pub show_noise: bool,
 
     /// Output format: `text` (default), `json`, or `unified` in diff mode.
-    /// In instance mode, also accepts `markdown`, `html`, `csv`, and `mermaid`
+    /// In instance mode, also accepts `markdown`, `html`, `csv`, `mermaid`, and `xml`
     /// (each maps to the corresponding trajectory exporter; feature-gated
     /// formats require the matching Cargo feature at build time).
     /// Use `--list-formats` to enumerate all formats compiled into this build
@@ -3477,7 +3477,7 @@ pub struct InspectCmd {
     pub list_formats: bool,
 
     /// Write output to a file instead of stdout. Supported with `markdown`,
-    /// `html`, `csv`, and `mermaid` formats in instance mode.
+    /// `html`, `csv`, `mermaid`, and `xml` formats in instance mode.
     #[arg(long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4037,7 +4037,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         }
         if i.output.is_some() {
             return Err(Error::Config(crate::error::ConfigError::Invalid(
-                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid)".into(),
+                "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/xml)".into(),
             )));
         }
         let format = parse_trajectory_diff_format(&i.format)?;
@@ -4058,7 +4058,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
 
     if i.output.is_some() {
         return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid), not `{}`",
+            "inspect: --output is only supported with export formats (markdown/html/csv/mermaid/xml), not `{}`",
             i.format
         ))));
     }
@@ -4068,7 +4068,7 @@ fn bench_inspect(i: args::InspectCmd) -> Result<(), Error> {
         "json" => crate::run::inspect::InspectFormat::Json,
         other => {
             return Err(Error::Config(crate::error::ConfigError::Invalid(format!(
-                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, or `mermaid`)"
+                "unknown --format `{other}` (expected `text`, `json`, `markdown`, `html`, `csv`, `mermaid`, or `xml`)"
             ))));
         }
     };
@@ -4110,7 +4110,8 @@ fn bench_inspect_export(i: args::InspectCmd) -> Result<(), Error> {
     })?;
     let instance_id = i.instance.as_deref().ok_or_else(|| {
         Error::Config(crate::error::ConfigError::Invalid(
-            "inspect: --instance is required for export formats (markdown/html/csv/mermaid)".into(),
+            "inspect: --instance is required for export formats (markdown/html/csv/mermaid/xml)"
+                .into(),
         ))
     })?;
     let traj_path =

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -109,6 +109,7 @@ pub const FEATURE_GATED_FORMATS: &[(&str, &str)] = &[
     ("csv", "csv-export"),
     ("html", "html-export"),
     ("mermaid", "mermaid-export"),
+    ("xml", "xml-export"),
 ];
 
 /// Returns `true` if `name` is a trajectory export format known to this codebase,
@@ -165,6 +166,9 @@ pub struct MermaidExporter;
 
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
+
+#[cfg(feature = "xml-export")]
+pub struct XmlExporter;
 
 use std::fmt::Write;
 
@@ -358,6 +362,47 @@ impl TrajectoryExporter for MermaidExporter {
     }
 }
 
+#[cfg(feature = "xml-export")]
+impl TrajectoryExporter for XmlExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut xml = String::new();
+
+        xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        xml.push_str("<trajectory>\n");
+
+        if let Some(task) = &trajectory.info.task {
+            let task = redactor.redact_text(task, surface::EXPORT).text;
+            let safe_task = task.replace("]]>", "]]]]><![CDATA[>");
+            let _ = writeln!(xml, "  <task><![CDATA[{safe_task}]]></task>");
+        }
+
+        if let Some(outcome) = &trajectory.info.outcome {
+            let outcome = redactor.redact_text(outcome, surface::EXPORT).text;
+            let safe_outcome = outcome.replace("]]>", "]]]]><![CDATA[>");
+            let _ = writeln!(xml, "  <outcome><![CDATA[{safe_outcome}]]></outcome>");
+        }
+
+        xml.push_str("  <messages>\n");
+
+        for msg in &trajectory.messages {
+            let role = msg.role.as_str();
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            let safe_content = content.replace("]]>", "]]]]><![CDATA[>");
+
+            let _ = writeln!(
+                xml,
+                "    <message role=\"{role}\">\n      <![CDATA[{safe_content}]]>\n    </message>"
+            );
+        }
+
+        xml.push_str("  </messages>\n");
+        xml.push_str("</trajectory>\n");
+
+        xml
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -452,5 +497,31 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+
+    #[cfg(feature = "xml-export")]
+    #[test]
+    fn test_xml_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature]]>with trap".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent <tag>"));
+        t.record_message(&Message::assistant("Trap: ]]> gotcha"));
+
+        let xml = XmlExporter::export(&t);
+
+        assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        assert!(xml.contains("<trajectory>"));
+        assert!(xml.contains("<task><![CDATA[Add a feature]]]]><![CDATA[>with trap]]></task>"));
+        assert!(xml.contains("<outcome><![CDATA[submitted]]></outcome>"));
+        assert!(xml.contains("<message role=\"system\">\n      <![CDATA[System prompt]]>"));
+        assert!(xml.contains("<message role=\"user\">\n      <![CDATA[Hello agent <tag>]]>"));
+        assert!(xml.contains(
+            "<message role=\"assistant\">\n      <![CDATA[Trap: ]]]]><![CDATA[> gotcha]]>"
+        ));
+        assert!(xml.contains("</messages>"));
+        assert!(xml.contains("</trajectory>"));
     }
 }


### PR DESCRIPTION
💡 **The Spark:** "I noticed we export trajectories to HTML, CSV, and Mermaid but enterprise systems often rely on XML for ingestion and validation."
🚀 **The Feature:** "Implemented `XmlExporter` under a new `xml-export` feature flag to convert Trajectories into well-formed XML."
🔮 **The Potential:** "Could be used for programmatic parsing by external systems, legacy integrations, and complex automated dashboards."
⚠️ **Risk:** "Low. Isolated in `src/trajectory/export.rs` and cleanly abstracted behind a standard trajectory export trait."

---
*PR created automatically by Jules for task [16438155979931669398](https://jules.google.com/task/16438155979931669398) started by @madmax983*