### PR TITLE
⚒️ Forge: Extract driver validation logic in mini.rs

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -536,7 +536,8 @@ mod tests {
             "expected --network flag in args: {args:?}"
         );
         assert_eq!(
-            args.get(network_pos.expect("expected network flag") + 1).map(String::as_str),
+            args.get(network_pos.expect("expected network flag") + 1)
+                .map(String::as_str),
             Some("none")
         );
     }
@@ -554,8 +555,14 @@ mod tests {
     #[allow(clippy::unwrap_used, clippy::expect_used)]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").expect("expected network flag");
-        let image_pos = args.iter().position(|a| a == "my-image").expect("expected image flag");
+        let network_pos = args
+            .iter()
+            .position(|a| a == "--network")
+            .expect("expected network flag");
+        let image_pos = args
+            .iter()
+            .position(|a| a == "my-image")
+            .expect("expected image flag");
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -527,6 +527,7 @@ mod tests {
     // ── Network mode RED-phase tests ─────────────────────────────────────────
 
     #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
         let network_pos = args.iter().position(|a| a == "--network");
@@ -535,7 +536,7 @@ mod tests {
             "expected --network flag in args: {args:?}"
         );
         assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
+            args.get(network_pos.expect("expected network flag") + 1).map(String::as_str),
             Some("none")
         );
     }
@@ -550,10 +551,11 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let network_pos = args.iter().position(|a| a == "--network").expect("expected network flag");
+        let image_pos = args.iter().position(|a| a == "my-image").expect("expected image flag");
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/run/mini.rs
+++ b/src/run/mini.rs
@@ -449,20 +449,7 @@ fn build_mini_manifest(
 }
 
 #[allow(clippy::too_many_lines)]
-pub async fn run(args: MiniArgs) -> Result<(), Error> {
-    let mut args = args;
-    let mut cancel_tx = None;
-    if args.cancellation.is_none()
-        && matches!(
-            args.interactive_mode,
-            InteractiveMode::Ratatui | InteractiveMode::RatatuiMonitor
-        )
-    {
-        let (tx, rx) = tokio::sync::watch::channel(false);
-        cancel_tx = Some(tx);
-        args.cancellation = Some(crate::env::CancellationToken::new(rx));
-    }
-
+fn validate_driver_contracts(args: &MiniArgs) -> Result<(), Error> {
     // The Claude Code driver shells out to the host `claude` binary and edits
     // the host working tree directly. It cannot honor several safety contracts
     // the built-in loop enforces inside `DefaultAgent::step`, so reject the
@@ -737,6 +724,26 @@ pub async fn run(args: MiniArgs) -> Result<(), Error> {
             )));
         }
     }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn run(args: MiniArgs) -> Result<(), Error> {
+    let mut args = args;
+    let mut cancel_tx = None;
+    if args.cancellation.is_none()
+        && matches!(
+            args.interactive_mode,
+            InteractiveMode::Ratatui | InteractiveMode::RatatuiMonitor
+        )
+    {
+        let (tx, rx) = tokio::sync::watch::channel(false);
+        cancel_tx = Some(tx);
+        args.cancellation = Some(crate::env::CancellationToken::new(rx));
+    }
+
+    validate_driver_contracts(&args)?;
 
     std::fs::create_dir_all(&args.output_dir)?;
 


### PR DESCRIPTION
- 🚮 Smell: The `run` function in `src/run/mini.rs` had a ~280 line block of driver validation logic at the very beginning, making it hard to see the actual execution flow (God function).
- ✨ Solution: Extracted the validation checks for `RunDriver::ClaudeCode` and `RunDriver::Codex` into a separate `validate_driver_contracts` helper function.
- 🧼 Benefit: Drastically reduces the length of the `run` function, separating configuration validation from runtime execution.
- 🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [17244845460164478407](https://jules.google.com/task/17244845460164478407) started by @madmax983*