### PR TITLE
⚒️ Forge: [refactor unwrap usages in docker tests]

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -530,14 +530,10 @@ mod tests {
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = network_pos else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +548,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("missing --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("missing my-image argument in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"


### PR DESCRIPTION
🚮 Smell: Use of `unwrap()` in `src/env/docker.rs` tests causing `clippy::unwrap_used` warnings.
✨ Solution: Replaced `unwrap()` calls with `let Some(x) = opt else { panic!("...") };` guard clauses containing helpful contextual error messages.
🧼 Benefit: Removes clippy warnings and improves error messages on test failure without changing any underlying test logic.
🛡️ Verification: Tests passed (`cargo test --features docker --lib -- env::docker`). No logic changed.

---
*PR created automatically by Jules for task [8457609709732695053](https://jules.google.com/task/8457609709732695053) started by @madmax983*