### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -196,3 +196,62 @@ pub trait Agent: Send {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exit_reason_labels() {
+        let cases = vec![
+            (
+                ExitReason::Submitted {
+                    final_output: "Done!".into(),
+                },
+                "submitted",
+            ),
+            (ExitReason::StepLimit { limit: 10 }, "step_limit"),
+            (
+                ExitReason::CostLimit {
+                    limit_usd: 1.0,
+                    spent_usd: 1.5,
+                },
+                "cost_limit",
+            ),
+            (
+                ExitReason::BudgetExhausted {
+                    limit_usd: 1.0,
+                    spent_usd: 1.5,
+                },
+                "budget_exhausted",
+            ),
+            (ExitReason::UserInterrupt, "user_interrupt"),
+            (
+                ExitReason::ModelRefusal {
+                    reason: "safety".into(),
+                },
+                "model_refusal",
+            ),
+            (
+                ExitReason::AgentStagnation {
+                    action_hash: "abc".into(),
+                    count: 3,
+                    window: 5,
+                },
+                "agent_stagnation",
+            ),
+            (
+                ExitReason::HistoryCompactionFailed,
+                "history_compaction_failed",
+            ),
+        ];
+
+        for (reason, expected_label) in cases {
+            assert_eq!(
+                reason.label(),
+                expected_label,
+                "Label mismatch for {reason:?}",
+            );
+        }
+    }
+}

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -527,17 +527,16 @@ mod tests {
     // ── Network mode RED-phase tests ─────────────────────────────────────────
 
     #[test]
-    fn build_run_args_include_network_none_when_mode_is_none() {
+    fn build_run_args_include_network_none_when_mode_is_none() -> anyhow::Result<()> {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
         assert!(
             network_pos.is_some(),
             "expected --network flag in args: {args:?}"
         );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let pos = network_pos.ok_or_else(|| anyhow::anyhow!("network_pos is None"))?;
+        assert_eq!(args.get(pos + 1).map(String::as_str), Some("none"));
+        Ok(())
     }
 
     #[test]
@@ -550,13 +549,20 @@ mod tests {
     }
 
     #[test]
-    fn build_run_args_network_none_positioned_before_image() {
+    fn build_run_args_network_none_positioned_before_image() -> anyhow::Result<()> {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let network_pos = args
+            .iter()
+            .position(|a| a == "--network")
+            .ok_or_else(|| anyhow::anyhow!("network_pos is None"))?;
+        let image_pos = args
+            .iter()
+            .position(|a| a == "my-image")
+            .ok_or_else(|| anyhow::anyhow!("image_pos is None"))?;
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"
         );
+        Ok(())
     }
 }


### PR DESCRIPTION
🎯 Target: `src/agent/mod.rs` (ExitReason labels) and `src/env/docker.rs` (DockerEnvironment).
💣 Risk: Untested enum variants for `ExitReason` could drift or be renamed without updating the labels, leading to broken outcomes in trajectory records. Unhandled `.unwrap()` calls in `src/env/docker.rs` present a risk of panicking the test suite if arguments are misconfigured.
🧪 Strategy: Added a new table-driven unit test module `tests` in `src/agent/mod.rs` to comprehensively assert the output of `ExitReason::label()` for every variant. Refactored the network mode tests in `src/env/docker.rs` to return `anyhow::Result<()>` and safely bubble up missing flags rather than panicking.
🔬 Verification: Run `cargo test --all-targets` and specifically `cargo test --package maxwells-daemon --lib -- agent::tests` and `cargo test --package maxwells-daemon --features docker --lib -- env::docker::tests`.

---
*PR created automatically by Jules for task [16529059282645601590](https://jules.google.com/task/16529059282645601590) started by @madmax983*