### PR TITLE
🗺️ Atlas: [architectural change]

### DIFF
--- a/src/agent/default.rs
+++ b/src/agent/default.rs
@@ -28,8 +28,9 @@ use crate::model::{
 };
 use crate::policy::{PolicyDecision, PolicyEngine, PolicyProfile};
 use crate::prompt_guard::{PromptGuard, UntrustedKind};
-use crate::redaction::{RedactingSink, Redactor, surface};
+use crate::redaction::{Redactor, surface};
 use crate::stagnation::StagnationDetector;
+use crate::stream::redact::RedactingSink;
 use crate::stream::{NullSink, StreamEvent, StreamSink};
 use crate::template::Renderer;
 use crate::tool::{

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2,6 +2,12 @@
 
 use std::path::PathBuf;
 
+use crate::run::audit::AuditCmd;
+use crate::run::bisect::BisectCmd;
+use crate::run::fork::ForkCmd;
+use crate::run::merge::MergeCmd;
+use crate::run::power::PowerCmd;
+
 use clap::{Args, Subcommand, ValueEnum};
 
 // ── Agent subcommands ─────────────────────────────────────────────────────────
@@ -1540,63 +1546,6 @@ pub enum BenchCmd {
     Du(DuCmd),
 }
 
-/// `bench merge` — combine completed sharded sweep directories into one canonical aggregate.
-///
-/// Recombines K independent sharded sweeps into a single canonical sweep directory
-/// that is a drop-in for `bench evaluate`, `bench report`, `bench triage`, and `bench audit`.
-/// Runs entirely offline with no model or network calls.
-#[derive(Debug, Args)]
-pub struct MergeCmd {
-    /// A completed sweep directory to merge. Repeat for each shard (2+ required).
-    #[arg(long = "shard", required = true, action = clap::ArgAction::Append)]
-    pub shards: Vec<std::path::PathBuf>,
-
-    /// Destination directory for the merged canonical sweep. Created if absent; must be empty otherwise.
-    #[arg(long)]
-    pub output: std::path::PathBuf,
-
-    /// Collision policy when the same instance_id appears in more than one shard.
-    /// `error` (default): fail with a clear message listing all colliding IDs.
-    /// `first-wins`: keep the occurrence from the earliest --shard.
-    /// `last-wins`: keep the occurrence from the latest --shard.
-    #[arg(long = "on-collision", value_enum, default_value_t = MergeCollisionPolicy::Error)]
-    pub on_collision: MergeCollisionPolicy,
-
-    /// Optional human-readable shard labels, positionally aligned with --shard.
-    /// Defaults to the directory name of each shard.
-    #[arg(long = "label", action = clap::ArgAction::Append)]
-    pub labels: Vec<String>,
-
-    /// Overwrite the output directory if it is non-empty.
-    #[arg(long, default_value_t = false)]
-    pub force: bool,
-
-    /// Output format: `text` (default) or `json`.
-    /// The `json` format emits a machine-readable summary to stdout.
-    #[arg(long, value_enum, default_value_t = MergeFormat::Text)]
-    pub format: MergeFormat,
-}
-
-/// Output format for `bench merge`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
-pub enum MergeFormat {
-    /// Human-readable text summary (default).
-    Text,
-    /// Machine-readable JSON summary.
-    Json,
-}
-
-/// Collision policy for `bench merge` when the same instance_id appears in multiple shards.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
-pub enum MergeCollisionPolicy {
-    /// Fail loudly if any instance_id appears in two or more shards (default).
-    Error,
-    /// Keep the occurrence from the earliest --shard; log duplicates in the report.
-    FirstWins,
-    /// Keep the occurrence from the latest --shard; log duplicates in the report.
-    LastWins,
-}
-
 /// `bench export-otlp` — re-export reconstructed sweep + instance spans from a
 /// completed sweep directory to an OTLP/HTTP collector.
 ///
@@ -1992,117 +1941,6 @@ pub struct DatasetVerifyCmd {
     pub canonical_dir: Option<PathBuf>,
 
     /// Format: `text` or `json`.
-    #[arg(long, default_value = "text")]
-    pub format: String,
-}
-
-/// `bench bisect` — identify the commit that introduced a resolved-rate regression.
-#[derive(Debug, Args, Clone)]
-pub struct BisectCmd {
-    /// Known-good sweep directory containing a results.json with manifest.
-    #[arg(long)]
-    pub good: PathBuf,
-
-    /// Known-bad sweep directory containing a results.json with manifest.
-    #[arg(long)]
-    pub bad: PathBuf,
-
-    /// Number of smoke instances to sample for the sweep.
-    #[arg(long, default_value_t = 5)]
-    pub smoke_instances: usize,
-
-    /// RNG seed for sampling candidate smoke instances (defaults to good manifest hash).
-    #[arg(long)]
-    pub smoke_seed: Option<u64>,
-
-    /// The model to run the smoke sweep against. Defaults to cheapest registered model.
-    #[arg(long)]
-    pub smoke_model: Option<String>,
-
-    /// Margin under which resolved rate is considered a regression.
-    #[arg(long, default_value_t = 0.20)]
-    pub regression_margin: f64,
-
-    /// Maximum USD cost before halting and writing partial results.
-    #[arg(long)]
-    pub max_cost_usd: Option<f64>,
-
-    /// Path to a bisect.json file to resume a previously interrupted run.
-    #[arg(long)]
-    pub resume: Option<PathBuf>,
-}
-
-/// `bench audit` — re-derive and verify sweep aggregates against trajectories.
-#[derive(Debug, Args, Clone)]
-pub struct AuditCmd {
-    /// Path to a completed sweep directory or extracted bench bundle directory.
-    #[arg(long)]
-    pub sweep: PathBuf,
-
-    /// Local dataset file to verify the recorded manifest hash.
-    #[arg(long)]
-    pub dataset_path: Option<PathBuf>,
-
-    /// USD tolerance for cost reconciliation.
-    #[arg(long, default_value_t = 0.0001)]
-    pub cost_tolerance_usd: f64,
-
-    /// Seconds tolerance for wall-clock reconciliation.
-    #[arg(long, default_value_t = 1.0)]
-    pub wallclock_tolerance_secs: f64,
-
-    /// Output format: `text` or `json`.
-    #[arg(long, default_value = "text")]
-    pub format: String,
-}
-
-/// `bench power` — statistical power, sample size, or MDE calculations.
-#[derive(Debug, Args, Clone)]
-pub struct PowerCmd {
-    /// Baseline resolved rate as a float (e.g. `0.35`). Required unless `--from-sweep` is provided.
-    #[arg(long)]
-    pub baseline_rate: Option<f64>,
-
-    /// Absolute percentage points delta (e.g. `0.05`).
-    /// Mutually exclusive with `--n` (Mode A).
-    #[arg(long, conflicts_with = "n")]
-    pub delta: Option<f64>,
-
-    /// Sample size per arm.
-    /// Mutually exclusive with `--delta` (Mode B).
-    #[arg(long, conflicts_with = "delta")]
-    pub n: Option<usize>,
-
-    /// Sweep directory to load baseline resolved rate from.
-    /// Mutually exclusive with `--baseline-rate`.
-    #[arg(long, conflicts_with = "baseline_rate")]
-    pub from_sweep: Option<PathBuf>,
-
-    /// Significance level / Type I error rate.
-    #[arg(long, default_value_t = 0.05)]
-    pub alpha: f64,
-
-    /// Target statistical power / 1 - Type II error rate.
-    #[arg(long, default_value_t = 0.80)]
-    pub power: f64,
-
-    /// Run a one-sided test instead of a two-sided test.
-    #[arg(long, default_value_t = false)]
-    pub one_sided: bool,
-
-    /// Number of study arms (default is 2). Bonferroni correction is applied if arms > 2.
-    #[arg(long, default_value_t = 2)]
-    pub arms: usize,
-
-    /// Optional average run cost in USD per instance.
-    #[arg(long)]
-    pub cost_per_instance: Option<f64>,
-
-    /// Optional path to a forecast report JSON to compute cost from.
-    #[arg(long, conflicts_with = "cost_per_instance")]
-    pub from_forecast: Option<PathBuf>,
-
-    /// Output format: `text` (default) or `json`.
     #[arg(long, default_value = "text")]
     pub format: String,
 }
@@ -4060,55 +3898,6 @@ pub struct SkillsPreviewCmd {
     /// Output format: `text` (default, human-readable) or `json` (schema-versioned).
     #[arg(long, default_value = "text")]
     pub format: String,
-}
-
-/// `bench fork` — fork a trajectory at step N and continue with config overrides.
-#[derive(Debug, Args)]
-#[allow(clippy::struct_excessive_bools)]
-pub struct ForkCmd {
-    /// Completed sweep directory containing the instance trajectory.
-    #[arg(long)]
-    pub sweep: std::path::PathBuf,
-
-    /// Specific instance id to fork.
-    #[arg(long)]
-    pub instance: String,
-
-    /// The step number to fork from (zero-indexed).
-    #[arg(long = "from-step")]
-    pub from_step: u32,
-
-    /// Output directory for the new trajectory.
-    #[arg(long)]
-    pub output: std::path::PathBuf,
-
-    /// Override model name for the tail (e.g. `claude-opus-4-7`).
-    #[arg(long)]
-    pub model: Option<String>,
-
-    /// Override system prompt file for the tail.
-    #[arg(long = "system-prompt-file")]
-    pub system_prompt_file: Option<std::path::PathBuf>,
-
-    /// Override max agent steps.
-    #[arg(long)]
-    pub step_limit: Option<u32>,
-
-    /// Override per-task USD budget cap for the tail.
-    #[arg(long)]
-    pub per_task_budget_usd: Option<f64>,
-
-    /// Override MCP stdio server command(s).
-    #[arg(long = "mcp-server", value_name = "COMMAND")]
-    pub mcp_servers: Vec<String>,
-
-    /// Override path to an MCP config JSON file.
-    #[arg(long = "mcp-config")]
-    pub mcp_config: Option<std::path::PathBuf>,
-
-    /// Allow forking from a parent trajectory that has no stored input fingerprints.
-    #[arg(long, default_value_t = false)]
-    pub allow_unfingerprinted: bool,
 }
 
 // ── bench annotate ────────────────────────────────────────────────────────────

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4238,7 +4238,7 @@ fn bench_test_progress(t: args::TestProgressCmd) -> Result<(), Error> {
     Ok(())
 }
 
-fn bench_power(p: &args::PowerCmd) -> Result<(), Error> {
+fn bench_power(p: &crate::run::power::PowerCmd) -> Result<(), Error> {
     let is_json = match p.format.as_str() {
         "text" => false,
         "json" => true,
@@ -6559,17 +6559,17 @@ fn bench_dataset_verify(s: args::DatasetVerifyCmd) -> Result<(), Error> {
     Ok(())
 }
 
-async fn bench_bisect(b: args::BisectCmd) -> Result<(), Error> {
+async fn bench_bisect(b: crate::run::bisect::BisectCmd) -> Result<(), Error> {
     crate::run::bisect::run(&b).await
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn bench_audit(a: args::AuditCmd) -> Result<(), Error> {
+fn bench_audit(a: crate::run::audit::AuditCmd) -> Result<(), Error> {
     crate::run::audit::run(&a)
 }
 
-fn bench_merge(m: &args::MergeCmd) -> Result<(), Error> {
-    let is_json = matches!(m.format, args::MergeFormat::Json);
+fn bench_merge(m: &crate::run::merge::MergeCmd) -> Result<(), Error> {
+    let is_json = matches!(m.format, crate::run::merge::MergeFormat::Json);
     let report = crate::run::merge::run(m)?;
     if is_json {
         println!("{}", serde_json::to_string_pretty(&report)?);

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,15 +529,10 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +547,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected my-image in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::config::RedactionCfg;
-use crate::stream::{StreamEvent, StreamSink};
 
 // ── Public check types ────────────────────────────────────────────────────────
 
@@ -613,123 +612,6 @@ impl Redactor {
             }
             _ => false,
         }
-    }
-}
-
-pub struct RedactingSink {
-    inner: Arc<dyn StreamSink>,
-    redactor: Redactor,
-}
-
-impl RedactingSink {
-    pub fn new(inner: Arc<dyn StreamSink>, redactor: Redactor) -> Self {
-        Self { inner, redactor }
-    }
-}
-
-impl StreamSink for RedactingSink {
-    fn emit(&self, event: StreamEvent) {
-        self.inner.emit(redact_stream_event(&event, &self.redactor));
-    }
-}
-
-pub fn redact_stream_event(event: &StreamEvent, redactor: &Redactor) -> StreamEvent {
-    match event {
-        StreamEvent::RunStarted {
-            task,
-            model,
-            started_at,
-        } => StreamEvent::RunStarted {
-            task: redactor.redact_text(task, surface::STREAM).text,
-            model: redactor.redact_text(model, surface::STREAM).text,
-            started_at: started_at.clone(),
-        },
-        StreamEvent::AssistantMessage {
-            step,
-            content,
-            cost_usd,
-            timestamp,
-        } => StreamEvent::AssistantMessage {
-            step: *step,
-            content: redactor.redact_text(content, surface::STREAM).text,
-            cost_usd: *cost_usd,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::BashStart {
-            step,
-            command,
-            timestamp,
-        } => StreamEvent::BashStart {
-            step: *step,
-            command: redactor.redact_text(command, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::BashResult {
-            step,
-            exit_code,
-            stdout,
-            stderr,
-            timed_out,
-            timestamp,
-        } => StreamEvent::BashResult {
-            step: *step,
-            exit_code: *exit_code,
-            stdout: redactor.redact_text(stdout, surface::STREAM).text,
-            stderr: redactor.redact_text(stderr, surface::STREAM).text,
-            timed_out: *timed_out,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::ToolStart {
-            step,
-            label,
-            timestamp,
-        } => StreamEvent::ToolStart {
-            step: *step,
-            label: redactor.redact_text(label, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::ToolEnd { step, timestamp } => StreamEvent::ToolEnd {
-            step: *step,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::Observation {
-            step,
-            content,
-            timestamp,
-        } => StreamEvent::Observation {
-            step: *step,
-            content: redactor.redact_text(content, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::FormatError {
-            step,
-            content,
-            timestamp,
-        } => StreamEvent::FormatError {
-            step: *step,
-            content: redactor.redact_text(content, surface::STREAM).text,
-            timestamp: timestamp.clone(),
-        },
-        StreamEvent::RunEnded {
-            exit_reason,
-            failure_category,
-            final_output,
-            steps,
-            total_cost_usd,
-            ended_at,
-        } => StreamEvent::RunEnded {
-            exit_reason: exit_reason.clone(),
-            failure_category: *failure_category,
-            final_output: final_output
-                .as_ref()
-                .map(|value| redactor.redact_text(value, surface::STREAM).text),
-            steps: *steps,
-            total_cost_usd: *total_cost_usd,
-            ended_at: ended_at.clone(),
-        },
-        StreamEvent::AutoApproveRuleCreated { scope } => StreamEvent::AutoApproveRuleCreated {
-            scope: redactor.redact_text(scope, surface::STREAM).text,
-        },
     }
 }
 

--- a/src/run/audit.rs
+++ b/src/run/audit.rs
@@ -5,8 +5,32 @@ use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-use crate::cli::args::AuditCmd;
 use crate::error::Error;
+use clap::Args;
+
+/// `bench audit` — re-derive and verify sweep aggregates against trajectories.
+#[derive(Debug, Args, Clone)]
+pub struct AuditCmd {
+    /// Path to a completed sweep directory or extracted bench bundle directory.
+    #[arg(long)]
+    pub sweep: PathBuf,
+
+    /// Local dataset file to verify the recorded manifest hash.
+    #[arg(long)]
+    pub dataset_path: Option<PathBuf>,
+
+    /// USD tolerance for cost reconciliation.
+    #[arg(long, default_value_t = 0.0001)]
+    pub cost_tolerance_usd: f64,
+
+    /// Seconds tolerance for wall-clock reconciliation.
+    #[arg(long, default_value_t = 1.0)]
+    pub wallclock_tolerance_secs: f64,
+
+    /// Output format: `text` or `json`.
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
 
 /// Recompute sweep-wide aggregates and reconcile with results.json and evaluation.json.
 #[allow(clippy::too_many_lines)]

--- a/src/run/bisect.rs
+++ b/src/run/bisect.rs
@@ -10,9 +10,46 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::Command;
 
-use crate::cli::args::BisectCmd;
 use crate::error::Error;
 use crate::run::swebench::{ProvenanceManifest, SweepResults};
+use clap::Args;
+use std::path::PathBuf;
+
+/// `bench bisect` — identify the commit that introduced a resolved-rate regression.
+#[derive(Debug, Args, Clone)]
+pub struct BisectCmd {
+    /// Known-good sweep directory containing a results.json with manifest.
+    #[arg(long)]
+    pub good: PathBuf,
+
+    /// Known-bad sweep directory containing a results.json with manifest.
+    #[arg(long)]
+    pub bad: PathBuf,
+
+    /// Number of smoke instances to sample for the sweep.
+    #[arg(long, default_value_t = 5)]
+    pub smoke_instances: usize,
+
+    /// RNG seed for sampling candidate smoke instances (defaults to good manifest hash).
+    #[arg(long)]
+    pub smoke_seed: Option<u64>,
+
+    /// The model to run the smoke sweep against. Defaults to cheapest registered model.
+    #[arg(long)]
+    pub smoke_model: Option<String>,
+
+    /// Margin under which resolved rate is considered a regression.
+    #[arg(long, default_value_t = 0.20)]
+    pub regression_margin: f64,
+
+    /// Maximum USD cost before halting and writing partial results.
+    #[arg(long)]
+    pub max_cost_usd: Option<f64>,
+
+    /// Path to a bisect.json file to resume a previously interrupted run.
+    #[arg(long)]
+    pub resume: Option<PathBuf>,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommitResult {

--- a/src/run/fork.rs
+++ b/src/run/fork.rs
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 use sha2::Digest;
 
 use crate::agent::{Agent, DefaultAgent, default::DefaultAgentBuilder};
-use crate::cli::args::ForkCmd;
 use crate::config::{Config, EnvKind, McpServerCfg};
 #[cfg(feature = "docker")]
 use crate::env::DockerEnvironment;
@@ -25,6 +24,56 @@ use crate::run::reproduce::{
     DriftSeverity, compare_manifests, filter_hard_drifts, load_manifest_from_sweep,
 };
 use crate::trajectory::{ForkLineage, Trajectory};
+use clap::Args;
+
+/// `bench fork` — fork a trajectory at step N and continue with config overrides.
+#[derive(Debug, Args)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct ForkCmd {
+    /// Completed sweep directory containing the instance trajectory.
+    #[arg(long)]
+    pub sweep: std::path::PathBuf,
+
+    /// Specific instance id to fork.
+    #[arg(long)]
+    pub instance: String,
+
+    /// The step number to fork from (zero-indexed).
+    #[arg(long = "from-step")]
+    pub from_step: u32,
+
+    /// Output directory for the new trajectory.
+    #[arg(long)]
+    pub output: std::path::PathBuf,
+
+    /// Override model name for the tail (e.g. `claude-opus-4-7`).
+    #[arg(long)]
+    pub model: Option<String>,
+
+    /// Override system prompt file for the tail.
+    #[arg(long = "system-prompt-file")]
+    pub system_prompt_file: Option<std::path::PathBuf>,
+
+    /// Override max agent steps.
+    #[arg(long)]
+    pub step_limit: Option<u32>,
+
+    /// Override per-task USD budget cap for the tail.
+    #[arg(long)]
+    pub per_task_budget_usd: Option<f64>,
+
+    /// Override MCP stdio server command(s).
+    #[arg(long = "mcp-server", value_name = "COMMAND")]
+    pub mcp_servers: Vec<String>,
+
+    /// Override path to an MCP config JSON file.
+    #[arg(long = "mcp-config")]
+    pub mcp_config: Option<std::path::PathBuf>,
+
+    /// Allow forking from a parent trajectory that has no stored input fingerprints.
+    #[arg(long, default_value_t = false)]
+    pub allow_unfingerprinted: bool,
+}
 
 /// Hybrid model that replays a prefix using deterministic responses with
 /// fingerprint verification at strictly $0 cost, and delegates to a live

--- a/src/run/merge.rs
+++ b/src/run/merge.rs
@@ -14,11 +14,68 @@ use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-use crate::cli::args::{MergeCmd, MergeCollisionPolicy};
 use crate::error::Error;
 use crate::run::swebench::{
     MergeShardProvenance, SWEEP_STATUS_COMPLETED, SweepResults, write_sweep_results_atomic,
 };
+use clap::Args;
+
+/// Collision policy for `bench merge` when the same instance_id appears in multiple shards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum MergeCollisionPolicy {
+    /// Fail loudly if any instance_id appears in two or more shards (default).
+    Error,
+    /// Keep the occurrence from the earliest --shard; log duplicates in the report.
+    FirstWins,
+    /// Keep the occurrence from the latest --shard; log duplicates in the report.
+    LastWins,
+}
+
+/// Output format for `bench merge`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum MergeFormat {
+    /// Human-readable text summary (default).
+    Text,
+    /// Machine-readable JSON summary.
+    Json,
+}
+
+/// `bench merge` — combine completed sharded sweep directories into one canonical aggregate.
+///
+/// Recombines K independent sharded sweeps into a single canonical sweep directory
+/// that is a drop-in for `bench evaluate`, `bench report`, `bench triage`, and `bench audit`.
+/// Runs entirely offline with no model or network calls.
+#[derive(Debug, Args)]
+pub struct MergeCmd {
+    /// A completed sweep directory to merge. Repeat for each shard (2+ required).
+    #[arg(long = "shard", required = true, action = clap::ArgAction::Append)]
+    pub shards: Vec<std::path::PathBuf>,
+
+    /// Destination directory for the merged canonical sweep. Created if absent; must be empty otherwise.
+    #[arg(long)]
+    pub output: std::path::PathBuf,
+
+    /// Collision policy when the same instance_id appears in more than one shard.
+    /// `error` (default): fail with a clear message listing all colliding IDs.
+    /// `first-wins`: keep the occurrence from the earliest --shard.
+    /// `last-wins`: keep the occurrence from the latest --shard.
+    #[arg(long = "on-collision", value_enum, default_value_t = MergeCollisionPolicy::Error)]
+    pub on_collision: MergeCollisionPolicy,
+
+    /// Optional human-readable shard labels, positionally aligned with --shard.
+    /// Defaults to the directory name of each shard.
+    #[arg(long = "label", action = clap::ArgAction::Append)]
+    pub labels: Vec<String>,
+
+    /// Overwrite the output directory if it is non-empty.
+    #[arg(long, default_value_t = false)]
+    pub force: bool,
+
+    /// Output format: `text` (default) or `json`.
+    /// The `json` format emits a machine-readable summary to stdout.
+    #[arg(long, value_enum, default_value_t = MergeFormat::Text)]
+    pub format: MergeFormat,
+}
 
 // ── public types ──────────────────────────────────────────────────────────────
 

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -1003,7 +1003,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
         // one from the config. The agent will build its own for trajectory/model
         // surfaces; this one covers the stream surface only.
         let redactor = crate::redaction::Redactor::from_config_lossy(&args.config.root.redaction);
-        Arc::new(crate::redaction::RedactingSink::new(ws, redactor)) as Arc<dyn StreamSink>
+        Arc::new(crate::stream::redact::RedactingSink::new(ws, redactor)) as Arc<dyn StreamSink>
     });
     let event_log_sink: Option<Arc<dyn StreamSink>> = args.event_log.as_ref().and_then(|path| {
         match EventLogSink::new(
@@ -1028,7 +1028,7 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
                 }
                 let redactor =
                     crate::redaction::Redactor::from_config_lossy(&args.config.root.redaction);
-                Some(Arc::new(crate::redaction::RedactingSink::new(
+                Some(Arc::new(crate::stream::redact::RedactingSink::new(
                     Arc::new(sink),
                     redactor,
                 )) as Arc<dyn StreamSink>)

--- a/src/run/power.rs
+++ b/src/run/power.rs
@@ -15,9 +15,61 @@
 //!
 //! Run completely offline (zero network/model calls) in under 100ms.
 
-use crate::cli::args::PowerCmd;
 use crate::error::Error;
+use clap::Args;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// `bench power` — statistical power, sample size, or MDE calculations.
+#[derive(Debug, Args, Clone)]
+pub struct PowerCmd {
+    /// Baseline resolved rate as a float (e.g. `0.35`). Required unless `--from-sweep` is provided.
+    #[arg(long)]
+    pub baseline_rate: Option<f64>,
+
+    /// Absolute percentage points delta (e.g. `0.05`).
+    /// Mutually exclusive with `--n` (Mode A).
+    #[arg(long, conflicts_with = "n")]
+    pub delta: Option<f64>,
+
+    /// Sample size per arm.
+    /// Mutually exclusive with `--delta` (Mode B).
+    #[arg(long, conflicts_with = "delta")]
+    pub n: Option<usize>,
+
+    /// Sweep directory to load baseline resolved rate from.
+    /// Mutually exclusive with `--baseline-rate`.
+    #[arg(long, conflicts_with = "baseline_rate")]
+    pub from_sweep: Option<PathBuf>,
+
+    /// Significance level / Type I error rate.
+    #[arg(long, default_value_t = 0.05)]
+    pub alpha: f64,
+
+    /// Target statistical power / 1 - Type II error rate.
+    #[arg(long, default_value_t = 0.80)]
+    pub power: f64,
+
+    /// Run a one-sided test instead of a two-sided test.
+    #[arg(long, default_value_t = false)]
+    pub one_sided: bool,
+
+    /// Number of study arms (default is 2). Bonferroni correction is applied if arms > 2.
+    #[arg(long, default_value_t = 2)]
+    pub arms: usize,
+
+    /// Optional average run cost in USD per instance.
+    #[arg(long)]
+    pub cost_per_instance: Option<f64>,
+
+    /// Optional path to a forecast report JSON to compute cost from.
+    #[arg(long, conflicts_with = "cost_per_instance")]
+    pub from_forecast: Option<PathBuf>,
+
+    /// Output format: `text` (default) or `json`.
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PowerReport {

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -15,6 +15,7 @@ use serde::Serialize;
 
 pub mod broadcast;
 pub mod event_log;
+pub mod redact;
 pub mod sse;
 #[cfg(feature = "webhook")]
 pub mod sweep_webhook;

--- a/src/stream/redact.rs
+++ b/src/stream/redact.rs
@@ -1,0 +1,120 @@
+use crate::redaction::{Redactor, surface};
+use crate::stream::{StreamEvent, StreamSink};
+use std::sync::Arc;
+
+pub struct RedactingSink {
+    inner: Arc<dyn StreamSink>,
+    redactor: Redactor,
+}
+
+impl RedactingSink {
+    pub fn new(inner: Arc<dyn StreamSink>, redactor: Redactor) -> Self {
+        Self { inner, redactor }
+    }
+}
+
+impl StreamSink for RedactingSink {
+    fn emit(&self, event: StreamEvent) {
+        self.inner.emit(redact_stream_event(&event, &self.redactor));
+    }
+}
+
+pub fn redact_stream_event(event: &StreamEvent, redactor: &Redactor) -> StreamEvent {
+    match event {
+        StreamEvent::RunStarted {
+            task,
+            model,
+            started_at,
+        } => StreamEvent::RunStarted {
+            task: redactor.redact_text(task, surface::STREAM).text,
+            model: redactor.redact_text(model, surface::STREAM).text,
+            started_at: started_at.clone(),
+        },
+        StreamEvent::AssistantMessage {
+            step,
+            content,
+            cost_usd,
+            timestamp,
+        } => StreamEvent::AssistantMessage {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            cost_usd: *cost_usd,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::BashStart {
+            step,
+            command,
+            timestamp,
+        } => StreamEvent::BashStart {
+            step: *step,
+            command: redactor.redact_text(command, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::BashResult {
+            step,
+            exit_code,
+            stdout,
+            stderr,
+            timed_out,
+            timestamp,
+        } => StreamEvent::BashResult {
+            step: *step,
+            exit_code: *exit_code,
+            stdout: redactor.redact_text(stdout, surface::STREAM).text,
+            stderr: redactor.redact_text(stderr, surface::STREAM).text,
+            timed_out: *timed_out,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::ToolStart {
+            step,
+            label,
+            timestamp,
+        } => StreamEvent::ToolStart {
+            step: *step,
+            label: redactor.redact_text(label, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::ToolEnd { step, timestamp } => StreamEvent::ToolEnd {
+            step: *step,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::Observation {
+            step,
+            content,
+            timestamp,
+        } => StreamEvent::Observation {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::FormatError {
+            step,
+            content,
+            timestamp,
+        } => StreamEvent::FormatError {
+            step: *step,
+            content: redactor.redact_text(content, surface::STREAM).text,
+            timestamp: timestamp.clone(),
+        },
+        StreamEvent::RunEnded {
+            exit_reason,
+            failure_category,
+            final_output,
+            steps,
+            total_cost_usd,
+            ended_at,
+        } => StreamEvent::RunEnded {
+            exit_reason: exit_reason.clone(),
+            failure_category: *failure_category,
+            final_output: final_output
+                .as_ref()
+                .map(|value| redactor.redact_text(value, surface::STREAM).text),
+            steps: *steps,
+            total_cost_usd: *total_cost_usd,
+            ended_at: ended_at.clone(),
+        },
+        StreamEvent::AutoApproveRuleCreated { scope } => StreamEvent::AutoApproveRuleCreated {
+            scope: redactor.redact_text(scope, surface::STREAM).text,
+        },
+    }
+}


### PR DESCRIPTION
🕸️ Tangle: The codebase had two significant circular dependency knots. First, the `stream` module and `redaction` module had a bidirectional dependency due to `redaction` referencing `stream::{StreamEvent, StreamSink}` and `stream::sweep_webhook` referencing `redaction::Redactor`. Second, the `cli` and `run` modules had a tight loop where `cli` called runner functions from `run`, but `run` modules reached back into `cli::args` to pull their specific Clap argument definitions.

📐 Blueprint:
- Broken `stream` <-> `redaction` cycle: Extracted `RedactingSink` and `redact_stream_event` from `src/redaction.rs` into a new `src/stream/redact.rs` module, shifting the dependency so that `stream` now fully encapsulates stream event manipulation and only depends on `redaction` for its utilities.
- Broken `cli` <-> `run` cycle: Moved the concrete Command structs (`PowerCmd`, `ForkCmd`, `MergeCmd`, `AuditCmd`, `BisectCmd`) and their associated components (like `MergeCollisionPolicy` and `MergeFormat`) from the massive `cli/args.rs` directly into their respective runner files within `src/run/` (`power.rs`, `fork.rs`, etc.). This enforces high cohesion (commands live next to their logic) and unblocks unidirectional coupling.

🧱 Stability: Enforced strict unidirectional module boundaries (`cli` -> `run`, `stream` -> `redaction`). This architectural improvement reduces the "sprawl" of `cli/args.rs` and cleanly segregates domains, resulting in a more maintainable, tree-like dependency graph.

🔬 Verification: The architectural changes were verified using `cargo check` and `cargo test stream redaction cli run`. Code was properly formatted with `cargo fmt` and vetted against `cargo clippy --all-targets --all-features -- -D warnings`. All structural integrity checks passed successfully.

---
*PR created automatically by Jules for task [18089160959066815332](https://jules.google.com/task/18089160959066815332) started by @madmax983*