### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -532,10 +532,7 @@ mod tests {
         let Some(network_pos) = args.iter().position(|a| a == "--network") else {
             panic!("expected --network flag in args: {args:?}");
         };
-        assert_eq!(
-            args.get(network_pos + 1).map(String::as_str),
-            Some("none")
-        );
+        assert_eq!(args.get(network_pos + 1).map(String::as_str), Some("none"));
     }
 
     #[test]

--- a/src/env/docker.rs
+++ b/src/env/docker.rs
@@ -529,13 +529,11 @@ mod tests {
     #[test]
     fn build_run_args_include_network_none_when_mode_is_none() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network");
-        assert!(
-            network_pos.is_some(),
-            "expected --network flag in args: {args:?}"
-        );
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
         assert_eq!(
-            args.get(network_pos.unwrap() + 1).map(String::as_str),
+            args.get(network_pos + 1).map(String::as_str),
             Some("none")
         );
     }
@@ -552,8 +550,12 @@ mod tests {
     #[test]
     fn build_run_args_network_none_positioned_before_image() {
         let args = build_run_args("my-image", "/workspace", LABEL, Some("none"));
-        let network_pos = args.iter().position(|a| a == "--network").unwrap();
-        let image_pos = args.iter().position(|a| a == "my-image").unwrap();
+        let Some(network_pos) = args.iter().position(|a| a == "--network") else {
+            panic!("expected --network flag in args: {args:?}");
+        };
+        let Some(image_pos) = args.iter().position(|a| a == "my-image") else {
+            panic!("expected image name in args: {args:?}");
+        };
         assert!(
             network_pos < image_pos,
             "--network must appear before the image name"

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -471,7 +471,7 @@ impl Redactor {
 
     /// Run redaction and return per-match annotations for operator verification.
     ///
-    /// Unlike [`redact_text`], this method does not update surface-level telemetry
+    /// Unlike `redact_text`, this method does not update surface-level telemetry
     /// counts and does not require a surface label. It is designed for the
     /// `agent redact-check` preflight command.
     #[must_use]

--- a/src/run/claude_driver.rs
+++ b/src/run/claude_driver.rs
@@ -405,10 +405,10 @@ fn record_claude_config(agent: &mut DefaultAgent, cwd: &Path, isolated: bool) {
 ///   OAuth/keychain auth, ambient `.claude` discovery (hooks, skills, plugins,
 ///   MCP, memory, `CLAUDE.md`), native session persistence, and the team's own
 ///   permission settings. The harness *records* the discovered config (see
-///   [`discover_claude_config`]) into the trajectory so the run is auditable
+///   `discover_claude_config`) into the trajectory so the run is auditable
 ///   without being sterilized. This is the enterprise-auditing case.
 /// - `true` (*isolation*): pass `--bare` (skip ambient discovery), `--tools`
-///   (restrict to [`ALLOWED_TOOLS`]), and `--no-session-persistence` for a
+///   (restrict to `ALLOWED_TOOLS`), and `--no-session-persistence` for a
 ///   reproducible measurement run. Note: `--bare` forces API-key-only auth, so
 ///   OAuth/keychain logins do not apply in this mode.
 #[allow(clippy::too_many_lines)]

--- a/src/run/codex_driver.rs
+++ b/src/run/codex_driver.rs
@@ -3,7 +3,7 @@
 //! Similar to `claude_driver.rs`, this module lets an operator point the *same*
 //! run machinery at the OpenAI Codex CLI instead of the built-in bash-first loop.
 //! `codex` runs in `--full-auto --json` mode; we read its newline-delimited JSON
-//! stream and translate each event into the harness [`Trajectory`] format so that
+//! stream and translate each event into the harness [`crate::trajectory::Trajectory`] format so that
 //! patch capture, verification, `bench inspect`, and evaluation all keep working
 //! unchanged.
 //!

--- a/src/run/contamination_check.rs
+++ b/src/run/contamination_check.rs
@@ -6,9 +6,9 @@
 //!
 //! | Signal | Description | Range |
 //! |--------|-------------|-------|
-//! | `edit_before_read_ratio` | Fraction of edited files never read before patching | [0,1] |
-//! | `patch_similarity_to_gold` | Normalised similarity between agent patch and gold patch | [0,1] |
-//! | `time_to_first_edit` | Suspicion from early first edit (step 0 → 1.0, last step → 0.0) | [0,1] |
+//! | `edit_before_read_ratio` | Fraction of edited files never read before patching | \[0,1\] |
+//! | `patch_similarity_to_gold` | Normalised similarity between agent patch and gold patch | \[0,1\] |
+//! | `time_to_first_edit` | Suspicion from early first edit (step 0 → 1.0, last step → 0.0) | \[0,1\] |
 //! | `verbatim_recall` | Whether agent message contains ≥ N tokens from gold patch surface | {0,1} |
 //!
 //! # Risk tiers

--- a/src/run/redact_audit.rs
+++ b/src/run/redact_audit.rs
@@ -1,6 +1,6 @@
 //! `agent redact-audit <dir>` — post-hoc secret-leak detection for sweep artifacts.
 //!
-//! Issue #342. The runtime [`Redactor`](crate::redaction::Redactor) masks secrets
+//! Issue #342. The runtime [`Redactor`] masks secrets
 //! *at write-time* and explicitly does not retroactively rewrite stored
 //! artifacts. Trajectories and sweep outputs are routinely shared (PRs, HTML
 //! exports, bundles), so a redaction-config bug or an unanticipated secret shape

--- a/src/run/suite.rs
+++ b/src/run/suite.rs
@@ -8,8 +8,8 @@
 //! `--rerun-failed` (issue #825) re-runs only the tasks whose last recorded
 //! result was non-passing, carrying every already-passing result forward
 //! unchanged (zero model calls, zero fresh cost) into a freshly merged
-//! `suite-results.json`. See [`tasks_needing_rerun`] and
-//! [`load_prior_suite_state`].
+//! `suite-results.json`. See `tasks_needing_rerun` and
+//! `load_prior_suite_state`.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/src/run/sweep_dashboard.rs
+++ b/src/run/sweep_dashboard.rs
@@ -10,7 +10,7 @@
 //! (`crate::run::inspect::build_inspect_steps_with_max`).
 //!
 //! The module is split so the state machine and rendering are pure,
-//! deterministic functions ([`handle_key`], [`draw`]) testable with
+//! deterministic functions (`handle_key`, `draw`) testable with
 //! ratatui's `TestBackend` — no real terminal required — while [`run`] is
 //! the thin IO shell that owns the terminal and the poll loop.
 

--- a/src/run/ui.rs
+++ b/src/run/ui.rs
@@ -39,7 +39,7 @@ pub struct InstanceEntry {
     pub traj_path: PathBuf,
 }
 
-/// Arguments forwarded from the CLI to [`run`].
+/// Arguments forwarded from the CLI to `run`.
 pub struct UiArgs {
     pub sweep: PathBuf,
     pub port: u16,

--- a/src/trajectory/export.rs
+++ b/src/trajectory/export.rs
@@ -6,7 +6,7 @@
 //! narrative document, complete with headers and code blocks.
 //!
 //! You can extend this module with new formats by implementing the [`crate::trajectory::export::TrajectoryExporter`] trait.
-//! Every new exporter MUST register in [`registry`] and MUST apply redaction via
+//! Every new exporter MUST register in `registry` and MUST apply redaction via
 //! [`crate::redaction::Redactor::default_enabled`] on [`crate::redaction::surface::EXPORT`] before emitting any output.
 //! See `docs/spec-export.md` for the full governing contract.
 


### PR DESCRIPTION
📖 Chapter: Documentation links and tests across multiple modules.
🔦 Insight: Escaped brackets incorrectly treated as links, converted private intra-doc links to code elements, fixed unresolvable links, removed redundant targets, and updated tests with `let else` blocks to satisfy `clippy::unwrap_used`.
🧪 Example: Refactored `unwrap` in `tests` within `env/docker.rs`.
🖼️ Preview: `cargo doc` now builds cleanly without broken intra-doc link warnings, and tests pass clippy rules.

---
*PR created automatically by Jules for task [18100406114799951897](https://jules.google.com/task/18100406114799951897) started by @madmax983*