### PR TITLE
🌟 Nova: [XML Trajectory Exporter]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+xml-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
 

--- a/docs/spec-export.md
+++ b/docs/spec-export.md
@@ -34,6 +34,7 @@ max bench inspect --list-formats
 | `csv` | stable | `csv-export` | spreadsheets, jq pipelines, tabular tools |
 | `html` | stable | `html-export` | self-contained browser view, shared notebooks |
 | `mermaid` | experimental | `mermaid-export` | Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live) |
+| `xml` | experimental | `xml-export` | XML processors, enterprise integration, automated parsing |
 
 Feature-gated formats require rebuilding with the corresponding feature:
 

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -534,10 +534,12 @@ mod tests {
             network_pos.is_some(),
             "expected --network flag in args: {args:?}"
         );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        if let Some(pos) = network_pos {
+            assert_eq!(
+                args.get(pos + 1).map(String::as_str),
+                Some("none")
+            );
+        }
     }
 
     #[test]
@@ -552,11 +554,15 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
-        assert!(
-            network_pos < image_pos,
-            "--network must appear before the image name"
-        );
+        let network_pos = args.iter().position(|a| a == "--network");
+        let image_pos = args.iter().position(|a| a == "my-image");
+        if let (Some(np), Some(ip)) = (network_pos, image_pos) {
+            assert!(
+                np < ip,
+                "--network must appear before the image name"
+            );
+        } else {
+            panic!("missing flags");
+        }
     }
 }

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -6,7 +6,7 @@
 //! narrative document, complete with headers and code blocks.
 //!
 //! You can extend this module with new formats by implementing the [`crate::trajectory::export::TrajectoryExporter`] trait.
-//! Every new exporter MUST register in [`registry`] and MUST apply redaction via
+//! Every new exporter MUST register in [`crate::trajectory::export::registry`] and MUST apply redaction via
 //! [`crate::redaction::Redactor::default_enabled`] on [`crate::redaction::surface::EXPORT`] before emitting any output.
 //! See `docs/spec-export.md` for the full governing contract.
 
@@ -95,6 +95,14 @@ pub fn registry() -> Vec<ExportFormat> {
         render: MermaidExporter::export,
     });
 
+    #[cfg(feature = "xml-export")]
+    formats.push(ExportFormat {
+        name: "xml",
+        tier: StabilityTier::Experimental,
+        consumer: "XML processors, enterprise integration, automated parsing",
+        render: XmlExporter::export,
+    });
+
     formats
 }
 
@@ -109,6 +117,7 @@ pub const FEATURE_GATED_FORMATS: &[(&str, &str)] = &[
     ("csv", "csv-export"),
     ("html", "html-export"),
     ("mermaid", "mermaid-export"),
+    ("xml", "xml-export"),
 ];
 
 /// Returns `true` if `name` is a trajectory export format known to this codebase,
@@ -165,6 +174,9 @@ pub struct MermaidExporter;
 
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
+
+#[cfg(feature = "xml-export")]
+pub struct XmlExporter;
 
 use std::fmt::Write;
 
@@ -358,6 +370,44 @@ impl TrajectoryExporter for MermaidExporter {
     }
 }
 
+#[cfg(feature = "xml-export")]
+impl TrajectoryExporter for XmlExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut xml = String::new();
+
+        xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        xml.push_str("<trajectory>\n");
+
+        if let Some(task) = &trajectory.info.task {
+            let task_redacted = redactor.redact_text(task, surface::EXPORT).text;
+            let safe_task = task_redacted.replace("]]>", "]]]]><![CDATA[>");
+            let _ = writeln!(xml, "  <task><![CDATA[{safe_task}]]></task>");
+        }
+
+        if let Some(outcome) = &trajectory.info.outcome {
+            let outcome_redacted = redactor.redact_text(outcome, surface::EXPORT).text;
+            let safe_outcome = outcome_redacted.replace("]]>", "]]]]><![CDATA[>");
+            let _ = writeln!(xml, "  <outcome><![CDATA[{safe_outcome}]]></outcome>");
+        }
+
+        xml.push_str("  <messages>\n");
+        for msg in &trajectory.messages {
+            let role = msg.role.as_str();
+            let content = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            let safe_content = content.replace("]]>", "]]]]><![CDATA[>");
+            let _ = writeln!(
+                xml,
+                "    <message role=\"{role}\"><![CDATA[{safe_content}]]></message>"
+            );
+        }
+        xml.push_str("  </messages>\n");
+
+        xml.push_str("</trajectory>\n");
+        xml
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -452,5 +502,34 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+
+    #[cfg(feature = "xml-export")]
+    #[test]
+    fn test_xml_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent\nMulti-line <test>"));
+        t.record_message(&Message::assistant("Hello ]]> \"user\""));
+
+        let xml = XmlExporter::export(&t);
+
+        assert!(xml.starts_with("<?xml version=\"1.0\""));
+        assert!(xml.contains("<trajectory>"));
+        assert!(xml.contains("<task><![CDATA[Add a feature]]></task>"));
+        assert!(xml.contains("<outcome><![CDATA[submitted]]></outcome>"));
+        assert!(xml.contains("<messages>"));
+        assert!(xml.contains("<message role=\"system\"><![CDATA[System prompt]]></message>"));
+        assert!(xml.contains(
+            "<message role=\"user\"><![CDATA[Hello agent\nMulti-line <test>]]></message>"
+        ));
+        assert!(xml.contains(
+            "<message role=\"assistant\"><![CDATA[Hello ]]]]><![CDATA[> \"user\"]]></message>"
+        ));
+        assert!(xml.contains("</messages>"));
+        assert!(xml.contains("</trajectory>"));
     }
 }


### PR DESCRIPTION
💡 **The Spark:** "We have trajectory exporters for markdown, html, csv, and mermaid, but we don't have a format optimized for enterprise integrations or automated processing pipelines that expect strict schemas."

🚀 **The Feature:** "Implemented `XmlExporter` under the `xml-export` feature flag. It serializes trajectories into a clean XML structure, securely wrapping all content in sanitized `CDATA` blocks."

🔮 **The Potential:** "Could be used to feed trajectories directly into XML-based analytics tools, legacy enterprise systems, or automated document generation pipelines without relying on JSON."

⚠️ **Risk:** "Low. Isolated behind the `xml-export` feature flag in `src/trajectory/export.rs` and fully conforms to the mandatory redaction and testing invariants."

---
*PR created automatically by Jules for task [507655719759584935](https://jules.google.com/task/507655719759584935) started by @madmax983*