### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -530,14 +530,10 @@ mod tests {
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = network_pos else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +548,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("missing --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("missing image argument in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"


### PR DESCRIPTION
🎯 Target: `src/env/docker.rs` unit tests (`build_run_args_include_network_none_when_mode_is_none` and `build_run_args_network_none_positioned_before_image`).

💣 Risk: Use of `.unwrap()` on `Option` variants (`args.get(...)`, `position(...)`) risks opaque thread panics with generic errors (like "called `Option::unwrap()` on a `None` value") instead of clear, descriptive failures that indicate exactly what assertion failed.

🧪 Strategy: Replaced `.unwrap()` calls with idiomatic `let Some(..) = .. else { panic!(...) }` guards, printing custom error messages that include the diagnostic state (`{args:?}`). This clears `clippy::unwrap_used` warnings and makes the tests robust against silent failures.

🔬 Verification: Run `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test --all-features`.

---
*PR created automatically by Jules for task [9248534447746422532](https://jules.google.com/task/9248534447746422532) started by @madmax983*