### PR TITLE
🎨 Mosaic: UI Polish for run::ui

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -527,6 +527,7 @@ mod tests {
     // ── Network mode RED-phase tests ─────────────────────────────────────────
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
@@ -550,6 +551,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network").unwrap();

--- a/src/run/ui.rs
+++ b/src/run/ui.rs
@@ -376,11 +376,11 @@ fn serve_instance(entry: &InstanceEntry) -> String {
         Ok(t) => t,
         Err(e) => {
             tracing::warn!(path = ?entry.traj_path, error = %e, "ui: failed to read trajectory");
-            return http_response(
+            return serve_error_page(
                 500,
-                "Internal Server Error",
-                "text/plain",
-                "500 Internal Server Error: failed to read trajectory",
+                "500 Internal Server Error",
+                "Failed to read trajectory artifact from disk.",
+                Some(&e.to_string()),
             );
         }
     };
@@ -389,11 +389,11 @@ fn serve_instance(entry: &InstanceEntry) -> String {
         Ok(t) => t,
         Err(e) => {
             tracing::warn!(path = ?entry.traj_path, error = %e, "ui: failed to parse trajectory");
-            return http_response(
+            return serve_error_page(
                 500,
-                "Internal Server Error",
-                "text/plain",
-                "500 Internal Server Error: failed to parse trajectory",
+                "500 Internal Server Error",
+                "Failed to parse trajectory JSON artifact.",
+                Some(&e.to_string()),
             );
         }
     };
@@ -425,7 +425,12 @@ fn http_response(status: u16, reason: &str, content_type: &str, body: &str) -> S
 }
 
 fn http_404() -> String {
-    http_response(404, "Not Found", "text/plain", "404 Not Found")
+    serve_error_page(
+        404,
+        "404 Not Found",
+        "The requested trajectory or path does not exist.",
+        None,
+    )
 }
 
 fn html_escape(s: &str) -> String {
@@ -433,6 +438,30 @@ fn html_escape(s: &str) -> String {
         .replace('<', "&lt;")
         .replace('>', "&gt;")
         .replace('"', "&quot;")
+}
+
+fn serve_error_page(status: u16, title: &str, message: &str, detail: Option<&str>) -> String {
+    let safe_title = html_escape(title);
+    let safe_message = html_escape(message);
+
+    let detail_html = if let Some(d) = detail {
+        let safe_detail = html_escape(d);
+        format!("<div class=\"detail\">{safe_detail}</div>")
+    } else {
+        String::new()
+    };
+
+    let body = format!(
+        "<!DOCTYPE html>\n         <html>\n         <head>\n         <meta charset=\"UTF-8\">\n         <title>{safe_title}</title>\n         <style>\n         body{{font-family:sans-serif;margin:40px;max-width:800px;background:#fff;color:#333}}\n         .error-container{{padding:24px;border:1px solid #ff4444;border-left:6px solid #ff4444;border-radius:4px;background:#fff9f9}}\n         h1{{margin-top:0;color:#cc0000;font-size:24px}}\n         p{{font-size:16px;line-height:1.5}}\n         .detail{{margin-top:16px;padding:12px;background:#f5f5f5;border-radius:4px;font-family:monospace;font-size:14px;color:#555;white-space:pre-wrap}}\n         .actions{{margin-top:24px}}\n         a{{display:inline-block;padding:8px 16px;background:#f0f0f0;color:#333;text-decoration:none;border-radius:4px;font-weight:600;border:1px solid #ddd}}\n         a:hover{{background:#e0e0e0}}\n         </style>\n         </head>\n         <body>\n         <div class=\"error-container\">\n         <h1>{safe_title}</h1>\n         <p>{safe_message}</p>\n         {detail_html}\n         <div class=\"actions\">\n         <a href=\"/\">&larr; Return to Sweep Browser</a>\n         </div>\n         </div>\n         </body>\n         </html>"
+    );
+
+    let reason = match status {
+        404 => "Not Found",
+        500 => "Internal Server Error",
+        _ => "Error",
+    };
+
+    http_response(status, reason, "text/html; charset=UTF-8", &body)
 }
 
 // ── Request parsing ───────────────────────────────────────────────────────────


### PR DESCRIPTION
🖌️ **Before:**
The web UI server (`ui_server`) returned raw plain-text error messages for 404 (Not Found) and 500 (Internal Server Error) endpoints (e.g., `500 Internal Server Error: failed to read trajectory`). These appeared as unstyled log output, breaking the user experience and violating Mosaic's core philosophy ("If the user has to guess, I failed" and "A CLI tool should look like a dashboard, not a log file").

✨ **After:**
Intercepted 404 and 500 paths inside `src/run/ui.rs` to render a human-readable, beautifully styled HTML error page (`serve_error_page`). The errors now include contextual details when applicable, safe HTML escaping, and consistent navigation back to the root application.

🖼️ **Visuals:**
The new layout leverages the Z-Pattern scanning layout with high contrast (dark gray text on white/light gray background) and features a bold red accent (`border-left: 6px solid #ff4444`) to make error states clearly recognizable. A prominent "Return to Sweep Browser" button offers an immediate feedback loop for recovery.

---
*PR created automatically by Jules for task [3009816673470654715](https://jules.google.com/task/3009816673470654715) started by @madmax983*