### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected my-image flag in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -245,4 +245,40 @@ mod tests {
         let s = "no secrets here";
         assert_eq!(normalize_redaction_markers(s), s);
     }
+
+    #[test]
+    fn cap_canonical_does_not_truncate_short_string() {
+        let s = "hello";
+        let (capped, truncated) = cap_canonical(s, 10);
+        assert_eq!(capped, "hello");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn cap_canonical_truncates_long_string() {
+        let s = "hello world";
+        let (capped, truncated) = cap_canonical(s, 5);
+        assert_eq!(capped, "hello[truncated]");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn cap_canonical_truncates_at_char_boundary() {
+        // "🦀" is 4 bytes.
+        let s = "hi 🦀!";
+
+        // Capping at 4 bytes would cut the crab in half.
+        let (capped, truncated) = cap_canonical(s, 5);
+        // Should truncate before the crab
+        assert_eq!(capped, "hi [truncated]");
+        assert!(truncated);
+
+        let (capped, truncated) = cap_canonical(s, 6);
+        assert_eq!(capped, "hi [truncated]");
+        assert!(truncated);
+
+        let (capped, truncated) = cap_canonical(s, 7);
+        assert_eq!(capped, "hi 🦀[truncated]");
+        assert!(truncated);
+    }
 }


### PR DESCRIPTION
🎯 Target: `cap_canonical` in `src/fingerprint.rs` and docker environment arguments logic in `src/env/docker.rs`.
💣 Risk: `cap_canonical` lacked test coverage, hiding potential multibyte truncation bugs. Unsafe `.unwrap()` usage in docker argument tests risked confusing trace panics.
🧪 Strategy: Added explicit tests for `cap_canonical` boundary cases (including unicode char slicing). Refactored `.unwrap()` to idiomatic `let Some(...) else { panic!(...) }` with descriptive assertions.
🔭 Verification: `cargo test --features docker --lib -- fingerprint env::docker`

---
*PR created automatically by Jules for task [3421139196974193990](https://jules.google.com/task/3421139196974193990) started by @madmax983*