### PR TITLE
👺 Havoc: [Remove all unsafe env modifications in tests]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,6 +1372,7 @@ dependencies = [
  "sha2",
  "similar",
  "tar",
+ "temp-env",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -2274,6 +2275,16 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "futures",
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ proptest = "1"
 insta = { version = "1", features = ["json"] }
 pretty_assertions = "1"
 tokio = { version = "1", features = ["full", "test-util"] }
+temp-env = { version = "0.3.6", features = ["async_closure"] }
 
 [features]
 default = ["webhook"]

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -530,12 +530,9 @@ mod tests {
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
+        let Some(network_pos) = network_pos else { panic!("expected --network flag in args: {args:?}") };
         assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
+            args.get(network_pos + 1).map(String::as_str),
             Some("none")
         );
     }
@@ -552,8 +549,8 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else { panic!("missing network arg") };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else { panic!("missing image arg") };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/stream/sweep_webhook.rs
+++ b/src/stream/sweep_webhook.rs
@@ -455,28 +455,29 @@ mod tests {
         // Synthetic env var picked up automatically by from_config_lossy.
         let unique_val = format!("sk-deadbeef-sweep-wh-{}", addr.port());
         let env_name = format!("FAKE_API_KEY_SWH_{}", addr.port());
-        // SAFETY: single-threaded test context; no concurrent env reads.
-        unsafe { std::env::set_var(&env_name, &unique_val) };
-        let redactor = Redactor::default_enabled();
 
-        let sink = SweepWebhookSink::new(url, &[], redactor, "sweep-redact".to_owned()).unwrap();
-        sink.emit(SweepNotificationEvent::InstanceCompleted {
-            instance_id: unique_val.clone(),
-            resolved: false,
-            failure_category: None,
-            cost_usd: None,
-            duration_secs: None,
-        });
+        temp_env::async_with_vars([(&env_name, Some(&unique_val))], async {
+            let redactor = Redactor::default_enabled();
 
-        let socket = accept(&listener).await;
-        let req = read_http(socket).await;
-        // SAFETY: single-threaded test context; no concurrent env reads.
-        unsafe { std::env::remove_var(&env_name) };
+            let sink =
+                SweepWebhookSink::new(url, &[], redactor, "sweep-redact".to_owned()).unwrap();
+            sink.emit(SweepNotificationEvent::InstanceCompleted {
+                instance_id: unique_val.clone(),
+                resolved: false,
+                failure_category: None,
+                cost_usd: None,
+                duration_secs: None,
+            });
 
-        assert!(
-            !req.contains(&unique_val),
-            "sensitive env var value must not appear verbatim in posted payload"
-        );
+            let socket = accept(&listener).await;
+            let req = read_http(socket).await;
+
+            assert!(
+                !req.contains(&unique_val),
+                "sensitive env var value must not appear verbatim in posted payload"
+            );
+        })
+        .await;
     }
 
     // ── RED: drop counting ─────────────────────────────────────────────────

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1124,17 +1124,6 @@ pub(crate) mod build {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::float_cmp)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
-
-    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        ENV_LOCK
-            .get_or_init(Mutex::default)
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
-
     #[test]
     fn trace_id_is_32_hex_chars() {
         let tid = new_trace_id("django__django__1234", "sweep-abc");
@@ -1166,65 +1155,64 @@ mod tests {
 
     #[test]
     fn resolve_endpoint_prefers_cli_flag() {
-        let _guard = env_lock();
-        // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-host:4318");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
-        let ep = resolve_endpoint(Some("http://cli-host:4318"));
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-        }
-        // CLI flag is a base URL; /v1/traces is appended.
-        assert_eq!(ep.as_deref(), Some("http://cli-host:4318/v1/traces"));
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", Some("http://env-host:4318")),
+                ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None::<&str>),
+            ],
+            || {
+                let ep = resolve_endpoint(Some("http://cli-host:4318"));
+                // CLI flag is a base URL; /v1/traces is appended.
+                assert_eq!(ep.as_deref(), Some("http://cli-host:4318/v1/traces"));
+            },
+        );
     }
 
     #[test]
     fn resolve_endpoint_falls_back_to_env_var() {
-        let _guard = env_lock();
-        // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-host:4318");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
-        let ep = resolve_endpoint(None);
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-        }
-        // Generic env var is a base URL; /v1/traces is appended.
-        assert_eq!(ep.as_deref(), Some("http://env-host:4318/v1/traces"));
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", Some("http://env-host:4318")),
+                ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None::<&str>),
+            ],
+            || {
+                let ep = resolve_endpoint(None);
+                // Generic env var is a base URL; /v1/traces is appended.
+                assert_eq!(ep.as_deref(), Some("http://env-host:4318/v1/traces"));
+            },
+        );
     }
 
     #[test]
     fn resolve_endpoint_traces_env_var_used_as_full_url() {
-        let _guard = env_lock();
-        // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-            std::env::set_var(
-                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-                "http://traces-host:4318/v1/traces",
-            );
-        }
-        let ep = resolve_endpoint(None);
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
-        // Trace-specific env var is a full URL; used as-is without appending.
-        assert_eq!(ep.as_deref(), Some("http://traces-host:4318/v1/traces"));
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", None::<&str>),
+                (
+                    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+                    Some("http://traces-host:4318/v1/traces"),
+                ),
+            ],
+            || {
+                let ep = resolve_endpoint(None);
+                // Trace-specific env var is a full URL; used as-is without appending.
+                assert_eq!(ep.as_deref(), Some("http://traces-host:4318/v1/traces"));
+            },
+        );
     }
 
     #[test]
     fn resolve_endpoint_returns_none_when_unset() {
-        let _guard = env_lock();
-        // SAFETY: serialized by ENV_LOCK; no other thread mutates this var.
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-        }
-        let ep = resolve_endpoint(None);
-        assert!(ep.is_none());
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", None::<&str>),
+                ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None::<&str>),
+            ],
+            || {
+                let ep = resolve_endpoint(None);
+                assert!(ep.is_none());
+            },
+        );
     }
 
     #[test]
@@ -1247,129 +1235,115 @@ mod tests {
 
     #[test]
     fn resolve_metrics_endpoint_prefers_cli_flag() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-host:4318");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
-        }
-        let ep = resolve_metrics_endpoint(Some("http://cli-host:4318"));
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-        }
-        assert_eq!(ep.as_deref(), Some("http://cli-host:4318/v1/metrics"));
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", Some("http://env-host:4318")),
+                ("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", None::<&str>),
+            ],
+            || {
+                let ep = resolve_metrics_endpoint(Some("http://cli-host:4318"));
+                assert_eq!(ep.as_deref(), Some("http://cli-host:4318/v1/metrics"));
+            },
+        );
     }
 
     #[test]
     fn resolve_metrics_endpoint_falls_back_to_env_var() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-host:4318");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
-        }
-        let ep = resolve_metrics_endpoint(None);
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-        }
-        assert_eq!(ep.as_deref(), Some("http://env-host:4318/v1/metrics"));
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", Some("http://env-host:4318")),
+                ("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", None::<&str>),
+            ],
+            || {
+                let ep = resolve_metrics_endpoint(None);
+                assert_eq!(ep.as_deref(), Some("http://env-host:4318/v1/metrics"));
+            },
+        );
     }
 
     #[test]
     fn resolve_metrics_endpoint_metrics_env_var_used_as_full_url() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-            std::env::set_var(
-                "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
-                "http://metrics-host:4318/v1/metrics",
-            );
-        }
-        let ep = resolve_metrics_endpoint(None);
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
-        }
-        assert_eq!(ep.as_deref(), Some("http://metrics-host:4318/v1/metrics"));
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", None::<&str>),
+                (
+                    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+                    Some("http://metrics-host:4318/v1/metrics"),
+                ),
+            ],
+            || {
+                let ep = resolve_metrics_endpoint(None);
+                assert_eq!(ep.as_deref(), Some("http://metrics-host:4318/v1/metrics"));
+            },
+        );
     }
 
     #[test]
     fn resolve_metrics_endpoint_returns_none_when_unset() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
-        }
-        let ep = resolve_metrics_endpoint(None);
-        assert!(ep.is_none());
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", None::<&str>),
+                ("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", None::<&str>),
+            ],
+            || {
+                let ep = resolve_metrics_endpoint(None);
+                assert!(ep.is_none());
+            },
+        );
     }
 
     #[test]
     fn resolve_metrics_interval_prefers_env_var() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::set_var("OTEL_METRIC_EXPORT_INTERVAL", "30000");
-        }
-        let interval = resolve_metrics_interval(Some(10));
-        unsafe {
-            std::env::remove_var("OTEL_METRIC_EXPORT_INTERVAL");
-        }
-        assert_eq!(interval, std::time::Duration::from_secs(30));
+        temp_env::with_var("OTEL_METRIC_EXPORT_INTERVAL", Some("30000"), || {
+            let interval = resolve_metrics_interval(Some(10));
+            assert_eq!(interval, std::time::Duration::from_secs(30));
+        });
     }
 
     #[test]
     fn resolve_metrics_interval_prefers_cli_secs() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::remove_var("OTEL_METRIC_EXPORT_INTERVAL");
-        }
-        let interval = resolve_metrics_interval(Some(10));
-        assert_eq!(interval, std::time::Duration::from_secs(10));
+        temp_env::with_var("OTEL_METRIC_EXPORT_INTERVAL", None::<&str>, || {
+            let interval = resolve_metrics_interval(Some(10));
+            assert_eq!(interval, std::time::Duration::from_secs(10));
+        });
     }
 
     #[test]
     fn resolve_metrics_interval_defaults_to_15s() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::remove_var("OTEL_METRIC_EXPORT_INTERVAL");
-        }
-        let interval = resolve_metrics_interval(None);
-        assert_eq!(interval, std::time::Duration::from_secs(15));
+        temp_env::with_var("OTEL_METRIC_EXPORT_INTERVAL", None::<&str>, || {
+            let interval = resolve_metrics_interval(None);
+            assert_eq!(interval, std::time::Duration::from_secs(15));
+        });
     }
 
     #[test]
     fn resolve_metrics_interval_clamps_zero_env_var_to_1s() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::set_var("OTEL_METRIC_EXPORT_INTERVAL", "0");
-        }
-        let interval = resolve_metrics_interval(None);
-        unsafe {
-            std::env::remove_var("OTEL_METRIC_EXPORT_INTERVAL");
-        }
-        assert_eq!(interval, std::time::Duration::from_secs(1));
+        temp_env::with_var("OTEL_METRIC_EXPORT_INTERVAL", Some("0"), || {
+            let interval = resolve_metrics_interval(None);
+            assert_eq!(interval, std::time::Duration::from_secs(1));
+        });
     }
 
     #[test]
     fn resolve_metrics_interval_clamps_zero_cli_secs_to_1s() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::remove_var("OTEL_METRIC_EXPORT_INTERVAL");
-        }
-        let interval = resolve_metrics_interval(Some(0));
-        assert_eq!(interval, std::time::Duration::from_secs(1));
+        temp_env::with_var("OTEL_METRIC_EXPORT_INTERVAL", None::<&str>, || {
+            let interval = resolve_metrics_interval(Some(0));
+            assert_eq!(interval, std::time::Duration::from_secs(1));
+        });
     }
 
     #[test]
     fn resolve_metrics_headers_prefers_metrics_var() {
-        let _guard = env_lock();
-        unsafe {
-            std::env::set_var("OTEL_EXPORTER_OTLP_HEADERS", "a=1,b=2");
-            std::env::set_var("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "c=3");
-        }
-        let headers = resolve_metrics_headers();
-        unsafe {
-            std::env::remove_var("OTEL_EXPORTER_OTLP_HEADERS");
-            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_HEADERS");
-        }
-        assert_eq!(headers, vec![("c".to_owned(), "3".to_owned())]);
+        temp_env::with_vars(
+            [
+                ("OTEL_EXPORTER_OTLP_HEADERS", Some("a=1,b=2")),
+                ("OTEL_EXPORTER_OTLP_METRICS_HEADERS", Some("c=3")),
+            ],
+            || {
+                let headers = resolve_metrics_headers();
+                assert_eq!(headers, vec![("c".to_owned(), "3".to_owned())]);
+            },
+        );
     }
 
     #[test]


### PR DESCRIPTION
🧨 **The Trigger:** Test suites were mutating `std::env` inside `unsafe {}` blocks to mock credentials and settings. While some tried to serialize this via a custom `ENV_LOCK`, it was fundamentally fragile because `std::env::set_var` is not thread-safe and crashes tests concurrently calling libc `getenv`.
📉 **The Stack Trace:** No stack trace, but flaky test failures and UB when threads collide over the environment map.
🧪 **Reproduction:** Run `cargo test` enough times on an overloaded machine and watch it burn.
😈 **Comment:** "You thought `unsafe` in a single-threaded test context was fine until you realized `cargo test` is multi-threaded by default. I have sanitized your environment mocking."

---
*PR created automatically by Jules for task [6110907141497593565](https://jules.google.com/task/6110907141497593565) started by @madmax983*