### PR TITLE
🎨 Mosaic: UI Polish for bench commands

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -534,10 +534,10 @@ mod tests {
             network_pos.is_some(),
             "expected --network flag in args: {args:?}"
         );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(pos) = network_pos else {
+            panic!("expected --network flag");
+        };
+        assert_eq!(args.get(pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +552,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("network option found");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("image found");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -821,7 +821,27 @@ fn write_artifact_version_section(s: &mut String, mismatches: &[String], warning
 }
 
 fn write_transition_matrix(s: &mut String, transitions: &BTreeMap<TransitionKind, usize>) {
-    s.push_str("\nTransition matrix:\n");
+    use comfy_table::CellAlignment;
+    use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
+    s.push_str(
+        "
+Transition matrix:
+",
+    );
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(["Transition", "Count"]);
+
+    for column in table.column_iter_mut() {
+        column.set_cell_alignment(CellAlignment::Right);
+    }
+    if let Some(col) = table.column_mut(0) {
+        col.set_cell_alignment(CellAlignment::Left);
+    }
+
     for kind in [
         TransitionKind::PassPass,
         TransitionKind::PassFail,
@@ -831,8 +851,9 @@ fn write_transition_matrix(s: &mut String, transitions: &BTreeMap<TransitionKind
         TransitionKind::PresentMissing,
     ] {
         let n = transitions.get(&kind).copied().unwrap_or(0);
-        let _ = writeln!(s, "  {:<18} {n}", kind.label());
+        table.add_row([kind.label().to_string(), n.to_string()]);
     }
+    let _ = writeln!(s, "{table}");
 }
 
 fn write_failure_delta_section(

--- a/src/run/frontier.rs
+++ b/src/run/frontier.rs
@@ -145,34 +145,21 @@ pub fn render_json(report: &FrontierReport) -> String {
 
 #[must_use]
 pub fn render_text(report: &FrontierReport) -> String {
+    use comfy_table::CellAlignment;
+    use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL};
     let mut out = String::new();
-    out.push_str("\n=== bench frontier ===\n");
+    out.push_str(
+        "
+=== bench frontier ===
+",
+    );
     if report.points.is_empty() {
-        out.push_str("No sweep directories provided.\n");
+        out.push_str(
+            "No sweep directories provided.
+",
+        );
         return out;
     }
-
-    let col_width = report
-        .points
-        .iter()
-        .map(|p| p.dir.display().to_string().len())
-        .max()
-        .unwrap_or(4)
-        .max(4);
-
-    let header = format!(
-        "  {:<width$}  {:>10}  {:>14}  {:>8}  {}",
-        "dir",
-        "resolved%",
-        "$/resolved",
-        "frontier",
-        "total_cost_usd",
-        width = col_width
-    );
-    out.push_str(&header);
-    out.push('\n');
-    out.push_str(&"-".repeat(header.len()));
-    out.push('\n');
 
     let mut sorted: Vec<&FrontierPoint> = report.points.iter().collect();
     sorted.sort_by(|a, b| {
@@ -186,26 +173,42 @@ pub fn render_text(report: &FrontierReport) -> String {
             })
     });
 
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header([
+            "dir",
+            "resolved%",
+            "$/resolved",
+            "frontier",
+            "total_cost_usd",
+        ]);
+
+    for column in table.column_iter_mut() {
+        column.set_cell_alignment(CellAlignment::Right);
+    }
+    if let Some(col) = table.column_mut(0) {
+        col.set_cell_alignment(CellAlignment::Left);
+    } // dir should be left aligned
+
     for p in &sorted {
         let cpr = match p.cost_per_resolved_usd {
             Some(v) => format!("${v:.4}"),
             None => "NaN".to_owned(),
         };
-        let frontier_mark = if p.on_frontier { "*" } else { " " };
-        let _ = writeln!(
-            out,
-            "{} {:<width$}  {:>9.2}%  {:>14}  {:>8}  ${:.4}",
-            frontier_mark,
-            p.dir.display(),
-            p.resolved_rate * 100.0,
+        let frontier_mark = if p.on_frontier { "yes *" } else { "no" };
+        table.add_row([
+            p.dir.display().to_string(),
+            format!("{:.2}%", p.resolved_rate * 100.0),
             cpr,
-            if p.on_frontier { "yes" } else { "no" },
-            p.total_cost_usd,
-            width = col_width
-        );
+            frontier_mark.to_string(),
+            format!("${:.4}", p.total_cost_usd),
+        ]);
     }
 
-    out.push('\n');
+    let _ = writeln!(out, "{table}");
+
     let frontier_count = report.points.iter().filter(|p| p.on_frontier).count();
     let _ = writeln!(
         out,


### PR DESCRIPTION
🎨 **Mosaic: UI Polish for bench compare and frontier**

🖌️ **Before:** 
The outputs for `max bench compare` (the transition matrix) and `max bench frontier` were formatted as simple space-aligned text blocks, which looked like raw logs rather than a polished dashboard.

✨ **After:** 
Both commands now use `comfy_table` to render their data in a clean, bordered table format with the `UTF8_FULL` preset and `UTF8_ROUND_CORNERS` modifier. This improves readability and provides a proper "dashboard" feel.

🖼️ **Visuals:** 
- The transition matrix in `bench compare` is now a 2-column table with borders.
- The `bench frontier` output is now a 5-column table with proper borders, and alignment matching the table header types.

---
*PR created automatically by Jules for task [2942555473266521415](https://jules.google.com/task/2942555473266521415) started by @madmax983*