### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -534,10 +534,10 @@ mod tests {
             network_pos.is_some(),
             "expected --network flag in args: {args:?}"
         );
-        assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
-            Some("none")
-        );
+        let Some(pos) = network_pos else {
+            panic!("expected --network")
+        };
+        assert_eq!(args.get(pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]
@@ -552,8 +552,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network")
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected my-image")
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -634,4 +634,84 @@ mod tests {
             "disk_usage_prune_blocked"
         );
     }
+
+    #[test]
+    fn from_error_agent_stagnation_is_agent_stagnation() {
+        assert_eq!(
+            ExitCode::from_error(&Error::AgentStagnation {
+                count: 0,
+                window: 0
+            }),
+            ExitCode::AgentStagnation
+        );
+    }
+
+    #[test]
+    fn from_error_bisect_budget_exhausted_is_bisect_budget_exhausted() {
+        assert_eq!(
+            ExitCode::from_error(&Error::BisectBudgetExhausted),
+            ExitCode::BisectBudgetExhausted
+        );
+    }
+
+    #[test]
+    fn from_error_bisect_schema_break_is_bisect_schema_break() {
+        assert_eq!(
+            ExitCode::from_error(&Error::BisectSchemaBreak),
+            ExitCode::BisectSchemaBreak
+        );
+    }
+
+    #[test]
+    fn from_error_audit_is_audit_failure() {
+        assert_eq!(
+            ExitCode::from_error(&Error::Audit("foo".into())),
+            ExitCode::AuditFailure
+        );
+    }
+
+    #[test]
+    fn from_error_internal_errors_is_internal_error() {
+        assert_eq!(
+            ExitCode::from_error(&Error::Trajectory("foo".into())),
+            ExitCode::InternalError
+        );
+        assert_eq!(
+            ExitCode::from_error(&Error::Github("foo".into())),
+            ExitCode::InternalError
+        );
+        let Err(json_err) = serde_json::from_str::<serde_json::Value>("") else { panic!("expected err") };
+        assert_eq!(
+            ExitCode::from_error(&Error::Json(json_err)),
+            ExitCode::InternalError
+        );
+    }
+
+    #[test]
+    fn from_error_github_issue_is_mapped_correctly() {
+        assert_eq!(
+            ExitCode::from_error(&Error::GithubIssue(
+                crate::error::GithubIssueError::MissingToken("foo".into())
+            )),
+            ExitCode::GithubIssueMissingToken
+        );
+        assert_eq!(
+            ExitCode::from_error(&Error::GithubIssue(
+                crate::error::GithubIssueError::NotFound("foo".into())
+            )),
+            ExitCode::GithubIssueNotFound
+        );
+        assert_eq!(
+            ExitCode::from_error(&Error::GithubIssue(
+                crate::error::GithubIssueError::RateLimited("foo".into())
+            )),
+            ExitCode::GithubIssueRateLimited
+        );
+        assert_eq!(
+            ExitCode::from_error(&Error::GithubIssue(
+                crate::error::GithubIssueError::RequestFailed("foo".into())
+            )),
+            ExitCode::TaskUnsuccessful
+        );
+    }
 }

--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -680,7 +680,9 @@ mod tests {
             ExitCode::from_error(&Error::Github("foo".into())),
             ExitCode::InternalError
         );
-        let Err(json_err) = serde_json::from_str::<serde_json::Value>("") else { panic!("expected err") };
+        let Err(json_err) = serde_json::from_str::<serde_json::Value>("") else {
+            panic!("expected err")
+        };
         assert_eq!(
             ExitCode::from_error(&Error::Json(json_err)),
             ExitCode::InternalError


### PR DESCRIPTION
🎯 Target: `src/exit_code.rs` (`ExitCode::from_error`) and `src/env/docker.rs`
💣 Risk: Previously, a missing or incorrect `ExitCode` mapping could lead to silent changes in agent exit statuses, causing obscure regressions or incorrect systemic halts. The use of `.unwrap()` in tests is risky and explicitly forbidden by Sentry's strict testing directives.
🧪 Strategy: 
1. Added a block of unit tests in `src/exit_code.rs` for `Error::AgentStagnation`, `Error::BisectBudgetExhausted`, `Error::BisectSchemaBreak`, `Error::Audit`, internal errors, and `GithubIssue` variants to ensure all are faithfully translated to the correct `ExitCode`.
2. Removed ticking time bombs (`.unwrap()`) in `src/env/docker.rs` test functions, replacing them with `let Some(..) = .. else { panic!(..) }` blocks that clearly declare missing assumptions.
🔬 Verification: Run `cargo check`, `cargo test env::docker --features docker`, `cargo test exit_code`, `cargo fmt --all`, and `cargo clippy --all-targets --all-features -- -D warnings`. All commands passed successfully.

---
*PR created automatically by Jules for task [6881319570990528457](https://jules.google.com/task/6881319570990528457) started by @madmax983*