### PR TITLE
🌟 Nova: [JSONL Exporter]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ html-export = []
 webhook = []
 csv-export = []
 mermaid-export = []
+jsonl-export = []
 # Enables the `max ui` local sweep browser. Requires `html-export` for rendering.
 ui-server = ["html-export"]
 

--- a/docs/spec-export.md
+++ b/docs/spec-export.md
@@ -33,6 +33,7 @@ max bench inspect --list-formats
 | `markdown` | stable | always compiled | docs, PR review, human readers |
 | `csv` | stable | `csv-export` | spreadsheets, jq pipelines, tabular tools |
 | `html` | stable | `html-export` | self-contained browser view, shared notebooks |
+| `jsonl` | stable | `jsonl-export` | log aggregation, streaming pipelines |
 | `mermaid` | experimental | `mermaid-export` | Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live) |
 
 Feature-gated formats require rebuilding with the corresponding feature:
@@ -120,6 +121,7 @@ $ max bench inspect --list-formats
 markdown    stable        docs, PR review, human readers
 csv         stable        spreadsheets, jq pipelines, tabular tools
 html        stable        self-contained browser view, shared notebooks
+jsonl       stable        log aggregation, streaming pipelines
 mermaid     experimental  Mermaid sequence-diagram renderers (GitLab, GitHub markdown, mermaid.live)
 ```
 

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,13 +529,11 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
         assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
+            args.get(network_pos + 1).map(String::as_str),
             Some("none")
         );
     }
@@ -552,8 +550,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected my-image");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -6,7 +6,7 @@
 //! narrative document, complete with headers and code blocks.
 //!
 //! You can extend this module with new formats by implementing the [`crate::trajectory::export::TrajectoryExporter`] trait.
-//! Every new exporter MUST register in [`registry`] and MUST apply redaction via
+//! Every new exporter MUST register in [`crate::trajectory::export::registry`] and MUST apply redaction via
 //! [`crate::redaction::Redactor::default_enabled`] on [`crate::redaction::surface::EXPORT`] before emitting any output.
 //! See `docs/spec-export.md` for the full governing contract.
 
@@ -85,6 +85,14 @@ pub fn registry() -> Vec<ExportFormat> {
         tier: StabilityTier::Stable,
         consumer: "self-contained browser view, shared notebooks",
         render: HtmlExporter::export,
+    });
+
+    #[cfg(feature = "jsonl-export")]
+    formats.push(ExportFormat {
+        name: "jsonl",
+        tier: StabilityTier::Stable,
+        consumer: "log aggregation, streaming pipelines",
+        render: JsonlExporter::export,
     });
 
     #[cfg(feature = "mermaid-export")]
@@ -166,6 +174,9 @@ pub struct MermaidExporter;
 #[cfg(feature = "html-export")]
 pub struct HtmlExporter;
 
+#[cfg(feature = "jsonl-export")]
+pub struct JsonlExporter;
+
 use std::fmt::Write;
 
 #[cfg(feature = "csv-export")]
@@ -229,6 +240,32 @@ impl TrajectoryExporter for MarkdownExporter {
         }
 
         md
+    }
+}
+
+#[cfg(feature = "jsonl-export")]
+impl TrajectoryExporter for JsonlExporter {
+    fn export(trajectory: &Trajectory) -> String {
+        let redactor = Redactor::default_enabled();
+        let mut jsonl = String::new();
+
+        for msg in &trajectory.messages {
+            let mut redacted_msg = serde_json::to_value(msg).unwrap_or(serde_json::Value::Null);
+            if let Some(obj) = redacted_msg.as_object_mut() {
+                if let Some(content) = obj.get("content").and_then(|c| c.as_str()) {
+                    let redacted_content = redactor.redact_text(content, surface::EXPORT).text;
+                    obj.insert(
+                        "content".to_string(),
+                        serde_json::Value::String(redacted_content),
+                    );
+                }
+            }
+            if let Ok(line) = serde_json::to_string(&redacted_msg) {
+                let _ = writeln!(jsonl, "{line}");
+            }
+        }
+
+        jsonl
     }
 }
 
@@ -432,6 +469,29 @@ mod tests {
         assert!(mermaid.contains("U->>A: Hello \"user\""));
 
         assert!(mermaid.contains("Note over S,T: Outcome: submitted"));
+    }
+
+    #[cfg(feature = "jsonl-export")]
+    #[test]
+    fn test_jsonl_export_format() {
+        let mut t = Trajectory::new();
+        t.info.task = Some("Add a feature".to_string());
+        t.info.outcome = Some("submitted".to_string());
+
+        t.record_message(&Message::system("System prompt"));
+        t.record_message(&Message::user("Hello agent"));
+        t.record_message(&Message::assistant("Hello \"user\""));
+
+        let jsonl = JsonlExporter::export(&t);
+        let lines: Vec<&str> = jsonl.lines().collect();
+
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].contains(r#""role":"system""#));
+        assert!(lines[0].contains(r#""content":"System prompt""#));
+        assert!(lines[1].contains(r#""role":"user""#));
+        assert!(lines[1].contains(r#""content":"Hello agent""#));
+        assert!(lines[2].contains(r#""role":"assistant""#));
+        assert!(lines[2].contains(r#""content":"Hello \"user\"""#));
     }
 
     #[cfg(feature = "html-export")]


### PR DESCRIPTION
💡 **The Spark:**
Trajectories are great for programmatic analysis, but the raw `traj.json` format can be difficult to consume easily in some streaming logs or pipeline contexts without fully loading the large file structure. A one-line-per-message JSONL export provides a clean, easily parsable stream of events.

🚀 **The Feature:**
Implemented a new `JsonlExporter` behind the `jsonl-export` feature flag. The exporter properly handles redactions by applying `Redactor::default_enabled().redact_text` to the content, and leverages `serde_json::to_string` to create a lightweight, line-delimited export. Included a suite test and updated `docs/spec-export.md` to reflect the new feature in the Supported Formats table and the Discoverability outputs.

🔮 **The Potential:**
The JSONL format makes it trivial for operators to integrate Maxwell's Daemon trajectory outputs with external log aggregation tools (like Elasticsearch, fluentd, datadog) and streaming bash tools like `jq` that naturally parse line-delimited JSON objects.

⚠️ **Risk:**
Low. The feature is completely isolated under a new Cargo feature (`jsonl-export`) and does not modify any core parsing or execution logic. It strictly implements the existing `TrajectoryExporter` trait boundary.

---
*PR created automatically by Jules for task [17649028088491621705](https://jules.google.com/task/17649028088491621705) started by @madmax983*