### PR TITLE
🌟 Nova: [XML Trajectory Exporter]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+xml-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
 

--- a/docs/spec-export.md
+++ b/docs/spec-export.md
@@ -34,11 +34,12 @@ max bench inspect --list-formats
 | `csv` | stable | `csv-export` | spreadsheets, jq pipelines, tabular tools |
 | `html` | stable | `html-export` | self-contained browser view, shared notebooks |
 | `mermaid` | experimental | `mermaid-export` | Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live) |
+| `xml` | experimental | `xml-export` | XML structured data processors, enterprise integrations |
 
 Feature-gated formats require rebuilding with the corresponding feature:
 
 ```bash
-cargo build --features csv-export,html-export,mermaid-export
+cargo build --features csv-export,html-export,mermaid-export,xml-export
 ```
 
 When a format is requested but its Cargo feature was not compiled in, the command exits

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected my-image in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -6,7 +6,7 @@
 //! narrative document, complete with headers and code blocks.
 //!
 //! You can extend this module with new formats by implementing the [`crate::trajectory::export::TrajectoryExporter`] trait.
-//! Every new exporter MUST register in [`registry`] and MUST apply redaction via
+//! Every new exporter MUST register in [`crate::trajectory::export::registry`] and MUST apply redaction via
 //! [`crate::redaction::Redactor::default_enabled`] on [`crate::redaction::surface::EXPORT`] before emitting any output.
 //! See `docs/spec-export.md` for the full governing contract.
 
@@ -95,6 +95,14 @@ pub fn registry() -> Vec<ExportFormat> {
         render: MermaidExporter::export,
     });
 
+    #[cfg(feature = "xml-export")]
+    formats.push(ExportFormat {
+        name: "xml",
+        tier: StabilityTier::Experimental,
+        consumer: "XML structured data processors, enterprise integrations",
+        render: XmlExporter::export,
+    });
+
     formats
 }
 
@@ -109,6 +117,7 @@ pub const FEATURE_GATED_FORMATS: &[(&str, &str)] = &[
     ("csv", "csv-export"),
     ("html", "html-export"),
     ("mermaid", "mermaid-export"),
+    ("xml", "xml-export"),
 ];
 
 /// Returns `true` if `name` is a trajectory export format known to this codebase,
@@ -153,6 +162,54 @@ pub trait TrajectoryExporter {
 /// assert!(md.contains("Hello agent"));
 /// ```
 pub struct MarkdownExporter;
+
+/// Transforms a [`Trajectory`] into an XML document, keeping content in `CDATA` sections.
+#[cfg(feature = "xml-export")]
+pub struct XmlExporter;
+
+#[cfg(feature = "xml-export")]
+impl TrajectoryExporter for XmlExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        use std::fmt::Write;
+        let redactor = Redactor::default_enabled();
+        let mut xml = String::new();
+
+        xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        xml.push_str("<trajectory>\n");
+
+        if trajectory.info.task.is_some() || trajectory.info.outcome.is_some() {
+            xml.push_str("  <info>\n");
+            if let Some(task) = &trajectory.info.task {
+                let task_redacted = redactor.redact_text(task, surface::EXPORT).text;
+                let task_cdata = task_redacted.replace("]]>", "]]]]><![CDATA[>");
+                let _ = writeln!(xml, "    <task><![CDATA[{task_cdata}]]></task>");
+            }
+            if let Some(outcome) = &trajectory.info.outcome {
+                let outcome_redacted = redactor.redact_text(outcome, surface::EXPORT).text;
+                let outcome_cdata = outcome_redacted.replace("]]>", "]]]]><![CDATA[>");
+                let _ = writeln!(xml, "    <outcome><![CDATA[{outcome_cdata}]]></outcome>");
+            }
+            xml.push_str("  </info>\n");
+        }
+
+        xml.push_str("  <messages>\n");
+
+        for msg in &trajectory.messages {
+            let role = msg.role.as_str();
+            let content_redacted = redactor.redact_text(&msg.content, surface::EXPORT).text;
+            let content_cdata = content_redacted.replace("]]>", "]]]]><![CDATA[>");
+            let _ = writeln!(
+                xml,
+                "    <message role=\"{role}\"><![CDATA[{content_cdata}]]></message>"
+            );
+        }
+
+        xml.push_str("  </messages>\n");
+        xml.push_str("</trajectory>\n");
+
+        xml
+    }
+}
 
 /// Transforms a [`Trajectory`] into a flat CSV file, with `role` and `content` columns.
 ///
@@ -452,5 +509,36 @@ mod tests {
         assert!(html.contains("submitted"));
         assert!(html.contains("Hello agent"));
         assert!(html.contains("Hello user"));
+    }
+
+    #[cfg(feature = "xml-export")]
+    #[test]
+    fn test_xml_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some(outcome::SUBMITTED.to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent\nMulti-line"));
+        t.record_message(&Message::assistant("Here is the code: ]]>"));
+
+        let xml = XmlExporter::export(&t);
+
+        assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        assert!(xml.contains("<trajectory>"));
+        assert!(xml.contains("<info>"));
+        assert!(xml.contains("<task><![CDATA[Add a feature]]></task>"));
+        assert!(xml.contains("<outcome><![CDATA[submitted]]></outcome>"));
+        assert!(xml.contains("</info>"));
+        assert!(xml.contains("<messages>"));
+        assert!(xml.contains("<message role=\"system\"><![CDATA[System prompt]]></message>"));
+        assert!(
+            xml.contains("<message role=\"user\"><![CDATA[Hello agent\nMulti-line]]></message>")
+        );
+        assert!(xml.contains(
+            "<message role=\"assistant\"><![CDATA[Here is the code: ]]]]><![CDATA[>]]></message>"
+        ));
+        assert!(xml.contains("</messages>"));
+        assert!(xml.contains("</trajectory>"));
     }
 }


### PR DESCRIPTION
💡 **The Spark:** "Systems integration often requires structured formats, but JSON can be dense and some legacy/enterprise environments prefer XML for document-like data."
🚀 **The Feature:** "Implemented `XmlExporter` to format trajectories into an XML document, safely embedding content natively inside `<![CDATA[ ... ]]>` blocks."
🔮 **The Potential:** "Easy integration with enterprise logging systems, XML-based data lakes, or RSS syndication pipelines."
⚠️ **Risk:** "Low. Isolated in `src/trajectory/export.rs` behind the `xml-export` feature flag."

---
*PR created automatically by Jules for task [6166978126577190827](https://jules.google.com/task/6166978126577190827) started by @madmax983*