### PR TITLE
👺 Havoc: [OOM Crash in StagnationDetector via Unbounded Preallocation]

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,12 @@
+## Havoc Persona Target: StagnationDetector Out-of-Memory / Denial-of-Service via `VecDeque::with_capacity`
+
+### Overview
+1. **The Weak Point**: `StagnationDetector::new` allocates memory using `VecDeque::with_capacity(window as usize)`. The `window` parameter comes from `stagnation_window` in the config or CLI args (`--stagnation-window`).
+2. **The Vulnerability**: A user can set a huge `window` size (e.g., `4_000_000_000`), causing an immediate Out-Of-Memory (OOM) panic and process crash. The maximum memory limit should be capped, or we shouldn't preallocate the whole window size immediately.
+3. **The Defense**: Change `VecDeque::with_capacity(window as usize)` to bound the initial capacity (e.g., `VecDeque::with_capacity(std::cmp::min(1024, window as usize))`), or just use `VecDeque::new()` and let it grow naturally. Since it's a sliding window of actions, most agent runs never approach `4_000_000_000` steps. Using `VecDeque::new()` eliminates the OOM on initialization without breaking logic.
+4. **Execution Process**:
+   - Write a failing property test in `src/stagnation.rs` using `proptest` showing it can panic with `window = u32::MAX`.
+   - Update the code in `src/stagnation.rs` to fix the panic.
+   - Run tests (especially `cargo test stagnation` and `cargo test havoc`).
+   - Run persona verification checks.
+   - Commit PR as "👺 Havoc: [OOM Crash in StagnationDetector via Unbounded Allocation]".

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -527,6 +527,7 @@ mod tests {
     // ── Network mode RED-phase tests ─────────────────────────────────────────
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
@@ -550,6 +551,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network").unwrap();

--- a/src/stagnation.rs
+++ b/src/stagnation.rs
@@ -113,7 +113,7 @@ impl StagnationDetector {
         Self {
             window,
             threshold,
-            buffer: VecDeque::with_capacity(window as usize),
+            buffer: VecDeque::new(),
         }
     }
 
@@ -226,5 +226,25 @@ mod tests {
         assert!(det.observe(1, "ls").is_none());
         assert!(det.observe(2, "ls").is_none());
         assert!(det.observe(3, "ls").is_some());
+    }
+}
+
+#[cfg(test)]
+mod havoc_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn havoc_stagnation_fuzzing(window in 0..=u32::MAX, threshold in 0..10_000u32, steps in 0..100u32) {
+            if window >= threshold {
+                let mut det = StagnationDetector::new(threshold, window);
+                for i in 0..steps {
+                    det.observe(i, "ls");
+                    // buffer should never exceed window size unless window is 0
+                    assert!(det.buffer.len() <= std::cmp::max(1, window as usize), "Buffer size exceeded window!");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
* 🧨 **The Trigger:** Passing a massive `--stagnation-window` value (e.g., 4,000,000,000) causes an immediate OOM panic during agent initialization due to `VecDeque::with_capacity`.
* 📉 **The Stack Trace:** memory allocation of 128000000000 bytes failed.
* 🧪 **Reproduction:** Run `cargo run --bin max --features docker -- mini --task "hello" --detect-stagnation=true --stagnation-window 4000000000 --model mock-model`.
* 😈 **Comment:** "You assumed attackers wouldn't ask for a window larger than your RAM. You were wrong."

---
*PR created automatically by Jules for task [7441776563811075509](https://jules.google.com/task/7441776563811075509) started by @madmax983*