### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected image name");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/run/eval_flake.rs
+++ b/src/run/eval_flake.rs
@@ -342,7 +342,8 @@ pub fn run_with_stub(
         })
         .collect();
 
-    let mut results: Vec<InstanceFlakeResult> = Vec::new();
+    // PERFORMANCE: Pre-allocate `results` vector with `instance_ids.len()` to avoid multiple heap re-allocations as elements are pushed.
+    let mut results: Vec<InstanceFlakeResult> = Vec::with_capacity(instance_ids.len());
     for id in &instance_ids {
         let stub_verdicts = stub.verdicts.get(id.as_str());
         let verdicts: Vec<Verdict> = (0..args.replays)
@@ -418,10 +419,12 @@ pub fn run(args: &EvalFlakeArgs) -> Result<EvalFlakeReport, Error> {
         );
     }
 
+    // PERFORMANCE: Pre-allocate the `Verdict` vectors within `all_verdicts` with capacity `args.replays`.
+    // This prevents repeated heap allocations during the evaluation replays since we know exactly how many replays will be appended.
     // Collect verdicts per instance across replays.
     let mut all_verdicts: HashMap<String, Vec<Verdict>> = patchable
         .iter()
-        .map(|id| (id.clone(), Vec::new()))
+        .map(|id| (id.clone(), Vec::with_capacity(args.replays)))
         .collect();
 
     for replay_idx in 0..args.replays {
@@ -459,14 +462,13 @@ pub fn run(args: &EvalFlakeArgs) -> Result<EvalFlakeReport, Error> {
         }
     }
 
-    let mut results: Vec<InstanceFlakeResult> = patchable
-        .iter()
-        .map(|id| {
-            let verdicts = all_verdicts.remove(id).unwrap_or_default();
-            let orig = original.get(id.as_str()).copied();
-            build_instance_result(id.clone(), verdicts, orig)
-        })
-        .collect();
+    // PERFORMANCE: Pre-allocate `results` vector with `patchable.len()` to avoid multiple heap re-allocations during iteration.
+    let mut results: Vec<InstanceFlakeResult> = Vec::with_capacity(patchable.len());
+    results.extend(patchable.iter().map(|id| {
+        let verdicts = all_verdicts.remove(id).unwrap_or_default();
+        let orig = original.get(id.as_str()).copied();
+        build_instance_result(id.clone(), verdicts, orig)
+    }));
 
     results.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
 


### PR DESCRIPTION
💡 What: Pre-allocated vectors (`results` and inner vectors of `all_verdicts`) in `src/run/eval_flake.rs` using `Vec::with_capacity` instead of `Vec::new`. Replaced `.unwrap()` with `let Some(...) = ... else { panic!(...) }` in docker tests to satisfy strict clippy lints.
🎯 Why: `Vec::new()` causes the underlying buffer to dynamically grow and re-allocate on the heap as elements are pushed or collected into it. Since the exact final size of both vectors is known upfront (`instance_ids.len()` and `args.replays`), pre-allocating memory removes these overheads.
📊 Impact: Reduces heap re-allocations during `eval-flake` aggregation, improving performance for large sweeps without compromising safety.
🔬 Measurement: Run `cargo run -- bench eval-flake ...` to verify performance or `cargo test --lib -- run::eval_flake` to ensure correctness.

---
*PR created automatically by Jules for task [8332470258270817615](https://jules.google.com/task/8332470258270817615) started by @madmax983*