### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2263,7 +2263,7 @@ pub async fn bench_swebench(s: args::SwebenchCmd) -> Result<(), Error> {
                 force: false,
             };
             let eval = crate::run::evaluate::run(&eval_args)?;
-            let loaded_sweep = crate::run::compare::load_sweep(&output_dir)?;
+            let loaded_sweep = crate::run::load::load_sweep(&output_dir)?;
             let summary = crate::run::evaluate::summarize_with_model(
                 &eval,
                 &loaded_sweep.instances,
@@ -3481,7 +3481,7 @@ fn bench_evaluate(e: args::EvaluateCmd) -> Result<(), Error> {
         force: e.force,
     };
     let eval = crate::run::evaluate::run(&args)?;
-    let loaded_sweep = crate::run::compare::load_sweep(&e.sweep)?;
+    let loaded_sweep = crate::run::load::load_sweep(&e.sweep)?;
     let summary = crate::run::evaluate::summarize_with_model(
         &eval,
         &loaded_sweep.instances,
@@ -5072,7 +5072,7 @@ fn bench_import(i: args::ImportCmd) -> Result<(), Error> {
             print!("{}", crate::run::import::format_summary_text(&summary));
             if let Some(eval) = &summary.evaluation {
                 let sweep_dir = std::path::PathBuf::from(&summary.output_path);
-                let loaded_sweep = crate::run::compare::load_sweep(&sweep_dir)?;
+                let loaded_sweep = crate::run::load::load_sweep(&sweep_dir)?;
                 let eval_summary = crate::run::evaluate::summarize_with_model(
                     eval,
                     &loaded_sweep.instances,

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -488,6 +488,7 @@ const _COMPILE_TIME_USED: Duration = Duration::from_secs(0);
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
 
     fn test_env() -> DockerEnvironment {

--- a/src/run/behavior.rs
+++ b/src/run/behavior.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::artifact::{ArtifactKind, classify_json_value};
 use crate::error::Error;
-use crate::run::compare::{load_evaluation_results_checked, load_sweep};
+use crate::run::evaluate::load_evaluation_results_checked;
+use crate::run::load::load_sweep;
+
 use crate::run::swebench::InstanceResult;
 use crate::trajectory::{FailureCategory, Trajectory};
 

--- a/src/run/budget_fit.rs
+++ b/src/run/budget_fit.rs
@@ -14,7 +14,9 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
-use crate::run::compare::{load_evaluation_results, load_sweep};
+use crate::run::evaluate::load_evaluation_results;
+use crate::run::load::load_sweep;
+
 use crate::run::swebench::{
     InstanceResult, SWEEP_STATUS_COMPLETED, resolved_count as instance_resolved_count,
 };

--- a/src/run/cache_stats.rs
+++ b/src/run/cache_stats.rs
@@ -14,7 +14,7 @@ use crate::cost::{
     ANTHROPIC_CACHE_CREATION_MULTIPLIER, ANTHROPIC_CACHE_READ_MULTIPLIER, SONNET_INPUT_USD_PER_MTOK,
 };
 use crate::error::Error;
-use crate::run::compare::load_sweep;
+use crate::run::load::load_sweep;
 
 // ── public calculation helpers (unit-testable) ────────────────────────────────
 

--- a/src/run/command_stats.rs
+++ b/src/run/command_stats.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Serialize};
 use crate::artifact::{ArtifactKind, classify_json_value};
 use crate::env::RunResult;
 use crate::error::Error;
-use crate::run::compare::{load_evaluation_results_checked, load_sweep};
+use crate::run::evaluate::load_evaluation_results_checked;
+use crate::run::load::load_sweep;
+
 use crate::run::swebench::InstanceResult;
 use crate::trajectory::{FailureCategory, Trajectory};
 

--- a/src/run/compare.rs
+++ b/src/run/compare.rs
@@ -12,22 +12,27 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 
-use crate::artifact::{ArtifactCompatibility, ArtifactKind, classify_json_value};
+use crate::artifact::{ArtifactCompatibility, ArtifactKind};
 use crate::error::Error;
 use crate::run::evaluate::{
     BreakdownAxis, CostAttributionBucket, EvaluationResults, cost_attribution_bucket_label, pct,
     round_dp,
 };
+pub use crate::run::evaluate::{
+    LoadedEvaluationResults, load_evaluation_results, load_evaluation_results_checked,
+};
+pub use crate::run::load::{
+    LoadedRunSlot, LoadedSweep, fallback_totals_from_slots, load_run, load_run_slots, load_sweep,
+    optional_sum,
+};
 use crate::run::patch_stats::PatchStats;
 use crate::run::swebench::{
-    FilterSpec, InstanceResult, ProvenanceManifest, SweepResults, TokenBreakdown, effective_runs,
-    resolved_count,
+    FilterSpec, InstanceResult, ProvenanceManifest, TokenBreakdown, effective_runs, resolved_count,
 };
-use crate::trajectory::{FailureCategory, Trajectory, outcome};
+use crate::trajectory::{FailureCategory, outcome};
 
 /// Output format for the compare report.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1042,474 +1047,12 @@ pub fn build_model_mix_warnings(
     warnings
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// back to scanning per-instance `*.traj.json` files when no `results.json`
-/// exists, reconstructing minimal `InstanceResult`s. Tolerant of missing
-/// newer fields: defaults flow through serde.
-pub fn load_run(dir: &Path) -> Result<HashMap<String, InstanceResult>, Error> {
-    Ok(load_sweep(dir)?.instances)
-}
-
-#[derive(Debug, Clone)]
-pub struct LoadedSweep {
-    pub instances: HashMap<String, InstanceResult>,
-    pub manifest: Option<ProvenanceManifest>,
-    pub filter_spec: Option<FilterSpec>,
-    pub rate_limit_events: Option<crate::run::rate_limit::RateLimitEvents>,
-    pub artifact: Option<ArtifactCompatibility>,
-    pub artifact_warnings: Vec<String>,
-    pub total_fallbacks: u64,
-    pub model_mix: std::collections::BTreeMap<String, usize>,
-}
-
 struct DiffContext<'a> {
     manifest_deltas: Vec<String>,
     artifact_version_mismatches: Vec<String>,
     artifact_warnings: Vec<String>,
     baseline_model_name: Option<&'a str>,
     candidate_model_name: Option<&'a str>,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct LoadedRunSlot {
-    pub instance_id: String,
-    pub run_index: u32,
-    pub result: InstanceResult,
-}
-
-#[allow(clippy::too_many_lines)]
-pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
-    let results_path = dir.join("results.json");
-    if results_path.exists() {
-        let text = std::fs::read_to_string(&results_path)?;
-        let value: serde_json::Value = serde_json::from_str(&text)?;
-        let artifact = classify_json_value(
-            &value,
-            ArtifactKind::SweepResults,
-            results_path.display().to_string(),
-        )
-        .map_err(|err| Error::Trajectory(err.to_string()))?;
-        let artifact_warnings = artifact.warnings.clone();
-        let filter_spec_present = value.get("filter_spec").is_some();
-        let sweep: SweepResults = serde_json::from_value(value)?;
-        let rate_limit_events = sweep.rate_limit_events.clone();
-        let total_fallbacks = sweep.total_fallbacks;
-        let model_mix = sweep.model_mix.clone();
-        let partial_incomplete = sweep
-            .manifest
-            .as_ref()
-            .is_some_and(|m| m.runtime.finished_at_utc.is_none());
-        if partial_incomplete {
-            let resume_mode = sweep
-                .manifest
-                .as_ref()
-                .is_some_and(manifest_indicates_resume);
-            let min_mtime = if resume_mode {
-                None
-            } else {
-                sweep
-                    .manifest
-                    .as_ref()
-                    .and_then(|m| {
-                        chrono::DateTime::parse_from_rfc3339(&m.runtime.started_at_utc).ok()
-                    })
-                    .map(std::convert::Into::into)
-            };
-            let scanned_slots = scan_trajectory_run_slots(dir, min_mtime)?;
-            let (slot_fallbacks, slot_mix) = fallback_totals_from_slots(&scanned_slots);
-            let scanned = aggregate_scanned_results(scanned_slots);
-            let manifest = sweep.manifest;
-            // When trajectory files are fresher than results.json, use scanned
-            // instances and re-derive fallback totals from per-run-slot data so
-            // model-mix warnings count all reruns, not just the winning slot.
-            let (effective_fallbacks, effective_mix) = if scanned.is_empty() {
-                (total_fallbacks, model_mix)
-            } else {
-                (slot_fallbacks, slot_mix)
-            };
-            return Ok(LoadedSweep {
-                instances: if scanned.is_empty() {
-                    sweep
-                        .instances
-                        .into_iter()
-                        .map(|r| (r.instance_id.clone(), r))
-                        .collect()
-                } else {
-                    scanned
-                },
-                manifest,
-                filter_spec: if filter_spec_present {
-                    Some(sweep.filter_spec)
-                } else {
-                    None
-                },
-                rate_limit_events,
-                artifact: Some(artifact),
-                artifact_warnings,
-                total_fallbacks: effective_fallbacks,
-                model_mix: effective_mix,
-            });
-        }
-        return Ok(LoadedSweep {
-            instances: sweep
-                .instances
-                .into_iter()
-                .map(|r| (r.instance_id.clone(), r))
-                .collect(),
-            manifest: sweep.manifest,
-            filter_spec: if filter_spec_present {
-                Some(sweep.filter_spec)
-            } else {
-                None
-            },
-            rate_limit_events,
-            artifact: Some(artifact),
-            artifact_warnings,
-            total_fallbacks,
-            model_mix,
-        });
-    }
-    if !dir.exists() {
-        return Err(Error::Trajectory(format!(
-            "compare: directory does not exist: {}",
-            dir.display()
-        )));
-    }
-
-    let slots = scan_trajectory_run_slots(dir, None)?;
-    let (total_fallbacks, model_mix) = fallback_totals_from_slots(&slots);
-    let out = aggregate_scanned_results(slots);
-    Ok(LoadedSweep {
-        instances: out,
-        manifest: None,
-        filter_spec: None,
-        rate_limit_events: None,
-        artifact: None,
-        artifact_warnings: Vec::new(),
-        total_fallbacks,
-        model_mix,
-    })
-}
-
-fn manifest_indicates_resume(manifest: &ProvenanceManifest) -> bool {
-    manifest.runtime.resume_mode || manifest.cli.argv.iter().any(|arg| arg == "--resume")
-}
-
-/// Compute `total_fallbacks` and `model_mix` from per-run-slot data before
-/// aggregation, so that reruns with different responding models are all counted.
-fn fallback_totals_from_slots(
-    slots: &[LoadedRunSlot],
-) -> (u64, std::collections::BTreeMap<String, usize>) {
-    let total_fallbacks: u64 = slots
-        .iter()
-        .filter_map(|s| s.result.fallback_count)
-        .map(u64::from)
-        .sum();
-    let mut model_mix: std::collections::BTreeMap<String, usize> =
-        std::collections::BTreeMap::new();
-    for s in slots {
-        if let Some(model) = s.result.final_model.as_deref() {
-            *model_mix.entry(model.to_owned()).or_insert(0) += 1;
-        }
-    }
-    (total_fallbacks, model_mix)
-}
-
-fn scan_trajectory_run_slots(
-    dir: &Path,
-    min_mtime: Option<SystemTime>,
-) -> Result<Vec<LoadedRunSlot>, Error> {
-    let mut instance_dirs: Vec<(String, std::path::PathBuf)> = Vec::new();
-    let mut root_trajectories: Vec<(String, std::path::PathBuf)> = Vec::new();
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_dir() {
-            let Some(instance_id) = path
-                .file_name()
-                .and_then(std::ffi::OsStr::to_str)
-                .map(str::to_owned)
-            else {
-                continue;
-            };
-            instance_dirs.push((instance_id, path));
-            continue;
-        }
-        if !path_passes_mtime(&path, min_mtime) {
-            continue;
-        }
-        let Some(name_str) = path.file_name().and_then(std::ffi::OsStr::to_str) else {
-            continue;
-        };
-        let Some(id) = name_str.strip_suffix(".traj.json") else {
-            continue;
-        };
-        root_trajectories.push((id.to_owned(), path));
-    }
-    instance_dirs.sort_by(|a, b| a.0.cmp(&b.0));
-    root_trajectories.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let mut scanned = Vec::new();
-    for (instance_id, path) in instance_dirs {
-        scan_nested_run_trajectories(&path, &instance_id, min_mtime, &mut scanned)?;
-    }
-    for (id, path) in root_trajectories {
-        if let Some(result) = instance_result_from_trajectory(&id, &path)? {
-            scanned.push(LoadedRunSlot {
-                instance_id: id,
-                run_index: 1,
-                result,
-            });
-        }
-    }
-    Ok(dedupe_run_slots(scanned))
-}
-
-fn scan_nested_run_trajectories(
-    instance_dir: &Path,
-    instance_id: &str,
-    min_mtime: Option<SystemTime>,
-    out: &mut Vec<LoadedRunSlot>,
-) -> Result<(), Error> {
-    let mut run_trajectories: Vec<(u32, std::path::PathBuf)> = Vec::new();
-    for entry in std::fs::read_dir(instance_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if !path.is_file() || !path_passes_mtime(&path, min_mtime) {
-            continue;
-        }
-        let Some(name) = path.file_name().and_then(std::ffi::OsStr::to_str) else {
-            continue;
-        };
-        let Some(run_index) = name
-            .strip_prefix("run-")
-            .and_then(|s| s.strip_suffix(".traj.json"))
-            .and_then(|s| s.parse::<u32>().ok())
-        else {
-            continue;
-        };
-        run_trajectories.push((run_index, path));
-    }
-    run_trajectories.sort_by_key(|(run_index, _)| *run_index);
-    for (run_index, path) in run_trajectories {
-        if let Some(result) = instance_result_from_trajectory(instance_id, &path)? {
-            out.push(LoadedRunSlot {
-                instance_id: instance_id.to_owned(),
-                run_index,
-                result,
-            });
-        }
-    }
-    Ok(())
-}
-
-fn dedupe_run_slots(scanned: Vec<LoadedRunSlot>) -> Vec<LoadedRunSlot> {
-    let mut seen = BTreeSet::new();
-    let mut deduped = Vec::with_capacity(scanned.len());
-    for slot in scanned {
-        let key = (slot.instance_id.clone(), slot.run_index);
-        if seen.insert(key) {
-            deduped.push(slot);
-        }
-    }
-    deduped
-}
-
-fn path_passes_mtime(path: &Path, min_mtime: Option<SystemTime>) -> bool {
-    let Some(min) = min_mtime else {
-        return true;
-    };
-    path.metadata()
-        .ok()
-        .and_then(|m| m.modified().ok())
-        .is_some_and(|modified| modified >= min)
-}
-
-fn instance_result_from_trajectory(
-    instance_id: &str,
-    path: &Path,
-) -> Result<Option<InstanceResult>, Error> {
-    let text = std::fs::read_to_string(path)?;
-    let value: serde_json::Value = match serde_json::from_str(&text) {
-        Ok(value) => value,
-        Err(_) => return Ok(None),
-    };
-    classify_json_value(&value, ArtifactKind::Trajectory, path.display().to_string())
-        .map_err(|err| Error::Trajectory(err.to_string()))?;
-    let traj: Trajectory = match serde_json::from_value(value) {
-        Ok(t) => t,
-        Err(_) => return Ok(None),
-    };
-    let info = traj.info;
-    let (prompt_tokens, cache_read_tokens, cache_creation_tokens, completion_tokens) = info
-        .token_usage
-        .as_ref()
-        .map_or((None, None, None, None), |t| {
-            (
-                Some(t.prompt_tokens),
-                Some(t.cache_read_tokens),
-                Some(t.cache_creation_tokens),
-                Some(t.completion_tokens),
-            )
-        });
-    let resolved =
-        info.outcome.as_deref() == Some(outcome::SUBMITTED) && info.failure_category.is_none();
-    Ok(Some(InstanceResult {
-        instance_id: instance_id.to_owned(),
-        exit_reason: info.exit_reason.clone().unwrap_or_default(),
-        outcome: info.outcome.clone(),
-        failure_category: info.failure_category,
-        steps: info.steps,
-        cost_usd: info.actual_cost_usd.or(info.total_cost_usd),
-        prompt_tokens,
-        cache_read_tokens,
-        cache_creation_tokens,
-        completion_tokens,
-        duration_secs: info.duration_secs,
-        error: None,
-        github_pr_error: None,
-        patch_present: false,
-        non_empty_patch: false,
-        attempts: 1,
-        retry_reasons: Vec::new(),
-        runs: 1,
-        resolved_count: u32::from(resolved),
-        pass_at_1: resolved,
-        tests_run_before_submit: info.tests_run_before_submit,
-        last_tests_passed: info.last_tests_passed,
-        fallback_count: info.fallback_summary.as_ref().map(|s| s.fallback_count),
-        // Exclude all-failed runs from model_mix — final_model is only the
-        // last attempted model when all_failed=true, not a responding model.
-        final_model: info.fallback_summary.as_ref().and_then(|s| {
-            if s.all_failed {
-                None
-            } else {
-                Some(s.final_model.clone())
-            }
-        }),
-        retry_id: None,
-        previous_failure_category: None,
-        trace_id: info.trace_id,
-        context_pressure: Default::default(),
-        peak_memory_bytes: info.peak_memory_bytes,
-        cpu_seconds: info.cpu_seconds,
-    }))
-}
-
-pub(crate) fn load_run_slots<S: std::hash::BuildHasher>(
-    dir: &Path,
-    fallback: &HashMap<String, InstanceResult, S>,
-) -> Result<Vec<LoadedRunSlot>, Error> {
-    let mut slots = scan_trajectory_run_slots(dir, None)?;
-    let active_ids: BTreeSet<&str> = fallback.keys().map(String::as_str).collect();
-    slots.retain(|slot| active_ids.contains(slot.instance_id.as_str()));
-    let seen_ids: BTreeSet<String> = slots.iter().map(|slot| slot.instance_id.clone()).collect();
-    if slots.is_empty() {
-        slots.extend(fallback.iter().map(|(instance_id, result)| LoadedRunSlot {
-            instance_id: instance_id.clone(),
-            run_index: 1,
-            result: result.clone(),
-        }));
-    } else {
-        slots.extend(
-            fallback
-                .iter()
-                .filter(|(instance_id, _)| !seen_ids.contains(*instance_id))
-                .map(|(instance_id, result)| LoadedRunSlot {
-                    instance_id: instance_id.clone(),
-                    run_index: 1,
-                    result: result.clone(),
-                }),
-        );
-    }
-    slots.sort_by(|a, b| {
-        a.instance_id
-            .cmp(&b.instance_id)
-            .then_with(|| a.run_index.cmp(&b.run_index))
-    });
-    Ok(slots)
-}
-
-fn aggregate_scanned_results(scanned: Vec<LoadedRunSlot>) -> HashMap<String, InstanceResult> {
-    let mut grouped: BTreeMap<String, Vec<(u32, InstanceResult)>> = BTreeMap::new();
-    for slot in scanned {
-        grouped
-            .entry(slot.instance_id)
-            .or_default()
-            .push((slot.run_index, slot.result));
-    }
-    let mut out = HashMap::new();
-    for (id, mut rows) in grouped {
-        rows.sort_by_key(|(run_index, _)| *run_index);
-        let Some((_, first)) = rows.first() else {
-            continue;
-        };
-        let mut aggregate = first.clone();
-        aggregate.runs = rows
-            .iter()
-            .map(|(run_index, _)| *run_index)
-            .max()
-            .unwrap_or(1);
-        aggregate.resolved_count = rows
-            .iter()
-            .filter(|(_, result)| result.resolved_count > 0)
-            .count()
-            .try_into()
-            .unwrap_or(u32::MAX);
-        aggregate.pass_at_1 = rows
-            .iter()
-            .find(|(run_index, _)| *run_index == 1)
-            .is_some_and(|(_, result)| result.resolved_count > 0);
-        aggregate.tests_run_before_submit = rows
-            .iter()
-            .any(|(_, result)| result.tests_run_before_submit);
-        aggregate.last_tests_passed = rows
-            .iter()
-            .rev()
-            .find_map(|(_, result)| result.last_tests_passed);
-        aggregate.cost_usd = optional_sum(rows.iter().filter_map(|(_, result)| result.cost_usd));
-        // Sum fallback counts across all run slots; keep final_model from the
-        // first (pass@1 representative) run.
-        aggregate.fallback_count = Some(
-            rows.iter()
-                .filter_map(|(_, result)| result.fallback_count)
-                .fold(0u32, u32::saturating_add),
-        );
-        aggregate.final_model.clone_from(&first.final_model);
-        aggregate.prompt_tokens = Some(
-            rows.iter()
-                .filter_map(|(_, result)| result.prompt_tokens)
-                .fold(0u64, u64::saturating_add),
-        );
-        aggregate.cache_read_tokens = Some(
-            rows.iter()
-                .filter_map(|(_, result)| result.cache_read_tokens)
-                .fold(0u64, u64::saturating_add),
-        );
-        aggregate.cache_creation_tokens = Some(
-            rows.iter()
-                .filter_map(|(_, result)| result.cache_creation_tokens)
-                .fold(0u64, u64::saturating_add),
-        );
-        aggregate.completion_tokens = Some(
-            rows.iter()
-                .filter_map(|(_, result)| result.completion_tokens)
-                .fold(0u64, u64::saturating_add),
-        );
-        out.insert(id, aggregate);
-    }
-    out
-}
-
-fn optional_sum(values: impl Iterator<Item = f64>) -> Option<f64> {
-    let mut seen = false;
-    let mut total = 0.0;
-    for value in values {
-        seen = true;
-        total += value;
-    }
-    seen.then_some(total)
 }
 
 /// Compute a `CompareReport` from two on-disk sweep directories.
@@ -2465,40 +2008,6 @@ fn wilson_ci(successes: u64, total: u64) -> ConfidenceInterval {
     }
 }
 
-pub fn load_evaluation_results(dir: &Path) -> Result<Option<EvaluationResults>, Error> {
-    Ok(load_evaluation_results_checked(dir)?.map(|loaded| loaded.results))
-}
-
-#[derive(Debug, Clone)]
-pub struct LoadedEvaluationResults {
-    pub results: EvaluationResults,
-    pub artifact: ArtifactCompatibility,
-    pub artifact_warnings: Vec<String>,
-}
-
-pub fn load_evaluation_results_checked(
-    dir: &Path,
-) -> Result<Option<LoadedEvaluationResults>, Error> {
-    let path = crate::run::evaluate::evaluation_path(dir);
-    if !path.exists() {
-        return Ok(None);
-    }
-    let text = std::fs::read_to_string(&path)?;
-    let value: serde_json::Value = serde_json::from_str(&text)?;
-    let artifact = classify_json_value(
-        &value,
-        ArtifactKind::EvaluationResults,
-        path.display().to_string(),
-    )
-    .map_err(|err| Error::Trajectory(err.to_string()))?;
-    let artifact_warnings = artifact.warnings.clone();
-    Ok(Some(LoadedEvaluationResults {
-        results: serde_json::from_value(value)?,
-        artifact,
-        artifact_warnings,
-    }))
-}
-
 fn resolved_overrides_from_eval(eval: &EvaluationResults) -> HashMap<String, ResolutionOverride> {
     eval.instances
         .iter()
@@ -3340,7 +2849,13 @@ fn build_cost_attribution_delta<S: std::hash::BuildHasher>(
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+
+    use crate::run::swebench::SweepResults;
+    use crate::trajectory::Trajectory;
+
+
     use super::*;
 
     fn assert_f64_eq(actual: f64, expected: f64) {

--- a/src/run/context_pressure.rs
+++ b/src/run/context_pressure.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::run::compare::load_sweep;
+use crate::run::load::load_sweep;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;

--- a/src/run/eval_flake.rs
+++ b/src/run/eval_flake.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::artifact::{ArtifactKind, ArtifactSchemaVersion};
 use crate::error::Error;
-use crate::run::compare::load_sweep;
 use crate::run::evaluate::{BreakdownSelection, EvalExitReason, EvaluateArgs, EvaluateBackend};
+use crate::run::load::load_sweep;
 
 // ── Public types ──────────────────────────────────────────────────────────────
 

--- a/src/run/eval_parity.rs
+++ b/src/run/eval_parity.rs
@@ -387,8 +387,8 @@ fn has_evaluatable_patch(
 
 /// Run eval-parity against a real sweep by invoking both evaluator backends.
 pub fn run(args: &EvalParityArgs) -> Result<EvalParityReport, Error> {
-    use crate::run::compare::load_sweep;
     use crate::run::evaluate::{BreakdownSelection, EvaluateArgs, EvaluateBackend};
+    use crate::run::load::load_sweep;
 
     let loaded = load_sweep(&args.sweep_dir).map_err(|e| {
         Error::Trajectory(format!(

--- a/src/run/evaluate.rs
+++ b/src/run/evaluate.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
 use crate::redaction::{Redactor, surface};
-use crate::run::compare::{load_run_slots, load_sweep};
+use crate::run::load::{load_run_slots, load_sweep};
 use crate::run::patch_stats::{PatchClassifiers, PatchStats, score_patch};
 use crate::run::swebench::{self, InstanceResult, TokenBreakdown, effective_runs};
 use crate::trajectory::{FailureCategory, outcome};
@@ -2718,7 +2718,7 @@ fn build_behavioral_metrics(
 /// aggregate bytes. Returns (elision_instances, bytes_elided_total, compaction_failed_count).
 fn build_elision_stats(
     sweep_dir: &Path,
-    run_slots: &[crate::run::compare::LoadedRunSlot],
+    run_slots: &[crate::run::load::LoadedRunSlot],
 ) -> (usize, u64, usize) {
     let compaction_failed = run_slots
         .iter()
@@ -2873,7 +2873,7 @@ fn missing_eval_for_result(id: &str, result: &InstanceResult) -> InstanceEvaluat
 /// counted independently; its resolution comes from the per-slot key in
 /// `resolved_by_run` (falls back to `false` when no evaluation result exists).
 fn build_model_mix_summary_from_slots(
-    slots: &[crate::run::compare::LoadedRunSlot],
+    slots: &[crate::run::load::LoadedRunSlot],
     resolved_by_run: &HashMap<RunSlotKey, bool>,
 ) -> Vec<ModelMixBucket> {
     let mut by_model: BTreeMap<String, (usize, usize, f64)> = BTreeMap::new();
@@ -2926,7 +2926,7 @@ fn build_model_mix_summary_from_slots(
 /// stay schema-clean.
 fn build_latency_summary_from_slots(
     sweep_dir: &Path,
-    slots: &[crate::run::compare::LoadedRunSlot],
+    slots: &[crate::run::load::LoadedRunSlot],
 ) -> Option<LatencySummary> {
     let mut model_totals: Vec<u64> = Vec::new();
     let mut tool_totals: Vec<u64> = Vec::new();
@@ -3201,7 +3201,7 @@ fn build_cost_attribution<S: std::hash::BuildHasher>(
 }
 
 fn build_cost_attribution_from_run_slots(
-    run_slots: &[crate::run::compare::LoadedRunSlot],
+    run_slots: &[crate::run::load::LoadedRunSlot],
     resolved_by_run: &HashMap<RunSlotKey, bool>,
     model_name: Option<&str>,
 ) -> CostAttributionReport {
@@ -4025,11 +4025,11 @@ mod tests {
         run_index: u32,
         final_model: Option<&str>,
         cost_usd: Option<f64>,
-    ) -> crate::run::compare::LoadedRunSlot {
+    ) -> crate::run::load::LoadedRunSlot {
         let mut r = submitted(instance_id);
         r.final_model = final_model.map(str::to_owned);
         r.cost_usd = cost_usd;
-        crate::run::compare::LoadedRunSlot {
+        crate::run::load::LoadedRunSlot {
             instance_id: instance_id.into(),
             run_index,
             result: r,
@@ -4436,12 +4436,12 @@ mod tests {
             cpu_seconds: None,
         };
         let run_slots = vec![
-            crate::run::compare::LoadedRunSlot {
+            crate::run::load::LoadedRunSlot {
                 instance_id: "inst-a".to_owned(),
                 run_index: 1,
                 result: make_result("inst-a", None),
             },
-            crate::run::compare::LoadedRunSlot {
+            crate::run::load::LoadedRunSlot {
                 instance_id: "inst-b".to_owned(),
                 run_index: 1,
                 result: make_result("inst-b", Some(FailureCategory::HistoryCompactionFailed)),
@@ -4675,4 +4675,39 @@ mod tests {
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], "p::t1");
     }
+}
+
+use crate::artifact::{ArtifactCompatibility, ArtifactKind, classify_json_value};
+pub fn load_evaluation_results(dir: &Path) -> Result<Option<EvaluationResults>, Error> {
+    Ok(load_evaluation_results_checked(dir)?.map(|loaded| loaded.results))
+}
+
+#[derive(Debug, Clone)]
+pub struct LoadedEvaluationResults {
+    pub results: EvaluationResults,
+    pub artifact: ArtifactCompatibility,
+    pub artifact_warnings: Vec<String>,
+}
+
+pub fn load_evaluation_results_checked(
+    dir: &Path,
+) -> Result<Option<LoadedEvaluationResults>, Error> {
+    let path = evaluation_path(dir);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let text = std::fs::read_to_string(&path)?;
+    let value: serde_json::Value = serde_json::from_str(&text)?;
+    let artifact = classify_json_value(
+        &value,
+        ArtifactKind::EvaluationResults,
+        path.display().to_string(),
+    )
+    .map_err(|err| Error::Trajectory(err.to_string()))?;
+    let artifact_warnings = artifact.warnings.clone();
+    Ok(Some(LoadedEvaluationResults {
+        results: serde_json::from_value(value)?,
+        artifact,
+        artifact_warnings,
+    }))
 }

--- a/src/run/failure_digest.rs
+++ b/src/run/failure_digest.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::env::RunResult;
 use crate::error::Error;
 use crate::redaction::{Redactor, surface};
-use crate::run::compare::load_sweep;
+use crate::run::load::load_sweep;
 use crate::run::swebench::InstanceResult;
 use crate::run::triage::{
     FailureSignature, TriageReport, failure_label, last_non_empty_line, load_trajectory,

--- a/src/run/frontier.rs
+++ b/src/run/frontier.rs
@@ -11,7 +11,9 @@ use std::path::{Path, PathBuf};
 use serde::Serialize;
 
 use crate::error::Error;
-use crate::run::compare::{LoadedSweep, load_evaluation_results, load_sweep};
+use crate::run::evaluate::load_evaluation_results;
+use crate::run::load::{LoadedSweep, load_sweep};
+
 use crate::run::evaluate::{EvaluationResults, pct};
 use crate::run::swebench::InstanceResult;
 

--- a/src/run/grep.rs
+++ b/src/run/grep.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::artifact::{ArtifactKind, classify_json_value};
 use crate::error::Error;
 use crate::redaction::{Redactor, surface};
-use crate::run::compare::load_sweep;
+use crate::run::load::load_sweep;
 use crate::trajectory::Trajectory;
 
 #[derive(Debug, Clone)]

--- a/src/run/inspect.rs
+++ b/src/run/inspect.rs
@@ -348,7 +348,7 @@ pub fn run(args: &InspectArgs) -> Result<InspectOutput, Error> {
 fn build_summary(sweep: &Path, filter: &str) -> Result<SummaryReport, Error> {
     let filter = parse_filter(filter)?;
     let mut rows: Vec<SummaryRow> = Vec::new();
-    let loaded = crate::run::compare::load_sweep(sweep)?;
+    let loaded = crate::run::load::load_sweep(sweep)?;
     let resolved = load_evaluation_overrides(sweep)?.unwrap_or_default();
     let mut chaos = ChaosSummary {
         fail_every: loaded.manifest.as_ref().map_or(0, |m| m.chaos_fail_every),
@@ -381,7 +381,7 @@ fn build_summary(sweep: &Path, filter: &str) -> Result<SummaryReport, Error> {
     }
     rows.sort_by(|a, b| a.instance_id.cmp(&b.instance_id));
     let evaluator_provenance =
-        crate::run::compare::load_evaluation_results(sweep)?.and_then(|eval| eval.provenance);
+        crate::run::evaluate::load_evaluation_results(sweep)?.and_then(|eval| eval.provenance);
     Ok(SummaryReport {
         sweep_dir: sweep.to_path_buf(),
         filter: filter.raw,

--- a/src/run/instance_history.rs
+++ b/src/run/instance_history.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
 use crate::redaction::{Redactor, surface};
-use crate::run::compare::load_sweep;
+use crate::run::load::load_sweep;
 use crate::run::swebench::{effective_runs, resolved_count as instance_resolved_count};
 
 // ── output format ─────────────────────────────────────────────────────────────

--- a/src/run/load.rs
+++ b/src/run/load.rs
@@ -1,0 +1,470 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::Path;
+use std::time::SystemTime;
+
+use crate::artifact::{ArtifactCompatibility, ArtifactKind, classify_json_value};
+use crate::error::Error;
+use crate::run::swebench::{FilterSpec, InstanceResult, ProvenanceManifest, SweepResults};
+use crate::trajectory::{Trajectory, outcome};
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// back to scanning per-instance `*.traj.json` files when no `results.json`
+/// exists, reconstructing minimal `InstanceResult`s. Tolerant of missing
+/// newer fields: defaults flow through serde.
+pub fn load_run(dir: &Path) -> Result<HashMap<String, InstanceResult>, Error> {
+    Ok(load_sweep(dir)?.instances)
+}
+
+#[derive(Debug, Clone)]
+pub struct LoadedSweep {
+    pub instances: HashMap<String, InstanceResult>,
+    pub manifest: Option<ProvenanceManifest>,
+    pub filter_spec: Option<FilterSpec>,
+    pub rate_limit_events: Option<crate::run::rate_limit::RateLimitEvents>,
+    pub artifact: Option<ArtifactCompatibility>,
+    pub artifact_warnings: Vec<String>,
+    pub total_fallbacks: u64,
+    pub model_mix: std::collections::BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LoadedRunSlot {
+    pub instance_id: String,
+    pub run_index: u32,
+    pub result: InstanceResult,
+}
+
+#[allow(clippy::too_many_lines)]
+pub fn load_sweep(dir: &Path) -> Result<LoadedSweep, Error> {
+    let results_path = dir.join("results.json");
+    if results_path.exists() {
+        let text = std::fs::read_to_string(&results_path)?;
+        let value: serde_json::Value = serde_json::from_str(&text)?;
+        let artifact = classify_json_value(
+            &value,
+            ArtifactKind::SweepResults,
+            results_path.display().to_string(),
+        )
+        .map_err(|err| Error::Trajectory(err.to_string()))?;
+        let artifact_warnings = artifact.warnings.clone();
+        let filter_spec_present = value.get("filter_spec").is_some();
+        let sweep: SweepResults = serde_json::from_value(value)?;
+        let rate_limit_events = sweep.rate_limit_events.clone();
+        let total_fallbacks = sweep.total_fallbacks;
+        let model_mix = sweep.model_mix.clone();
+        let partial_incomplete = sweep
+            .manifest
+            .as_ref()
+            .is_some_and(|m| m.runtime.finished_at_utc.is_none());
+        if partial_incomplete {
+            let resume_mode = sweep
+                .manifest
+                .as_ref()
+                .is_some_and(manifest_indicates_resume);
+            let min_mtime = if resume_mode {
+                None
+            } else {
+                sweep
+                    .manifest
+                    .as_ref()
+                    .and_then(|m| {
+                        chrono::DateTime::parse_from_rfc3339(&m.runtime.started_at_utc).ok()
+                    })
+                    .map(std::convert::Into::into)
+            };
+            let scanned_slots = scan_trajectory_run_slots(dir, min_mtime)?;
+            let (slot_fallbacks, slot_mix) = fallback_totals_from_slots(&scanned_slots);
+            let scanned = aggregate_scanned_results(scanned_slots);
+            let manifest = sweep.manifest;
+            // When trajectory files are fresher than results.json, use scanned
+            // instances and re-derive fallback totals from per-run-slot data so
+            // model-mix warnings count all reruns, not just the winning slot.
+            let (effective_fallbacks, effective_mix) = if scanned.is_empty() {
+                (total_fallbacks, model_mix)
+            } else {
+                (slot_fallbacks, slot_mix)
+            };
+            return Ok(LoadedSweep {
+                instances: if scanned.is_empty() {
+                    sweep
+                        .instances
+                        .into_iter()
+                        .map(|r| (r.instance_id.clone(), r))
+                        .collect()
+                } else {
+                    scanned
+                },
+                manifest,
+                filter_spec: if filter_spec_present {
+                    Some(sweep.filter_spec)
+                } else {
+                    None
+                },
+                rate_limit_events,
+                artifact: Some(artifact),
+                artifact_warnings,
+                total_fallbacks: effective_fallbacks,
+                model_mix: effective_mix,
+            });
+        }
+        return Ok(LoadedSweep {
+            instances: sweep
+                .instances
+                .into_iter()
+                .map(|r| (r.instance_id.clone(), r))
+                .collect(),
+            manifest: sweep.manifest,
+            filter_spec: if filter_spec_present {
+                Some(sweep.filter_spec)
+            } else {
+                None
+            },
+            rate_limit_events,
+            artifact: Some(artifact),
+            artifact_warnings,
+            total_fallbacks,
+            model_mix,
+        });
+    }
+    if !dir.exists() {
+        return Err(Error::Trajectory(format!(
+            "compare: directory does not exist: {}",
+            dir.display()
+        )));
+    }
+
+    let slots = scan_trajectory_run_slots(dir, None)?;
+    let (total_fallbacks, model_mix) = fallback_totals_from_slots(&slots);
+    let out = aggregate_scanned_results(slots);
+    Ok(LoadedSweep {
+        instances: out,
+        manifest: None,
+        filter_spec: None,
+        rate_limit_events: None,
+        artifact: None,
+        artifact_warnings: Vec::new(),
+        total_fallbacks,
+        model_mix,
+    })
+}
+
+fn manifest_indicates_resume(manifest: &ProvenanceManifest) -> bool {
+    manifest.runtime.resume_mode || manifest.cli.argv.iter().any(|arg| arg == "--resume")
+}
+
+/// Compute `total_fallbacks` and `model_mix` from per-run-slot data before
+/// aggregation, so that reruns with different responding models are all counted.
+pub fn fallback_totals_from_slots(
+    slots: &[LoadedRunSlot],
+) -> (u64, std::collections::BTreeMap<String, usize>) {
+    let total_fallbacks: u64 = slots
+        .iter()
+        .filter_map(|s| s.result.fallback_count)
+        .map(u64::from)
+        .sum();
+    let mut model_mix: std::collections::BTreeMap<String, usize> =
+        std::collections::BTreeMap::new();
+    for s in slots {
+        if let Some(model) = s.result.final_model.as_deref() {
+            *model_mix.entry(model.to_owned()).or_insert(0) += 1;
+        }
+    }
+    (total_fallbacks, model_mix)
+}
+
+fn scan_trajectory_run_slots(
+    dir: &Path,
+    min_mtime: Option<SystemTime>,
+) -> Result<Vec<LoadedRunSlot>, Error> {
+    let mut instance_dirs: Vec<(String, std::path::PathBuf)> = Vec::new();
+    let mut root_trajectories: Vec<(String, std::path::PathBuf)> = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            let Some(instance_id) = path
+                .file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                .map(str::to_owned)
+            else {
+                continue;
+            };
+            instance_dirs.push((instance_id, path));
+            continue;
+        }
+        if !path_passes_mtime(&path, min_mtime) {
+            continue;
+        }
+        let Some(name_str) = path.file_name().and_then(std::ffi::OsStr::to_str) else {
+            continue;
+        };
+        let Some(id) = name_str.strip_suffix(".traj.json") else {
+            continue;
+        };
+        root_trajectories.push((id.to_owned(), path));
+    }
+    instance_dirs.sort_by(|a, b| a.0.cmp(&b.0));
+    root_trajectories.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut scanned = Vec::new();
+    for (instance_id, path) in instance_dirs {
+        scan_nested_run_trajectories(&path, &instance_id, min_mtime, &mut scanned)?;
+    }
+    for (id, path) in root_trajectories {
+        if let Some(result) = instance_result_from_trajectory(&id, &path)? {
+            scanned.push(LoadedRunSlot {
+                instance_id: id,
+                run_index: 1,
+                result,
+            });
+        }
+    }
+    Ok(dedupe_run_slots(scanned))
+}
+
+fn scan_nested_run_trajectories(
+    instance_dir: &Path,
+    instance_id: &str,
+    min_mtime: Option<SystemTime>,
+    out: &mut Vec<LoadedRunSlot>,
+) -> Result<(), Error> {
+    let mut run_trajectories: Vec<(u32, std::path::PathBuf)> = Vec::new();
+    for entry in std::fs::read_dir(instance_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() || !path_passes_mtime(&path, min_mtime) {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(std::ffi::OsStr::to_str) else {
+            continue;
+        };
+        let Some(run_index) = name
+            .strip_prefix("run-")
+            .and_then(|s| s.strip_suffix(".traj.json"))
+            .and_then(|s| s.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        run_trajectories.push((run_index, path));
+    }
+    run_trajectories.sort_by_key(|(run_index, _)| *run_index);
+    for (run_index, path) in run_trajectories {
+        if let Some(result) = instance_result_from_trajectory(instance_id, &path)? {
+            out.push(LoadedRunSlot {
+                instance_id: instance_id.to_owned(),
+                run_index,
+                result,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn dedupe_run_slots(scanned: Vec<LoadedRunSlot>) -> Vec<LoadedRunSlot> {
+    let mut seen = BTreeSet::new();
+    let mut deduped = Vec::with_capacity(scanned.len());
+    for slot in scanned {
+        let key = (slot.instance_id.clone(), slot.run_index);
+        if seen.insert(key) {
+            deduped.push(slot);
+        }
+    }
+    deduped
+}
+
+fn path_passes_mtime(path: &Path, min_mtime: Option<SystemTime>) -> bool {
+    let Some(min) = min_mtime else {
+        return true;
+    };
+    path.metadata()
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .is_some_and(|modified| modified >= min)
+}
+
+fn instance_result_from_trajectory(
+    instance_id: &str,
+    path: &Path,
+) -> Result<Option<InstanceResult>, Error> {
+    let text = std::fs::read_to_string(path)?;
+    let value: serde_json::Value = match serde_json::from_str(&text) {
+        Ok(value) => value,
+        Err(_) => return Ok(None),
+    };
+    classify_json_value(&value, ArtifactKind::Trajectory, path.display().to_string())
+        .map_err(|err| Error::Trajectory(err.to_string()))?;
+    let traj: Trajectory = match serde_json::from_value(value) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let info = traj.info;
+    let (prompt_tokens, cache_read_tokens, cache_creation_tokens, completion_tokens) = info
+        .token_usage
+        .as_ref()
+        .map_or((None, None, None, None), |t| {
+            (
+                Some(t.prompt_tokens),
+                Some(t.cache_read_tokens),
+                Some(t.cache_creation_tokens),
+                Some(t.completion_tokens),
+            )
+        });
+    let resolved =
+        info.outcome.as_deref() == Some(outcome::SUBMITTED) && info.failure_category.is_none();
+    Ok(Some(InstanceResult {
+        instance_id: instance_id.to_owned(),
+        exit_reason: info.exit_reason.clone().unwrap_or_default(),
+        outcome: info.outcome.clone(),
+        failure_category: info.failure_category,
+        steps: info.steps,
+        cost_usd: info.actual_cost_usd.or(info.total_cost_usd),
+        prompt_tokens,
+        cache_read_tokens,
+        cache_creation_tokens,
+        completion_tokens,
+        duration_secs: info.duration_secs,
+        error: None,
+        github_pr_error: None,
+        patch_present: false,
+        non_empty_patch: false,
+        attempts: 1,
+        retry_reasons: Vec::new(),
+        runs: 1,
+        resolved_count: u32::from(resolved),
+        pass_at_1: resolved,
+        tests_run_before_submit: info.tests_run_before_submit,
+        last_tests_passed: info.last_tests_passed,
+        fallback_count: info.fallback_summary.as_ref().map(|s| s.fallback_count),
+        // Exclude all-failed runs from model_mix — final_model is only the
+        // last attempted model when all_failed=true, not a responding model.
+        final_model: info.fallback_summary.as_ref().and_then(|s| {
+            if s.all_failed {
+                None
+            } else {
+                Some(s.final_model.clone())
+            }
+        }),
+        retry_id: None,
+        previous_failure_category: None,
+        trace_id: info.trace_id,
+        context_pressure: Default::default(),
+        peak_memory_bytes: info.peak_memory_bytes,
+        cpu_seconds: info.cpu_seconds,
+    }))
+}
+
+pub fn load_run_slots<S: std::hash::BuildHasher>(
+    dir: &Path,
+    fallback: &HashMap<String, InstanceResult, S>,
+) -> Result<Vec<LoadedRunSlot>, Error> {
+    let mut slots = scan_trajectory_run_slots(dir, None)?;
+    let active_ids: BTreeSet<&str> = fallback.keys().map(String::as_str).collect();
+    slots.retain(|slot| active_ids.contains(slot.instance_id.as_str()));
+    let seen_ids: BTreeSet<String> = slots.iter().map(|slot| slot.instance_id.clone()).collect();
+    if slots.is_empty() {
+        slots.extend(fallback.iter().map(|(instance_id, result)| LoadedRunSlot {
+            instance_id: instance_id.clone(),
+            run_index: 1,
+            result: result.clone(),
+        }));
+    } else {
+        slots.extend(
+            fallback
+                .iter()
+                .filter(|(instance_id, _)| !seen_ids.contains(*instance_id))
+                .map(|(instance_id, result)| LoadedRunSlot {
+                    instance_id: instance_id.clone(),
+                    run_index: 1,
+                    result: result.clone(),
+                }),
+        );
+    }
+    slots.sort_by(|a, b| {
+        a.instance_id
+            .cmp(&b.instance_id)
+            .then_with(|| a.run_index.cmp(&b.run_index))
+    });
+    Ok(slots)
+}
+
+fn aggregate_scanned_results(scanned: Vec<LoadedRunSlot>) -> HashMap<String, InstanceResult> {
+    let mut grouped: BTreeMap<String, Vec<(u32, InstanceResult)>> = BTreeMap::new();
+    for slot in scanned {
+        grouped
+            .entry(slot.instance_id)
+            .or_default()
+            .push((slot.run_index, slot.result));
+    }
+    let mut out = HashMap::new();
+    for (id, mut rows) in grouped {
+        rows.sort_by_key(|(run_index, _)| *run_index);
+        let Some((_, first)) = rows.first() else {
+            continue;
+        };
+        let mut aggregate = first.clone();
+        aggregate.runs = rows
+            .iter()
+            .map(|(run_index, _)| *run_index)
+            .max()
+            .unwrap_or(1);
+        aggregate.resolved_count = rows
+            .iter()
+            .filter(|(_, result)| result.resolved_count > 0)
+            .count()
+            .try_into()
+            .unwrap_or(u32::MAX);
+        aggregate.pass_at_1 = rows
+            .iter()
+            .find(|(run_index, _)| *run_index == 1)
+            .is_some_and(|(_, result)| result.resolved_count > 0);
+        aggregate.tests_run_before_submit = rows
+            .iter()
+            .any(|(_, result)| result.tests_run_before_submit);
+        aggregate.last_tests_passed = rows
+            .iter()
+            .rev()
+            .find_map(|(_, result)| result.last_tests_passed);
+        aggregate.cost_usd = optional_sum(rows.iter().filter_map(|(_, result)| result.cost_usd));
+        // Sum fallback counts across all run slots; keep final_model from the
+        // first (pass@1 representative) run.
+        aggregate.fallback_count = Some(
+            rows.iter()
+                .filter_map(|(_, result)| result.fallback_count)
+                .fold(0u32, u32::saturating_add),
+        );
+        aggregate.final_model.clone_from(&first.final_model);
+        aggregate.prompt_tokens = Some(
+            rows.iter()
+                .filter_map(|(_, result)| result.prompt_tokens)
+                .fold(0u64, u64::saturating_add),
+        );
+        aggregate.cache_read_tokens = Some(
+            rows.iter()
+                .filter_map(|(_, result)| result.cache_read_tokens)
+                .fold(0u64, u64::saturating_add),
+        );
+        aggregate.cache_creation_tokens = Some(
+            rows.iter()
+                .filter_map(|(_, result)| result.cache_creation_tokens)
+                .fold(0u64, u64::saturating_add),
+        );
+        aggregate.completion_tokens = Some(
+            rows.iter()
+                .filter_map(|(_, result)| result.completion_tokens)
+                .fold(0u64, u64::saturating_add),
+        );
+        out.insert(id, aggregate);
+    }
+    out
+}
+
+pub fn optional_sum(values: impl Iterator<Item = f64>) -> Option<f64> {
+    let mut seen = false;
+    let mut total = 0.0;
+    for value in values {
+        seen = true;
+        total += value;
+    }
+    seen.then_some(total)
+}

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -53,6 +53,7 @@ pub mod inspect;
 pub mod instance_history;
 pub mod ladder;
 pub mod ledger;
+pub mod load;
 pub mod matrix;
 pub mod merge;
 pub mod mini;

--- a/src/run/near_miss.rs
+++ b/src/run/near_miss.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::artifact::ArtifactKind;
 use crate::error::Error;
-use crate::run::compare::load_evaluation_results;
+use crate::run::evaluate::load_evaluation_results;
 
 // ── format ───────────────────────────────────────────────────────────────────
 

--- a/src/run/power.rs
+++ b/src/run/power.rs
@@ -330,7 +330,7 @@ pub fn run(cmd: &PowerCmd) -> Result<PowerReport, Error> {
                 ))));
             }
             // First try evaluation.json
-            let evaluation = crate::run::compare::load_evaluation_results_checked(path)?;
+            let evaluation = crate::run::evaluate::load_evaluation_results_checked(path)?;
             if let Some(ev) = evaluation {
                 let total = ev.results.instances.len();
                 if total == 0 {
@@ -349,7 +349,7 @@ pub fn run(cmd: &PowerCmd) -> Result<PowerReport, Error> {
                         path.display()
                     ))));
                 }
-                let sweep = crate::run::compare::load_sweep(path)?;
+                let sweep = crate::run::load::load_sweep(path)?;
                 let total = sweep.instances.len();
                 if total == 0 {
                     return Err(Error::Config(crate::error::ConfigError::Usage(

--- a/src/run/report.rs
+++ b/src/run/report.rs
@@ -12,7 +12,9 @@ use std::path::{Path, PathBuf};
 
 use crate::artifact::{ArtifactKind, ArtifactSchemaVersion, classify_json_value};
 use crate::error::Error;
-use crate::run::compare::{self, CompareReport, LoadedSweep, load_sweep};
+use crate::run::compare::{self, CompareReport};
+use crate::run::load::{LoadedSweep, load_sweep};
+
 use crate::run::evaluate::{BreakdownSelection, EvaluationResults, evaluation_path};
 use crate::run::swebench::{
     InstanceResult, ProvenanceManifest, effective_runs, pass_at_1 as sweep_pass_at_1,

--- a/src/run/skill_coverage.rs
+++ b/src/run/skill_coverage.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Serialize};
 use crate::artifact::{ArtifactKind, classify_json_value};
 use crate::error::Error;
 use crate::redaction::{Redactor, surface};
-use crate::run::compare::{load_evaluation_results_checked, load_sweep};
+use crate::run::evaluate::load_evaluation_results_checked;
+use crate::run::load::load_sweep;
+
 use crate::run::swebench::InstanceResult;
 use crate::trajectory::{FailureCategory, Trajectory};
 

--- a/src/run/stagnation_report.rs
+++ b/src/run/stagnation_report.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use crate::artifact::ArtifactKind;
 use crate::error::Error;
 use crate::redaction::{Redactor, surface};
-use crate::run::compare::load_sweep;
+use crate::run::load::load_sweep;
 use crate::stagnation::{action_hash, canonicalize_action};
 use crate::trajectory::{FailureCategory, Trajectory};
 

--- a/src/run/test_progress.rs
+++ b/src/run/test_progress.rs
@@ -12,7 +12,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
 use crate::redaction::{Redactor, surface};
-use crate::run::compare::{load_evaluation_results_checked, load_sweep};
+use crate::run::evaluate::load_evaluation_results_checked;
+use crate::run::load::load_sweep;
+
 use crate::run::evaluate::{EvalExitReason, InstanceEvaluation};
 use crate::run::swebench::SweBenchInstance;
 

--- a/src/run/tool_coverage.rs
+++ b/src/run/tool_coverage.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Serialize};
 use crate::artifact::{ArtifactKind, classify_json_value};
 use crate::error::Error;
 use crate::redaction::{Redactor, surface};
-use crate::run::compare::{load_evaluation_results_checked, load_sweep};
+use crate::run::evaluate::load_evaluation_results_checked;
+use crate::run::load::load_sweep;
+
 use crate::run::swebench::InstanceResult;
 use crate::trajectory::{FailureCategory, Trajectory};
 

--- a/src/run/triage.rs
+++ b/src/run/triage.rs
@@ -10,7 +10,9 @@ use sha2::{Digest as _, Sha256};
 use crate::artifact::{ArtifactKind, classify_json_value};
 use crate::env::RunResult;
 use crate::error::Error;
-use crate::run::compare::{load_evaluation_results_checked, load_sweep};
+use crate::run::evaluate::load_evaluation_results_checked;
+use crate::run::load::load_sweep;
+
 use crate::run::swebench::{InstanceResult, resolved_count};
 use crate::trajectory::{FailureCategory, Trajectory};
 

--- a/src/run/triage_diff.rs
+++ b/src/run/triage_diff.rs
@@ -13,7 +13,9 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
-use crate::run::compare::{load_evaluation_results_checked, load_sweep};
+use crate::run::evaluate::load_evaluation_results_checked;
+use crate::run::load::load_sweep;
+
 use crate::run::triage::{
     TriageArgs, TriageCluster, TriageReport, candidate_instance_ids, extract_instance_signature,
     resolve_trajectory_path,

--- a/src/run/utilization.rs
+++ b/src/run/utilization.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{ConfigError, Error};
-use crate::run::compare::load_sweep;
+use crate::run::load::load_sweep;
 use crate::run::swebench::{
     DEFAULT_PARALLEL, InstanceResult, ProvenanceManifest, SWEEP_STATUS_COMPLETED, effective_runs,
 };

--- a/src/run/variance.rs
+++ b/src/run/variance.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
-use crate::run::compare::load_sweep;
+use crate::run::load::load_sweep;
 
 const Z95: f64 = 1.96;
 


### PR DESCRIPTION
🕸️ Tangle: 
A classic structural circular dependency had formed between `src/run/compare.rs` and `src/run/evaluate.rs`. `compare` used types from `evaluate` (like `EvaluationResults`), while `evaluate` imported fundamental loading routines (`load_sweep`, `load_run_slots`) originally placed in `compare`.

📐 Blueprint: 
Created a new cohesive `src/run/load.rs` module dedicated solely to fetching and parsing sweep datasets and evaluations from disk. Extracted `load_sweep`, `load_evaluation_results`, and their helper routines (e.g., `scan_trajectory_run_slots`) into this new module. This correctly roots `compare` and `evaluate` as leaves that both depend on `load`, breaking the cycle.

🧱 Stability: 
Resolved the structural knot, leaving a clean, unidirectional directed graph. Faster compile times and clear domain separation achieved.

🔬 Verification: 
Extensive compilation, unit tests, and `cargo clippy --all-targets --all-features -- -D warnings` ran and succeeded cleanly across 23 updated files.

---
*PR created automatically by Jules for task [11155204437884672210](https://jules.google.com/task/11155204437884672210) started by @madmax983*