### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -28,8 +28,9 @@ use crate::model::{
 };
 use crate::policy::{PolicyDecision, PolicyEngine, PolicyProfile};
 use crate::prompt_guard::{PromptGuard, UntrustedKind};
-use crate::redaction::{RedactingSink, Redactor, surface};
+use crate::redaction::{Redactor, surface};
 use crate::stagnation::StagnationDetector;
+use crate::stream::RedactingSink;
 use crate::stream::{NullSink, StreamEvent, StreamSink};
 use crate::template::Renderer;
 use crate::tool::{

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1485,17 +1485,17 @@ pub enum BenchCmd {
     /// Compute per-test partial-credit scores across a completed sweep.
     TestProgress(TestProgressCmd),
     /// Fork a trajectory at step N and continue with config overrides.
-    Fork(ForkCmd),
+    Fork(crate::run::args::ForkCmd),
     /// Calculate statistical power or required sample size.
-    Power(PowerCmd),
+    Power(crate::run::args::PowerCmd),
     /// Preview SWE-bench dataset composition offline and zero-cost before running a sweep.
     DatasetStats(DatasetStatsCmd),
     /// Verify a candidate dataset offline against its canonical official release.
     DatasetVerify(DatasetVerifyCmd),
     /// Identify the commit that introduced a resolved-rate regression.
-    Bisect(BisectCmd),
+    Bisect(crate::run::args::BisectCmd),
     /// Re-derive and verify sweep aggregates against trajectories.
-    Audit(AuditCmd),
+    Audit(crate::run::args::AuditCmd),
     /// Emit a self-contained failure summary for one instance in a completed sweep.
     FailureDigest(FailureDigestCmd),
     /// Quantify evaluator-side verdict noise by replaying the evaluator N times per patch.
@@ -1529,7 +1529,7 @@ pub enum BenchCmd {
     /// Classify per-instance flakiness from a rerun sweep (zero cost: reads only on-disk artifacts).
     Variance(BenchVarianceCmd),
     /// Combine two or more completed sharded sweep directories into one canonical aggregate (offline; zero model cost).
-    Merge(MergeCmd),
+    Merge(crate::run::args::MergeCmd),
     /// Deterministically partition a dataset into N disjoint, balanced, provenance-stamped shards (offline; zero model cost).
     Shard(ShardCmd),
     /// Report context-window pressure telemetry per sweep (zero-cost: reads only on-disk artifacts).
@@ -1538,63 +1538,6 @@ pub enum BenchCmd {
     Ledger(LedgerCmd),
     /// Report run-directory disk footprint per sweep/category and safely reclaim stale sweeps (zero-cost: reads only on-disk artifacts).
     Du(DuCmd),
-}
-
-/// `bench merge` — combine completed sharded sweep directories into one canonical aggregate.
-///
-/// Recombines K independent sharded sweeps into a single canonical sweep directory
-/// that is a drop-in for `bench evaluate`, `bench report`, `bench triage`, and `bench audit`.
-/// Runs entirely offline with no model or network calls.
-#[derive(Debug, Args)]
-pub struct MergeCmd {
-    /// A completed sweep directory to merge. Repeat for each shard (2+ required).
-    #[arg(long = "shard", required = true, action = clap::ArgAction::Append)]
-    pub shards: Vec<std::path::PathBuf>,
-
-    /// Destination directory for the merged canonical sweep. Created if absent; must be empty otherwise.
-    #[arg(long)]
-    pub output: std::path::PathBuf,
-
-    /// Collision policy when the same instance_id appears in more than one shard.
-    /// `error` (default): fail with a clear message listing all colliding IDs.
-    /// `first-wins`: keep the occurrence from the earliest --shard.
-    /// `last-wins`: keep the occurrence from the latest --shard.
-    #[arg(long = "on-collision", value_enum, default_value_t = MergeCollisionPolicy::Error)]
-    pub on_collision: MergeCollisionPolicy,
-
-    /// Optional human-readable shard labels, positionally aligned with --shard.
-    /// Defaults to the directory name of each shard.
-    #[arg(long = "label", action = clap::ArgAction::Append)]
-    pub labels: Vec<String>,
-
-    /// Overwrite the output directory if it is non-empty.
-    #[arg(long, default_value_t = false)]
-    pub force: bool,
-
-    /// Output format: `text` (default) or `json`.
-    /// The `json` format emits a machine-readable summary to stdout.
-    #[arg(long, value_enum, default_value_t = MergeFormat::Text)]
-    pub format: MergeFormat,
-}
-
-/// Output format for `bench merge`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
-pub enum MergeFormat {
-    /// Human-readable text summary (default).
-    Text,
-    /// Machine-readable JSON summary.
-    Json,
-}
-
-/// Collision policy for `bench merge` when the same instance_id appears in multiple shards.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
-pub enum MergeCollisionPolicy {
-    /// Fail loudly if any instance_id appears in two or more shards (default).
-    Error,
-    /// Keep the occurrence from the earliest --shard; log duplicates in the report.
-    FirstWins,
-    /// Keep the occurrence from the latest --shard; log duplicates in the report.
-    LastWins,
 }
 
 /// `bench export-otlp` — re-export reconstructed sweep + instance spans from a
@@ -1992,117 +1935,6 @@ pub struct DatasetVerifyCmd {
     pub canonical_dir: Option<PathBuf>,
 
     /// Format: `text` or `json`.
-    #[arg(long, default_value = "text")]
-    pub format: String,
-}
-
-/// `bench bisect` — identify the commit that introduced a resolved-rate regression.
-#[derive(Debug, Args, Clone)]
-pub struct BisectCmd {
-    /// Known-good sweep directory containing a results.json with manifest.
-    #[arg(long)]
-    pub good: PathBuf,
-
-    /// Known-bad sweep directory containing a results.json with manifest.
-    #[arg(long)]
-    pub bad: PathBuf,
-
-    /// Number of smoke instances to sample for the sweep.
-    #[arg(long, default_value_t = 5)]
-    pub smoke_instances: usize,
-
-    /// RNG seed for sampling candidate smoke instances (defaults to good manifest hash).
-    #[arg(long)]
-    pub smoke_seed: Option<u64>,
-
-    /// The model to run the smoke sweep against. Defaults to cheapest registered model.
-    #[arg(long)]
-    pub smoke_model: Option<String>,
-
-    /// Margin under which resolved rate is considered a regression.
-    #[arg(long, default_value_t = 0.20)]
-    pub regression_margin: f64,
-
-    /// Maximum USD cost before halting and writing partial results.
-    #[arg(long)]
-    pub max_cost_usd: Option<f64>,
-
-    /// Path to a bisect.json file to resume a previously interrupted run.
-    #[arg(long)]
-    pub resume: Option<PathBuf>,
-}
-
-/// `bench audit` — re-derive and verify sweep aggregates against trajectories.
-#[derive(Debug, Args, Clone)]
-pub struct AuditCmd {
-    /// Path to a completed sweep directory or extracted bench bundle directory.
-    #[arg(long)]
-    pub sweep: PathBuf,
-
-    /// Local dataset file to verify the recorded manifest hash.
-    #[arg(long)]
-    pub dataset_path: Option<PathBuf>,
-
-    /// USD tolerance for cost reconciliation.
-    #[arg(long, default_value_t = 0.0001)]
-    pub cost_tolerance_usd: f64,
-
-    /// Seconds tolerance for wall-clock reconciliation.
-    #[arg(long, default_value_t = 1.0)]
-    pub wallclock_tolerance_secs: f64,
-
-    /// Output format: `text` or `json`.
-    #[arg(long, default_value = "text")]
-    pub format: String,
-}
-
-/// `bench power` — statistical power, sample size, or MDE calculations.
-#[derive(Debug, Args, Clone)]
-pub struct PowerCmd {
-    /// Baseline resolved rate as a float (e.g. `0.35`). Required unless `--from-sweep` is provided.
-    #[arg(long)]
-    pub baseline_rate: Option<f64>,
-
-    /// Absolute percentage points delta (e.g. `0.05`).
-    /// Mutually exclusive with `--n` (Mode A).
-    #[arg(long, conflicts_with = "n")]
-    pub delta: Option<f64>,
-
-    /// Sample size per arm.
-    /// Mutually exclusive with `--delta` (Mode B).
-    #[arg(long, conflicts_with = "delta")]
-    pub n: Option<usize>,
-
-    /// Sweep directory to load baseline resolved rate from.
-    /// Mutually exclusive with `--baseline-rate`.
-    #[arg(long, conflicts_with = "baseline_rate")]
-    pub from_sweep: Option<PathBuf>,
-
-    /// Significance level / Type I error rate.
-    #[arg(long, default_value_t = 0.05)]
-    pub alpha: f64,
-
-    /// Target statistical power / 1 - Type II error rate.
-    #[arg(long, default_value_t = 0.80)]
-    pub power: f64,
-
-    /// Run a one-sided test instead of a two-sided test.
-    #[arg(long, default_value_t = false)]
-    pub one_sided: bool,
-
-    /// Number of study arms (default is 2). Bonferroni correction is applied if arms > 2.
-    #[arg(long, default_value_t = 2)]
-    pub arms: usize,
-
-    /// Optional average run cost in USD per instance.
-    #[arg(long)]
-    pub cost_per_instance: Option<f64>,
-
-    /// Optional path to a forecast report JSON to compute cost from.
-    #[arg(long, conflicts_with = "cost_per_instance")]
-    pub from_forecast: Option<PathBuf>,
-
-    /// Output format: `text` (default) or `json`.
     #[arg(long, default_value = "text")]
     pub format: String,
 }
@@ -4060,55 +3892,6 @@ pub struct SkillsPreviewCmd {
     /// Output format: `text` (default, human-readable) or `json` (schema-versioned).
     #[arg(long, default_value = "text")]
     pub format: String,
-}
-
-/// `bench fork` — fork a trajectory at step N and continue with config overrides.
-#[derive(Debug, Args)]
-#[allow(clippy::struct_excessive_bools)]
-pub struct ForkCmd {
-    /// Completed sweep directory containing the instance trajectory.
-    #[arg(long)]
-    pub sweep: std::path::PathBuf,
-
-    /// Specific instance id to fork.
-    #[arg(long)]
-    pub instance: String,
-
-    /// The step number to fork from (zero-indexed).
-    #[arg(long = "from-step")]
-    pub from_step: u32,
-
-    /// Output directory for the new trajectory.
-    #[arg(long)]
-    pub output: std::path::PathBuf,
-
-    /// Override model name for the tail (e.g. `claude-opus-4-7`).
-    #[arg(long)]
-    pub model: Option<String>,
-
-    /// Override system prompt file for the tail.
-    #[arg(long = "system-prompt-file")]
-    pub system_prompt_file: Option<std::path::PathBuf>,
-
-    /// Override max agent steps.
-    #[arg(long)]
-    pub step_limit: Option<u32>,
-
-    /// Override per-task USD budget cap for the tail.
-    #[arg(long)]
-    pub per_task_budget_usd: Option<f64>,
-
-    /// Override MCP stdio server command(s).
-    #[arg(long = "mcp-server", value_name = "COMMAND")]
-    pub mcp_servers: Vec<String>,
-
-    /// Override path to an MCP config JSON file.
-    #[arg(long = "mcp-config")]
-    pub mcp_config: Option<std::path::PathBuf>,
-
-    /// Allow forking from a parent trajectory that has no stored input fingerprints.
-    #[arg(long, default_value_t = false)]
-    pub allow_unfingerprinted: bool,
 }
 
 // ── bench annotate ────────────────────────────────────────────────────────────

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4238,7 +4238,7 @@ fn bench_test_progress(t: args::TestProgressCmd) -> Result<(), Error> {
     Ok(())
 }
 
-fn bench_power(p: &args::PowerCmd) -> Result<(), Error> {
+fn bench_power(p: &crate::run::args::PowerCmd) -> Result<(), Error> {
     let is_json = match p.format.as_str() {
         "text" => false,
         "json" => true,
@@ -6559,17 +6559,17 @@ fn bench_dataset_verify(s: args::DatasetVerifyCmd) -> Result<(), Error> {
     Ok(())
 }
 
-async fn bench_bisect(b: args::BisectCmd) -> Result<(), Error> {
+async fn bench_bisect(b: crate::run::args::BisectCmd) -> Result<(), Error> {
     crate::run::bisect::run(&b).await
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn bench_audit(a: args::AuditCmd) -> Result<(), Error> {
+fn bench_audit(a: crate::run::args::AuditCmd) -> Result<(), Error> {
     crate::run::audit::run(&a)
 }
 
-fn bench_merge(m: &args::MergeCmd) -> Result<(), Error> {
-    let is_json = matches!(m.format, args::MergeFormat::Json);
+fn bench_merge(m: &crate::run::args::MergeCmd) -> Result<(), Error> {
+    let is_json = matches!(m.format, crate::run::args::MergeFormat::Json);
     let report = crate::run::merge::run(m)?;
     if is_json {
         println!("{}", serde_json::to_string_pretty(&report)?);

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -530,14 +530,10 @@ mod tests {
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = network_pos else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +548,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected my-image in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::config::RedactionCfg;
-use crate::stream::{StreamEvent, StreamSink};
 
 // ── Public check types ────────────────────────────────────────────────────────
 
@@ -471,7 +470,7 @@ impl Redactor {
 
     /// Run redaction and return per-match annotations for operator verification.
     ///
-    /// Unlike [`redact_text`], this method does not update surface-level telemetry
+    /// Unlike [`Redactor::redact_text`], this method does not update surface-level telemetry
     /// counts and does not require a surface label. It is designed for the
     /// `agent redact-check` preflight command.
     #[must_use]
@@ -613,123 +612,6 @@ impl Redactor {
             }
             _ => false,
         }
-    }
-}
-
-pub struct RedactingSink {
-    inner: Arc<dyn StreamSink>,
-    redactor: Redactor,
-}
-
-impl RedactingSink {
-    pub fn new(inner: Arc<dyn StreamSink>, redactor: Redactor) -> Self {
-        Self { inner, redactor }
-    }
-}
-
-impl StreamSink for RedactingSink {
-    fn emit(&self, event: StreamEvent) {
-        self.inner.emit(redact_stream_event(&event, &self.redactor));
-    }
-}
-
-pub fn redact_stream_event(event: &StreamEvent, redactor: &Redactor) -> StreamEvent {
-    match event {
-        StreamEvent::RunStarted {
-            task,
-            model,
-            started_at,
-        } => StreamEvent::RunStarted {
-            task: redactor.redact_text(task, surface::STREAM).text,
-            model: redactor.redact_text(model, surface::STREAM).text,
-            started_at: started_at.clone(),
-        },
-        StreamEvent::AssistantMessage {
-            step,
-            content,
-            cost_usd,
-            timestamp,
-        } => StreamEvent::AssistantMessage {
-            step: *step,
-            content: redactor.redact_text(content, surface::STREAM).text,
-            cost_usd: *cost_usd,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::BashStart {
-            step,
-            command,
-            timestamp,
-        } => StreamEvent::BashStart {
-            step: *step,
-            command: redactor.redact_text(command, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::BashResult {
-            step,
-            exit_code,
-            stdout,
-            stderr,
-            timed_out,
-            timestamp,
-        } => StreamEvent::BashResult {
-            step: *step,
-            exit_code: *exit_code,
-            stdout: redactor.redact_text(stdout, surface::STREAM).text,
-            stderr: redactor.redact_text(stderr, surface::STREAM).text,
-            timed_out: *timed_out,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::ToolStart {
-            step,
-            label,
-            timestamp,
-        } => StreamEvent::ToolStart {
-            step: *step,
-            label: redactor.redact_text(label, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::ToolEnd { step, timestamp } => StreamEvent::ToolEnd {
-            step: *step,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::Observation {
-            step,
-            content,
-            timestamp,
-        } => StreamEvent::Observation {
-            step: *step,
-            content: redactor.redact_text(content, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::FormatError {
-            step,
-            content,
-            timestamp,
-        } => StreamEvent::FormatError {
-            step: *step,
-            content: redactor.redact_text(content, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::RunEnded {
-            exit_reason,
-            failure_category,
-            final_output,
-            steps,
-            total_cost_usd,
-            ended_at,
-        } => StreamEvent::RunEnded {
-            exit_reason: exit_reason.clone(),
-            failure_category: *failure_category,
-            final_output: final_output
-                .as_ref()
-                .map(|value| redactor.redact_text(value, surface::STREAM).text),
-            steps: *steps,
-            total_cost_usd: *total_cost_usd,
-            ended_at: ended_at.clone(),
-        },
-        StreamEvent::AutoApproveRuleCreated { scope } => StreamEvent::AutoApproveRuleCreated {
-            scope: redactor.redact_text(scope, surface::STREAM).text,
-        },
     }
 }
 

--- a/src/run/args.rs
+++ b/src/run/args.rs
@@ -1,0 +1,219 @@
+use clap::Args;
+use std::path::PathBuf;
+
+/// `bench power` — statistical power, sample size, or MDE calculations.
+#[derive(Debug, Args, Clone)]
+pub struct PowerCmd {
+    /// Baseline resolved rate as a float (e.g. `0.35`). Required unless `--from-sweep` is provided.
+    #[arg(long)]
+    pub baseline_rate: Option<f64>,
+
+    /// Absolute percentage points delta (e.g. `0.05`).
+    /// Mutually exclusive with `--n` (Mode A).
+    #[arg(long, conflicts_with = "n")]
+    pub delta: Option<f64>,
+
+    /// Sample size per arm.
+    /// Mutually exclusive with `--delta` (Mode B).
+    #[arg(long, conflicts_with = "delta")]
+    pub n: Option<usize>,
+
+    /// Sweep directory to load baseline resolved rate from.
+    /// Mutually exclusive with `--baseline-rate`.
+    #[arg(long, conflicts_with = "baseline_rate")]
+    pub from_sweep: Option<PathBuf>,
+
+    /// Significance level / Type I error rate.
+    #[arg(long, default_value_t = 0.05)]
+    pub alpha: f64,
+
+    /// Target statistical power / 1 - Type II error rate.
+    #[arg(long, default_value_t = 0.80)]
+    pub power: f64,
+
+    /// Run a one-sided test instead of a two-sided test.
+    #[arg(long, default_value_t = false)]
+    pub one_sided: bool,
+
+    /// Number of study arms (default is 2). Bonferroni correction is applied if arms > 2.
+    #[arg(long, default_value_t = 2)]
+    pub arms: usize,
+
+    /// Optional average run cost in USD per instance.
+    #[arg(long)]
+    pub cost_per_instance: Option<f64>,
+
+    /// Optional path to a forecast report JSON to compute cost from.
+    #[arg(long, conflicts_with = "cost_per_instance")]
+    pub from_forecast: Option<PathBuf>,
+
+    /// Output format: `text` (default) or `json`.
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
+/// `bench fork` — fork a trajectory at step N and continue with config overrides.
+#[derive(Debug, Args)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct ForkCmd {
+    /// Completed sweep directory containing the instance trajectory.
+    #[arg(long)]
+    pub sweep: std::path::PathBuf,
+
+    /// Specific instance id to fork.
+    #[arg(long)]
+    pub instance: String,
+
+    /// The step number to fork from (zero-indexed).
+    #[arg(long = "from-step")]
+    pub from_step: u32,
+
+    /// Output directory for the new trajectory.
+    #[arg(long)]
+    pub output: std::path::PathBuf,
+
+    /// Override model name for the tail (e.g. `claude-opus-4-7`).
+    #[arg(long)]
+    pub model: Option<String>,
+
+    /// Override system prompt file for the tail.
+    #[arg(long = "system-prompt-file")]
+    pub system_prompt_file: Option<std::path::PathBuf>,
+
+    /// Override max agent steps.
+    #[arg(long)]
+    pub step_limit: Option<u32>,
+
+    /// Override per-task USD budget cap for the tail.
+    #[arg(long)]
+    pub per_task_budget_usd: Option<f64>,
+
+    /// Override MCP stdio server command(s).
+    #[arg(long = "mcp-server", value_name = "COMMAND")]
+    pub mcp_servers: Vec<String>,
+
+    /// Override path to an MCP config JSON file.
+    #[arg(long = "mcp-config")]
+    pub mcp_config: Option<std::path::PathBuf>,
+
+    /// Allow forking from a parent trajectory that has no stored input fingerprints.
+    #[arg(long, default_value_t = false)]
+    pub allow_unfingerprinted: bool,
+}
+
+/// `bench merge` — combine completed sharded sweep directories into one canonical aggregate.
+///
+/// Recombines K independent sharded sweeps into a single canonical sweep directory
+/// that is a drop-in for `bench evaluate`, `bench report`, `bench triage`, and `bench audit`.
+/// Runs entirely offline with no model or network calls.
+#[derive(Debug, Args)]
+pub struct MergeCmd {
+    /// A completed sweep directory to merge. Repeat for each shard (2+ required).
+    #[arg(long = "shard", required = true, action = clap::ArgAction::Append)]
+    pub shards: Vec<std::path::PathBuf>,
+
+    /// Destination directory for the merged canonical sweep. Created if absent; must be empty otherwise.
+    #[arg(long)]
+    pub output: std::path::PathBuf,
+
+    /// Collision policy when the same instance_id appears in more than one shard.
+    /// `error` (default): fail with a clear message listing all colliding IDs.
+    /// `first-wins`: keep the occurrence from the earliest --shard.
+    /// `last-wins`: keep the occurrence from the latest --shard.
+    #[arg(long = "on-collision", value_enum, default_value_t = MergeCollisionPolicy::Error)]
+    pub on_collision: MergeCollisionPolicy,
+
+    /// Optional human-readable shard labels, positionally aligned with --shard.
+    /// Defaults to the directory name of each shard.
+    #[arg(long = "label", action = clap::ArgAction::Append)]
+    pub labels: Vec<String>,
+
+    /// Overwrite the output directory if it is non-empty.
+    #[arg(long, default_value_t = false)]
+    pub force: bool,
+
+    /// Output format: `text` (default) or `json`.
+    /// The `json` format emits a machine-readable summary to stdout.
+    #[arg(long, value_enum, default_value_t = MergeFormat::Text)]
+    pub format: MergeFormat,
+}
+
+/// Collision policy for `bench merge` when the same instance_id appears in multiple shards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum MergeCollisionPolicy {
+    /// Fail loudly if any instance_id appears in two or more shards (default).
+    Error,
+    /// Keep the occurrence from the earliest --shard; log duplicates in the report.
+    FirstWins,
+    /// Keep the occurrence from the latest --shard; log duplicates in the report.
+    LastWins,
+}
+
+/// Output format for `bench merge`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum MergeFormat {
+    /// Human-readable text summary (default).
+    Text,
+    /// Machine-readable JSON summary.
+    Json,
+}
+
+/// `bench audit` — re-derive and verify sweep aggregates against trajectories.
+#[derive(Debug, Args, Clone)]
+pub struct AuditCmd {
+    /// Path to a completed sweep directory or extracted bench bundle directory.
+    #[arg(long)]
+    pub sweep: PathBuf,
+
+    /// Local dataset file to verify the recorded manifest hash.
+    #[arg(long)]
+    pub dataset_path: Option<PathBuf>,
+
+    /// USD tolerance for cost reconciliation.
+    #[arg(long, default_value_t = 0.0001)]
+    pub cost_tolerance_usd: f64,
+
+    /// Seconds tolerance for wall-clock reconciliation.
+    #[arg(long, default_value_t = 1.0)]
+    pub wallclock_tolerance_secs: f64,
+
+    /// Output format: `text` or `json`.
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
+/// `bench bisect` — identify the commit that introduced a resolved-rate regression.
+#[derive(Debug, Args, Clone)]
+pub struct BisectCmd {
+    /// Known-good sweep directory containing a results.json with manifest.
+    #[arg(long)]
+    pub good: PathBuf,
+
+    /// Known-bad sweep directory containing a results.json with manifest.
+    #[arg(long)]
+    pub bad: PathBuf,
+
+    /// Number of smoke instances to sample for the sweep.
+    #[arg(long, default_value_t = 5)]
+    pub smoke_instances: usize,
+
+    /// RNG seed for sampling candidate smoke instances (defaults to good manifest hash).
+    #[arg(long)]
+    pub smoke_seed: Option<u64>,
+
+    /// The model to run the smoke sweep against. Defaults to cheapest registered model.
+    #[arg(long)]
+    pub smoke_model: Option<String>,
+
+    /// Margin under which resolved rate is considered a regression.
+    #[arg(long, default_value_t = 0.20)]
+    pub regression_margin: f64,
+
+    /// Maximum USD cost before halting and writing partial results.
+    #[arg(long)]
+    pub max_cost_usd: Option<f64>,
+
+    /// Path to a bisect.json file to resume a previously interrupted run.
+    #[arg(long)]
+    pub resume: Option<PathBuf>,
+}

--- a/src/run/audit.rs
+++ b/src/run/audit.rs
@@ -5,8 +5,8 @@ use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-use crate::cli::args::AuditCmd;
 use crate::error::Error;
+use crate::run::args::AuditCmd;
 
 /// Recompute sweep-wide aggregates and reconcile with results.json and evaluation.json.
 #[allow(clippy::too_many_lines)]

--- a/src/run/bisect.rs
+++ b/src/run/bisect.rs
@@ -10,8 +10,8 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::Command;
 
-use crate::cli::args::BisectCmd;
 use crate::error::Error;
+use crate::run::args::BisectCmd;
 use crate::run::swebench::{ProvenanceManifest, SweepResults};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/run/claude_driver.rs
+++ b/src/run/claude_driver.rs
@@ -405,10 +405,10 @@ fn record_claude_config(agent: &mut DefaultAgent, cwd: &Path, isolated: bool) {
 ///   OAuth/keychain auth, ambient `.claude` discovery (hooks, skills, plugins,
 ///   MCP, memory, `CLAUDE.md`), native session persistence, and the team's own
 ///   permission settings. The harness *records* the discovered config (see
-///   [`discover_claude_config`]) into the trajectory so the run is auditable
+///   `discover_claude_config`) into the trajectory so the run is auditable
 ///   without being sterilized. This is the enterprise-auditing case.
 /// - `true` (*isolation*): pass `--bare` (skip ambient discovery), `--tools`
-///   (restrict to [`ALLOWED_TOOLS`]), and `--no-session-persistence` for a
+///   (restrict to `ALLOWED_TOOLS`), and `--no-session-persistence` for a
 ///   reproducible measurement run. Note: `--bare` forces API-key-only auth, so
 ///   OAuth/keychain logins do not apply in this mode.
 #[allow(clippy::too_many_lines)]

--- a/src/run/codex_driver.rs
+++ b/src/run/codex_driver.rs
@@ -3,7 +3,7 @@
 //! Similar to `claude_driver.rs`, this module lets an operator point the *same*
 //! run machinery at the OpenAI Codex CLI instead of the built-in bash-first loop.
 //! `codex` runs in `--full-auto --json` mode; we read its newline-delimited JSON
-//! stream and translate each event into the harness [`Trajectory`] format so that
+//! stream and translate each event into the harness [`crate::trajectory::Trajectory`] format so that
 //! patch capture, verification, `bench inspect`, and evaluation all keep working
 //! unchanged.
 //!

--- a/src/run/contamination_check.rs
+++ b/src/run/contamination_check.rs
@@ -6,9 +6,9 @@
 //!
 //! | Signal | Description | Range |
 //! |--------|-------------|-------|
-//! | `edit_before_read_ratio` | Fraction of edited files never read before patching | [0,1] |
-//! | `patch_similarity_to_gold` | Normalised similarity between agent patch and gold patch | [0,1] |
-//! | `time_to_first_edit` | Suspicion from early first edit (step 0 → 1.0, last step → 0.0) | [0,1] |
+//! | `edit_before_read_ratio` | Fraction of edited files never read before patching | \[0,1\] |
+//! | `patch_similarity_to_gold` | Normalised similarity between agent patch and gold patch | \[0,1\] |
+//! | `time_to_first_edit` | Suspicion from early first edit (step 0 → 1.0, last step → 0.0) | \[0,1\] |
 //! | `verbatim_recall` | Whether agent message contains ≥ N tokens from gold patch surface | {0,1} |
 //!
 //! # Risk tiers

--- a/src/run/fork.rs
+++ b/src/run/fork.rs
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 use sha2::Digest;
 
 use crate::agent::{Agent, DefaultAgent, default::DefaultAgentBuilder};
-use crate::cli::args::ForkCmd;
 use crate::config::{Config, EnvKind, McpServerCfg};
 #[cfg(feature = "docker")]
 use crate::env::DockerEnvironment;
@@ -21,6 +20,7 @@ use crate::model::{
     DeterministicModel, FallbackModel, Message, Model, ModelResponse, ModelUsage, QueryOpts,
 };
 use crate::redaction::Redactor;
+use crate::run::args::ForkCmd;
 use crate::run::reproduce::{
     DriftSeverity, compare_manifests, filter_hard_drifts, load_manifest_from_sweep,
 };

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -14,8 +14,8 @@ use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-use crate::cli::args::{MergeCmd, MergeCollisionPolicy};
 use crate::error::Error;
+use crate::run::args::{MergeCmd, MergeCollisionPolicy};
 use crate::run::swebench::{
     MergeShardProvenance, SWEEP_STATUS_COMPLETED, SweepResults, write_sweep_results_atomic,
 };

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -1003,7 +1003,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         // one from the config. The agent will build its own for trajectory/model
         // surfaces; this one covers the stream surface only.
         let redactor = crate::redaction::Redactor::from_config_lossy(&args.config.root.redaction);
-        Arc::new(crate::redaction::RedactingSink::new(ws, redactor)) as Arc<dyn StreamSink>
+        Arc::new(crate::stream::RedactingSink::new(ws, redactor)) as Arc<dyn StreamSink>
     });
     let event_log_sink: Option<Arc<dyn StreamSink>> = args.event_log.as_ref().and_then(|path| {
         match EventLogSink::new(
@@ -1028,10 +1028,10 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
                 }
                 let redactor =
                     crate::redaction::Redactor::from_config_lossy(&args.config.root.redaction);
-                Some(Arc::new(crate::redaction::RedactingSink::new(
-                    Arc::new(sink),
-                    redactor,
-                )) as Arc<dyn StreamSink>)
+                Some(
+                    Arc::new(crate::stream::RedactingSink::new(Arc::new(sink), redactor))
+                        as Arc<dyn StreamSink>,
+                )
             }
             Err(err) => {
                 let _ = std::io::Write::write_all(

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -93,3 +93,5 @@ pub mod ui;
 pub mod utilization;
 pub mod variance;
 pub mod watch;
+
+pub mod args;

--- a/src/run/power.rs
+++ b/src/run/power.rs
@@ -15,8 +15,8 @@
 //!
 //! Run completely offline (zero network/model calls) in under 100ms.
 
-use crate::cli::args::PowerCmd;
 use crate::error::Error;
+use crate::run::args::PowerCmd;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/run/redact_audit.rs
+++ b/src/run/redact_audit.rs
@@ -1,6 +1,6 @@
 //! `agent redact-audit <dir>` — post-hoc secret-leak detection for sweep artifacts.
 //!
-//! Issue #342. The runtime [`Redactor`](crate::redaction::Redactor) masks secrets
+//! Issue #342. The runtime [`crate::redaction::Redactor`] masks secrets
 //! *at write-time* and explicitly does not retroactively rewrite stored
 //! artifacts. Trajectories and sweep outputs are routinely shared (PRs, HTML
 //! exports, bundles), so a redaction-config bug or an unanticipated secret shape

--- a/src/run/suite.rs
+++ b/src/run/suite.rs
@@ -8,8 +8,8 @@
 //! `--rerun-failed` (issue #825) re-runs only the tasks whose last recorded
 //! result was non-passing, carrying every already-passing result forward
 //! unchanged (zero model calls, zero fresh cost) into a freshly merged
-//! `suite-results.json`. See [`tasks_needing_rerun`] and
-//! [`load_prior_suite_state`].
+//! `suite-results.json`. See `tasks_needing_rerun` and
+//! `load_prior_suite_state`.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/src/run/sweep_dashboard.rs
+++ b/src/run/sweep_dashboard.rs
@@ -10,7 +10,7 @@
 //! (`crate::run::inspect::build_inspect_steps_with_max`).
 //!
 //! The module is split so the state machine and rendering are pure,
-//! deterministic functions ([`handle_key`], [`draw`]) testable with
+//! deterministic functions (`handle_key`, `draw`) testable with
 //! ratatui's `TestBackend` — no real terminal required — while [`run`] is
 //! the thin IO shell that owns the terminal and the poll loop.
 
@@ -86,7 +86,7 @@ impl DetailState {
     }
 }
 
-/// Full dashboard state. Pure data — no IO — so [`handle_key`] and [`draw`]
+/// Full dashboard state. Pure data — no IO — so `handle_key` and `draw`
 /// are unit-testable without a terminal.
 pub(crate) struct DashboardState {
     pub(crate) sweep_dir: PathBuf,

--- a/src/run/ui.rs
+++ b/src/run/ui.rs
@@ -39,7 +39,7 @@ pub struct InstanceEntry {
     pub traj_path: PathBuf,
 }
 
-/// Arguments forwarded from the CLI to [`run`].
+/// Arguments forwarded from the CLI to `run()`.
 pub struct UiArgs {
     pub sweep: PathBuf,
     pub port: u16,

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -11,6 +11,9 @@
 //! when there are zero subscribers, and the SSE per-connection task drops
 //! on the first write error without disturbing other clients or the agent.
 
+pub mod redacting_sink;
+pub use redacting_sink::{RedactingSink, redact_stream_event};
+
 use serde::Serialize;
 
 pub mod broadcast;

--- a/src/stream/redacting_sink.rs
+++ b/src/stream/redacting_sink.rs
@@ -1,0 +1,120 @@
+use crate::redaction::{Redactor, surface};
+use crate::stream::{StreamEvent, StreamSink};
+use std::sync::Arc;
+
+pub struct RedactingSink {
+    inner: Arc<dyn StreamSink>,
+    redactor: Redactor,
+}
+
+impl RedactingSink {
+    pub fn new(inner: Arc<dyn StreamSink>, redactor: Redactor) -> Self {
+        Self { inner, redactor }
+    }
+}
+
+impl StreamSink for RedactingSink {
+    fn emit(&self, event: StreamEvent) {
+        self.inner.emit(redact_stream_event(&event, &self.redactor));
+    }
+}
+
+pub fn redact_stream_event(event: &StreamEvent, redactor: &Redactor) -> StreamEvent {
+    match event {
+        StreamEvent::RunStarted {
+            task,
+            model,
+            started_at,
+        } => StreamEvent::RunStarted {
+            task: redactor.redact_text(task, surface::STREAM).text,
+            model: redactor.redact_text(model, surface::STREAM).text,
+            started_at: started_at.clone(),
+        },
+        StreamEvent::AssistantMessage {
+            step,
+            content,
+            cost_usd,
+            timestamp,
+        } => StreamEvent::AssistantMessage {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            cost_usd: *cost_usd,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::BashStart {
+            step,
+            command,
+            timestamp,
+        } => StreamEvent::BashStart {
+            step: *step,
+            command: redactor.redact_text(command, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::BashResult {
+            step,
+            exit_code,
+            stdout,
+            stderr,
+            timed_out,
+            timestamp,
+        } => StreamEvent::BashResult {
+            step: *step,
+            exit_code: *exit_code,
+            stdout: redactor.redact_text(stdout, surface::STREAM).text,
+            stderr: redactor.redact_text(stderr, surface::STREAM).text,
+            timed_out: *timed_out,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::ToolStart {
+            step,
+            label,
+            timestamp,
+        } => StreamEvent::ToolStart {
+            step: *step,
+            label: redactor.redact_text(label, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::ToolEnd { step, timestamp } => StreamEvent::ToolEnd {
+            step: *step,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::Observation {
+            step,
+            content,
+            timestamp,
+        } => StreamEvent::Observation {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::FormatError {
+            step,
+            content,
+            timestamp,
+        } => StreamEvent::FormatError {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::RunEnded {
+            exit_reason,
+            failure_category,
+            final_output,
+            steps,
+            total_cost_usd,
+            ended_at,
+        } => StreamEvent::RunEnded {
+            exit_reason: exit_reason.clone(),
+            failure_category: *failure_category,
+            final_output: final_output
+                .as_ref()
+                .map(|value| redactor.redact_text(value, surface::STREAM).text),
+            steps: *steps,
+            total_cost_usd: *total_cost_usd,
+            ended_at: ended_at.clone(),
+        },
+        StreamEvent::AutoApproveRuleCreated { scope } => StreamEvent::AutoApproveRuleCreated {
+            scope: redactor.redact_text(scope, surface::STREAM).text,
+        },
+    }
+}

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -6,7 +6,7 @@
 //! narrative document, complete with headers and code blocks.
 //!
 //! You can extend this module with new formats by implementing the [`crate::trajectory::export::TrajectoryExporter`] trait.
-//! Every new exporter MUST register in [`registry`] and MUST apply redaction via
+//! Every new exporter MUST register in `registry` and MUST apply redaction via
 //! [`crate::redaction::Redactor::default_enabled`] on [`crate::redaction::surface::EXPORT`] before emitting any output.
 //! See `docs/spec-export.md` for the full governing contract.
 
@@ -103,7 +103,7 @@ pub fn registry() -> Vec<ExportFormat> {
 ///
 /// Used to emit a helpful "feature not compiled in" error when an operator requests a
 /// format whose feature is disabled. Compiled-in formats (with metadata and a render fn)
-/// live in [`registry`]; a format gated *out* of this build is absent from `registry()`
+/// live in `registry`; a format gated *out* of this build is absent from `registry()`
 /// but present here so the CLI can still route it and explain how to enable it.
 pub const FEATURE_GATED_FORMATS: &[(&str, &str)] = &[
     ("csv", "csv-export"),
@@ -116,7 +116,7 @@ pub const FEATURE_GATED_FORMATS: &[(&str, &str)] = &[
 ///
 /// CLI routing uses this so a request for a gated-out format still reaches the export
 /// dispatch path (and gets a helpful "rebuild with --features" error) instead of falling
-/// through to a generic "unknown format" message. This keeps [`registry`] the single
+/// through to a generic "unknown format" message. This keeps `registry` the single
 /// source of truth for *compiled* formats while still recognizing the full catalog.
 pub fn is_export_format(name: &str) -> bool {
     registry().iter().any(|f| f.name == name)


### PR DESCRIPTION
🕸️ Tangle: The codebase had two structural dependency cycles: `cli` <-> `run` (due to `run` importing `cli::args` structs) and `redaction` <-> `stream` (due to `RedactingSink` in `redaction` using `StreamSink` from `stream`, while `stream` used `Redactor`).

📐 Blueprint: Broke the cycles by relocating the dependency-causing structs. Extracted clap command arguments specifically used by `run` (e.g. `PowerCmd`, `MergeCmd`, etc.) into `src/run/args.rs`. Moved `RedactingSink` into a new `src/stream/redacting_sink.rs` module so `stream` naturally depends on `redaction` but not vice versa. Addressed some rustdoc warnings along the way.

🧱 Stability: Enforces an acyclic dependency graph, improving modularity and compile times without altering runtime behavior. Module boundaries are cleaner.

🔬 Verification: Verified via `cargo check` and Python scripts analyzing `use` imports that no cyclic dependencies remain. Passed `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --features docker --lib -- cli run stream redaction env model agent`, and `cargo doc --no-deps`.

---
*PR created automatically by Jules for task [15338113671936939334](https://jules.google.com/task/15338113671936939334) started by @madmax983*